### PR TITLE
[FX] --fx-only does not need to check bazel

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -74,13 +74,14 @@ def which(program):
 
     return None
 
+BAZEL_EXE = None
+if not FX_ONLY:
+    BAZEL_EXE = which("bazelisk")
 
-BAZEL_EXE = which("bazelisk")
-
-if BAZEL_EXE is None:
-    BAZEL_EXE = which("bazel")
     if BAZEL_EXE is None:
-        sys.exit("Could not find bazel in PATH")
+        BAZEL_EXE = which("bazel")
+        if BAZEL_EXE is None:
+            sys.exit("Could not find bazel in PATH")
 
 
 def build_libtorchtrt_pre_cxx11_abi(develop=True, use_dist_dir=True, cxx11_abi=False):


### PR DESCRIPTION
# Description

Do not need to check bazel if --fx-only

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
