### PR TITLE
fix: Automatically send truncated long ints to cuda at shape analysis time

### DIFF
--- a/core/lowering/lowering.h
+++ b/core/lowering/lowering.h
@@ -20,7 +20,7 @@ struct LowerInfo {
   std::vector<std::string> forced_fallback_modules;
   friend std::ostream& operator<<(std::ostream& os, const LowerInfo& l);
 
-  std::string getGPUDeviceString() {
+  std::string getGPUDeviceString() const {
     return "cuda:" + std::to_string(target_device.gpu_id);
   };
 };

--- a/core/partitioning/partitioninginfo/PartitioningInfo.h
+++ b/core/partitioning/partitioninginfo/PartitioningInfo.h
@@ -16,6 +16,11 @@ struct PartitioningInfo {
   uint64_t min_block_size = 1;
   std::vector<std::string> forced_fallback_operators;
   bool truncate_long_and_double;
+  ir::Device target_device;
+
+  std::string getGPUDeviceString() const {
+    return "cuda:" + std::to_string(target_device.gpu_id);
+  };
 };
 
 std::ostream& operator<<(std::ostream& os, const PartitioningInfo& s);

--- a/cpp/src/compile_spec.cpp
+++ b/cpp/src/compile_spec.cpp
@@ -111,6 +111,7 @@ torchtrt::core::CompileSpec to_internal_compile_spec(CompileSpec external) {
   internal.convert_info.engine_settings.truncate_long_and_double = external.truncate_long_and_double;
   internal.convert_info.engine_settings.device.allow_gpu_fallback = external.device.allow_gpu_fallback;
   internal.lower_info.target_device.allow_gpu_fallback = external.device.allow_gpu_fallback;
+  internal.partitioning_info.target_device.allow_gpu_fallback = external.device.allow_gpu_fallback;
 
   TORCHTRT_CHECK(
       !(external.require_full_compilation && (external.torch_executed_ops.size() > 0)),
@@ -132,11 +133,13 @@ torchtrt::core::CompileSpec to_internal_compile_spec(CompileSpec external) {
     case Device::DeviceType::kDLA:
       internal.convert_info.engine_settings.device.device_type = nvinfer1::DeviceType::kDLA;
       internal.lower_info.target_device.device_type = nvinfer1::DeviceType::kDLA;
+      internal.partitioning_info.target_device.device_type = nvinfer1::DeviceType::kDLA;
       break;
     case Device::DeviceType::kGPU:
     default:
       internal.convert_info.engine_settings.device.device_type = nvinfer1::DeviceType::kGPU;
       internal.lower_info.target_device.device_type = nvinfer1::DeviceType::kGPU;
+      internal.partitioning_info.target_device.device_type = nvinfer1::DeviceType::kGPU;
   }
 
   switch (external.capability) {
@@ -155,6 +158,9 @@ torchtrt::core::CompileSpec to_internal_compile_spec(CompileSpec external) {
   internal.convert_info.engine_settings.device.dla_core = external.device.dla_core;
   internal.lower_info.target_device.gpu_id = external.device.gpu_id;
   internal.lower_info.target_device.dla_core = external.device.dla_core;
+  internal.partitioning_info.target_device.gpu_id = external.device.gpu_id;
+  internal.partitioning_info.target_device.dla_core = external.device.dla_core;
+
   internal.convert_info.engine_settings.num_avg_timing_iters = external.num_avg_timing_iters;
   internal.convert_info.engine_settings.workspace_size = external.workspace_size;
   internal.convert_info.engine_settings.dla_sram_size = external.dla_sram_size;


### PR DESCRIPTION
# Description

- Augment `aten::to` operator insertion at shape analysis time to insert the target device
- Add functionality to `PartitioningInfo` struct to store device information and produce cuda device string
- Make cuda device string function in `LowerInfo` and `PartitioningInfo` const to avoid altering struct fields

Uses schema
```python
Tensor.to(device : Device,
          dtype : int,
          non_blocking : bool=False,
          copy : bool=False,
          memory_format : Optional[int]) -> Tensor
```
Instead of 
```python
Tensor.to(dtype : int,
          non_blocking : bool=False,
          copy : bool=False,
          memory_format : Optional[int]) -> Tensor
```

This switch was made to ensure the device for truncated objects is GPU, regardless of their origin, to avoid adding another lowering pass for this case. Since an `aten::to` operation is already being inserted, use the opportunity to use correct tensor device (GPU).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
  - Tested on a few models, sample scripts + existing fallback test suite
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
