### PR TITLE
Support swin/bert with dynamic batch

### DIFF
--- a/core/conversion/converters/impl/element_wise.cpp
+++ b/core/conversion/converters/impl/element_wise.cpp
@@ -25,8 +25,6 @@ nvinfer1::ITensor* clamp_util(
   return clamp_layer_out;
 }
 
-
-
 auto element_wise_registrations TORCHTRT_UNUSED =
     RegisterNodeConversionPatterns()
         .pattern(


### PR DESCRIPTION
Signed-off-by: Cheng Hang <calvinhance@gmail.com>

# Description

To support dynamic-batch compilation of swin transformer/BERT, I have added dynamic batch support of the following relevant op converters:

1. `aten::reshape`
2. `aten::select`
3. `aten::roll`
4. `aten::flatten`
5. `aten::slice` The older version can support dynamic shape, but will report a lot of trt ERRORs, meanwhile compiles successfully.  This can be reproduced for TRT 8.4, and it did not appear for TRT 8.2. I suppose it is caused by some new checks performed in TRT8.4.
![7c2cdbf79765ad96768be343ad62acd](https://user-images.githubusercontent.com/15108866/184830851-fd145fc4-5847-4542-adae-d397bdacb69a.png)
To resolve this issue, I have slightly changed the order of codes for dynamic slice, and it did not change the logics. By such simple manipulation, the ERRORs disappear.

Fixes #1271

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
