### PR TITLE
[feat] Add partial converter support for aten::linalg_norm

### DIFF
--- a/core/conversion/converters/impl/normalize.cpp
+++ b/core/conversion/converters/impl/normalize.cpp
@@ -134,7 +134,7 @@ auto normalize_registrations TORCHTRT_UNUSED =
                auto self = args[0].ITensorOrFreeze(ctx);
                TORCHTRT_CHECK(
                    args[1].IValue()->isNone(),
-                   "aten::linalg_norm converter does not yet support non-None 'ord' arguments.");
+                   "aten::linalg_norm converter does not yet support non-None 'ord' arguments. Add aten::linalg_norm to torch_executed_ops to force it to fallback.");
                auto keep_dims = args[3].unwrapToBool();
                auto self_nb_dims = self->getDimensions().nbDims;
 

--- a/tests/core/conversion/converters/test_normalize.cpp
+++ b/tests/core/conversion/converters/test_normalize.cpp
@@ -139,3 +139,68 @@ TEST(Converters, ATenFrobeniusNormMatrix) {
 
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0]));
 }
+
+TEST(Converters, ATenLinAlgNorm_None) {
+  const auto graph = R"IR(
+    graph(%x : Tensor):
+      %none : NoneType = prim::Constant()
+      %keep : bool = prim::Constant[value=0]()
+      %out : Tensor = aten::linalg_norm(%x, %none, %none, %keep, %none)
+      return (%out))IR";
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+  auto x = at::randn({5, 5, 5}, {at::kCUDA});
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {x});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {x});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0]));
+}
+
+TEST(Converters, ATenLinAlgNorm_1D) {
+  const auto graph = R"IR(
+    graph(%x : Tensor):
+      %1 : int = prim::Constant[value=1]()
+      %none : NoneType = prim::Constant()
+      %keep : bool = prim::Constant[value=0]()
+      %dims : int[] = prim::ListConstruct(%1)
+      %out : Tensor = aten::linalg_norm(%x, %none, %dims, %keep, %none)
+      return (%out))IR";
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  auto x = at::randn({5, 5, 5}, {at::kCUDA});
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {x});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {x});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0]));
+}
+
+TEST(Converters, ATenLinAlgNorm_2D) {
+  const auto graph = R"IR(
+    graph(%x : Tensor):
+      %0 : int = prim::Constant[value=0]()
+      %1 : int = prim::Constant[value=-1]()
+      %none : NoneType = prim::Constant()
+      %keep : bool = prim::Constant[value=1]()
+      %dims : int[] = prim::ListConstruct(%0, %1)
+      %float : int = prim::Constant[value=6]()
+      %out : Tensor = aten::linalg_norm(%x, %none, %dims, %keep, %float)
+      return (%out))IR";
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  auto x = at::randn({5, 5, 5}, {at::kCUDA}).to(at::kHalf);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {x});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {x});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0]));
+}


### PR DESCRIPTION
# Description

Adds partial converter support for aten::linalg_norm. https://pytorch.org/docs/stable/generated/torch.linalg.norm.html. Non-None scalar ord arguments are not yet supported. Note that the string ord variant is a different schema and will fallback to torch.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
