### PR TITLE
fix: fix the "schema not found for node" error

### DIFF
--- a/core/partitioning/partitioning.cpp
+++ b/core/partitioning/partitioning.cpp
@@ -39,6 +39,7 @@ bool isModifyingNodes(torch::jit::Node* node, torch::jit::Value* val) {
     if (node->inputs()[i] == val) {
       const at::AliasInfo* formal = schema->arguments()[i].alias_info();
       if (formal && formal->isWrite()) {
+        LOG_GRAPH("<Whatever is doing the modifying> Is modifying node " << util::node_info(n));
         return true;
       }
     }

--- a/core/partitioning/partitioning.cpp
+++ b/core/partitioning/partitioning.cpp
@@ -39,7 +39,9 @@ bool isModifyingNodes(torch::jit::Node* node, torch::jit::Value* val) {
     if (node->inputs()[i] == val) {
       const at::AliasInfo* formal = schema->arguments()[i].alias_info();
       if (formal && formal->isWrite()) {
-        LOG_GRAPH("<Whatever is doing the modifying> Is modifying node " << util::node_info(node));
+        LOG_GRAPH(
+            util::node_info(node) << " is a modifying node for value " << val->debugName()
+                                  << ", add it to the dependency graph.");
         return true;
       }
     }

--- a/core/partitioning/partitioning.cpp
+++ b/core/partitioning/partitioning.cpp
@@ -31,10 +31,13 @@ bool containNonTensorOutputs(torch::jit::Node* n) {
 }
 
 bool isModifyingNodes(torch::jit::Node* node, torch::jit::Value* val) {
-  const auto& schema = node->schema();
+  const torch::jit::FunctionSchema* schema = node->maybeSchema();
+  if (!schema) {
+    return false;
+  }
   for (size_t i = 0; i < node->inputs().size(); ++i) {
     if (node->inputs()[i] == val) {
-      const at::AliasInfo* formal = schema.arguments()[i].alias_info();
+      const at::AliasInfo* formal = schema->arguments()[i].alias_info();
       if (formal && formal->isWrite()) {
         return true;
       }

--- a/core/partitioning/partitioning.cpp
+++ b/core/partitioning/partitioning.cpp
@@ -39,7 +39,7 @@ bool isModifyingNodes(torch::jit::Node* node, torch::jit::Value* val) {
     if (node->inputs()[i] == val) {
       const at::AliasInfo* formal = schema->arguments()[i].alias_info();
       if (formal && formal->isWrite()) {
-        LOG_GRAPH("<Whatever is doing the modifying> Is modifying node " << util::node_info(n));
+        LOG_GRAPH("<Whatever is doing the modifying> Is modifying node " << util::node_info(node));
         return true;
       }
     }


### PR DESCRIPTION
Signed-off-by: Bo Wang <bowa@nvidia.com>

# Description

In partitioning, when we check if a node would modify the input value, we use the node->schema() function from PyTorch previously. However, this function could return a nullptr in some cases, which triggers a error showing `Schema not found for node. File a bug report`

Fixes #1227 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
