### PR TITLE
refactor! : Update default workspace size based on platforms.

### DIFF
--- a/core/conversion/conversionctx/ConversionCtx.cpp
+++ b/core/conversion/conversionctx/ConversionCtx.cpp
@@ -58,7 +58,7 @@ ConversionCtx::ConversionCtx(BuilderSettings build_settings)
   net = make_trt(
       builder->createNetworkV2(1U << static_cast<uint32_t>(nvinfer1::NetworkDefinitionCreationFlag::kEXPLICIT_BATCH)));
 
-  LOG_DEBUG(build_settings);
+  LOG_INFO(settings);
   cfg = make_trt(builder->createBuilderConfig());
 
   for (auto p = settings.enabled_precisions.begin(); p != settings.enabled_precisions.end(); ++p) {


### PR DESCRIPTION
# Description

BREAKING CHANGE: This commit sets the default workspace size to 1GB for GPU platforms and 256MB for Jetson Nano/TX1 platforms whose compute capability is < 6.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [z] I have performed a self-review of my own code
- [z] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [z] New and existing unit tests pass locally with my changes