### PR TITLE
fix: Error with `aten::div` when using truncation with Int32 tensor inputs

### DIFF
--- a/core/conversion/converters/converter_util.h
+++ b/core/conversion/converters/converter_util.h
@@ -35,11 +35,19 @@ nvinfer1::ITensor* addUnpadding(
     bool trailing = true,
     bool use_zeros = true);
 
+// TODO: Change add_elementwise schema to output nvinfer1::ITensor* instead of nvinfer1::ILayer*,
+// for consistency with other utils. Need to change schema and usage in all calling contexts
 nvinfer1::ILayer* add_elementwise(
     ConversionCtx* ctx,
     nvinfer1::ElementWiseOperation op,
     nvinfer1::ITensor* self,
     nvinfer1::ITensor* other,
+    const std::string& name);
+
+nvinfer1::ITensor* add_abs(
+    ConversionCtx* ctx,
+    const torch::jit::Node* n,
+    nvinfer1::ITensor* self,
     const std::string& name);
 
 // Apply an identity operation on a tensor. Used in the case where an input is an output to a network.

--- a/core/conversion/converters/impl/unary.cpp
+++ b/core/conversion/converters/impl/unary.cpp
@@ -13,40 +13,10 @@ namespace {
 auto abs_registration TORCHTRT_UNUSED = RegisterNodeConversionPatterns().pattern(
     {"aten::abs(Tensor self) -> Tensor", [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
        auto in = args[0].ITensorOrFreeze(ctx);
-       bool unary_supported_input = in->getType() == nvinfer1::DataType::kFLOAT ||
-           in->getType() == nvinfer1::DataType::kHALF || in->getType() == nvinfer1::DataType::kINT8;
-       if (unary_supported_input) {
-         auto unary_layer = ctx->net->addUnary(*in, nvinfer1::UnaryOperation::kABS);
-         TORCHTRT_CHECK(unary_layer, "Unable to create abs layer from node: " << *n);
-         unary_layer->setName(util::node_info(n).c_str());
-         auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], unary_layer->getOutput(0));
-         LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
-         return true;
-       } else {
-         LOG_GRAPH(
-             "Tensor is of unsupported type "
-             << in->getType() << " for IUnaryLayer::kABS. Using backup implementation via IElementWise (max(x, -x)");
-         // For types not supported by kABS, use an elementwise implementation abs(x) = max(x, -1 * x)
-         at::Tensor neg_one = torch::full({1}, -1).to(util::TRTDataTypeToScalarType(in->getType()));
-         auto neg_one_const = tensor_to_const(ctx, neg_one);
-         auto neg_layer = add_elementwise(
-             ctx,
-             nvinfer1::ElementWiseOperation::kPROD,
-             in,
-             neg_one_const,
-             util::node_info(n) + std::string("_Negation"));
-         TORCHTRT_CHECK(neg_layer, "Unable to create prod layer from node: " << *n);
-         auto max_layer = add_elementwise(
-             ctx,
-             nvinfer1::ElementWiseOperation::kMAX,
-             in,
-             neg_layer->getOutput(0),
-             util::node_info(n) + std::string("_Max"));
-         TORCHTRT_CHECK(max_layer, "Unable to create max layer from node: " << *n);
-         auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], max_layer->getOutput(0));
-         LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
-         return true;
-       }
+       auto abs_tensor = add_abs(ctx, n, in, util::node_info(n));
+       auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], abs_tensor);
+       LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
+       return true;
      }});
 
 auto reciprocal_registration TORCHTRT_UNUSED = RegisterNodeConversionPatterns().pattern(


### PR DESCRIPTION
# Description
- `aten::div` with truncation on integer tensor inputs currently throws an error if both inputs are integer type, as the TRT unary operations for absolute value and floor do not apply to Int32 or Bool types
- For absolute value, this is a legitimate bug as `aten::abs` is functional for integer types
- For the floor operation, `aten::floor` does not explicitly support integer inputs, and `torch.floor()` does not work with Int32 inputs by default (on `1.13.0.dev20220921+cu116`). However, `torch.div(..., rounding_mode="trunc")` with integer tensors does return an integer value, and so the corollary Torch-TRT converter should behave similarly
- Modified `aten:abs` converter logic to be a utility (moved file location), as the operator is used in multiple locations
- Added regression test to ensure truncation divide with two integer tensors is functional

Note: The behavior of `torch.floor()` on Int32 types differs between `1.13.0.dev20220921+cu116` and `1.14.0.dev20221018+cu116`: the former does not by default support this operation, while the latter does. This PR does not fix the general `aten::floor` operator for Int32 inputs, but instead fixes the `aten::div` truncation operator only.

Fixes #1441 
Note: The issue was traced to a problem with `aten::div` with truncation enabled, and not `aten::floor`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
