### PR TITLE
[fix] incorrect casting behavior in floor_divide

### DIFF
--- a/core/conversion/converters/impl/element_wise.cpp
+++ b/core/conversion/converters/impl/element_wise.cpp
@@ -566,8 +566,7 @@ auto element_wise_registrations TORCHTRT_UNUSED =
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
                // TODO: Remove with functionalization
                auto self = args[0].ITensorOrFreeze(ctx);
-               auto otherScalar = args[1].unwrapToScalar().to<float>();
-               auto other = tensor_to_const(ctx, torch::tensor({otherScalar}));
+               auto other = scalar_to_tensor(ctx, args[1].unwrapToScalar());
                auto floor_divide =
                    add_elementwise(ctx, nvinfer1::ElementWiseOperation::kFLOOR_DIV, self, other, util::node_info(n));
                TORCHTRT_CHECK(floor_divide, "Unable to create floor_divide layer from node: " << *n);

--- a/tests/core/conversion/converters/test_element_wise.cpp
+++ b/tests/core/conversion/converters/test_element_wise.cpp
@@ -298,6 +298,7 @@ TEST(Converters, ATenFloorDivideWithScalarConvertsCorrectly) {
         %1 : Tensor = aten::floor_divide(%0, %scalar)
         return (%1))IR";
   pointwise_test_helper(graph, true);
+  pointwise_test_helper(graph, true, false, {5}, {5}, false, at::kInt);
 }
 
 TEST(Converters, ATenMaxConvertsCorrectly) {


### PR DESCRIPTION
# Description

Remove incorrect cast to float in the floor_divide converter that created type-mismatches between the converted and original models.

Fixes # ()

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified

