### PR TITLE
Facebook internal linter/formatter changes

### DIFF
--- a/py/torch_tensorrt/fx/converters/acc_ops_converters.py
+++ b/py/torch_tensorrt/fx/converters/acc_ops_converters.py
@@ -4,21 +4,20 @@ import operator
 import warnings
 from typing import cast, Dict, Optional, Sequence, Tuple, Union
 
-from ..tracer.acc_tracer import acc_ops
 import numpy as np
 
 # @manual=//deeplearning/trt/python:py_tensorrt
 import tensorrt as trt
 import torch
+
 from ..converter_registry import tensorrt_converter
+
+from ..tracer.acc_tracer import acc_ops
 from ..types import *  # noqa: F403
-from ..utils import (
-    get_dynamic_dims,
-    torch_dtype_from_trt,
-    torch_dtype_to_trt,
-)
 from torch.fx.immutable_collections import immutable_list
 from torch.fx.node import Argument, Target
+
+from ..utils import get_dynamic_dims, torch_dtype_from_trt, torch_dtype_to_trt
 
 from .converter_utils import *  # noqa: F403
 

--- a/py/torch_tensorrt/fx/converters/activation.py
+++ b/py/torch_tensorrt/fx/converters/activation.py
@@ -3,6 +3,7 @@ import numpy as np
 # @manual=//deeplearning/trt/python:py_tensorrt
 import tensorrt as trt
 import torch
+
 from ..converter_registry import tensorrt_converter
 
 from .converter_utils import mark_as_int8_layer

--- a/py/torch_tensorrt/fx/converters/adaptive_avgpool.py
+++ b/py/torch_tensorrt/fx/converters/adaptive_avgpool.py
@@ -1,6 +1,7 @@
 # @manual=//deeplearning/trt/python:py_tensorrt
 import tensorrt as trt
 import torch
+
 from ..converter_registry import tensorrt_converter
 
 from .converter_utils import extend_mod_attr_to_tuple, mark_as_int8_layer

--- a/py/torch_tensorrt/fx/converters/add.py
+++ b/py/torch_tensorrt/fx/converters/add.py
@@ -3,6 +3,7 @@ import operator
 # @manual=//deeplearning/trt/python:py_tensorrt
 import tensorrt as trt
 import torch
+
 from ..converter_registry import tensorrt_converter
 
 from .converter_utils import get_dyn_range, mark_as_int8_layer

--- a/py/torch_tensorrt/fx/converters/batchnorm.py
+++ b/py/torch_tensorrt/fx/converters/batchnorm.py
@@ -3,6 +3,7 @@ import numpy as np
 # @manual=//deeplearning/trt/python:py_tensorrt
 import tensorrt as trt
 import torch
+
 from ..converter_registry import tensorrt_converter
 
 from .converter_utils import get_dyn_range, mark_as_int8_layer, to_numpy

--- a/py/torch_tensorrt/fx/converters/converter_utils.py
+++ b/py/torch_tensorrt/fx/converters/converter_utils.py
@@ -7,6 +7,8 @@ import numpy as np
 # @manual=//deeplearning/trt/python:py_tensorrt
 import tensorrt as trt
 import torch
