### PR TITLE
fix: Add int support to constant_pad_nd

### DIFF
--- a/core/conversion/converters/impl/constant_pad.cpp
+++ b/core/conversion/converters/impl/constant_pad.cpp
@@ -108,7 +108,7 @@ auto constant_pad_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns
              // fill the right_gather_out with value
              auto fill_layer = ctx->net->addFill(nvinfer1::Dims{1, {1}}, nvinfer1::FillOperation::kLINSPACE);
              auto shape_gather_out = ctx->net->addShape(*right_gather_out)->getOutput(0);
-             fill_layer->setInput(0, *shape_gather_out);          
+             fill_layer->setInput(0, *shape_gather_out);
              fill_layer->setInput(1, *valueTensor);
              at::Tensor delta_tensor = torch::zeros(inRank, util::TRTDataTypeToScalarType(in->getType()));
              auto deltaTensor = tensor_to_const(ctx, delta_tensor);

--- a/core/conversion/converters/impl/constant_pad.cpp
+++ b/core/conversion/converters/impl/constant_pad.cpp
@@ -57,7 +57,7 @@ auto constant_pad_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns
              auto shape_gather_out = ctx->net->addShape(*left_gather_out)->getOutput(0);
              fill_layer->setInput(0, *shape_gather_out);
              fill_layer->setInput(1, *valueTensor);
-             at::Tensor delta_tensor = torch::zeros(inRank);
+             at::Tensor delta_tensor = torch::zeros(inRank, util::TRTDataTypeToScalarType(in->getType()));
              auto deltaTensor = tensor_to_const(ctx, delta_tensor);
              fill_layer->setInput(2, *deltaTensor);
              auto padTensor = fill_layer->getOutput(0);
@@ -69,7 +69,7 @@ auto constant_pad_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns
              inDims.d[axis] = padding[padding_index];
              auto fill_layer = ctx->net->addFill(inDims, nvinfer1::FillOperation::kLINSPACE);
              fill_layer->setInput(1, *valueTensor);
-             at::Tensor delta_tensor = torch::zeros(inRank);
+             at::Tensor delta_tensor = torch::zeros(inRank, util::TRTDataTypeToScalarType(in->getType()));
              auto deltaTensor = tensor_to_const(ctx, delta_tensor);
              fill_layer->setInput(2, *deltaTensor);
              auto padTensor = fill_layer->getOutput(0);
@@ -110,7 +110,7 @@ auto constant_pad_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns
              auto shape_gather_out = ctx->net->addShape(*right_gather_out)->getOutput(0);
              fill_layer->setInput(0, *shape_gather_out);          
              fill_layer->setInput(1, *valueTensor);
-             at::Tensor delta_tensor = torch::zeros(inRank);
+             at::Tensor delta_tensor = torch::zeros(inRank, util::TRTDataTypeToScalarType(in->getType()));
              auto deltaTensor = tensor_to_const(ctx, delta_tensor);
              fill_layer->setInput(2, *deltaTensor);
              auto padTensor = fill_layer->getOutput(0);
@@ -122,7 +122,7 @@ auto constant_pad_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns
              inDims.d[axis] = padding[padding_index + 1];
              auto fill_layer = ctx->net->addFill(inDims, nvinfer1::FillOperation::kLINSPACE);
              fill_layer->setInput(1, *valueTensor);
-             at::Tensor delta_tensor = torch::zeros(inRank);
+             at::Tensor delta_tensor = torch::zeros(inRank, util::TRTDataTypeToScalarType(in->getType()));
              auto deltaTensor = tensor_to_const(ctx, delta_tensor);
              fill_layer->setInput(2, *deltaTensor);
              auto padTensor = fill_layer->getOutput(0);

--- a/tests/core/conversion/converters/test_constant_pad.cpp
+++ b/tests/core/conversion/converters/test_constant_pad.cpp
@@ -28,6 +28,29 @@ TEST(Converters, ATenConstantPad1dTensorConvertsCorrectly) {
       torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
 }
 
+TEST(Converters, ATenConstantPad1dIntTensorConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor):
+        %1 : int[] = prim::Constant[value=[2, 3]]()
+        %2 : Scalar = prim::Constant[value=2]()
+        %3 : Tensor = aten::constant_pad_nd(%0, %1, %2)
+        return (%3))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  auto in1 = at::randint(1, 10, {1, 3, 4}, {at::kCUDA}).toType(at::kInt);
+
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in1});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in1});
+
+  ASSERT_TRUE(
+      torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}
+
 TEST(Converters, ATenConstantPad1dRightZeroTensorConvertsCorrectly) {
   const auto graph = R"IR(
       graph(%0 : Tensor):


### PR DESCRIPTION
# Description

The converter for aten::constant_pad_nd currently assumes float32 inputs. Change adds support and test for integer inputs.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
