### PR TITLE
fix: CUDA error 710 bugfix

### DIFF
--- a/core/partitioning/shape_analysis.cpp
+++ b/core/partitioning/shape_analysis.cpp
@@ -12,16 +12,24 @@ namespace partitioning {
 at::Tensor generateSingleInput(ir::Input& input, c10::optional<at::ScalarType>& type_opt) {
   auto cur_shape = input.input_shape;
   std::vector<int64_t> shape;
+
+  // Initialize min and max ranges for random number selection
+  int LoValIncl = 0;
+  int HiValExcl = 2;
+
   shape.insert(shape.begin(), std::begin(cur_shape.d), std::begin(cur_shape.d) + cur_shape.nbDims);
-  // auto type_opt = types[input.first][i];
+
   auto type = at::kFloat;
   if (type_opt) {
     type = type_opt.value();
   } else {
     LOG_WARNING("Input type for doing shape analysis could not be determined, defaulting to F32");
   }
-  auto in = at::randint(5, shape, {at::kCUDA}).to(type);
-  // ivalue_map[input.first] = in.clone();
+
+  // Make the value range for input tensor a uniform (float) distribution
+  // over [LoValIncl, HiValExcl), then cast to the desired dtype
+  auto in = ((HiValExcl - LoValIncl) * at::rand(shape, {at::kCUDA}) + LoValIncl).to(type);
+
   return in;
 }
 


### PR DESCRIPTION
# Description

Resolves a CUDA 710 error Issue arising when compiling BERT models with 3+ inputs. The issue arises due to the role of the third tensor in inference computations. Specifically, as specified in the [BERT model code linked here](https://github.com/huggingface/transformers/blob/15fd39ea0ec4f826deb4cb8f3064004939544d30/src/transformers/models/bert/modeling_bert.py#L812-L835), the third argument, `token_type_ids` is of type `torch.LongTensor`, but can only take indices in $[0,1]$. This means that when values outside of this set are used, the input is invalid.

This becomes problematic when the inputs are, for example, indices in a dictionary or embedding - which seems to be the case here. Specifically, `aten::embedding` is used with Tensors which are the product of `token_type_ids`. The issue traces to one line in the `shape_analysis` code previewed below, which initializes a random tensor with values in the range $[0,4]$.

```cpp
// shape_analysis.cpp [Line 23, Commit 5f3a5a3]
auto in = at::randint(5, shape, {at::kCUDA}).to(type);
```

This tensor is run through the `forward` function of the module to determine the shapes of outputs and causes the model compilation-time error, as featured [here](https://github.com/pytorch/TensorRT/blob/5a7f00e8db1ca1d974e4583657a1f03e810f15a9/core/partitioning/shape_analysis.cpp#L129) in the shape analysis code.

I have added a temporary fix by decreasing the range of allowed values to the random number generator for creating input tensors to 0-1, instead of 0-4, and am working on a more robust fix.

Fixes #1418 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
