### PR TITLE
fix: Update floor division schema replacement in lowering

### DIFF
--- a/core/lowering/passes/remove_unnecessary_casts.cpp
+++ b/core/lowering/passes/remove_unnecessary_casts.cpp
@@ -131,6 +131,13 @@ void RemoveSingleUse0DTensors(std::shared_ptr<torch::jit::Graph>& g) {
                               user->outputs()[0]->replaceAllUsesWith(new_node->outputs()[0]);
                               user->destroy();
                               break;
+                            case c10::aten::floor_divide:
+                              new_node = g->create(c10::aten::floordiv, user->inputs(), 1);
+                              new_node->insertAfter(user);
+                              new_node->outputs()[0]->setType(c10::IntType::get());
+                              user->outputs()[0]->replaceAllUsesWith(new_node->outputs()[0]);
+                              user->destroy();
+                              break;
                             default:
                               new_node = g->create(user->kind(), user->inputs(), 1);
                               new_node->insertAfter(user);


### PR DESCRIPTION
# Description
- Lowering can occasionally replace the `aten::floor_divide` inputs with integers or floats, for which the correct function name is `aten::floordiv`, which ultimately throws an unknown schema error
- Fix `RemoveSingleUse0DTensors` lowering pass to repair schema when replacing intermediate operation including an `aten::floor_divide` call
- Add test cases to ensure that the resulting graph is schematically correct, but also numerically accurate

Fixes #1462 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
