### PR TITLE
[fix]Disambiguate cast layer names

### DIFF
--- a/core/conversion/converters/converter_util.cpp
+++ b/core/conversion/converters/converter_util.cpp
@@ -205,7 +205,11 @@ nvinfer1::ITensor* applyIdentityOp(ConversionCtx* ctx, nvinfer1::ITensor* tensor
   return id_out_tensor;
 }
 
-nvinfer1::ITensor* castITensor(ConversionCtx* ctx, nvinfer1::ITensor* tensor, nvinfer1::DataType dtype) {
+nvinfer1::ITensor* castITensor(
+    ConversionCtx* ctx,
+    nvinfer1::ITensor* tensor,
+    nvinfer1::DataType dtype,
+    const std::string& layer_name_prefix) {
   if (tensor->getType() != dtype) {
     std::ostringstream tensor_id;
     tensor_id << reinterpret_cast<int*>(tensor);
@@ -219,6 +223,9 @@ nvinfer1::ITensor* castITensor(ConversionCtx* ctx, nvinfer1::ITensor* tensor, nv
     LOG_DEBUG(ctx->logger, "Casting ITensor " << tensor_id.str() << " from " << tensor->getType() << " to " << dtype);
 
     std::stringstream ss;
+    if (layer_name_prefix.size()) {
+      ss << layer_name_prefix << " ";
+    }
     ss << "[Cast ITensor " << tensor_id.str() << " from " << tensor->getType() << " to " << dtype << "]";
     id_layer->setName(ss.str().c_str());
     return casted_tensor;

--- a/core/conversion/converters/converter_util.h
+++ b/core/conversion/converters/converter_util.h
@@ -56,7 +56,11 @@ nvinfer1::ITensor* add_abs(
 nvinfer1::ITensor* applyIdentityOp(ConversionCtx* ctx, nvinfer1::ITensor* tensor, const std::string& name);
 
 // If an ITensor is of a type not dtype, add an Identity layer to cast it to dtype
-nvinfer1::ITensor* castITensor(ConversionCtx* ctx, nvinfer1::ITensor* tensor, nvinfer1::DataType dtype);
+nvinfer1::ITensor* castITensor(
+    ConversionCtx* ctx,
+    nvinfer1::ITensor* tensor,
+    nvinfer1::DataType dtype,
+    const std::string& layer_name_prefix = "");
 
 // Freeze an at::Tensor in a IConstant layer
 nvinfer1::ITensor* tensor_to_const(ConversionCtx* ctx, at::Tensor t, const std::string& name = std::string());

--- a/core/conversion/converters/impl/cast.cpp
+++ b/core/conversion/converters/impl/cast.cpp
@@ -26,7 +26,7 @@ auto cast_registrations TORCHTRT_UNUSED =
                } else {
                  trt_dtype = util::ScalarTypeToTRTDataType(static_cast<at::ScalarType>(output_dtype));
                }
-               auto casted_itensor = castITensor(ctx, self, trt_dtype);
+               auto casted_itensor = castITensor(ctx, self, trt_dtype, util::node_info(n));
                auto output = ctx->AssociateValueAndTensor(n->outputs()[0], casted_itensor);
                LOG_DEBUG("[aten::to.dtype] Output tensor shape: " << output->getDimensions());
 
@@ -48,7 +48,7 @@ auto cast_registrations TORCHTRT_UNUSED =
                } else {
                  trt_dtype = util::ScalarTypeToTRTDataType(static_cast<at::ScalarType>(output_dtype));
                }
-               auto casted_itensor = castITensor(ctx, self, trt_dtype);
+               auto casted_itensor = castITensor(ctx, self, trt_dtype, util::node_info(n));
                auto output = ctx->AssociateValueAndTensor(n->outputs()[0], casted_itensor);
                LOG_DEBUG("[aten::to.device] Output tensor shape: " << output->getDimensions());
 
@@ -59,7 +59,7 @@ auto cast_registrations TORCHTRT_UNUSED =
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
                auto self = args[0].ITensorOrFreeze(ctx);
                nvinfer1::DataType other_dtype = args[1].ITensorOrFreeze(ctx)->getType();
-               auto casted_itensor = castITensor(ctx, self, other_dtype);
+               auto casted_itensor = castITensor(ctx, self, other_dtype, util::node_info(n));
                auto output = ctx->AssociateValueAndTensor(n->outputs()[0], casted_itensor);
                LOG_DEBUG("[aten::to.other] Output tensor shape: " << output->getDimensions());
 
@@ -77,7 +77,7 @@ auto cast_registrations TORCHTRT_UNUSED =
 
                auto output_dtype = args[2].unwrapToScalar().to<int64_t>();
                auto trt_dtype = util::ScalarTypeToTRTDataType(static_cast<at::ScalarType>(output_dtype));
-               auto casted_itensor = castITensor(ctx, self, trt_dtype);
+               auto casted_itensor = castITensor(ctx, self, trt_dtype, util::node_info(n));
                auto output = ctx->AssociateValueAndTensor(n->outputs()[0], casted_itensor);
                LOG_DEBUG("[aten::to.prim_Device] Output tensor shape: " << output->getDimensions());
 


### PR DESCRIPTION
# Description

Add mechanism to add a prefix to cast layer names. This allows us to avoid name conflict errors in cases where we perform the same cast on a tensor twice either internally in ops or in cases where there is both an int32 cast and a long cast which is automatically truncated to int32.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
