### PR TITLE
fix: fix compilation stuck bug caused by elimination exception

### DIFF
--- a/core/lowering/lowering.cpp
+++ b/core/lowering/lowering.cpp
@@ -9,9 +9,8 @@
 #include "torch/csrc/jit/passes/lower_graph.h"
 #include "torch/csrc/jit/passes/lower_tuples.h"
 #include "torch/csrc/jit/passes/peephole.h"
-#include "torch/csrc/jit/passes/remove_mutation.h"
 #include "torch/csrc/jit/passes/remove_exceptions.h"
-
+#include "torch/csrc/jit/passes/remove_mutation.h"
 
 #include "core/lowering/lowering.h"
 #include "core/lowering/passes/passes.h"

--- a/core/lowering/lowering.cpp
+++ b/core/lowering/lowering.cpp
@@ -10,6 +10,8 @@
 #include "torch/csrc/jit/passes/lower_tuples.h"
 #include "torch/csrc/jit/passes/peephole.h"
 #include "torch/csrc/jit/passes/remove_mutation.h"
+#include "torch/csrc/jit/passes/remove_exceptions.h"
+
 
 #include "core/lowering/lowering.h"
 #include "core/lowering/passes/passes.h"
@@ -33,6 +35,7 @@ void LowerGraph(std::shared_ptr<torch::jit::Graph>& g, LowerInfo lower_info) {
   torch::jit::InlineFunctionalGraphs(g);
   torch::jit::PeepholeOptimize(g, false);
   torch::jit::FuseLinear(g);
+  torch::jit::EliminateExceptions(g);
   if (!lower_info.disable_cse) {
     torch::jit::EliminateCommonSubexpression(g);
   }

--- a/core/lowering/passes/exception_elimination.cpp
+++ b/core/lowering/passes/exception_elimination.cpp
@@ -4,7 +4,6 @@
 #include "torch/csrc/jit/passes/dead_code_elimination.h"
 #include "torch/csrc/jit/passes/guard_elimination.h"
 #include "torch/csrc/jit/passes/peephole.h"
-#include "torch/csrc/jit/passes/remove_exceptions.h"
 #include "torch/csrc/jit/runtime/graph_executor.h"
 
 #include "core/util/prelude.h"
@@ -22,7 +21,6 @@ struct ExceptionOrPassPatternElimination {
 
   void run() {
     findExceptionOrPassNodes(graph_->block());
-    torch::jit::EliminateExceptions(graph_);
     torch::jit::EliminateDeadCode(graph_);
     LOG_GRAPH("Post exeception or pass elimination: " << *graph_);
   }


### PR DESCRIPTION
Signed-off-by: Bo Wang <bowa@nvidia.com>

# Description
In some cases with exception , the compilation process stuck. The reason is that torch::jit::EliminateExceptions() pass conflict with EliminateCommonSubexpression() pass. 
This could be resolved by changing the execution order for now. 

Fixes #1408 
## Type of change

Please delete options that are not relevant and/or add your own.
- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
