### PR TITLE
[fix]: fix bug in aten::to, when network only have aten::to layer wil…

### DIFF
--- a/core/conversion/converters/converter_util.cpp
+++ b/core/conversion/converters/converter_util.cpp
@@ -129,24 +129,24 @@ nvinfer1::ITensor* applyIdentityOp(ConversionCtx* ctx, nvinfer1::ITensor* tensor
 }
 
 nvinfer1::ITensor* castITensor(ConversionCtx* ctx, nvinfer1::ITensor* tensor, nvinfer1::DataType dtype) {
-  // No matter whether tensor->getType() == dtype, identity layer is always needed.
-  // Otherwise will change the input tensor name in aten::to converter by AssociateValueAndTensor function
-  // When the input of aten::to is network input, will cause error
-  std::ostringstream tensor_id;
-  tensor_id << reinterpret_cast<int*>(tensor);
+  if (tensor->getType() != dtype) {
+    std::ostringstream tensor_id;
+    tensor_id << reinterpret_cast<int*>(tensor);
 
-  auto id_layer = ctx->net->addIdentity(*tensor);
-  TORCHTRT_CHECK(id_layer, "Unable to create identity layer for ITensor: " << tensor_id.str());
-  auto casted_tensor = id_layer->getOutput(0);
-  casted_tensor->setType(dtype);
+    auto id_layer = ctx->net->addIdentity(*tensor);
+    TORCHTRT_CHECK(id_layer, "Unable to create identity layer for ITensor: " << tensor_id.str());
+    auto casted_tensor = id_layer->getOutput(0);
+    casted_tensor->setType(dtype);
 
-  LOG_DEBUG(ctx->logger, "Casting ITensor " << tensor_id.str() << " from " << tensor->getType() << " to " << dtype);
+    LOG_DEBUG(ctx->logger, "Casting ITensor " << tensor_id.str() << " from " << tensor->getType() << " to " << dtype);
 
-  std::stringstream ss;
-  ss << "[Cast ITensor " << tensor_id.str() << " from " << tensor->getType() << " to " << dtype << "]";
-  id_layer->setName(ss.str().c_str());
-  return casted_tensor;
-
+    std::stringstream ss;
+    ss << "[Cast ITensor " << tensor_id.str() << " from " << tensor->getType() << " to " << dtype << "]";
+    id_layer->setName(ss.str().c_str());
+    return casted_tensor;
+  } else {
+    return tensor;
+  }
 }
 
 nvinfer1::ITensor* tensor_to_const(ConversionCtx* ctx, at::Tensor t, const std::string& name) {


### PR DESCRIPTION
…l change input name

Signed-off-by: inocsin <vcheungyi@163.com>

# Description

When (1) network only have aten::to layer or (2) the output of aten::to is same as input and the input of aten::to is network input, will change the input tensor's name, which will case an error.

```python
class Net(nn.Module):
  def __init__(self):
    super(Net, self).__init__()

  def forward(self, data, index):
    index = index.to(torch.int64) # in trt, output == input
    src = 1
    data = data.scatter_(1,index,src) # in torch
    return data
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
