### PR TITLE
fix: fix the parsing related model loading bug

### DIFF
--- a/core/compiler.cpp
+++ b/core/compiler.cpp
@@ -235,8 +235,11 @@ GraphAndMapping ConstructFallbackGraph(
 
   // the mapping from lowering graph => fallback global graph
   std::unordered_map<torch::jit::Value*, torch::jit::Value*> old_to_new_g;
-  for (auto input : block->inputs()) {
-    util::getOrAddInputForValue(input, new_g, old_to_new_g);
+
+  for (uint64_t i = 0; i < block->inputs().size(); i++) {
+    auto in_val = new_g->addInput(std::string("input_") + std::to_string(i));
+    in_val->setType(block->inputs()[i]->type());
+    old_to_new_g[block->inputs()[i]] = in_val;
   }
 
   for (auto& seg_block : segmented_blocks) {

--- a/tests/core/partitioning/BUILD
+++ b/tests/core/partitioning/BUILD
@@ -38,6 +38,21 @@ partitioning_test(
 )
 
 cc_test(
+  name = "test_loading_model",
+  srcs = ["test_loading_model.cpp"],
+  deps = [
+      "//tests/util",
+      "@googletest//:gtest_main",
+  ] + select({
+      ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
+      "//conditions:default":  ["@libtorch//:libtorch"],
+  }),
+  data = [
+      ":jit_models"
+  ]
+)
+
+cc_test(
   name = "test_fallback_graph_output",
   srcs = ["test_fallback_graph_output.cpp"],
   deps = [
@@ -92,6 +107,7 @@ test_suite(
         ":test_fallback_graph_output",
         ":test_loop_fallback",
         ":test_conditionals",
-        ":test_resolve_nontensor_inputs"
+        ":test_resolve_nontensor_inputs",
+        ":test_loading_model"
     ]
 )

--- a/tests/core/partitioning/test_loading_model.cpp
+++ b/tests/core/partitioning/test_loading_model.cpp
@@ -1,0 +1,39 @@
+#include <string>
+#include <unordered_set>
+#include "core/compiler.h"
+#include "gtest/gtest.h"
+#include "tests/util/util.h"
+#include "torch/script.h"
+
+#ifndef DISABLE_TEST_IN_CI
+
+TEST(Partitioning, ComputeResNet50FallbackGraphCorrectly) {
+  torch::jit::script::Module mod;
+  try {
+    mod = torch::jit::load("tests/modules/conditional_scripted.jit.pt");
+  } catch (const c10::Error& e) {
+    std::cerr << "error loading the model\n";
+    return;
+  }
+
+  const std::vector<std::vector<int64_t>> input_shapes = {{1, 3, 224, 224}};
+  std::vector<torch::jit::IValue> jit_inputs_ivalues;
+  std::vector<torch::jit::IValue> trt_inputs_ivalues;
+  for (auto in_shape : input_shapes) {
+    auto in = at::randint(5, in_shape, {at::kCUDA});
+    jit_inputs_ivalues.push_back(in.clone());
+    trt_inputs_ivalues.push_back(in.clone());
+  }
+
+  std::vector<torch_tensorrt::core::ir::Input> input_ranges{torch_tensorrt::core::ir::Input({1, 3, 224, 224})};
+
+  torch_tensorrt::core::CompileSpec cfg(input_ranges);
+  cfg.partition_info.enabled = true;
+
+  auto jit_results = mod.forward(jit_inputs_ivalues).toTensor();
+  auto trt_mod = torch_tensorrt::core::CompileGraph(mod, cfg);
+  trt_mod.save("loading_model.ts");
+  auto loaded_model = torch::jit::load("loading_model.ts");
+}
+
+#endif


### PR DESCRIPTION
Signed-off-by: Bo Wang <bowa@nvidia.com>

# Description
When there is fallback, the converted model will contain input names that inherited from loweredGraph, such as x.1. 
These names cannot be parsed by torch.jit.load().
This induces some errors like: #973 , #1112 . 
We stop using the names from loweredGraph, we use the input names that are similar to what we are using when there is no fallback: input_0, input_1, ..



Fixes #973,  #1112

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
