### PR TITLE
[FX] Changes done internally at Facebook

### DIFF
--- a/examples/fx/quantized_resnet_test.py
+++ b/examples/fx/quantized_resnet_test.py
@@ -8,7 +8,7 @@ import torch_tensorrt.fx.tracer.acc_tracer.acc_tracer as acc_tracer
 import torchvision.models as models
 from torch.ao.quantization.quantize_fx import (
     convert_fx,
-    convert_to_reference,
+    convert_to_reference_fx,
     prepare_fx,
 )
 from torch.fx.experimental.normalize import NormalizeArgs
@@ -52,7 +52,7 @@ def build_int8_trt(rn18):
     prepared = prepare_fx(rn18, {"": qconfig}, data)
     for _ in range(10):
         prepared(data)
-    quantized_rn18 = convert_to_reference(prepared)
+    quantized_rn18 = convert_to_reference_fx(prepared)
     ref_res = quantized_rn18(data)
     print("quantized model:", quantized_rn18)
 

--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -117,7 +117,7 @@ def compile(module: Any, ir="default", inputs=[], enabled_precisions=set([_enums
         else:
             raise ValueError(f"Precision {enabled_precisions} not supported on FX")
 
-        return lower_to_trt(module, inputs, lower_precision=lower_precision, max_batch_size=inputs[0].size(0), explicit_batch_dimension=True)
+        return lower_to_trt(module, inputs, lower_precision=lower_precision, max_batch_size=inputs[0].size(0), explicit_batch_dimension=True, dynamic_batch=False)
     else:
         raise RuntimeError("Module is an unknown format or the ir requested is unknown")
 

--- a/py/torch_tensorrt/fx/converters/acc_ops_converters.py
+++ b/py/torch_tensorrt/fx/converters/acc_ops_converters.py
@@ -591,9 +591,33 @@ def acc_ops_batch_norm(
     )
     power = np.ones_like(scale)
 
+    # For BatchNorm1d, reshape 1d to 2d
+    output_shape = input_val.shape
+    if not network.has_implicit_batch_dimension and len(input_val.shape) < 4:
+        assert (
+            len(get_dynamic_dims(input_val.shape)) <= 1
+        ), "BatchNorm1D with more than one dynamic dims is not currently supported."
+        reshape_layer = network.add_shuffle(input_val)
+        if len(input_val.shape) == 2:
+            reshape_layer.reshape_dims = (input_val.shape[0], input_val.shape[1], 1, 1)
+        else:  # len(input_val.shape) == 3
+            reshape_layer.reshape_dims = (
+                input_val.shape[0],
+                input_val.shape[1],
+                input_val.shape[2],
+                1,
+            )
+        set_layer_name(reshape_layer, target, f"{name}_reshape_2d")
+        input_val = reshape_layer.get_output(0)
     layer = network.add_scale(input_val, trt.ScaleMode.CHANNEL, bias, scale, power)
     set_layer_name(layer, target, name)
 
+    # For BatchNorm1d, reshape output back to 1d
+    if not network.has_implicit_batch_dimension and len(output_shape) < 4:
+        reshape_output_layer = network.add_shuffle(layer.get_output(0))
+        reshape_output_layer.reshape_dims = tuple(output_shape)
+        set_layer_name(reshape_output_layer, target, f"{name}_reshape_1d")
+        layer = reshape_output_layer
     return layer.get_output(0)
 
 
@@ -614,7 +638,18 @@ def acc_ops_layer_norm(network, target, args, kwargs, name):
     eps_field = trt.PluginField(
         "eps", np.array([kwargs["eps"]], dtype=np.float32), trt.PluginFieldType.FLOAT32
     )
-    field_collection = trt.PluginFieldCollection([gamma_field, beta_field, eps_field])
+    try:
+        normalized_shape = np.array(kwargs["normalized_shape"], dtype=np.int32)
+    except TypeError:
+        print("Unable to convert normalized_shape to a field, fall back to []")
+        normalized_shape = np.array([], dtype=np.int32)
+
+    normalized_shape_filed = trt.PluginField(
+        "normalized_shape", normalized_shape, trt.PluginFieldType.INT32
+    )
+    field_collection = trt.PluginFieldCollection(
+        [gamma_field, beta_field, eps_field, normalized_shape_filed]
+    )
 
     try:
         if network.has_implicit_batch_dimension:
@@ -2838,11 +2873,7 @@ def acc_ops_getitem(
         """
         Gather the number of slice in getitem slices.
         """
-        num_slice = 0
-        for s in slices:
-            if isinstance(s, slice) or isinstance(s, int):
-                num_slice += 1
-        return num_slice
+        return sum(1 for s in slices if isinstance(s, slice) or isinstance(s, int))
 
     def slice_to_trt_params(py_slice, dim_size):
         """
@@ -2878,9 +2909,9 @@ def acc_ops_getitem(
     new_slices = []
     for s in slices:
         if s == Ellipsis:
-            while num_ellipsis > 0:
+            # pass explicit start to guard against negative num_ellipsis
+            for _ in range(0, num_ellipsis):
                 new_slices.append(slice(None, None, None))
-                num_ellipsis -= 1
         else:
             new_slices.append(s)
     slices = new_slices

--- a/py/torch_tensorrt/fx/converters/converter_utils.py
+++ b/py/torch_tensorrt/fx/converters/converter_utils.py
@@ -41,6 +41,11 @@ def get_trt_plugin(
     Returns:
         A TensorRT plugin that can be added to TensorRT network as Plugin layer.
     """
+    # print the registered plugins
+    # PLUGIN_CREATORS = trt.get_plugin_registry().plugin_creator_list
+    # for plugin_creator in PLUGIN_CREATORS:
+    #     print(plugin_creator.name)
+
     plugin_registry = trt.get_plugin_registry()
     plugin_creator = plugin_registry.get_plugin_creator(
         plugin_name, version, plugin_namespace
@@ -214,7 +219,6 @@ def create_constant(
 
     if dtype:
         value = value.to(dtype)
-
     constant = network.add_constant(value.shape, to_numpy(value))
     constant.name = name
     return constant.get_output(0)

--- a/py/torch_tensorrt/fx/input_tensor_spec.py
+++ b/py/torch_tensorrt/fx/input_tensor_spec.py
@@ -6,15 +6,17 @@ from .types import Shape, ShapeRange
 from .utils import get_dynamic_dims
 
 
-def generate_input_specs(
-    inputs, lower_setting, additional_inputs=None, fixed_shape=False
-):
+def generate_input_specs(inputs, lower_setting, additional_inputs=None):
     # AIT lower setting doesn't have explicit_batch_dimension field and
     # we just return None.
     if not hasattr(lower_setting, "explicit_batch_dimension"):
         return None
 
-    if not lower_setting.explicit_batch_dimension or fixed_shape:
+    # dynamic_batch is TRT only flag. It does not exist in AIT lower setting
+    if (
+        not lower_setting.explicit_batch_dimension
+        or lower_setting.dynamic_batch is False
+    ):
         return InputTensorSpec.from_tensors(inputs)
 
     # If we don't have additional inputs, we assume the first dimension

--- a/py/torch_tensorrt/fx/lower.py
+++ b/py/torch_tensorrt/fx/lower.py
@@ -36,7 +36,7 @@ def lower_to_trt(
     timing_cache_prefix="",
     save_timing_cache=False,
     cuda_graph_batch_size=-1,
-    dynamic_batch=False,
+    dynamic_batch=True,
 ) -> nn.Module:
     """
     Takes in original module, input and lowering setting, run lowering workflow to turn module

--- a/py/torch_tensorrt/fx/lower_setting.py
+++ b/py/torch_tensorrt/fx/lower_setting.py
@@ -86,4 +86,4 @@ class LowerSetting(LowerSettingBasic):
     cuda_graph_batch_size: int = -1
     preset_lowerer: str = ""
     opt_profile_replica: int = 1
-    dynamic_batch: bool = False
+    dynamic_batch: bool = True

--- a/py/torch_tensorrt/fx/passes/lower_pass_manager_builder.py
+++ b/py/torch_tensorrt/fx/passes/lower_pass_manager_builder.py
@@ -1,3 +1,4 @@
+import datetime
 from functools import partial, wraps
 from typing import Any, Callable, Optional, Sequence
 
@@ -142,6 +143,9 @@ class LowerPassManagerBuilder:
 
                 # Only acc submodules will be lowered.
                 if not submod_name.startswith(split_result.non_acc_submodule_prefix):
+                    print("Now lowering submodule", submod_name)
+                    lowering_start_time = datetime.datetime.now()
+
                     self.lower_setting.input_specs = generate_input_specs(
                         submod_inputs,
                         self.lower_setting,
@@ -155,6 +159,10 @@ class LowerPassManagerBuilder:
                     setattr(split_result.split_module, submod_name, lowered_module)
                     LOWER_SPLIT_POST_OBSERVER.observe(
                         submod_name, lowered_module, submod_inputs
+                    )
+                    print(
+                        f"Lowering submodule {submod_name} elapsed time",
+                        datetime.datetime.now() - lowering_start_time,
                     )
 
             return split_result.split_module

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_as_strided.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_as_strided.py
@@ -3,7 +3,9 @@ import torch.nn as nn
 import torch_tensorrt.fx.tracer.acc_tracer.acc_ops as acc_ops
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
-from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase, InputTensorSpec
+from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase
+
+# from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase, InputTensorSpec
 
 
 class TestConverter(AccTestCase):
@@ -30,7 +32,9 @@ class TestConverter(AccTestCase):
             test_implicit_batch_dim=False,
         )
 
-    # Testing with shape (-1, -1, -1, -1) results into error: RuntimeError: setStorage: sizes [2, 3], strides [1, 2], storage offset 0, and itemsize 8 requiring a storage size of 48 are out of bounds for storage of size 1
+    # Testing with shape (-1, 3) results into error:
+    # RuntimeError: setStorage: sizes [2, 3], strides [1, 2], storage offset 0, and itemsize 8 requiring a storage size of 48 are out of bounds for storage of size 16
+
     """
     def test_as_strided_with_dynamic_shape_four_dimensions(self):
         class Stride(nn.Module):
@@ -39,9 +43,9 @@ class TestConverter(AccTestCase):
 
         input_specs = [
             InputTensorSpec(
-                shape=(-1, -1, -1, -1),
+                shape=(-1, 3),
                 dtype=torch.float32,
-                shape_ranges=[((1, 1, 1, 1), (3, 3, 3, 3), (5, 5, 5, 5))],
+                shape_ranges=[((1, 3), (2, 3), (2, 3))],
             ),
         ]
 

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_batchnorm.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_batchnorm.py
@@ -17,6 +17,27 @@ class TestBatchNormConverter(AccTestCase):
         inputs = [torch.randn(1, 3, 224, 224)]
         self.run_test(TestModule(), inputs, expected_ops={acc_ops.batch_norm})
 
+    def test_batchnorm1d_with_dynamic_shape(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.bn = torch.nn.BatchNorm1d(3)
+
+            def forward(self, x):
+                return self.bn(x)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, 3, 5),
+                dtype=torch.float32,
+                shape_ranges=[((2, 3, 5), (6, 3, 5), (10, 3, 5))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            TestModule(), input_specs, expected_ops={acc_ops.batch_norm}
+        )
+
     def test_batchnorm_with_dynamic_shape(self):
         class TestModule(torch.nn.Module):
             def __init__(self):

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_binary_ops.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_binary_ops.py
@@ -13,6 +13,8 @@ NEED_TEST_BOTH_CONSTANTS_CASE = True
 elementwise_ops = [
     ((lambda x, y: x + y), acc_ops.add, NEED_TEST_BOTH_CONSTANTS_CASE),
     ((lambda x, y: x - y), acc_ops.sub, NEED_TEST_BOTH_CONSTANTS_CASE),
+    ((lambda x, y: torch.sub(x, y)), acc_ops.sub, False),
+    ((lambda x, y: x.sub(y)), acc_ops.sub, False),
     ((lambda x, y: x / y), acc_ops.div, NEED_TEST_BOTH_CONSTANTS_CASE),
     ((lambda x, y: x // y), acc_ops.floor_div, NEED_TEST_BOTH_CONSTANTS_CASE),
     (

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_clamp.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_clamp.py
@@ -2,7 +2,7 @@ import torch
 import torch_tensorrt.fx.tracer.acc_tracer.acc_ops as acc_ops
 from parameterized import param, parameterized
 from torch.testing._internal.common_utils import run_tests
-from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase
+from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase, InputTensorSpec
 
 
 class TestClampConverter(AccTestCase):
@@ -27,8 +27,6 @@ class TestClampConverter(AccTestCase):
         inputs = [torch.randn(3, 4)]
         self.run_test(TestModule(), inputs, expected_ops={acc_ops.clamp})
 
-    # Error: RuntimeError: ShapeProp error for: node=%clamp : [#users=1] = call_function[target=torch.clamp](args = (%x, 1, 0), kwargs = {}) with meta={}
-    """
     @parameterized.expand(
         [
             param("default", min=-1, max=0),
@@ -55,8 +53,9 @@ class TestClampConverter(AccTestCase):
             ),
         ]
 
-        self.run_test(TestModule(), input_specs, expected_ops={acc_ops.clamp})
-    """
+        self.run_test_with_dynamic_shape(
+            TestModule(), input_specs, expected_ops={acc_ops.clamp}
+        )
 
 
 if __name__ == "__main__":

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_expand.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_expand.py
@@ -27,6 +27,8 @@ class TestExpandConverter(AccTestCase):
             expected_ops={acc_ops.expand},
         )
 
+    # Dynamic shape is not suitable for the expand operation.
+
 
 if __name__ == "__main__":
     run_tests()

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_gelu.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_gelu.py
@@ -1,3 +1,5 @@
+import unittest
+
 import torch
 import torch.nn as nn
 import torch_tensorrt.fx.tracer.acc_tracer.acc_ops as acc_ops
@@ -5,6 +7,9 @@ from torch.testing._internal.common_utils import run_tests
 from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase, InputTensorSpec
 
 
+@unittest.skip(
+    reason="Could not find CustomGeluPluginDynamic. Enable it once we upgrade TRT to 8.4"
+)
 class TestGELU(AccTestCase):
     def test_gelu(self):
         class TestModule(nn.Module):

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_interpolate.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_interpolate.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 import torch_tensorrt.fx.tracer.acc_tracer.acc_ops as acc_ops
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
-from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase
+from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase, InputTensorSpec
 
 
 class TestInterpolateConverter(AccTestCase):
@@ -104,6 +104,37 @@ class TestInterpolateConverter(AccTestCase):
             Interpolate(),
             inputs,
             expected_ops={acc_ops.interpolate},
+        )
+
+    @parameterized.expand(
+        [
+            # 4D
+            ("4d_dim_scale", (2, 3, 4, 5), (None), (2), ("nearest"), (None)),
+        ]
+    )
+    def test_interpolate_with_dynamic_shape_four_dimensions(
+        self, _, init_size, size, scale_factor, mode, align_corners
+    ):
+        class Interpolate(nn.Module):
+            def forward(self, x):
+                return torch.nn.functional.interpolate(
+                    x,
+                    size=size,
+                    scale_factor=scale_factor,
+                    mode=mode,
+                    align_corners=align_corners,
+                )  # only one of size or scale_factor should be defined
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 1, 1), (1, 2, 3, 3), (3, 3, 3, 3))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            Interpolate(), input_specs, expected_ops={acc_ops.interpolate}
         )
 
 

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_masked_fill.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_masked_fill.py
@@ -35,6 +35,9 @@ class TestMaskedFill(AccTestCase):
             test_implicit_batch_dim=False,
         )
 
+    # Testing with (-1, -1, -1, -1) results into following error:
+    # RuntimeError: Trying to create tensor with negative dimension -1: [-1, -1, -1, -1]
+
     @parameterized.expand(
         [
             ("same_dims", (2, 3), (2, 3), 5),

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_matmul.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_matmul.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 import torch_tensorrt.fx.tracer.acc_tracer.acc_ops as acc_ops
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
-from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase
+from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase, InputTensorSpec
 
 
 class TestMatMulConverter(AccTestCase):
@@ -83,6 +83,33 @@ class TestMatMulConverter(AccTestCase):
             inputs,
             expected_ops={acc_ops.matmul},
             test_implicit_batch_dim=test_implicit_batch_dim,
+        )
+
+    def test_matmal_dynamic_shape(
+        self,
+    ):
+        class Matmul(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, input, other):
+                return torch.matmul(input, other)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, 1, 2, 3),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 2, 3), (9, 1, 2, 3), (9, 1, 2, 3))],
+            ),
+            InputTensorSpec(
+                shape=(-1, -1, 3, 3),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 3, 3), (9, 4, 3, 3), (9, 4, 3, 3))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            Matmul(), input_specs, expected_ops={acc_ops.matmul}
         )
 
 

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_max.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_max.py
@@ -79,6 +79,35 @@ class TestMaxConverter(AccTestCase):
 
 
 class TestMaxConverterWithDynamicShape(AccTestCase):
