### PR TITLE
Support shape analysis for dynamic fallback

### DIFF
--- a/core/lowering/lowering.cpp
+++ b/core/lowering/lowering.cpp
@@ -65,7 +65,7 @@ void LowerGraph(std::shared_ptr<torch::jit::Graph>& g, LowerInfo lower_info) {
   passes::RemoveNOPs(g);
   passes::AliasOperators(g);
   passes::SiluToSigmoidMultipication(g);
-  passes::RemoveSingleUse0DTensors(g);
+  // passes::RemoveSingleUse0DTensors(g);
   passes::RemoveUnnecessaryCasts(g);
   LOG_GRAPH(*g);
 }

--- a/core/partitioning/partitioning.cpp
+++ b/core/partitioning/partitioning.cpp
@@ -435,7 +435,7 @@ PartitionedGraph segment_graph(
 
 PartitionedGraph Partition(
     torch::jit::Block* block,
-    std::unordered_map<const torch::jit::Value*, torch::jit::IValue>& example_tensor_map,
+    std::vector<std::unordered_map<const torch::jit::Value*, torch::jit::IValue>>& example_tensor_maps,
     const PartitionInfo& partition_info,
     std::unordered_map<torch::jit::Node*, int>& global_fallback_nodes) {
   LOG_DEBUG(partition_info);
@@ -453,7 +453,7 @@ PartitionedGraph Partition(
   registerSegmentsOutputs(segmented_blocks, block);
 
   // run shape analysis on each segmented block
-  runShapeAnalysis(segmented_blocks, example_tensor_map, partition_info);
+  runShapeAnalysis(segmented_blocks, example_tensor_maps, partition_info);
 
   for (uint64_t i = 0; i < segmented_blocks.size(); i++) {
     segmented_blocks[i].update_id(i);

--- a/core/partitioning/partitioning.h
+++ b/core/partitioning/partitioning.h
@@ -37,7 +37,7 @@ PartitionedGraph segment_graph(
 
 PartitionedGraph Partition(
     torch::jit::Block* block,
-    std::unordered_map<const torch::jit::Value*, torch::jit::IValue>& example_tensor_map,
+    std::vector<std::unordered_map<const torch::jit::Value*, torch::jit::IValue>>& example_tensor_map,
     const PartitionInfo& partition_info,
     std::unordered_map<torch::jit::Node*, int>& fallback_nodes);
 

--- a/core/partitioning/shape_analysis.h
+++ b/core/partitioning/shape_analysis.h
@@ -6,13 +6,13 @@ namespace torch_tensorrt {
 namespace core {
 namespace partitioning {
 
-std::unordered_map<const torch::jit::Value*, torch::jit::IValue> generateRandomInputs(
+std::vector<std::unordered_map<const torch::jit::Value*, torch::jit::IValue>> generateRandomInputs(
     std::unordered_map<const torch::jit::Value*, ir::Input>& input_ranges,
     std::unordered_map<const torch::jit::Value*, c10::optional<at::ScalarType>>& input_types);
 
 void runShapeAnalysis(
     std::vector<SegmentedBlock>& segmented_blocks,
-    std::unordered_map<const torch::jit::Value*, torch::jit::IValue>& ivalues_maps,
+    std::vector<std::unordered_map<const torch::jit::Value*, torch::jit::IValue>>& ivalues_maps,
     const PartitionInfo& partition_info);
 
 } // namespace partitioning


### PR DESCRIPTION
Signed-off-by: Cheng Hang <calvinhance@gmail.com>

# Description

Previously, when encountered ops/modules that have to fall back and meanwhile dynamic shape is used, shape analysis would fail when doing `generateRandomInputs()`, because tensors with `-1` contained in shape cannot be created. 

To support dynamic fallback, we have to firstly overcome this failure, by doing `generateRandomInputs()` with min/max/opt shape info. Then shape analysis can be executed three times, with min/max/opt shapes correspondingly.

Fixes #1113 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
