### PR TITLE
Fix parsing error caused by dot-separated variable debugNames

### DIFF
--- a/core/compiler.cpp
+++ b/core/compiler.cpp
@@ -447,6 +447,15 @@ torch::jit::Module CompileGraph(const torch::jit::Module& mod, CompileSpec cfg) 
         auto engine = conversion::ConvertBlockToEngine(g->block(), cfg.convert_info, static_params);
         AddEngineToGraph(new_mod, new_g, engine, cuda_device);
       }
+      for (auto input : new_g->block()->inputs()) {
+        LOG_DEBUG("input name:" << input->debugName());
+        if (input->debugName().find(".") != std::string::npos) {
+          auto pos = input->debugName().find(".");
+          auto newName = input->debugName().replace(pos, 1, "_");
+          input->setDebugName(newName);
+          LOG_DEBUG("changed name:" << input->debugName());
+        }
+      }
       auto new_method = new_mod._ivalue()->compilation_unit()->create_function(method.name(), new_g);
       auto schema = util::GenerateGraphSchema(new_method->name(), new_g);
       new_mod.type()->addMethod(new_method);


### PR DESCRIPTION
# Description

Sometimes when fallback is triggered, the debugName of parameter names could contain `.`, e.g., `input.1` and `input_ids.1`. Such torchscript files, after conversion and saving to disk, cannot be parsed successfully. We propose to replace such `.` with `_`, which can be a solution.

Fixes #1112 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