+    @parameterized.expand(
+        [
+            # keepdim can not be False for dynamic shape
+            ("dim0_keepdim", 0, True),
+            ("dim1_keepdim", 1, True),
+            ("dim2_keepdim", 2, True),
+            ("dim3_keepdim", 3, True),
+        ]
+    )
+    def test_max_dim_reduce(self, _, dim, keepdim):
+        class MaxDimReduce(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.max(x, dim, keepdim=keepdim)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 5, 5), (2, 3, 5, 5), (2, 3, 5, 5))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            MaxDimReduce(), input_specs, expected_ops={acc_ops.max_dim_reduce}
+        )
+
     def test_max_full_reduce(
         self,
     ):

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_min.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_min.py
@@ -79,6 +79,34 @@ class TestMinConverter(AccTestCase):
 
 
 class TestMinConverterWithDynamicShape(AccTestCase):
+    @parameterized.expand(
+        [
+            ("dim0_keepdim", 0, True),
+            ("dim1_keepdim", 1, True),
+            ("dim2_keepdim", 2, True),
+            ("dim3_keepdim", 3, True),
+        ]
+    )
+    def test_min_dim_reduce(self, test_name, dim, keepdim):
+        class MinDimReduce(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.min(x, dim, keepdim)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 5, 5), (2, 3, 5, 5), (2, 3, 5, 5))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            MinDimReduce(), input_specs, expected_ops={acc_ops.min_dim_reduce}
+        )
+
     def test_min_full_reduce(
         self,
     ):

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_narrow.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_narrow.py
@@ -3,7 +3,31 @@ import torch.nn as nn
 import torch_tensorrt.fx.tracer.acc_tracer.acc_ops as acc_ops
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
-from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase
+from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase, InputTensorSpec
+
+
+class TestNarrowConverterWithDynamicShape(AccTestCase):
+    @parameterized.expand(
+        [
+            ("positive_dim", 1, 0, 1),
+        ]
+    )
+    def test_narrow(self, _, dim, start, length):
+        class Narrow(nn.Module):
+            def forward(self, x):
+                return x.narrow(dim, start, length)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, 3, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 3, 5, 5), (2, 3, 5, 5), (2, 3, 5, 5))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            Narrow(), input_specs, expected_ops={acc_ops.slice_tensor}
+        )
 
 
 class TestNarrowConverter(AccTestCase):
@@ -26,34 +50,6 @@ class TestNarrowConverter(AccTestCase):
             test_explicit_batch_dim=False,
         )
 
-
-# Testing with (-1, -1, -1 , -1) results in following error:
-# AssertionError: Can't chunk on dynamic shape dimension!
-"""
-class TestNarrowConverterWithDynamicShape(AccTestCase):
-    @parameterized.expand(
-        [
-            ("positive_dim", 1, 0, 1),
-            ("negative_dim", -1, 1, 2),
-        ]
-    )
-    def test_narrow(self, _, dim, start, length):
-        class Narrow(nn.Module):
-            def forward(self, x):
-                return x.narrow(dim, start, length)
-
-        input_specs = [
-            InputTensorSpec(
-                shape=(-1, -1, -1, -1),
-                dtype=torch.float32,
-                shape_ranges=[((1, 1, 5, 5), (2, 3, 5, 5), (2, 3, 5, 5))],
-            ),
-        ]
-
-        self.run_test_with_dynamic_shape(
-            Narrow(), input_specs, expected_ops={acc_ops.slice_tensor}
-        )
-"""
 
 if __name__ == "__main__":
     run_tests()

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_pad.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_pad.py
@@ -5,9 +5,11 @@ import torch
 import torch.nn as nn
 
 import torch_tensorrt.fx.tracer.acc_tracer.acc_ops as acc_ops
-from parameterized import param, parameterized
+from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
 from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase
+
+# from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase, InputTensorSpec
 
 
 class TestPadConverter(AccTestCase):
@@ -50,6 +52,27 @@ class TestPadConverter(AccTestCase):
             # enable value will not work with implicit batch
             test_implicit_batch_dim=False,
         )
+
+    # Testing with (-1, 3, 3, 3) results into following error:
+    # test_pad_with_dynamic_shape_four_dimensions_0_2d (deeplearning.trt.torch_tensorrt.py.torch_tensorrt.fx.test.converters.acc_op.test_pad.TestPadConverter) ... [07/15/2022-09:23:18] [TRT] [E] 2: [intInterval.cpp::max::26] Error Code 2: Internal Error (Assertion !empty() failed. )
+    # Segmentation fault (core dumped)
+
+    """
+    def test_pad_with_dynamic_shape_four_dimensions(self):
+        class Pad(nn.Module):
+            def forward(self, x):
+                return torch.nn.functional.pad(x, (1, 1))
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, 3, 3, 3),
+                dtype=torch.float32,
+                shape_ranges=[((1, 3, 3, 3), (2, 3, 3, 3), (2, 3, 3, 3))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(Pad(), input_specs, expected_ops={acc_ops.pad})
+    """
 
     @parameterized.expand(
         [

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_split.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_split.py
@@ -76,6 +76,9 @@ class TestSplitConverter(AccTestCase):
             },
         )
 
+    # Testing with (-1, -1, -1) results into following error:
+    # AssertionError: Can't chunk on dynamic shape dimension!
+
     @parameterized.expand(
         [
             ("split_with_size", [2, 3, 5], 1),

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_squeeze.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_squeeze.py
@@ -14,6 +14,12 @@ class TestSqueeze(AccTestCase):
         inputs = [torch.randn(1, 2, 1)]
         self.run_test(Squeeze(), inputs, expected_ops={acc_ops.squeeze})
 
+    # Testing with shape=(-1, -1, -1, -1) results in error:
+    # AssertionError: We don't support squeeze dynamic dim.
+
+    # Testing with more than one dynamic dim results in error:
+    # AssertionError: Currently more than one dynamic dim for input to squeeze is not supported.
+
     def test_squeeze_with_dynamic_shape(self):
         class Squeeze(nn.Module):
             def forward(self, x):

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_std.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_std.py
@@ -2,7 +2,7 @@ import torch
 import torch_tensorrt.fx.tracer.acc_tracer.acc_ops as acc_ops
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
-from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase
+from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase, InputTensorSpec
 
 
 class TestMinConverter(AccTestCase):
@@ -31,6 +31,36 @@ class TestMinConverter(AccTestCase):
 
     @parameterized.expand(
         [
+            ("norm_1d", (-1), False),
+            ("norm_1d", (-1), True),
+            ("norm_2d", (2, 3), False),
+            ("norm_2d", (2, 3), True),
+        ]
+    )
+    def test_std_with_dynamic_shape_four_dimensions(self, _, dim, unbiased):
+        class Std(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.std(x, dim, unbiased=unbiased, keepdim=True)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 1, 1), (3, 3, 3, 3), (3, 3, 3, 3))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            Std(),
+            input_specs,
+            expected_ops={acc_ops.mean, acc_ops.sub, acc_ops.pow, acc_ops.sqrt},
+        )
+
+    @parameterized.expand(
+        [
             ("norm_1d", (-1), True),
             ("norm_1d", (-1), False),
             ("norm_2d", (2, 3), True),
@@ -49,6 +79,36 @@ class TestMinConverter(AccTestCase):
         self.run_test(
             Std(),
             inputs,
+            expected_ops={acc_ops.mean, acc_ops.sub, acc_ops.pow, acc_ops.sqrt},
+        )
+
+    @parameterized.expand(
+        [
+            ("norm_1d", (-1), True),
+            ("norm_1d", (-1), False),
+            ("norm_2d", (2, 3), True),
+            ("norm_2d", (2, 3), False),
+        ]
+    )
+    def test_std_method_with_dynamic_shape_four_dimensions(self, _, dim, unbiased):
+        class Std(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return x.std(dim, unbiased=unbiased, keepdim=True)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 1, 1), (3, 3, 3, 3), (3, 3, 3, 3))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            Std(),
+            input_specs,
             expected_ops={acc_ops.mean, acc_ops.sub, acc_ops.pow, acc_ops.sqrt},
         )
 

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_tile.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_tile.py
@@ -68,6 +68,32 @@ class TestTile(AccTestCase):
             Tile(dims), input_specs, expected_ops={acc_ops.tile}
         )
 
+    @parameterized.expand(
+        [
+            ("all_dynamic_dim", (-1, -1), (1, 2, 2, 1)),
+        ]
+    )
+    def test_tile_with_dynamic_shape_four_dimensions(self, _, shape, dims):
+        class Tile(nn.Module):
+            def __init__(self, dims):
+                super().__init__()
+                self.dims = dims
+
+            def forward(self, x):
+                return torch.tile(x, self.dims)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 1, 3), (3, 3, 3, 3), (3, 3, 3, 3))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            Tile(dims), input_specs, expected_ops={acc_ops.tile}
+        )
+
     def test_tile_non_int_dims(self):
         class Tile(nn.Module):
             def __init__(self):
@@ -86,6 +112,32 @@ class TestTile(AccTestCase):
             Tile(),
             input_specs,
             expected_ops={acc_ops.tile},
+        )
+
+    def test_tile_non_int_dims_with_dynamic_shape_four_dimensions(self):
+        class Tile(nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                y = y * 2
+                return torch.tile(x, (1, y.shape[1], y.shape[1]))
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 1, 3), (3, 3, 3, 3), (3, 3, 3, 3))],
+            ),
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 1, 3), (3, 3, 3, 3), (3, 3, 3, 3))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            Tile(), input_specs, expected_ops={acc_ops.tile}
         )
 
 

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_topk.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_topk.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 import torch_tensorrt.fx.tracer.acc_tracer.acc_ops as acc_ops
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
-from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase
+from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase, InputTensorSpec
 
 
 class TestTopKConverter(AccTestCase):
@@ -39,6 +39,44 @@ class TestTopKConverter(AccTestCase):
             inputs,
             expected_ops={acc_ops.topk},
             test_implicit_batch_dim=(dim != 0),
+        )
+
+    @parameterized.expand(
+        [
+            ("top1", 1, -1),
+            ("top2", 2, -1),
+            ("none_dim", 1, None),
+            ("smallest", 1, -1, False),
+            ("top1_dim0", 1, 0, False),
+        ]
+    )
+    def test_topk_with_dynamic_shape_four_dimensions(self, _, k, dim, largest=True):
+        class TopK(nn.Module):
+            def __init__(self, k, dim):
+                super().__init__()
+                self.k = k
+                self.dim = dim
+                self.largest = largest
+
+            def forward(self, x):
+                if self.dim is not None:
+                    out = torch.topk(
+                        x, k=self.k, dim=self.dim, largest=self.largest, sorted=False
+                    )
+                else:
+                    out = torch.topk(x, k=self.k, largest=self.largest, sorted=False)
+                return out[0], out[1]
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 1, 1), (3, 3, 3, 3), (3, 3, 3, 3))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            TopK(k, dim), input_specs, expected_ops={acc_ops.topk}
         )
 
 

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_type_as.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_type_as.py
@@ -1,7 +1,7 @@
 import torch
 import torch_tensorrt.fx.tracer.acc_tracer.acc_ops as acc_ops
 from torch.testing._internal.common_utils import run_tests
-from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase
+from torch_tensorrt.fx.tools.common_fx2trt import AccTestCase, InputTensorSpec
 from torch_tensorrt.fx.utils import LowerPrecision
 
 
@@ -101,6 +101,25 @@ class TestTypeAsConverter(AccTestCase):
             inputs,
             expected_ops={acc_ops.to_dtype},
             precision=LowerPrecision.FP16,
+        )
+
+    def test_type_tensor_with_dynamic_shape_four_dimensions(self):
+        class Type_as(torch.nn.Module):
+            def forward(self, input):
+                return input.type(dtype=torch.float32)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.int,
+                shape_ranges=[((1, 1, 1, 1), (3, 3, 3, 3), (3, 3, 3, 3))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            Type_as(),
+            input_specs,
+            expected_ops={acc_ops.to_dtype},
         )
 
     def test_type_tensor_ext(self):

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_unsqueeze.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_unsqueeze.py
@@ -26,6 +26,9 @@ class TestUnsqueeze(AccTestCase):
         inputs = [torch.randn(1, 2, 3)]
         self.run_test(Unsqueeze(dim), inputs, expected_ops={acc_ops.unsqueeze})
 
+    # Testing with more than one dynamic dims results in following error:
+    # AssertionError: Currently we don't support unsqueeze with more than one dynamic dims.
+
     @parameterized.expand(
         [
             ("negative_dim_dynamic", -4),

--- a/py/torch_tensorrt/fx/test/tracer/test_acc_tracer.py
+++ b/py/torch_tensorrt/fx/test/tracer/test_acc_tracer.py
@@ -2577,5 +2577,6 @@ class AccTracerTest(unittest.TestCase):
                 acc_ops.einsum,
                 acc_ops.as_strided,
                 acc_ops.var,
+                acc_ops.grid_sample,
             },
         )

--- a/py/torch_tensorrt/fx/tracer/acc_tracer/acc_tracer.py
+++ b/py/torch_tensorrt/fx/tracer/acc_tracer/acc_tracer.py
@@ -6,7 +6,7 @@ import logging
 import textwrap
 import warnings
 from types import FunctionType
-from typing import Any, Dict, Optional, Sequence, Set, Tuple, Type
+from typing import Any, Dict, Iterable, Optional, Sequence, Set, Tuple, Type
 
 import torch
 import torch.jit as jit
@@ -41,8 +41,11 @@ class Acc_Rewriter(ast.NodeTransformer):
     def __init__(self):
         super().__init__()
         self.exceptions_rewritten: Set[Type[Exception]] = set()
+        self.exceptions_bool_rewritten: Set[Type[Exception]] = set()
 
-    def rewrite(self, fn: FunctionType) -> Tuple[FunctionType, Set[Type[Exception]]]:
+    def rewrite(
+        self, fn: FunctionType
+    ) -> Tuple[FunctionType, Set[Type[Exception]], Set[Type[Exception]]]:
 
         # Normalize the source lines
         sourcelines, _ = inspect.getsourcelines(fn)
@@ -65,7 +68,7 @@ class Acc_Rewriter(ast.NodeTransformer):
 
         # Return the correct FunctionType object and the Exceptions that were
         # rewritten during visit_If.
-        return fn_compiled, self.exceptions_rewritten
+        return fn_compiled, self.exceptions_rewritten, self.exceptions_bool_rewritten
 
     def visit_Assert(self, node: ast.Assert):
         """
@@ -161,7 +164,23 @@ class Acc_Rewriter(ast.NodeTransformer):
         assert isinstance(exc_wrapper_node, ast.Expression)
         exc_wrapper_call_node = exc_wrapper_node.body
         assert isinstance(exc_wrapper_call_node, ast.Call)
-        exc_wrapper_call_node.args = [if_node.test, exc_msg]
+        if isinstance(if_node.test, ast.BoolOp) and isinstance(
+            if_node.test.op, ast.And
+        ):
+            self.exceptions_bool_rewritten.add(exc_type)
+            bool_wrapper_node = ast.parse(
+                f"self.{_get_exception_wrapper_attr_name(exc_type)}_bool()", mode="eval"
+            )
+            assert isinstance(exc_wrapper_node, ast.Expression)
+            bool_wrapper_call_node = bool_wrapper_node.body
+            assert isinstance(exc_wrapper_call_node, ast.Call)
+            bool_wrapper_call_node.args = if_node.test.values
+            exc_wrapper_call_node.args = [
+                _reuse_loc(bool_wrapper_call_node),
+                exc_msg,
+            ]
+        else:
+            exc_wrapper_call_node.args = [if_node.test, exc_msg]
 
         # Ensure that the new node conforms to the Python AST grammar
         expr_wrapper = _reuse_loc(ast.Expr(_reuse_loc(exc_wrapper_call_node)))
@@ -206,6 +225,39 @@ class ConditionalExceptionWrapper(nn.Module):
             raise self.exc if msg is None else self.exc(msg)
 
 
+class ConditionalExceptionBoolCondWrapper(nn.Module):
+    """
+    This is a wrapper class to for boolean ops used inside conditionals
+    raising exceptions.
+    This currently only handles binary input cases for the `and` operator
+    at one level of depth
+    For example:
+
+    .. code-block:: python
+
+    if self.name != "x" and self.name != "y":
+        raise AssertionError(f"Name was not x: {self.name}")
+
+    rewrites the `self.name != "x" and self.name != "y"` with
+    a `_conditional_exception_wrapper_AssertionError_bool` as follows:
+
+    .. code-block:: python
+
+        self._conditional_exception_wrapper_AssertionError(
+            self._conditional_exception_wrapper_AssertionError_bool(self.name != "x" and self.name != "y"), f"Name was not x: {self.name}"
+        )
+    """
+
+    # Mark as impure so that calls to it will not be removed during DCE.
+    _is_impure = True
+
+    def __init__(self, op):
+        super().__init__()
+
+    def forward(self, *conds: Iterable):
+        return all(conds)
+
+
 # Custom tracer that traces to the functional level and rewrites asserts and
 # exceptions.
 class AccRewritingTracer(Tracer):
@@ -217,6 +269,7 @@ class AccRewritingTracer(Tracer):
     # Note: Treat ConditionalExceptionWrapper as a leaf so that we don't
     # trace into it, because it contains control flow and raises an exception.
     DEFAULT_LEAF_MODULE_LIST = {
+        ConditionalExceptionBoolCondWrapper,
         ConditionalExceptionWrapper,
         torch.nn.quantized.Linear,
         torch.nn.quantized.Conv2d,
@@ -318,6 +371,7 @@ def _rewrite(
         # Acc_Rewriter calls into in this module so we can add them in init
         # below.
         all_added_wrappers: Set[Type[Exception]] = set()
+        all_added_bool_wrappers: Set[Type[Exception]] = set()
 
         # Note: Make this a subclass of our base class.
         class RewrittenModule(base_class):  # type: ignore[valid-type, misc]
@@ -349,8 +403,13 @@ def _rewrite(
                 if base_class not in allow_list:
                     vars()[method_name] = method
                 else:
-                    vars()[method_name], added_wrappers = Acc_Rewriter().rewrite(method)
+                    (
+                        vars()[method_name],
+                        added_wrappers,
+                        added_bool_wrappers,
+                    ) = Acc_Rewriter().rewrite(method)
                     all_added_wrappers.update(added_wrappers)
+                    all_added_bool_wrappers.update(added_bool_wrappers)
 
             def __init__(self, orig):
                 nn.Module.__init__(self)
@@ -365,6 +424,16 @@ def _rewrite(
                         wrapper_name,
                         ConditionalExceptionWrapper(exc_type),
                     )
+
+                for exc_type in all_added_bool_wrappers:
+                    wrapper_name = f"{_get_exception_wrapper_attr_name(exc_type)}_bool"
+                    assert not hasattr(self, wrapper_name)
+                    setattr(
+                        self,
+                        wrapper_name,
+                        ConditionalExceptionBoolCondWrapper(exc_type),
+                    )
+
                 # Recursively rewrite and copy all module attrs of this module.
                 for k, v in orig.__dict__.items():
                     if k == "_modules":
@@ -403,9 +472,12 @@ def _remove_exceptions(gm: torch.fx.GraphModule) -> bool:
     found in GraphModule gm. Returns whether the graph is modified.
     """
     changed = False
