### PR TITLE
fix: Change equals-check from reference to value for BERT model not compiling in FX

### DIFF
--- a/py/torch_tensorrt/fx/converters/acc_ops_converters.py
+++ b/py/torch_tensorrt/fx/converters/acc_ops_converters.py
@@ -3369,7 +3369,7 @@ def acc_ops_gelu(
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
     approximate = kwargs["approximate"]
-    if approximate is not "none":
+    if approximate != "none":
         raise RuntimeError("GeLU converter currently doesn't support fast gelu compute")
     if not isinstance(input_val, TRTTensor):
         raise RuntimeError(


### PR DESCRIPTION
# Description
- BERT model (https://huggingface.co/bert-base-uncased) failing to compile with TorchDynamo/fx2trt due to string references not being equal, whereas their accompanying values are
- Updated check in `acc_ops_gelu` to check for equality by value instead of reference on string keyword arg

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
