### PR TITLE
Use py3 next() syntax

### DIFF
--- a/examples/int8/training/vgg16/main.py
+++ b/examples/int8/training/vgg16/main.py
@@ -93,7 +93,7 @@ def main():
     model = model.cuda()
 
     data = iter(training_dataloader)
-    images, _ = data.next()
+    images, _ = next(data)
 
     writer.add_graph(model, images.cuda())
     writer.close()


### PR DESCRIPTION
# Description

The example uses the Python 2 `.next()` syntax [here](https://github.com/pytorch/TensorRT/blob/e19cbfc9d3e4313c43f15c17235255cff06b948e/examples/int8/training/vgg16/main.py#L96):
```python
    data = iter(training_dataloader)
    images, _ = data.next()
```
which will break if a PyTorch version after https://github.com/pytorch/pytorch/pull/78594 is used as the compat assignment was removed.

According to [PEP 3114](https://peps.python.org/pep-3114/) the new Python 3 syntax should be used:
```python
out = next(iterator)
```
