### PR TITLE
make padding layer converter more efficient

### DIFF
--- a/py/torch_tensorrt/fx/converters/acc_ops_converters.py
+++ b/py/torch_tensorrt/fx/converters/acc_ops_converters.py
@@ -413,7 +413,12 @@ def acc_ops_pad_with_slice_layer(
     )
 
     shape = tuple(
-        input_shape[i] + (pad[-(i - prefix_len) * 2 - 1] + pad[-(i - prefix_len) * 2 - 2] if i >= prefix_len else 0)
+        input_shape[i]
+        + (
+            pad[-(i - prefix_len) * 2 - 1] + pad[-(i - prefix_len) * 2 - 2]
+            if i >= prefix_len
+            else 0
+        )
         for i in range(0, len(input_shape))
     )
     stride = tuple([1] * len(shape))

--- a/py/torch_tensorrt/fx/converters/acc_ops_converters.py
+++ b/py/torch_tensorrt/fx/converters/acc_ops_converters.py
@@ -406,46 +406,29 @@ def acc_ops_pad_with_slice_layer(
     )
 
     input_shape = input_val.shape
-    pre_start = tuple(i - 1 for i in input_shape)
     prefix_len = len(input_shape) - len(pad) // 2
-    pre_shape = tuple(
-        input_shape[i] + (pad[-(i - prefix_len) * 2 - 2] if i >= prefix_len else 0)
+    start = tuple(
+        -pad[-(i - prefix_len) * 2 - 2] if i >= prefix_len else 0
         for i in range(0, len(input_shape))
     )
-    pre_stride = [-1] * len(input_shape)
+
+    shape = tuple(
+        input_shape[i] + (pad[-(i - prefix_len) * 2 - 1] + pad[-(i - prefix_len) * 2 - 2] if i >= prefix_len else 0)
+        for i in range(0, len(input_shape))
+    )
+    stride = tuple([1] * len(shape))
 
     layer = network.add_slice(
         input_val,
-        pre_start,
-        pre_shape,
-        pre_stride,
+        start,
+        shape,
+        stride,
     )
+
     layer.set_input(4, value_const)
     layer.mode = trt.SliceMode.FILL
-    set_layer_name(layer, target, f"pre_{name}")
-    half_pad_output = layer.get_output(0)
+    set_layer_name(layer, target, name)
 
-    shape = half_pad_output.shape
-    mid_start = tuple(i - 1 for i in shape)
-    mid_stride = [-1] * len(shape)
-    layer = network.add_slice(half_pad_output, mid_start, shape, mid_stride)
-    layer.set_input(4, value_const)
-    layer.mode = trt.SliceMode.FILL
-    set_layer_name(layer, target, f"transpose_{name}")
-    transpose_output = layer.get_output(0)
-
-    shape = transpose_output.shape
-    post_start = tuple([0] * len(shape))
-    post_shape = tuple(
-        shape[i] + (pad[-(i - prefix_len) * 2 - 1] if i >= prefix_len else 0)
-        for i in range(0, len(shape))
-    )
-    post_stride = tuple([1] * len(shape))
-
-    layer = network.add_slice(transpose_output, post_start, post_shape, post_stride)
-    layer.set_input(4, value_const)
-    layer.mode = trt.SliceMode.FILL
-    set_layer_name(layer, target, f"post_{name}")
     return layer.get_output(0)
 
 

--- a/py/torch_tensorrt/fx/test/passes/test_fuse_permute_matmul_trt.py
+++ b/py/torch_tensorrt/fx/test/passes/test_fuse_permute_matmul_trt.py
@@ -37,8 +37,20 @@ class TestFusePermuteMatmul(AccTestCase):
                 lambda x: x.permute(0, 1, 3, 2),
                 torch.matmul,
             ),
-            param("transpose_lhs_bmm_broadcast", (3, 2), (3, 3, 4), tranpose_last_two_dims, op=torch.matmul),
-            param("transpose_rhs_bmm_broadcast", (3, 3, 4), (3, 4), rhs_op=tranpose_last_two_dims, op=torch.matmul),
+            param(
+                "transpose_lhs_bmm_broadcast",
+                (3, 2),
+                (3, 3, 4),
+                tranpose_last_two_dims,
+                op=torch.matmul,
+            ),
+            param(
+                "transpose_rhs_bmm_broadcast",
+                (3, 3, 4),
+                (3, 4),
+                rhs_op=tranpose_last_two_dims,
+                op=torch.matmul,
+            ),
         ]
     )
     def test_fuse_permute_matmul(


### PR DESCRIPTION
# Description

Copy of #1466 to bypass CLA issue.

In the current padding layer converter for version > 8.2, there are 3 padding layers: pre_pad + mid_pad + post_pad to do the converter. But please consider this case, we want to pad tensor from (2048, 628, 20) to (2048, 628, 32), the pre_pad and mid_pad can be erased because they are doing the opposite operation and waste time.
And consider that from version 8.2, the start of the slice layer can support negative. So let's use one padding layer to do this.

Fixes # (issue)

As described above, we can improve perf significantly.

## Type of change

- Perf improves, so no additional functional unit test is needed.

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
