### PR TITLE
[FX] Sync to OSS

### DIFF
--- a/py/torch_tensorrt/fx/lower.py
+++ b/py/torch_tensorrt/fx/lower.py
@@ -92,7 +92,18 @@ class LowerTrtInterpreter:
         input_specs_val = (
             self.lower_setting.input_specs
             if self.lower_setting.input_specs
-            else InputTensorSpec.from_tensors(input)
+            else (
+                InputTensorSpec.from_tensors_with_dynamic_batch_size(
+                    input,
+                    (
+                        0,
+                        self.lower_setting.max_batch_size,
+                        self.lower_setting.max_batch_size,
+                    ),
+                )
+                if self.lower_setting.explicit_batch_dimension
+                else InputTensorSpec.from_tensors(input)
+            )
         )
 
         # Prepare algorithm selector and timing_cache for TRTInterpreter

--- a/py/torch_tensorrt/fx/lower_setting.py
+++ b/py/torch_tensorrt/fx/lower_setting.py
@@ -63,6 +63,12 @@ class LowerSetting(LowerSettingBasic):
     save_timing_cache: Save updated timing cache data into timing cache file if the timing
     cache file is provided.
     cuda_graph_batch_size (int): Cuda graph batch size, default to be -1.
+    preset_lowerer (str): when specified, use a preset logic to build the
+    instance of Lowerer. Refer to
+    `caffe2.torch.fb.model_transform.fx2trt.presets.LowererPresetsManager` on
+    how presets are applied. Refer to
+    `caffe2.torch.fb.model_transform.fx2trt.presets.ESUHMLowererPreset` on how
+    to add a preset.
     """
 
     input_specs: List[InputTensorSpec] = dc.field(default_factory=list)
@@ -79,3 +85,4 @@ class LowerSetting(LowerSettingBasic):
     timing_cache_prefix: str = ""
     save_timing_cache: bool = False
     cuda_graph_batch_size: int = -1
+    preset_lowerer: str = ""

--- a/py/torch_tensorrt/fx/passes/lower_basic_pass.py
+++ b/py/torch_tensorrt/fx/passes/lower_basic_pass.py
@@ -31,7 +31,9 @@ def run_const_fold(traced_mod: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 return True
         return False
 
-    const_split_mod = split_const_subgraphs(traced_mod, skip_folding_quant_dequant)
+    const_split_mod = split_const_subgraphs(
+        traced_mod, skip_folding_quant_dequant, device_for_folded_attrs="cuda"
+    )
     const_split_mod.run_folding()
     return const_split_mod
 

--- a/py/torch_tensorrt/fx/test/tracer/test_acc_tracer.py
+++ b/py/torch_tensorrt/fx/test/tracer/test_acc_tracer.py
@@ -2576,5 +2576,6 @@ class AccTracerTest(unittest.TestCase):
                 acc_ops.new_ones,
                 acc_ops.einsum,
                 acc_ops.as_strided,
+                acc_ops.var,
             },
         )

--- a/py/torch_tensorrt/fx/tracer/acc_tracer/acc_ops.py
+++ b/py/torch_tensorrt/fx/tracer/acc_tracer/acc_ops.py
@@ -2864,3 +2864,18 @@ def as_strided(*, input, size, stride, storage_offset=0):
     return torch.as_strided(
         input=input, size=size, stride=stride, storage_offset=storage_offset
     )
+
+
+@register_acc_op_mapping(op_and_target=("call_function", torch.var))
+@register_acc_op_mapping(
+    op_and_target=("call_method", "var"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim"),
+        ("unbiased", "unbiased"),
+        ("keepdim", "keepdim"),
+    ],
+)
+@register_acc_op
+def var(*, input, dim, unbiased, keepdim=False):
+    return torch.var(input=input, dim=dim, unbiased=unbiased, keepdim=keepdim)


### PR DESCRIPTION
364639a8ab2ee7531ce5259b8985a3c90bda4fdf Wei Wei <wwei6@fb.com> [fx2trt] target files added
07d8e842b54b9c727f4215239f6c007cc7a62c9f Wei Wei <wwei6@fb.com> Swap fx2trt_oss to torch_tensorrt
74731c90fd63e41ff5997887d8f72ca0b805cf8d Yinghai Lu <yinghai@fb.com> Fix uru_10x10 test
6c53d36a08a7d465a1108d7154ef29a373eb38cc Wei Wei <wwei6@fb.com> [fx2trt] Modify lower setting class to accommandate AIT lowering
6f873f4f3ece9d476479eb7c9633d38554dd8692 Oleg Khabinov <khabinov@fb.com> [fx2trt] Make sure acc_tracer belongs only to single target
529a5750ace2bede6e9b7a9922a0f75c459df16b Shirong Wu <shirong@fb.com> Enable explicit batch dim for MTS gpu benchmark
2d284df94ddb530f3a8875fdc76796fad508ec29 Wei Wei <wwei6@fb.com> [fx2trt] remove wildcard for obj of torch_fx2trt in TARGETS
84b53b15427cc08fb1e36143b6bdec4557f50d7e Shirong Wu <shirong@fb.com> Add var converter
17e309b17b3ba66cda0e7d5712089d860a5e125e Jordan Fix <jfix@fb.com> [const_fold] Set requires_grad based on the folded tensor; add device_for_folding option
2c8f1b23be30ec968ad27215256d250c872616b0 Kefei Lu <kefeilu@fb.com> lowering: support creating lowerer instance with "presets"
50fa26d1b56888ec25eb839d4813bc695be20da9 wwei6 <wwei6@fb.com> [fx2trt] target files added
6e7f9b6c4f8afa32383c457e8133674640348810 wwei6 <wwei6@fb.com> fx2trt_oss change set1


# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