+from torch.fx.node import Argument, Target
+
 from ..types import (
     Shape,
     TRTDataType,
@@ -18,7 +20,6 @@ from ..types import (
     TRTTensor,
 )
 from ..utils import torch_dtype_from_trt
-from torch.fx.node import Argument, Target
 
 
 def get_trt_plugin(

--- a/py/torch_tensorrt/fx/converters/convolution.py
+++ b/py/torch_tensorrt/fx/converters/convolution.py
@@ -2,6 +2,7 @@
 import numpy as np
 import tensorrt as trt
 import torch
+
 from ..converter_registry import tensorrt_converter
 
 from .converter_utils import (

--- a/py/torch_tensorrt/fx/converters/linear.py
+++ b/py/torch_tensorrt/fx/converters/linear.py
@@ -1,6 +1,7 @@
 # @manual=//deeplearning/trt/python:py_tensorrt
 import tensorrt as trt
 import torch
+
 from ..converter_registry import tensorrt_converter
 
 from .converter_utils import get_dyn_range, mark_as_int8_layer, to_numpy

--- a/py/torch_tensorrt/fx/converters/maxpool.py
+++ b/py/torch_tensorrt/fx/converters/maxpool.py
@@ -1,6 +1,7 @@
 # @manual=//deeplearning/trt/python:py_tensorrt
 import tensorrt as trt
 import torch
+
 from ..converter_registry import tensorrt_converter
 
 from .converter_utils import extend_mod_attr_to_tuple, mark_as_int8_layer

--- a/py/torch_tensorrt/fx/converters/mul.py
+++ b/py/torch_tensorrt/fx/converters/mul.py
@@ -3,6 +3,7 @@ import operator
 # @manual=//deeplearning/trt/python:py_tensorrt
 import tensorrt as trt
 import torch
+
 from ..converter_registry import tensorrt_converter
 
 from .converter_utils import get_dyn_range, mark_as_int8_layer

--- a/py/torch_tensorrt/fx/converters/quantization.py
+++ b/py/torch_tensorrt/fx/converters/quantization.py
@@ -1,6 +1,7 @@
 # @manual=//deeplearning/trt/python:py_tensorrt
 import tensorrt as trt
 import torch
+
 from ..converter_registry import tensorrt_converter
 
 from .converter_utils import get_dyn_range, get_inputs_from_args_and_kwargs

--- a/py/torch_tensorrt/fx/converters/transformation.py
+++ b/py/torch_tensorrt/fx/converters/transformation.py
@@ -1,6 +1,7 @@
 # @manual=//deeplearning/trt/python:py_tensorrt
 import tensorrt as trt
 import torch
+
 from ..converter_registry import tensorrt_converter
 
 from .converter_utils import mark_as_int8_layer

--- a/py/torch_tensorrt/fx/example/test_fx2trt.py
+++ b/py/torch_tensorrt/fx/example/test_fx2trt.py
@@ -1,29 +1,35 @@
-import torch_tensorrt
 import torch
+import torch_tensorrt
+
 
 class MyModel(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.linear = torch.nn.Linear(5,3)
+        self.linear = torch.nn.Linear(5, 3)
         self.relu = torch.nn.functional.relu
-    def forward(self,x):
+
+    def forward(self, x):
         x = self.linear(x)
         x = self.relu(x)
         return x
 
 
-model = MyModel().eval() # torch module needs to be in eval (not training) mode
+model = MyModel().eval()  # torch module needs to be in eval (not training) mode
 
 # torch tensorrt
-inputs = [torch_tensorrt.Input(
-            (2,5),
-            dtype=torch.half,
-        )]
-enabled_precisions = {torch.float, torch.half} # Run with fp16
+inputs = [
+    torch_tensorrt.Input(
+        (2, 5),
+        dtype=torch.half,
+    )
+]
+enabled_precisions = {torch.float, torch.half}  # Run with fp16
 
-trt_ts_module = torch_tensorrt.compile(model, inputs=inputs, enabled_precisions=enabled_precisions)
+trt_ts_module = torch_tensorrt.compile(
+    model, inputs=inputs, enabled_precisions=enabled_precisions
+)
 
-inputs_ts = [torch.ones(2,5)]
+inputs_ts = [torch.ones(2, 5)]
 inputs_ts = [i.cuda().half() for i in inputs_ts]
 result = trt_ts_module(*inputs_ts)
 print(result)
@@ -33,12 +39,14 @@ ref = model(*inputs_ts)
 print(ref)
 
 # fx2trt
-inputs_fx = [torch.ones((2,5))]
+inputs_fx = [torch.ones((2, 5))]
 
 model.cuda().half()
 inputs_fx = [i.cuda().half() for i in inputs_fx]
 
-trt_fx_module = torch_tensorrt.compile(model, ir="fx", inputs=inputs_fx, enabled_precisions={torch.half})
+trt_fx_module = torch_tensorrt.compile(
+    model, ir="fx", inputs=inputs_fx, enabled_precisions={torch.half}
+)
 result = trt_fx_module(*inputs_fx)
 print(result)
 

--- a/py/torch_tensorrt/fx/fx2trt.py
+++ b/py/torch_tensorrt/fx/fx2trt.py
@@ -9,12 +9,12 @@ import numpy
 import tensorrt as trt
 import torch
 import torch.fx
-from .observer import Observer
 from torch.fx.node import _get_qualified_name
 from torch.fx.passes.shape_prop import TensorMetadata
 
 from .converter_registry import CONVERTERS
 from .input_tensor_spec import InputTensorSpec
+from .observer import Observer
 from .utils import get_dynamic_dims, LowerPrecision, torch_dtype_to_trt
 
 

--- a/py/torch_tensorrt/fx/lower.py
+++ b/py/torch_tensorrt/fx/lower.py
@@ -2,23 +2,27 @@ import dataclasses as dc
 import logging
 from typing import Any, Callable, Sequence
 
-from .tracer.acc_tracer import acc_tracer
-
 # @manual=//deeplearning/trt/python:py_tensorrt
 import tensorrt as trt
 import torch
 import torch.fx as fx
 import torch.nn as nn
-from .lower_setting import LowerSetting
-from .passes.pass_utils import decorate_method, validate_inference
-from .passes.splitter_base import SplitResult
 
 from .fx2trt import TRTInterpreter, TRTInterpreterResult
 from .input_tensor_spec import InputTensorSpec
+from .lower_setting import LowerSetting
 from .passes.lower_pass_manager_builder import LowerPassManagerBuilder
-from .passes.pass_utils import chain_passes, PassFunc
+from .passes.pass_utils import (
+    chain_passes,
+    decorate_method,
+    PassFunc,
+    validate_inference,
+)
+from .passes.splitter_base import SplitResult
 from .tools.timing_cache_utils import TimingCacheManager
 from .tools.trt_splitter import TRTSplitter, TRTSplitterSetting
+
+from .tracer.acc_tracer import acc_tracer
 from .trt_module import TRTModule
 from .utils import LowerPrecision
 

--- a/py/torch_tensorrt/fx/lower_setting.py
+++ b/py/torch_tensorrt/fx/lower_setting.py
@@ -1,14 +1,12 @@
 import dataclasses as dc
 from typing import List, Optional, Sequence, Set, Type
 
-from .input_tensor_spec import InputTensorSpec
-from .passes.lower_basic_pass import (
-    fuse_permute_linear,
-    fuse_permute_matmul,
-)
-from .utils import LowerPrecision
 from torch import nn
 from torch.fx.passes.pass_manager import PassManager
+
+from .input_tensor_spec import InputTensorSpec
+from .passes.lower_basic_pass import fuse_permute_linear, fuse_permute_matmul
+from .utils import LowerPrecision
 
 
 @dc.dataclass

--- a/py/torch_tensorrt/fx/passes/lower_basic_pass.py
+++ b/py/torch_tensorrt/fx/passes/lower_basic_pass.py
@@ -3,13 +3,15 @@ import operator
 import warnings
 from typing import Any
 
-from ..tracer.acc_tracer import acc_ops
 import torch
 import torch.fx
-from ..observer import observable
-from .pass_utils import log_before_after, validate_inference
-from ..tracer.acc_tracer.acc_utils import get_attr
 from torch.fx.experimental.const_fold import split_const_subgraphs
+
+from ..observer import observable
+
+from ..tracer.acc_tracer import acc_ops
+from ..tracer.acc_tracer.acc_utils import get_attr
+from .pass_utils import log_before_after, validate_inference
 
 # Create an alias for module input type to avoid littering pyre-ignore for Any
 # throughout the file.

--- a/py/torch_tensorrt/fx/passes/lower_pass_manager_builder.py
+++ b/py/torch_tensorrt/fx/passes/lower_pass_manager_builder.py
@@ -2,17 +2,16 @@ from functools import partial, wraps
 from typing import Any, Callable, NamedTuple, Sequence
 
 import torch
-from ..lower_setting import LowerSetting
-from ..observer import Observer
-from .passes.remove_duplicate_output_args import (
-    remove_duplicate_output_args,
-)
 from torch import nn
 from torch.fx.passes.pass_manager import inplace_wrapper, PassManager
 from torch.fx.passes.shape_prop import ShapeProp
 from torch.fx.passes.splitter_base import SplitResult
 
+from ..lower_setting import LowerSetting
+from ..observer import Observer
+
 from .lower_basic_pass import run_const_fold
+from .passes.remove_duplicate_output_args import remove_duplicate_output_args
 
 Input = Sequence[Any]
 

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_embedding.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_embedding.py
@@ -6,7 +6,10 @@ from parameterized import param, parameterized
 from torch.testing._internal.common_fx2trt import AccTestCase
 from torch.testing._internal.common_utils import run_tests
 
-@unittest.skip("Current implementation is limited. All implementations in hf use int64. T113156424")
+
+@unittest.skip(
+    "Current implementation is limited. All implementations in hf use int64. T113156424"
+)
 class TestEmbeddingConverter(AccTestCase):
     @parameterized.expand(
         [

--- a/py/torch_tensorrt/fx/tools/trt_minimizer.py
+++ b/py/torch_tensorrt/fx/tools/trt_minimizer.py
@@ -2,8 +2,9 @@ from typing import Any, Callable, Tuple
 
 import torch
 import torch.fx.passes.net_min_base as net_min_base
-from .. import InputTensorSpec, TRTInterpreter, TRTModule
 from torch.fx.passes.tools_common import Tensors
+
+from .. import InputTensorSpec, TRTInterpreter, TRTModule
 
 
 def lower_mod_default(

--- a/py/torch_tensorrt/fx/tools/trt_profiler_sorted.py
+++ b/py/torch_tensorrt/fx/tools/trt_profiler_sorted.py
@@ -4,6 +4,7 @@ from typing import List, Mapping, Optional
 
 import tensorrt as trt
 import torch
+
 from .. import TRTModule
 
 

--- a/py/torch_tensorrt/fx/tools/trt_splitter.py
+++ b/py/torch_tensorrt/fx/tools/trt_splitter.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, Iterable, Sequence
 import torch
 import torch.fx.passes.operator_support as ops
 import torch.fx.passes.splitter_base as splitter_base
+from torch.fx.passes.tools_common import get_acc_ops_name, Tensors
+
 from .. import (
     CONVERTERS,
     InputTensorSpec,
@@ -12,7 +14,6 @@ from .. import (
     TRTModule,
 )
 from ..tools.trt_minimizer import TensorRTMinimizer
-from torch.fx.passes.tools_common import get_acc_ops_name, Tensors
 
 
 def create_trt_operator_support(use_implicit_batch_dim=True) -> ops.OperatorSupportBase:

--- a/py/torch_tensorrt/fx/tracer/acc_tracer/acc_normalizer.py
+++ b/py/torch_tensorrt/fx/tracer/acc_tracer/acc_normalizer.py
@@ -2,10 +2,11 @@ import inspect
 import re
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
-from . import acc_utils
 import torch
 import torch.fx
 from torch.fx.node import _get_qualified_name
+
+from . import acc_utils
 
 # Need to keep up-to-date with https://fburl.com/codesearch/7r2hhh53
 ALIAS_MAP = {

--- a/py/torch_tensorrt/fx/tracer/acc_tracer/acc_ops.py
+++ b/py/torch_tensorrt/fx/tracer/acc_tracer/acc_ops.py
@@ -5,18 +5,16 @@ import warnings
 import torch  # isort:skip
 from typing import cast, Iterable, List, Sequence
 
-from . import acc_utils
 import torch.nn as nn
+from torch.fx.passes.shape_prop import _extract_tensor_metadata
+
+from . import acc_utils
 from .acc_normalizer import (
     register_acc_op,
     register_acc_op_mapping,
     register_custom_acc_mapper_fn,
 )
-from .acc_op_properties import (
-    AccOpProperty,
-    register_acc_op_properties,
-)
-from torch.fx.passes.shape_prop import _extract_tensor_metadata
+from .acc_op_properties import AccOpProperty, register_acc_op_properties
 
 this_arg_is_optional = True
 move_to_qparams = True
@@ -222,6 +220,7 @@ def avg_pool2d(
 @register_acc_op
 def sign(*, input):
     return torch.sign(input)
+
 
 @register_custom_acc_mapper_fn(
     op_and_target=("call_method", "type"),

--- a/py/torch_tensorrt/fx/tracer/acc_tracer/acc_tracer.py
+++ b/py/torch_tensorrt/fx/tracer/acc_tracer/acc_tracer.py
@@ -8,10 +8,6 @@ import warnings
 from types import FunctionType
 from typing import Any, Dict, Optional, Sequence, Set, Tuple, Type
 
-from . import acc_normalizer
-from . import acc_ops  # noqa: F401
-from . import acc_shape_prop
-from . import acc_utils
 import torch
 import torch.jit as jit
 import torch.nn as nn
@@ -20,6 +16,8 @@ from torch.fx import Graph, Tracer
 from torch.fx.experimental.normalize import NormalizeArgs
 from torch.fx.node import Argument, Node, Target
 from torch.fx.passes import shape_prop
+
+from . import acc_normalizer, acc_ops, acc_shape_prop, acc_utils  # noqa: F401
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/core/partitioning/partitioning_test.bzl
+++ b/tests/core/partitioning/partitioning_test.bzl
@@ -1,4 +1,4 @@
-def partitioning_test(name, visibility=None):
+def partitioning_test(name, visibility = None):
     native.cc_test(
         name = name,
         srcs = [name + ".cpp"],
@@ -7,8 +7,8 @@ def partitioning_test(name, visibility=None):
             "//tests/util",
             "@googletest//:gtest_main",
         ] + select({
-            ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
-            "//conditions:default":  ["@libtorch//:libtorch"],
+            ":use_pre_cxx11_abi": ["@libtorch_pre_cxx11_abi//:libtorch"],
+            "//conditions:default": ["@libtorch//:libtorch"],
         }),
-        timeout="short"
+        timeout = "short",
     )


### PR DESCRIPTION
# Description

fb internal codebase has forced formatter and linter. They made changes internally and I synced the changes to github. I have excluded all non-fx2trt to avoid the format discrepancy issue. So supposedly, there are only fx2trt code are formatted by internal tools. 
One exception is [tests/core/partitioning/partitioning_test.bzl](https://github.com/pytorch/TensorRT/compare/fb-sync-wwei6?expand=1#diff-bb91d0223480ada10118f24e33459b3a3fd42cac07468bd8ab64a710cc2c0c51) which I can not exclude. If it is ok for you @narendasan , please consider accept it.


Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes