### PR TITLE
fix: Repair Citrinet-1024 compilation issues [Duplicate of PR #1488 for Release 1.3]

### DIFF
--- a/core/conversion/converters/impl/element_wise.cpp
+++ b/core/conversion/converters/impl/element_wise.cpp
@@ -325,7 +325,8 @@ auto element_wise_registrations TORCHTRT_UNUSED =
                      add_elementwise(ctx, nvinfer1::ElementWiseOperation::kFLOOR_DIV, self, other, util::node_info(n));
                } else if (rounding_mode == "trunc") {
                  // trunc = floor(abs(div)) * sign(div)
-                 auto tmp_div = add_elementwise(ctx, nvinfer1::ElementWiseOperation::kDIV, self, other, "tmp_div");
+                 auto tmp_div = add_elementwise(
+                     ctx, nvinfer1::ElementWiseOperation::kDIV, self, other, util::node_info(n) + "_tmp_div");
                  auto abs = add_abs(ctx, n, tmp_div->getOutput(0), util::node_info(n) + "_absolute_val");
 
                  // In this case, we allow the floor unary on non-TRT Unary types, as it is needed for this

--- a/core/conversion/converters/impl/reduce.cpp
+++ b/core/conversion/converters/impl/reduce.cpp
@@ -113,6 +113,14 @@ auto reduce_registrations TORCHTRT_UNUSED =
                LOG_DEBUG("Keep dims: " << keepdim);
 
                LOG_WARNING("Sum converter disregards dtype");
+
+               if (in_tensor->getType() == nvinfer1::DataType::kBOOL) {
+                 LOG_DEBUG(
+                     "Found type  " << in_tensor->getType() << " in aten::sum, casting to "
+                                    << nvinfer1::DataType::kINT32 << " for compatibility.");
+                 in_tensor = castITensor(ctx, in_tensor, nvinfer1::DataType::kINT32);
+               }
+
                auto sum_layer = ctx->net->addReduce(*in_tensor, nvinfer1::ReduceOperation::kSUM, axis_mask, keepdim);
 
                TORCHTRT_CHECK(sum_layer, "Unable to create sum layer from node: " << *n);

--- a/tests/core/conversion/converters/test_reduce.cpp
+++ b/tests/core/conversion/converters/test_reduce.cpp
@@ -5,6 +5,7 @@
 #include "tests/util/util.h"
 #include "torch/csrc/jit/ir/irparser.h"
 #include "torch/csrc/jit/passes/common_subexpression_elimination.h"
+#include "torch/torch.h"
 
 namespace {
 std::string gen_basic_graph(const std::string& op) {
@@ -159,6 +160,19 @@ TEST(Converters, ATenSumDimNegOneIndexKeepDimsConvertsCorrectly) {
       %5 : Tensor = aten::sum(%0, %2, %3, %4)
       return (%5))IR";
   auto in = at::randint(-5, 5, {4, 4, 4}, at::kCUDA);
+  test_body(graph, in);
+}
+
+TEST(Converters, ATenSumDimNegOneIndexKeepDimsBoolTensorConvertsCorrectly) {
+  const auto graph = R"IR(
+    graph(%0 : Tensor):
+      %1 : int = prim::Constant[value=-1]()
+      %2 : int[] = prim::ListConstruct(%1)
+      %3 : bool = prim::Constant[value=1]()
+      %4 : None = prim::Constant()
+      %5 : Tensor = aten::sum(%0, %2, %3, %4)
+      return (%5))IR";
+  auto in = at::randint(0, 2, {4, 4, 4}, at::kCUDA).to(torch::kBool);
   test_body(graph, in);
 }
 


### PR DESCRIPTION
# Description
**Duplicate of PR #1488 targeted at Release 1.3**
Fix compilation issues with Citrinet-1024 arising from type-casting issue in `aten::sum` and layer-naming issue in `aten::div`.

- Enable automatic type-casting in `aten::sum` for bool tensor inputs to agree with Torch casting behavior
- Fix bug in `aten::div` where all internal div layers have the same name
- Add test cases for `aten::sum` type-casting

Without type-casting, the error arises from the following:
```python
DEBUG: [Torch-TensorRT - Debug Build] - ITensor shape: [1, 1, 256]
DEBUG: [Torch-TensorRT - Debug Build] - ITensor type: Bool
DEBUG: [Torch-TensorRT - Debug Build] - InDims 1 1 256
DEBUG: [Torch-TensorRT - Debug Build] - Dim to reduce(original):[-1]
DEBUG: [Torch-TensorRT - Debug Build] - Dim to reduce(converted):[2]
DEBUG: [Torch-TensorRT - Debug Build] - Axis Mask: 00000000000000000000000000000100
DEBUG: [Torch-TensorRT - Debug Build] - Keep dims: 1
WARNING: [Torch-TensorRT - Debug Build] - Sum converter disregards dtype
ERROR: [Torch-TensorRT TorchScript Conversion Context] - 3: %66 : Tensor = aten::sum(%mask2.2, %65, %26, %3779)
# ReduceLayer only supports Float, Half, Int8, and Int32 data types.
```

With type casting, one error is resolved, but another appears:
```python
ERROR: [Torch-TensorRT TorchScript Conversion Context] - 4: [network.cpp::validate::2761] Error Code 4: Internal Error (Repeated layer name: tmp_div (layers must have distinct names))
ERROR: [Torch-TensorRT TorchScript Conversion Context] - 2: [builder.cpp::buildSerializedNetwork::742] Error Code 2: Internal Error (Assertion engine != nullptr failed. )
```

With both updates, the model compiles succesfully.

Fixes #1487 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified