### PR TITLE
fix: Add check to ensure einsum converter has no more than 2 tensor inputs

### DIFF
--- a/core/conversion/converters/impl/einsum.cpp
+++ b/core/conversion/converters/impl/einsum.cpp
@@ -18,6 +18,13 @@ auto einsum_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns().pat
        auto equation = args[0].unwrapToString();
        auto in = args[1].IValue()->toListRef();
 
+       TORCHTRT_CHECK(
+           in.size() <= 2,
+           "TensorRT currently supports up to 2 input tensors "
+               << "to einsum but operation had " << in.size()
+               << " input tensors, please specify torch_executed_ops=[aten::einsum] "
+               << "at compilation time to avoid this error.");
+
        std::vector<nvinfer1::ITensor*> tensors;
 
        // Populate vector of ITensor pointers

--- a/core/conversion/converters/impl/einsum.cpp
+++ b/core/conversion/converters/impl/einsum.cpp
@@ -22,7 +22,7 @@ auto einsum_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns().pat
            in.size() <= 2,
            "TensorRT currently supports up to 2 input tensors "
                << "to einsum but operation had " << in.size()
-               << " input tensors, please specify torch_executed_ops=[aten::einsum] "
+               << " input tensors, please specify torch_executed_ops=[\"aten::einsum\"] "
                << "at compilation time to avoid this error.");
 
        std::vector<nvinfer1::ITensor*> tensors;


### PR DESCRIPTION
# Description
- TRT einsum implementation currently supports 2 tensor inputs, however the converter will accept any number of tensor arguments (it accepts a list of tensors) and TRT throws an error at compilation
- `aten::einsum` converter now checks that the tensor argument list does not exceed 2 elements, and throws an informative error otherwise

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
