### PR TITLE
fix: skip None output instead of throw an error

### DIFF
--- a/core/conversion/conversion.cpp
+++ b/core/conversion/conversion.cpp
@@ -229,6 +229,11 @@ void MarkOutputs(ConversionCtx* ctx, at::ArrayRef<const torch::jit::Value*> outp
           LOG_INFO(
               ctx->logger, "Marking Output " << out->debugName() << " named " << name << " in engine (ctx.MarkOutput)");
           ctx->num_outputs += 1;
+        } else if (out_ivalue.isNone()) { // skip a None output layer
+          std::string name = std::string("output_") + std::to_string(ctx->num_outputs);
+          LOG_INFO(
+              ctx->logger, "Skipping None Output " << out->debugName() << " named " << name << " in engine (ctx.MarkOutput)");
+          ctx->num_outputs += 1;
         } else {
           TORCHTRT_THROW_ERROR("Unknown output type. Only a single tensor or a TensorList type is supported.");
         }

--- a/core/conversion/conversion.cpp
+++ b/core/conversion/conversion.cpp
@@ -231,7 +231,7 @@ void MarkOutputs(ConversionCtx* ctx, at::ArrayRef<const torch::jit::Value*> outp
           ctx->num_outputs += 1;
         } else if (out_ivalue.isNone()) { // skip a None output layer
           std::string name = std::string("output_") + std::to_string(ctx->num_outputs);
-          LOG_INFO(
+          LOG_WARNING(
               ctx->logger, "Skipping None Output " << out->debugName() << " named " << name << " in engine (ctx.MarkOutput)");
           ctx->num_outputs += 1;
         } else {


### PR DESCRIPTION
# Description
For some models, there may be `None` output for scripted model, for example, in `torchvision.inception_v3`, the second output is a None constant.

Current implementation throws error as reported in issue #469 .

I added a special case for `out_ivalue.isNone()` and skip the output to make the model compile.

## Call for discussion
Personally I don't know if it's a good idea to skip an output, it may cause error in client code (out of index error when try to get the output), but I don't know how to build a `None` tensor with TensorRT.

Fixes # (issue)
#469 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes