### PR TITLE
Added PTQ section to BERT notebook

### DIFF
--- a/notebooks/Hugging-Face-BERT.ipynb
+++ b/notebooks/Hugging-Face-BERT.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "9369b63c",
+   "id": "06eecb22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d0a97ac5",
+   "id": "94543375",
    "metadata": {},
    "source": [
     "<img src=\"http://developer.download.nvidia.com/notebooks/dlsw-notebooks/tensorrt_torchtrt_hf_bert/nvidia_logo.png\" width=\"90px\">\n",
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83f47edb",
+   "id": "3527c0f4",
    "metadata": {},
    "source": [
     "## Learning objectives\n",
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "596fa151",
+   "id": "332c4d9e",
    "metadata": {},
    "source": [
     "<a id=\"1\"></a>\n",
@@ -68,7 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "58e687d1",
+   "id": "ea0d4f99",
    "metadata": {},
    "outputs": [
     {
@@ -76,26 +76,22 @@
      "output_type": "stream",
      "text": [
       "Looking in indexes: https://pypi.org/simple, https://pypi.ngc.nvidia.com\n",
-      "Requirement already satisfied: transformers in /opt/conda/lib/python3.8/site-packages (4.18.0)\n",
-      "Requirement already satisfied: tqdm>=4.27 in /opt/conda/lib/python3.8/site-packages (from transformers) (4.63.0)\n",
-      "Requirement already satisfied: regex!=2019.12.17 in /opt/conda/lib/python3.8/site-packages (from transformers) (2022.3.15)\n",
-      "Requirement already satisfied: huggingface-hub<1.0,>=0.1.0 in /opt/conda/lib/python3.8/site-packages (from transformers) (0.5.1)\n",
-      "Requirement already satisfied: tokenizers!=0.11.3,<0.13,>=0.11.1 in /opt/conda/lib/python3.8/site-packages (from transformers) (0.12.1)\n",
-      "Requirement already satisfied: numpy>=1.17 in /opt/conda/lib/python3.8/site-packages (from transformers) (1.22.3)\n",
-      "Requirement already satisfied: sacremoses in /opt/conda/lib/python3.8/site-packages (from transformers) (0.0.49)\n",
-      "Requirement already satisfied: requests in /opt/conda/lib/python3.8/site-packages (from transformers) (2.27.1)\n",
+      "Requirement already satisfied: transformers in /opt/conda/lib/python3.8/site-packages (4.20.1)\n",
+      "Requirement already satisfied: tqdm>=4.27 in /opt/conda/lib/python3.8/site-packages (from transformers) (4.64.0)\n",
       "Requirement already satisfied: pyyaml>=5.1 in /opt/conda/lib/python3.8/site-packages (from transformers) (6.0)\n",
-      "Requirement already satisfied: filelock in /opt/conda/lib/python3.8/site-packages (from transformers) (3.6.0)\n",
+      "Requirement already satisfied: tokenizers!=0.11.3,<0.13,>=0.11.1 in /opt/conda/lib/python3.8/site-packages (from transformers) (0.12.1)\n",
+      "Requirement already satisfied: numpy>=1.17 in /opt/conda/lib/python3.8/site-packages (from transformers) (1.22.4)\n",
+      "Requirement already satisfied: regex!=2019.12.17 in /opt/conda/lib/python3.8/site-packages (from transformers) (2022.6.2)\n",
+      "Requirement already satisfied: filelock in /opt/conda/lib/python3.8/site-packages (from transformers) (3.7.1)\n",
+      "Requirement already satisfied: requests in /opt/conda/lib/python3.8/site-packages (from transformers) (2.27.1)\n",
       "Requirement already satisfied: packaging>=20.0 in /opt/conda/lib/python3.8/site-packages (from transformers) (21.3)\n",
-      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /opt/conda/lib/python3.8/site-packages (from huggingface-hub<1.0,>=0.1.0->transformers) (4.1.1)\n",
-      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /opt/conda/lib/python3.8/site-packages (from packaging>=20.0->transformers) (3.0.7)\n",
-      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /opt/conda/lib/python3.8/site-packages (from requests->transformers) (1.26.8)\n",
+      "Requirement already satisfied: huggingface-hub<1.0,>=0.1.0 in /opt/conda/lib/python3.8/site-packages (from transformers) (0.8.1)\n",
+      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /opt/conda/lib/python3.8/site-packages (from huggingface-hub<1.0,>=0.1.0->transformers) (4.2.0)\n",
+      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /opt/conda/lib/python3.8/site-packages (from packaging>=20.0->transformers) (3.0.9)\n",
+      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /opt/conda/lib/python3.8/site-packages (from requests->transformers) (1.26.9)\n",
       "Requirement already satisfied: charset-normalizer~=2.0.0 in /opt/conda/lib/python3.8/site-packages (from requests->transformers) (2.0.12)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /opt/conda/lib/python3.8/site-packages (from requests->transformers) (2021.10.8)\n",
       "Requirement already satisfied: idna<4,>=2.5 in /opt/conda/lib/python3.8/site-packages (from requests->transformers) (3.3)\n",
-      "Requirement already satisfied: six in /opt/conda/lib/python3.8/site-packages (from sacremoses->transformers) (1.16.0)\n",
-      "Requirement already satisfied: click in /opt/conda/lib/python3.8/site-packages (from sacremoses->transformers) (8.0.4)\n",
-      "Requirement already satisfied: joblib in /opt/conda/lib/python3.8/site-packages (from sacremoses->transformers) (1.1.0)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /opt/conda/lib/python3.8/site-packages (from requests->transformers) (2022.5.18.1)\n",
       "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\n"
      ]
     }
@@ -107,9 +103,18 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "1104c4f1",
+   "id": "96c12c4a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/lib/python3.8/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "from transformers import BertTokenizer, BertForMaskedLM\n",
     "import torch\n",
@@ -121,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acf67a5e",
+   "id": "e467cb5a",
    "metadata": {},
    "source": [
     "<a id=\"2\"></a>\n",
@@ -136,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19e711c0",
+   "id": "8bce3c12",
    "metadata": {},
    "source": [
     "<a id=\"3\"></a>\n",
@@ -145,7 +150,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81d4c6f6",
+   "id": "46c8a5e1",
    "metadata": {},
    "source": [
     "First, create a pretrained BERT tokenizer from the `bert-base-uncased` model"
@@ -154,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "c7c8721e",
+   "id": "020c3b8c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b7c1c679",
+   "id": "7d798649",
    "metadata": {},
    "source": [
     "Create dummy inputs to generate a traced TorchScript model later"
@@ -172,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "c3827087",
+   "id": "bb13b877",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +194,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e31b27f",
+   "id": "91ec993a",
    "metadata": {},
    "source": [
     "Obtain a BERT masked language model from Hugging Face in the (scripted) TorchScript, then use the dummy inputs to trace it"
@@ -198,14 +203,14 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "a3cd5a35",
+   "id": "e5fd9e5e",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Some weights of the model checkpoint at bert-base-uncased were not used when initializing BertForMaskedLM: ['cls.seq_relationship.bias', 'cls.seq_relationship.weight']\n",
+      "Some weights of the model checkpoint at bert-base-uncased were not used when initializing BertForMaskedLM: ['cls.seq_relationship.weight', 'cls.seq_relationship.bias']\n",
       "- This IS expected if you are initializing BertForMaskedLM from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
       "- This IS NOT expected if you are initializing BertForMaskedLM from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n"
      ]
@@ -218,7 +223,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8d2217a",
+   "id": "cb10ecc0",
    "metadata": {},
    "source": [
     "Define 4 masked sentences, with 1 word in each sentence hidden from the model. Fluent English speakers will probably be able to guess the masked words, but just in case, they are `'capital'`, `'language'`, `'innings'`, and `'mathematics'`.\n",
@@ -229,7 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "4d1af982",
+   "id": "2b990017",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +247,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4d89b4c8",
+   "id": "7d5ed481",
    "metadata": {},
    "source": [
     "Pass the masked sentences into the (scripted) TorchScript MLM model and verify that the unmasked sentences yield the expected results.  \n",
@@ -253,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "d2d7546b",
+   "id": "2285a3fb",
    "metadata": {},
    "outputs": [
     {
@@ -279,7 +284,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0b423ff",
+   "id": "76b056f8",
    "metadata": {},
    "source": [
     "Pass the masked sentences into the traced MLM model and verify that the unmasked sentences yield the expected results. \n",
@@ -290,7 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "683a4a73",
+   "id": "ed03cb4a",
    "metadata": {},
    "outputs": [
     {
@@ -316,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a31b545",
+   "id": "edbdcf15",
    "metadata": {},
    "source": [
     "<a id=\"4\"></a>\n",
@@ -325,7 +330,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "413d8b4f",
+   "id": "38f2b7d5",
    "metadata": {},
    "source": [
     "Change the logging level to avoid long printouts"
@@ -334,7 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "42862893",
+   "id": "9131a307",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +349,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "121d6d59",
+   "id": "f92ae602",
    "metadata": {},
    "source": [
     "Compile the model"
@@ -353,7 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "eab90150",
+   "id": "b9ca114c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +374,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a96751ce",
+   "id": "77f2897f",
    "metadata": {},
    "source": [
     "Pass the masked sentences into the compiled model and verify that the unmasked sentences yield the expected results."
@@ -378,7 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "097ea381",
+   "id": "eade106c",
    "metadata": {},
    "outputs": [
     {
@@ -405,7 +410,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a398271d",
+   "id": "fb930f29",
    "metadata": {},
    "source": [
     "Compile the model again, this time with 16-bit precision"
@@ -414,7 +419,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "a063dee2",
+   "id": "e619e243",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +435,164 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a926334a",
+   "id": "4b1a6eed",
+   "metadata": {},
+   "source": [
+    "### Compile the model with 8-bit precision using post-training quantization (PTQ)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1194ce7e",
+   "metadata": {},
+   "source": [
+    "Set up dummy inputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "c3f9cfc7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_data = []\n",
+    "for i in range(len(masked_sentences)):\n",
+    "    test_data.append((encoded_inputs['input_ids'][i], encoded_inputs['token_type_ids'][i], encoded_inputs['attention_mask'][i]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3bbde83",
+   "metadata": {},
+   "source": [
+    "Create a PyTorch DataLoader from the dummy inputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "b9b1d739",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "testing_dataloader = torch.utils.data.DataLoader(test_data,\n",
+    "                                                 batch_size=batch_size,\n",
+    "                                                 shuffle=False,\n",
+    "                                                 num_workers=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df5b19d6",
+   "metadata": {},
+   "source": [
+    "Configure the PTQ calibration settings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "c9afa773",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calibrator = torch_tensorrt.ptq.DataLoaderCalibrator(testing_dataloader,\n",
+    "                                                     cache_file='./calibration.cache',\n",
+    "                                                     use_cache=False,\n",
+    "                                                     algo_type=torch_tensorrt.ptq.CalibrationAlgo.ENTROPY_CALIBRATION_2,\n",
+    "                                                     device=torch.device('cuda:0'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3fab923b",
+   "metadata": {},
+   "source": [
+    "Set up the 8-bit integer compilation specifications."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "81e98692",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "compile_spec = {\n",
+    "         \"inputs\": [torch_tensorrt.Input(shape=[batch_size, 128], dtype=torch.int32),  # input_ids\n",
+    "                    torch_tensorrt.Input(shape=[batch_size, 128], dtype=torch.int32),  # token_type_ids\n",
+    "                    torch_tensorrt.Input(shape=[batch_size, 128], dtype=torch.int32)], # attention_mask\n",
+    "         \"enabled_precisions\": {torch.int8}, # Run with 8-bit precision\n",
+    "         \"calibrator\": calibrator,\n",
+    "         \"device\": {\n",
+    "             \"device_type\": torch_tensorrt.DeviceType.GPU,\n",
+    "             \"gpu_id\": 0,\n",
+    "             \"dla_core\": 0,\n",
+    "             \"allow_gpu_fallback\": False,\n",
+    "             \"disable_tf32\": False\n",
+    "         },\n",
+    "         \"truncate_long_and_double\": True\n",
+    "     }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26b4f8fd",
+   "metadata": {},
+   "source": [
+    "Compile the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "ea454fa7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trt_model_int8 = torch_tensorrt.compile(traced_mlm_model, **compile_spec)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8192e2b2",
+   "metadata": {},
+   "source": [
+    "Pass the masked sentences into the PTQ-compiled model and verify that the unmasked sentences yield the expected results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "73647f4f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Paris is the capital of France.\n",
+      "The primary language of the United States is English.\n",
+      "A baseball game consists of at least nine innings.\n",
+      "Topology is a branch of mathematics concerned with the properties of geometric objects that remain unchanged under continuous transformations.\n"
+     ]
+    }
+   ],
+   "source": [
+    "enc_inputs = enc(masked_sentences, return_tensors='pt', padding='max_length', max_length=128)\n",
+    "enc_inputs = {k: v.type(torch.int32).cuda() for k, v in enc_inputs.items()}\n",
+    "output_trt_int8 = trt_model_int8(enc_inputs['input_ids'], enc_inputs['token_type_ids'], enc_inputs['attention_mask'])\n",
+    "most_likely_token_ids_trt_int8 = [torch.argmax(output_trt_int8[i, pos, :]) for i, pos in enumerate(pos_masks)] \n",
+    "unmasked_tokens_trt_int8 = enc.decode(most_likely_token_ids_trt_int8).split(' ')\n",
+    "unmasked_sentences_trt_int8 = [masked_sentences[i].replace('[MASK]', token) for i, token in enumerate(unmasked_tokens_trt_int8)]\n",
+    "for sentence in unmasked_sentences_trt_int8:\n",
+    "    print(sentence)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2db44867",
    "metadata": {},
    "source": [
     "<a id=\"5\"></a>\n",
@@ -441,7 +603,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "976c6fb9",
+   "id": "fb437866",
    "metadata": {},
    "source": [
     "This function passes the inputs into the model and runs inference `num_loops` times, then returns a list of length containing the amount of time in seconds that each instance of inference took."
@@ -449,8 +611,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "b72a091e",
+   "execution_count": 20,
+   "id": "f368d82b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -478,7 +640,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0b44dcf8",
+   "id": "944387ba",
    "metadata": {},
    "source": [
     "This function prints the number of input batches the model is able to process each second and summary statistics of the model's latency."
@@ -486,8 +648,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "2ef71ab7",
+   "execution_count": 21,
+   "id": "6dd3c522",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -515,8 +677,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "afe97b9b",
+   "execution_count": 22,
+   "id": "33ca9954",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -525,7 +687,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eba98b24",
+   "id": "9140a9bc",
    "metadata": {},
    "source": [
     "Benchmark the (scripted) TorchScript model on GPU"
@@ -533,8 +695,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "bab5fa8f",
+   "execution_count": 23,
+   "id": "5f3c1f14",
    "metadata": {},
    "outputs": [
     {
@@ -546,8 +708,8 @@
       "\n",
       "BERT =================================\n",
       "batch size=4, num iterations=50\n",
-      "  Median text batches/second: 599.1, mean: 597.6\n",
-      "  Median latency: 0.006677, mean: 0.006693, 99th_p: 0.006943, std_dev: 0.000059\n",
+      "  Median text batches/second: 302.0, mean: 295.7\n",
+      "  Median latency: 0.013246, mean: 0.013556, 99th_p: 0.016146, std_dev: 0.000672\n",
       "\n"
      ]
     }
@@ -560,7 +722,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc79c452",
+   "id": "97c785da",
    "metadata": {},
    "source": [
     "Benchmark the traced model on GPU"
@@ -568,8 +730,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "5c0bd8e9",
+   "execution_count": 24,
+   "id": "066517c6",
    "metadata": {},
    "outputs": [
     {
@@ -581,8 +743,8 @@
       "\n",
       "BERT =================================\n",
       "batch size=4, num iterations=50\n",
-      "  Median text batches/second: 951.2, mean: 951.0\n",
-      "  Median latency: 0.004205, mean: 0.004206, 99th_p: 0.004256, std_dev: 0.000015\n",
+      "  Median text batches/second: 571.3, mean: 563.9\n",
+      "  Median latency: 0.007002, mean: 0.007102, 99th_p: 0.008021, std_dev: 0.000258\n",
       "\n"
      ]
     }
@@ -595,7 +757,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41db22a1",
+   "id": "980aa0ad",
    "metadata": {},
    "source": [
     "Benchmark the compiled FP32 model on GPU"
@@ -603,8 +765,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "ade7b508",
+   "execution_count": 25,
+   "id": "0940a75d",
    "metadata": {},
    "outputs": [
     {
@@ -616,8 +778,8 @@
       "\n",
       "BERT =================================\n",
       "batch size=4, num iterations=50\n",
-      "  Median text batches/second: 1216.9, mean: 1216.4\n",
-      "  Median latency: 0.003287, mean: 0.003289, 99th_p: 0.003317, std_dev: 0.000007\n",
+      "  Median text batches/second: 1157.1, mean: 1141.0\n",
+      "  Median latency: 0.003457, mean: 0.003516, 99th_p: 0.004312, std_dev: 0.000223\n",
       "\n"
      ]
     }
@@ -630,7 +792,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57b696de",
+   "id": "7a9ef86e",
    "metadata": {},
    "source": [
     "Benchmark the compiled FP16 model on GPU"
@@ -638,8 +800,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "id": "f61b83fd",
+   "execution_count": 26,
+   "id": "d36db0f3",
    "metadata": {},
    "outputs": [
     {
@@ -651,8 +813,8 @@
       "\n",
       "BERT =================================\n",
       "batch size=4, num iterations=50\n",
-      "  Median text batches/second: 1776.7, mean: 1771.1\n",
-      "  Median latency: 0.002251, mean: 0.002259, 99th_p: 0.002305, std_dev: 0.000015\n",
+      "  Median text batches/second: 1780.2, mean: 1782.3\n",
+      "  Median latency: 0.002247, mean: 0.002244, 99th_p: 0.002262, std_dev: 0.000010\n",
       "\n"
      ]
     }
@@ -665,18 +827,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43f67ba3",
+   "id": "27654386",
+   "metadata": {},
+   "source": [
+    "Benchmark the PTQ-compiled INT8 model on GPU"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "b426dc63",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warm up ...\n",
+      "Start timing ...\n",
+      "\n",
+      "BERT =================================\n",
+      "batch size=4, num iterations=50\n",
+      "  Median text batches/second: 1158.1, mean: 1143.6\n",
+      "  Median latency: 0.003454, mean: 0.003499, 99th_p: 0.003672, std_dev: 0.000078\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "timings = timeGraph(trt_model_int8, enc_inputs['input_ids'], enc_inputs['token_type_ids'], enc_inputs['attention_mask'])\n",
+    "\n",
+    "printStats(\"BERT\", timings, batch_size)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1afce5e9",
    "metadata": {},
    "source": [
     "<a id=\"6\"></a>\n",
     "## 6. Conclusion\n",
     "\n",
-    "In this notebook, we have walked through the complete process of compiling TorchScript models with Torch-TensorRT for Masked Language Modeling with Hugging Face's `bert-base-uncased` transformer and testing the performance impact of the optimization. With Torch-TensorRT on an NVIDIA A100 GPU, we observe the speedups indicated below. These acceleration numbers will vary from GPU to GPU (as well as implementation to implementation based on the ops used) and we encorage you to try out latest generation of Data center compute cards for maximum acceleration.\n",
+    "In this notebook, we have walked through the complete process of compiling TorchScript models with Torch-TensorRT for Masked Language Modeling with Hugging Face's `bert-base-uncased` transformer and testing the performance impact of the optimization. With Torch-TensorRT on an NVIDIA A100 GPU, we observe the speedups indicated below. These acceleration numbers will vary from GPU to GPU (as well as implementation to implementation based on the ops used) and we encourage you to try out latest generation of Data center compute cards for maximum acceleration.\n",
     "\n",
-    "Scripted (GPU): 1.0x\n",
-    "Traced (GPU): 1.62x\n",
-    "Torch-TensorRT (FP32): 2.14x\n",
-    "Torch-TensorRT (FP16): 3.15x\n",
+    "Scripted (GPU): 1.0x <br>\n",
+    "Traced (GPU): 1.62x <br>\n",
+    "Torch-TensorRT (FP32): 2.14x <br>\n",
+    "Torch-TensorRT (FP16): 3.15x <br>\n",
+    "Torch-TensorRT (INT8, PTQ): 2.14x <br>\n",
     "\n",
     "### What's next\n",
     "Now it's time to try Torch-TensorRT on your own model. If you run into any issues, you can fill them at https://github.com/pytorch/TensorRT. Your involvement will help future development of Torch-TensorRT."
@@ -685,7 +883,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ebd152d",
+   "id": "ba1d48d5",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/py/torch_tensorrt/ptq.py
+++ b/py/torch_tensorrt/ptq.py
@@ -30,12 +30,13 @@ def get_batch(self, names):
 
     batch = self.dataset_iterator.next()
     self.current_batch_idx += self.batch_size
-    # Treat the first element as input and others as targets.
+    inputs_gpu=[]
     if isinstance(batch, list):
-        batch = batch[0].to(self.device)
+        for example in batch:
+            inputs_gpu.append(example.to(self.device).data_ptr())
     else:
-        batch = batch.to(self.device)
-    return [batch.data_ptr()]
+        inputs_gpu.append(batch.to(self.device).data_ptr())
+    return inputs_gpu
 
 
 def read_calibration_cache(self):


### PR DESCRIPTION
# Description

Added a section on post-training quantization to the BERT notebook. This follows @peri044's fixes in https://github.com/pytorch/TensorRT/pull/1191 to allow support for post-training quantization with multiple inputs. 

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
