### PR TITLE
Remove Bazel related file from Python wheel packaging

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -428,8 +428,6 @@ setup(
             "include/torch_tensorrt/core/util/*.h",
             "include/torch_tensorrt/core/util/logging/*.h",
             "bin/*",
-            "BUILD",
-            "WORKSPACE",
         ],
     },
     exclude_package_data={


### PR DESCRIPTION
# Description

I'm not sure if the issue is with `rules_python` or Bazel but it is not possible to install a Python wheels with Bazel and rules_python if the wheels contains Bazel related files (e.g WORKSPACE, BUILD) on the root folder. 

This patch will remove the two files from the Python wheel packaging (reducing it size by a very marginal amount 😄 ) 

I have tested that the python wheel can be built successfully and installed in a Bazel environment. 

Fixes #1262 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