-    for node in gm.graph.nodes:
-        if node.op == "call_module" and isinstance(
-            gm.get_submodule(node.target), ConditionalExceptionWrapper
+    for node in reversed(gm.graph.nodes):
+        if node.op == "call_module" and (
+            isinstance(gm.get_submodule(node.target), ConditionalExceptionWrapper)
+            or isinstance(
+                gm.get_submodule(node.target), ConditionalExceptionBoolCondWrapper
+            )
         ):
             gm.graph.erase_node(node)
             changed = True

--- a/py/torch_tensorrt/fx/tracer/acc_tracer/acc_utils.py
+++ b/py/torch_tensorrt/fx/tracer/acc_tracer/acc_utils.py
@@ -171,7 +171,9 @@ def map_tensor_metadata(a: Any, fn: Callable):
     Map some `fn` to `a`, where `a` is either a TensorMetadata, or else a tuple/list
     recursively containing TensorMetadata.
     """
-    if isinstance(a, TensorMetadata):
+    if isinstance(a, int):
+        return 1
+    elif isinstance(a, TensorMetadata):
         return fn(a)
     elif isinstance(a, tuple):
         return tuple(map_tensor_metadata(elem, fn) for elem in a)


### PR DESCRIPTION
6703b98dff0695d91026f057b951dba1355825fa Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for acc_ops.prod
c822345d6d673e1653c2208435e34ab400bada3d Jason Park <jasonjk@fb.com> Add support for generic torch ops to be used in training.
e5758602a0592d6c2b71d6d66a0398c4dd9b5e20 Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for repeat interleave
c13c633f04df162500eed477c0569eb2b81eb070 Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for reduce ops
863476cf43b210922b88585b8f196dd84fbebb56 Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for acc_op.convolution
5b6a8d2d6be979983a52ac96225fefb510c3817c Andrew Or <andrewor@fb.com> [Quant][fx] Rename convert_to_reference to convert_to_reference_fx
996a0e080b8a8bc0b292a7c2ac92f41f6db33a2e Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for acc_op.expand
084631fe74b304fbb9481ca15fd452a3714fb1b8 Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for acc_op.to_dtype
b3195e76329ccddbb5c4640cfa884d0e457d2d34 Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for std
a5d964e62bdf769cf8c2e67321138b33e1f524a7 Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for acc_op.tile
3d33d45b2fc7f10f25c22946ba474b227e4b6529 Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for squeeze
09085abf63d7e7732e2cd66e600e8afc6d58964f Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for acc_op.topk
65edc7ea12899e9bd2af42c890a64de853d9b7fe Huamin Li <huaminli@fb.com> temporarily skip gelu tests
d11e521f9b90554ca86912a49920afa4406bb40d Shirong Wu <shirong@fb.com> Suppress accuracy check for remove_reshape_with_batch_size_change
6d948298b2327d229e010a34f1c221b11d2eb504 Ankur Singla <ankursingla@fb.com> [GPULowering] Suppress accuracy check for fuse_unsqueeze_cat_sum
e780b647fc9571b77d9f41c963041a6ac3d66f33 Janet Yang <qxy11@fb.com> Lower xrayvideo2022 to fx2trt
433c7207fef16b1fdff985546ea969c39fa83e7c generatedunixname89002005287564 <generatedunixname89002005287564@fb.com> [Codemod][Remove @noautodeps and @autodeps-skip tags] deeplearning/trt 1/2
66fdb65cffa925660c77b4758388399db3cbfe48 Scott Wolchok <swolchok@fb.com> [fx2ait] Minor Python cleanup in acc_ops_getitem
188132ecb2c19bcbf83cb2dc381f6e3798629f87 generatedunixname89002005324833 <generatedunixname89002005324833@fb.com> [AutoAccept][Codemod][FBSourceBuckFormatLinter] Daily `arc lint --take BUCKFORMAT`
4536bae4686dd01f2149541ea7fb330e178a4969 Wei Wei <wwei6@fb.com> [fx2trt] support sub
064602e666f86c110d931cd90a8536112a19b4ad Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for acc_ops.interpolate
9dfd0ee0cecb1975e3f53c44de237d67ca443ec5 Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for unary_ops
39b9efad8d5d82463a2016d135c0cf277de1c3c6 Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for unsqueeze
2bb17667d1dabc95391950426fc1f921eb3d0959 Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for acc_ops.split
64dfb7b096686cb2fd33197340dc72f30d525456 Shirong Wu <shirong@fb.com> Group LN trt plugin
438f670e28df59b0734baa092a514fba3d75eb4f Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for acc_ops.avgpool
df0fe32dae4343827bd9b37b72daae761b02f228 Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for acc_ops masked fill
44fe735d3493ea2d05a56b49093e4a23dd63a98e Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shaope support for acc_ops.pad
4f931acca706d8ce79045ceafef2ea0486609149 Wei Wei <wwei6@fb.com> [fx2trt] torch.max dynamic shape test
bf6f6cbe217d26a95ca9122574adf7de3966db9e Shreyansh Prajapati <shreyanshp@fb.com> Change the name of the test from full_reduce to dim_reduce
1c5680ed107d9206f3514eff4069a3f6c870ba8c Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for acc_ops.type_as
33e4c175a4f5fec78ac0b1c8eb262ca777c7aaba Shreyansh Prajapati <shreyanshp@fb.com> Test dynamic shape support for acc_ops.min
f37be34bcef9716080b8bafbd1f4ad72e412c44c Wei Wei <wwei6@fb.com> [fx2trt] plugin for grid_sample
57b5cc6a0f4839686ae360361a3a13b424794ee7 generatedunixname89002005367269 <generatedunixname89002005367269@fb.com> [AutoAccept][Codemod][FBSourceBlackLinter] Daily `arc lint --take BLACK`
eb741cc5e5a7babdc94e72d411670905f54da3e0 Shreyansh Prajapati <shreyanshp@fb.com> Updated the dynamic shape support for narrow op
521c36b96a14741ae89d7af6cbb658120bcec2ea Shreyansh Prajapati <shreyanshp@fb.com> Removing the comment for 4 dims dynamic shape support after analysis
e947343375967fe9efb0a16fdb9f63bff1449328 Shreyansh Prajapati <shreyanshp@fb.com> Updated the pad test for dynamic batch for analysis
3d64087014e91bc301a315eae43683b1aa2b66bc Oleg Khabinov <khabinov@fb.com> [trt_bc] Some improvements
dfd937a56fa01aca88a89b46176befdac4c202c4 Shreyansh Prajapati <shreyanshp@fb.com> Updated the test for as_strided op for analysis
932046ff6ea6dead114c0222b23ca3854690cffa Wei Wei <wwei6@fb.com> [fx2trt] bridge the dynamic batch and fixed shape

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
