### PR TITLE
fix: fix the renaming error in squeeze converter

### DIFF
--- a/core/conversion/conversionctx/ConversionCtx.cpp
+++ b/core/conversion/conversionctx/ConversionCtx.cpp
@@ -130,7 +130,6 @@ ConversionCtx::~ConversionCtx() {
 }
 
 nvinfer1::ITensor* ConversionCtx::AssociateValueAndTensor(const torch::jit::Value* value, nvinfer1::ITensor* tensor) {
-  tensor->setName(value->debugName().c_str());
   this->value_tensor_map[value] = tensor;
   return tensor;
 }

--- a/core/conversion/converters/impl/squeeze.cpp
+++ b/core/conversion/converters/impl/squeeze.cpp
@@ -26,7 +26,8 @@ auto squeeze_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns().pa
        }
 
        if (selfDim[dim] != 1) {
-         auto out = ctx->AssociateValueAndTensor(n->outputs()[0], self);
+         auto id_layer = ctx->net->addIdentity(*self);
+         auto out = ctx->AssociateValueAndTensor(n->outputs()[0], id_layer->getOutput(0));
 
          LOG_DEBUG("Output tensor shape: " << out->getDimensions());
 

--- a/core/conversion/converters/impl/squeeze.cpp
+++ b/core/conversion/converters/impl/squeeze.cpp
@@ -26,8 +26,7 @@ auto squeeze_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns().pa
        }
 
        if (selfDim[dim] != 1) {
-         auto id_layer = ctx->net->addIdentity(*self);
-         auto out = ctx->AssociateValueAndTensor(n->outputs()[0], id_layer->getOutput(0));
+         auto out = ctx->AssociateValueAndTensor(n->outputs()[0], self);
 
          LOG_DEBUG("Output tensor shape: " << out->getDimensions());
 

--- a/tests/core/conversion/converters/test_squeeze.cpp
+++ b/tests/core/conversion/converters/test_squeeze.cpp
@@ -56,3 +56,29 @@ TEST(Converters, ATenSqueezeDontNeedSqueezeConvertsCorrectly) {
   ASSERT_TRUE(
       torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
 }
+
+TEST(Converters, ATenSqueezeNeedIdentityConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor):
+        %2 : int = prim::Constant[value=1]()
+        %3 : Tensor = aten::squeeze(%0, %2)
+        return (%3))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, &*g);
+
+  auto in = at::randint(1, 10, {2, 3, 3}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(jit_in);
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
+
+  ASSERT_TRUE(
+      torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}

--- a/tests/core/conversion/converters/test_squeeze.cpp
+++ b/tests/core/conversion/converters/test_squeeze.cpp
@@ -57,7 +57,8 @@ TEST(Converters, ATenSqueezeDontNeedSqueezeConvertsCorrectly) {
       torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
 }
 
-TEST(Converters, ATenSqueezeNeedIdentityConvertsCorrectly) {
+// Test for renaming ITensor related binding issues
+TEST(Converters, ATenSqueezeSingleConvertsCorrectly) {
   const auto graph = R"IR(
       graph(%0 : Tensor):
         %2 : int = prim::Constant[value=1]()


### PR DESCRIPTION
Signed-off-by: Bo Wang <bowa@nvidia.com>

# Description
Some converters may have the risks of renaming ITensors, which might cause errors. 

Fixes: #930 , #982

More PRs related to this PR: 
#1004 , #1167 ,  


## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
