### PR TITLE
Add missing comma for proper torch versioning in setup.py

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -299,7 +299,7 @@ setup(
     long_description=long_description,
     ext_modules=ext_modules,
     install_requires=[
-        'torch>=1.11.0+cu113<1.12.0',
+        'torch>=1.11.0+cu113,<1.12.0',
     ],
     setup_requires=[],
     cmdclass={


### PR DESCRIPTION
# Description

Fixes torch upper bound version restriction in setup.py install_requires by adding missing comma.

Fixes [# (1002)](https://github.com/pytorch/TensorRT/issues/1002)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)