### PR TITLE
fix: Resolve non-determinism in registerSegmentsOutputs

### DIFF
--- a/core/partitioning/partitioning.cpp
+++ b/core/partitioning/partitioning.cpp
@@ -178,7 +178,7 @@ void resolveTRTNonTensorInputs(PartitionedGraph& segmented_blocks) {
 
 void registerSegmentsOutputs(PartitionedGraph& segmented_blocks, torch::jit::Block* block) {
   // find the corresponding raw values in original global graph for this segmented block's inputs/outputs
-  auto cmp = [](torch::jit::Value* a, torch::jit::Value* b) { return a->unique() < b->unique();};
+  auto cmp = [](torch::jit::Value* a, torch::jit::Value* b) { return a->unique() < b->unique(); };
   std::set<torch::jit::Value*, decltype(cmp)> input_values(cmp);
   for (auto& seg_block : segmented_blocks) {
     for (auto& input : seg_block.raw_inputs()) {

--- a/core/partitioning/partitioning.cpp
+++ b/core/partitioning/partitioning.cpp
@@ -178,7 +178,8 @@ void resolveTRTNonTensorInputs(PartitionedGraph& segmented_blocks) {
 
 void registerSegmentsOutputs(PartitionedGraph& segmented_blocks, torch::jit::Block* block) {
   // find the corresponding raw values in original global graph for this segmented block's inputs/outputs
-  std::set<torch::jit::Value*> input_values;
+  auto cmp = [](torch::jit::Value* a, torch::jit::Value* b) { return a->unique() < b->unique();};
+  std::set<torch::jit::Value*, decltype(cmp)> input_values(cmp);
   for (auto& seg_block : segmented_blocks) {
     for (auto& input : seg_block.raw_inputs()) {
       input_values.insert(input);


### PR DESCRIPTION
# Description

Using a set of Value* in registerSegmentsOutputs introduces unnecessary non-determinism in partitioning. Sort the set by Value*->unique to resolve this. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
