### PR TITLE
feat: keep model's original input signature

### DIFF
--- a/core/compiler.cpp
+++ b/core/compiler.cpp
@@ -28,7 +28,7 @@
 namespace torch_tensorrt {
 namespace core {
 
-void AssociateInputSignature(torch::jit::Graph* g, torch::jit::Graph* new_g) {
+void AssociateInputSignature(std::shared_ptr<torch::jit::Graph>& g, std::shared_ptr<torch::jit::Graph> new_g) {
   int input_offset = new_g->inputs().size() == g->inputs().size() ? 0 : 1;
   for (size_t i = 0; i < g->inputs().size(); ++i) {
     auto old_g_name = g->inputs()[i]->debugName();

--- a/tests/core/partitioning/test_resolve_nontensor_inputs.cpp
+++ b/tests/core/partitioning/test_resolve_nontensor_inputs.cpp
@@ -116,11 +116,11 @@ TEST(Partitioning, ResolveNonTensorInputsCorrectly) {
   inputs.push_back(torch_tensorrt::core::ir::Input({16, 3, 3, 3}));
   inputs.push_back(torch_tensorrt::core::ir::Input({16}));
 
-  torch_tensorrt::core::ir::CollectionInputSpecMap inputs_map;
-  std::unordered_map<const torch::jit::Value*, std::vector<c10::optional<at::ScalarType>>> input_types;
+  std::unordered_map<const torch::jit::Value*, torch_tensorrt::core::ir::Input> inputs_map;
+  std::unordered_map<const torch::jit::Value*, c10::optional<at::ScalarType>> input_types;
   for (size_t i = 0; i < g->inputs().size(); ++i) {
-    inputs_map.insert({g->inputs()[i], {inputs[i]}});
-    input_types.insert({g->inputs()[i], {{at::kFloat}}});
+    inputs_map.insert({g->inputs()[i], inputs[i]});
+    input_types.insert({g->inputs()[i], {at::kFloat}});
   }
   auto input_ivalues_map = torch_tensorrt::core::partitioning::generateRandomInputs(inputs_map, input_types);
   std::unordered_map<torch::jit::Node*, int> fallback_nodes;
@@ -175,11 +175,11 @@ TEST(Partitioning, ResolveTensorListInputsInTrtCorrectly) {
   inputs.push_back(torch_tensorrt::core::ir::Input({16, 6, 3, 3}));
   inputs.push_back(torch_tensorrt::core::ir::Input({16}));
 
-  std::unordered_map<const torch::jit::Value*, std::vector<torch_tensorrt::core::ir::Input>> inputs_map;
-  std::unordered_map<const torch::jit::Value*, std::vector<c10::optional<at::ScalarType>>> input_types;
+  std::unordered_map<const torch::jit::Value*, torch_tensorrt::core::ir::Input> inputs_map;
+  std::unordered_map<const torch::jit::Value*, c10::optional<at::ScalarType>> input_types;
   for (size_t i = 0; i < g->inputs().size(); ++i) {
-    inputs_map.insert({g->inputs()[i], {inputs[i]}});
-    input_types.insert({g->inputs()[i], {{at::kFloat}}});
+    inputs_map.insert({g->inputs()[i], inputs[i]});
+    input_types.insert({g->inputs()[i], {at::kFloat}});
   }
   auto input_ivalues_map = torch_tensorrt::core::partitioning::generateRandomInputs(inputs_map, input_types);
   std::unordered_map<torch::jit::Node*, int> fallback_nodes;
@@ -206,7 +206,7 @@ TEST(Partitioning, ResolveTensorListInputsInTrtCorrectly) {
 
 TEST(Partitioning, ConvertForTensorListInputsInFallbackCorrectly) {
   const auto graph = R"IR(
-          graph(%0 : Float(1, 3, 16, 16, strides=[768, 256, 16, 1]),
+          graph(%a : Float(1, 3, 16, 16, strides=[768, 256, 16, 1]),
                 %1 : Float(16, 6, 3, 3, strides=[54, 9, 3, 1]),
                 %2 : Float(16, strides=[1])):
             %3 : int[] = prim::Constant[value=[0, 0]]()
@@ -215,8 +215,8 @@ TEST(Partitioning, ConvertForTensorListInputsInFallbackCorrectly) {
             %6 : bool = prim::Constant[value=1]()
             %7 : int = prim::Constant[value=1]()
             %8 : int = prim::Constant[value=0]()
-            %9 : Tensor[] = prim::ListConstruct(%0, %0)
-            %11 : Tensor = aten::log_sigmoid(%0)
+            %9 : Tensor[] = prim::ListConstruct(%a, %a)
+            %11 : Tensor = aten::log_sigmoid(%a)
             %12 : Tensor = aten::cat(%9, %7)
             %13 : Tensor = aten::_convolution(%12, %1, %2, %4, %3, %4, %5, %3, %7, %5, %5, %6, %6)
             %14 : Tensor = aten::relu(%13)
@@ -367,11 +367,11 @@ TEST(Partitioning, ResolveOnlyNeccessaryNonTensorInputs) {
   inputs.push_back(torch_tensorrt::core::ir::Input({4, 4}));
   inputs.push_back(torch_tensorrt::core::ir::Input({4, 4}));
 
-  torch_tensorrt::core::ir::CollectionInputSpecMap inputs_map;
-  std::unordered_map<const torch::jit::Value*, std::vector<c10::optional<at::ScalarType>>> input_types;
+  std::unordered_map<const torch::jit::Value*, torch_tensorrt::core::ir::Input> inputs_map;
+  std::unordered_map<const torch::jit::Value*, c10::optional<at::ScalarType>> input_types;
   for (size_t i = 0; i < g->inputs().size(); ++i) {
-    inputs_map.insert({g->inputs()[i], {inputs[i]}});
-    input_types.insert({g->inputs()[i], {{at::kFloat}}});
+    inputs_map.insert({g->inputs()[i], inputs[i]});
+    input_types.insert({g->inputs()[i], {at::kFloat}});
   }
   auto input_ivalues_map = torch_tensorrt::core::partitioning::generateRandomInputs(inputs_map, input_types);
   std::unordered_map<torch::jit::Node*, int> fallback_nodes;

--- a/tests/core/partitioning/test_stitched_graph.cpp
+++ b/tests/core/partitioning/test_stitched_graph.cpp
@@ -26,7 +26,7 @@ bool checkAllInputsExistInStitchedGraph(std::shared_ptr<torch::jit::Graph> g) {
 
 TEST(Partitioning, StitchSequentialModelSegmentedBlockCorrectly) {
   const auto graph = R"IR(
-          graph(%0 : Tensor,
+          graph(%a : Tensor,
                 %w1 : Float(32, 3, 3, 3, strides=[27, 9, 3, 1]),
                 %b1 : Float(32),
                 %w2 : Float(16, 32, 3, 3, strides=[288, 9, 3, 1]),
@@ -37,7 +37,7 @@ TEST(Partitioning, StitchSequentialModelSegmentedBlockCorrectly) {
             %3 : int = prim::Constant[value=1]()
             %10 : bool = prim::Constant[value=0]()
             %11 : int[] = prim::Constant[value=[0, 0]]()
-            %12: Tensor = aten::_convolution(%0, %w1, %b1, %2, %2, %2, %10, %11, %3, %10, %10, %10, %10)
+            %12: Tensor = aten::_convolution(%a, %w1, %b1, %2, %2, %2, %10, %11, %3, %10, %10, %10, %10)
             %13 : Tensor = aten::relu(%12)
             %14 : Tensor = aten::_convolution(%13, %w2, %b2, %2, %2, %2, %10, %11, %3, %10, %10, %10, %10)
             %15 : Tensor = aten::log_sigmoid(%14)
@@ -83,7 +83,7 @@ TEST(Partitioning, StitchSequentialModelSegmentedBlockCorrectly) {
 
 TEST(Partitioning, StitchBranchModelSegmentedBlockCorrectly) {
   const auto graph = R"IR(
-                  graph(%0 : Tensor,
+                  graph(%a : Tensor,
                         %1 : Float(32, 3, 3, 3, strides=[27, 9, 3, 1]),
                         %2 : Float(32),
                         %3 : Float(16, 32, 3, 3, strides=[288, 9, 3, 1]),
@@ -93,7 +93,7 @@ TEST(Partitioning, StitchBranchModelSegmentedBlockCorrectly) {
                     %7 : bool = prim::Constant[value=0]()
                     %8 : int[] = prim::Constant[value=[1, 1]]()
                     %9 : int = prim::Constant[value=1]()
-                    %10: Tensor = aten::_convolution(%0, %1, %2, %8, %8, %8, %7, %5, %9, %7, %7, %7, %7)
+                    %10: Tensor = aten::_convolution(%a, %1, %2, %8, %8, %8, %7, %5, %9, %7, %7, %7, %7)
                     %11 : Tensor = aten::_convolution(%10, %3, %4, %8, %8, %8, %7, %5, %9, %7, %7, %7, %7)
                     %12: Tensor = aten::log_sigmoid(%10)
                     %13 : Tensor = aten::_convolution(%12, %3, %4,  %8, %8, %8, %7, %5, %9, %7, %7, %7, %7)

--- a/tests/core/partitioning/test_tensorrt_conversion.cpp
+++ b/tests/core/partitioning/test_tensorrt_conversion.cpp
@@ -17,7 +17,7 @@ int count_trt_engines(std::shared_ptr<torch::jit::Graph> g) {
 
 TEST(Partitioning, ConvertSequentialModelSegmentedBlockCorrectly) {
   const auto graph = R"IR(
-            graph(%0 : Tensor,
+            graph(%a : Tensor,
                   %w1 : Float(32, 3, 3, 3, strides=[27, 9, 3, 1]),
                   %b1 : Float(32),
                   %w2 : Float(16, 32, 3, 3, strides=[288, 9, 3, 1]),
@@ -28,7 +28,7 @@ TEST(Partitioning, ConvertSequentialModelSegmentedBlockCorrectly) {
               %3 : int = prim::Constant[value=1]()
               %10 : bool = prim::Constant[value=0]()
               %11 : int[] = prim::Constant[value=[0, 0]]()
-              %12: Tensor = aten::_convolution(%0, %w1, %b1, %2, %2, %2, %10, %11, %3, %10, %10, %10, %10)
+              %12: Tensor = aten::_convolution(%a, %w1, %b1, %2, %2, %2, %10, %11, %3, %10, %10, %10, %10)
               %13 : Tensor = aten::relu(%12)
               %14 : Tensor = aten::_convolution(%13, %w2, %b2, %2, %2, %2, %10, %11, %3, %10, %10, %10, %10)
               %15 : Tensor = aten::log_sigmoid(%14)
@@ -75,7 +75,7 @@ TEST(Partitioning, ConvertSequentialModelSegmentedBlockCorrectly) {
 
 TEST(Partitioning, ConvertBranchModelSegmentedBlockCorrectly) {
   const auto graph = R"IR(
-                graph(%0 : Tensor,
+                graph(%a : Tensor,
                       %1 : Float(32, 3, 3, 3, strides=[27, 9, 3, 1]),
                       %2 : Float(32),
                       %3 : Float(16, 32, 3, 3, strides=[288, 9, 3, 1]),
@@ -85,7 +85,7 @@ TEST(Partitioning, ConvertBranchModelSegmentedBlockCorrectly) {
                   %7 : bool = prim::Constant[value=0]()
                   %8 : int[] = prim::Constant[value=[1, 1]]()
                   %9 : int = prim::Constant[value=1]()
-                  %10: Tensor = aten::_convolution(%0, %1, %2, %8, %8, %8, %7, %5, %9, %7, %7, %7, %7)
+                  %10: Tensor = aten::_convolution(%a, %1, %2, %8, %8, %8, %7, %5, %9, %7, %7, %7, %7)
                   %11 : Tensor = aten::_convolution(%10, %3, %4, %8, %8, %8, %7, %5, %9, %7, %7, %7, %7)
                   %12: Tensor = aten::log_sigmoid(%10)
                   %13 : Tensor = aten::_convolution(%12, %3, %4,  %8, %8, %8, %7, %5, %9, %7, %7, %7, %7)


### PR DESCRIPTION
Signed-off-by: Bo Wang <bowa@nvidia.com>

# Description

There are some requests that users doesn't want to change the models' inputs signature for input, which could make it difficult to use in a deployment environment. We can keep original inputs signature. 


## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
