### PR TITLE
Improve batch_norm fp16 accuracy

### DIFF
--- a/tests/core/conversion/converters/test_batch_norm.cpp
+++ b/tests/core/conversion/converters/test_batch_norm.cpp
@@ -165,5 +165,5 @@ TEST(Converters, ATenBatchNormHalfConvertsCorrectly) {
   params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {trt_mean, trt_var});
   auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in}, {nvinfer1::DataType::kHALF});
 
-  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-2));
 }


### PR DESCRIPTION
# Description

Use float types for compile-time calculations around batch_norm. Improves fp16 accuracy relative to pytorch. Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified