### PR TITLE
correct sha256sum of cudnn

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -76,8 +76,8 @@ http_archive(
 http_archive(
     name = "cudnn",
     build_file = "@//third_party/cudnn/archive:BUILD",
-    sha256 = "7f3fbe6201708de409532a32d647af6b4bdb10d7f045d557270549e286487289",
-    strip_prefix = "cudnn-linux-x86_64-8.4.1.114_cuda11.4-archive",
+    sha256 = "ec96d2376d81fca42bdd3d4c3d705a99b29a065bab57f920561c763e29c67d01",
+    strip_prefix = "cudnn-linux-x86_64-8.4.1.50_cuda11.6-archive",
     urls = [
         "https://developer.nvidia.com/compute/cudnn/secure/8.4.1/local_installers/11.6/cudnn-linux-x86_64-8.4.1.50_cuda11.6-archive.tar.xz",
     ],


### PR DESCRIPTION
# Description

The SHA256 and strip_prefix of cudnn in `WORKSPACE` file is incorrect, which causes compilation error.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
