### PR TITLE
Update README dependencies section for v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ torch.jit.save(trt_ts_module, "trt_torchscript_module.ts") # save the TRT embedd
 These are the following dependencies used to verify the testcases. Torch-TensorRT can work with other versions, but the tests are not guaranteed to pass.
 
 - Bazel 5.2.0
-- Libtorch 1.12.1 (built with CUDA 11.6)
-- CUDA 11.6
-- cuDNN 8.4.1
-- TensorRT 8.4.3.1
+- Libtorch 1.13.0 (built with CUDA 11.7)
+- CUDA 11.7
+- cuDNN 8.5.0
+- TensorRT 8.5.0
 
 ## Prebuilt Binaries and Wheel files
 


### PR DESCRIPTION
# Description

The dependencies section of README doesn't reflect the update of 1.3.0
Ref: https://github.com/pytorch/TensorRT/releases/tag/v1.3.0

## Type of change

- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
