### PR TITLE
Add correct pip install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ These are the following dependencies used to verify the testcases. Torch-TensorR
 
 Releases: https://github.com/pytorch/TensorRT/releases
 
+```
+pip install nvidia-pyindex
+pip install nvidia-tensorrt==8.4.3.1
+pip install torch-tensorrt==1.2.0 --find-links https://github.com/pytorch/TensorRT/releases/expanded_assets/v1.2.0
+```
+
 ## Compiling Torch-TensorRT
 
 ### Installing Dependencies

--- a/README.md
+++ b/README.md
@@ -123,8 +123,6 @@ These are the following dependencies used to verify the testcases. Torch-TensorR
 Releases: https://github.com/pytorch/TensorRT/releases
 
 ```
-pip install nvidia-pyindex
-pip install nvidia-tensorrt==8.4.3.1
 pip install torch-tensorrt==1.2.0 --find-links https://github.com/pytorch/TensorRT/releases/expanded_assets/v1.2.0
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ requires = [
     "cffi",
     "typing_extensions",
     "future",
+    "nvidia-pyindex",
+    "nvidia-tensorrt==8.4.3.1"
 ]
 
 # Use legacy backend to import local packages in setup.py


### PR DESCRIPTION
# Description

I've seen a few people (including myself get bit by not having clear instructions to pip install the library)

https://github.com/pytorch/TensorRT/issues/1233
https://github.com/pytorch/TensorRT/issues/1214

I can't update the release notes to fix the actual issue but regardless I believe installation instructions should be on the front page

If you like I can also update the dependencies here https://github.com/pytorch/TensorRT/blob/master/pyproject.toml so installation instructions will be a 1 liner