### PR TITLE
feat (//cpp): Using atol and rtol based tolerance threshold for torchtrtc

### DIFF
--- a/cpp/bin/torchtrtc/README.md
+++ b/cpp/bin/torchtrtc/README.md
@@ -89,10 +89,12 @@ torchtrtc [input_file_path] [output_file_path]
                                         used to select kernels
       --workspace-size=[workspace_size] Maximum size of workspace given to
                                         TensorRT
-      -t[threshold],
-      --threshold=[threshold]           Maximum acceptable numerical deviation
-                                        from standard torchscript output
-                                        (default 2e-5)
+      --atol=[atol]                     Absolute tolerance threshold for acceptable
+                                        numerical deviation from standard torchscript
+                                        output (default 1e-8)
+      --rtol=[rtol]                     Relative tolerance threshold for acceptable
+                                        numerical deviation from standard torchscript
+                                        output  (default 1e-5)
       --no-threshold-check              Skip checking threshold compliance
       --truncate-long-double,
       --truncate, --truncate-64bit      Truncate weights that are provided in

--- a/cpp/bin/torchtrtc/accuracy.h
+++ b/cpp/bin/torchtrtc/accuracy.h
@@ -12,7 +12,7 @@ namespace torchtrtc {
 namespace accuracy {
 
 bool check_rtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs, float threshold);
-bool almost_equal(const at::Tensor& a, const at::Tensor& b, float threshold);
+bool almost_equal(const at::Tensor& computed_tensor, const at::Tensor& gt_tensor, float atol = 1e-8, float rtol = 1e-5);
 
 } // namespace accuracy
 } // namespace torchtrtc

--- a/cpp/bin/torchtrtc/main.cpp
+++ b/cpp/bin/torchtrtc/main.cpp
@@ -119,11 +119,16 @@ int main(int argc, char** argv) {
       parser, "num_iters", "Number of averaging timing iterations used to select kernels", {"num-avg-timing-iters"});
   args::ValueFlag<uint64_t> workspace_size(
       parser, "workspace_size", "Maximum size of workspace given to TensorRT", {"workspace-size"});
-  args::ValueFlag<double> threshold(
+  args::ValueFlag<double> atol(
       parser,
-      "threshold",
-      "Maximum acceptable numerical deviation from standard torchscript output (default 2e-5)",
-      {'t', "threshold"});
+      "atol",
+      "Absolute tolerance threshold for acceptable numerical deviation from standard torchscript output (default 1e-8)",
+      {"atol"});
+  args::ValueFlag<double> rtol(
+      parser,
+      "rtol",
+      "Relative tolerance threshold for acceptable numerical deviation from standard torchscript output (default 1e-5)",
+      {"rtol"});
 
   args::Flag no_threshold_check(
       parser, "no-threshold-check", "Skip checking threshold compliance", {"no-threshold-check", "no-threshold-check"});
@@ -392,9 +397,13 @@ int main(int argc, char** argv) {
         (compile_settings.enabled_precisions.size() == 1 &&
          compile_settings.enabled_precisions.find(torchtrt::DataType::kFloat) !=
              compile_settings.enabled_precisions.end())) {
-      double threshold_val = 2e-5;
-      if (threshold) {
-        threshold_val = args::get(threshold);
+      double atol_val = 1e-8;
+      double rtol_val = 1e-5;
+      if (atol) {
+        atol_val = args::get(atol);
+      }
+      if (rtol) {
+        rtol_val = args::get(rtol);
       }
 
       std::vector<torch::jit::IValue> jit_inputs_ivalues;
@@ -431,14 +440,18 @@ int main(int argc, char** argv) {
       }
 
       for (size_t i = 0; i < trt_results.size(); i++) {
+        std::ostringstream threshold_ss;
+        threshold_ss << "atol: " << atol_val << " rtol: " << rtol_val;
         if (!torchtrtc::accuracy::almost_equal(
-                jit_results[i], trt_results[i].reshape_as(jit_results[i]), threshold_val)) {
-          std::ostringstream threshold_ss;
-          threshold_ss << threshold_val;
+                jit_results[i], trt_results[i].reshape_as(jit_results[i]), atol_val, rtol_val)) {
           torchtrt::logging::log(
               torchtrt::logging::Level::kWARNING,
-              std::string("Maximum numerical deviation for output exceeds set threshold (") + threshold_ss.str() +
-                  std::string(")"));
+              std::string("Maximum numerical deviation for output exceeds tolerance thresholds (") +
+                  threshold_ss.str() + std::string(")"));
+        } else {
+          torchtrt::logging::log(
+              torchtrt::logging::Level::kDEBUG,
+              std::string("Maximum numerical deviation within threshold limits ") + threshold_ss.str());
         }
       }
     } else {

--- a/docsrc/tutorials/torchtrtc.rst
+++ b/docsrc/tutorials/torchtrtc.rst
@@ -92,10 +92,12 @@ to standard TorchScript. Load with ``torch.jit.load()`` and run like you would r
                                           used to select kernels
         --workspace-size=[workspace_size] Maximum size of workspace given to
                                           TensorRT
-        -t[threshold],
-        --threshold=[threshold]           Maximum acceptable numerical deviation
-                                          from standard torchscript output
-                                          (default 2e-5)
+        --atol=[atol]                     Absolute tolerance threshold for acceptable
+                                          numerical deviation from standard torchscript
+                                          output (default 1e-8)
+        --rtol=[rtol]                     Relative tolerance threshold for acceptable
+                                          numerical deviation from standard torchscript
+                                          output  (default 1e-5)
         --no-threshold-check              Skip checking threshold compliance
         --truncate-long-double,
         --truncate, --truncate-64bit      Truncate weights that are provided in


### PR DESCRIPTION
# Description

Added rtol + atol tolerance check for torchtrtc. Similar to what we have for test benchmarks.

This PR is a replica of https://github.com/NVIDIA/Torch-TensorRT/pull/1038

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)
#1030 

## Type of change

Please delete options that are not relevant and/or add your own.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes