### PR TITLE
[feat]Canonicalize aten::multiply to aten::mul

### DIFF
--- a/core/lowering/passes/op_aliasing.cpp
+++ b/core/lowering/passes/op_aliasing.cpp
@@ -35,6 +35,20 @@ void AliasOperators(std::shared_ptr<torch::jit::Graph>& graph) {
   rewrite_scatter.RegisterRewritePattern(scatter_sub_pattern, scatter_pattern);
   rewrite_scatter.runOnGraph(graph);
   LOG_GRAPH("Post map scatter_ -> scatter: " << *graph);
+
+  std::string multiply_pattern = R"IR(
+        graph(%self, %other):
+            %o : Tensor = aten::multiply(%self, %other)
+            return (%o))IR";
+  std::string mul_pattern = R"IR(
+        graph(%self, %other):
+            %o : Tensor = aten::mul(%self, %other)
+            return (%o))IR";
+
+  torch::jit::SubgraphRewriter rewrite_multiply;
+  rewrite_multiply.RegisterRewritePattern(multiply_pattern, mul_pattern);
+  rewrite_multiply.runOnGraph(graph);
+  LOG_GRAPH("Post map multiply -> mul: " << *graph);
 }
 
 } // namespace passes

--- a/tests/core/lowering/test_operator_aliasing_pass.cpp
+++ b/tests/core/lowering/test_operator_aliasing_pass.cpp
@@ -25,3 +25,23 @@ TEST(LoweringPasses, LoweringTrueDivideCorrectly) {
 
   ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
 }
+
+TEST(LoweringPasses, LoweringMultiplyCorrectly) {
+  std::string source_graph = R"IR(
+    graph(%s, %o):
+      %2 = aten::multiply(%s, %o)
+      return (%2))IR";
+  std::string target_graph = R"IR(
+    graph(%s, %o):
+      %2 = aten::mul(%s, %o)
+      return (%2))IR";
+
+  auto sg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(source_graph, sg.get());
+  torch_tensorrt::core::lowering::passes::AliasOperators(sg);
+
+  auto tg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(target_graph, tg.get());
+
+  ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
+}


### PR DESCRIPTION
# Description

Add a trivial pass to convert aten::multiply to aten::mul https://pytorch.org/docs/stable/generated/torch.multiply.html.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
