### PR TITLE
fix: Properly cast intermediate Int8 tensors to TensorRT Engines in Fallback

### DIFF
--- a/core/partitioning/partitioninginfo/PartitioningInfo.h
+++ b/core/partitioning/partitioninginfo/PartitioningInfo.h
@@ -17,6 +17,7 @@ struct PartitioningInfo {
   std::vector<std::string> forced_fallback_operators;
   bool truncate_long_and_double;
   ir::Device target_device;
+  bool cast_int8_inputs = false;
 
   std::string getGPUDeviceString() const {
     return "cuda:" + std::to_string(target_device.gpu_id);

--- a/core/util/trt_util.cpp
+++ b/core/util/trt_util.cpp
@@ -252,6 +252,7 @@ const std::unordered_map<at::ScalarType, nvinfer1::DataType>& get_at_trt_type_ma
       {at::kHalf, nvinfer1::DataType::kHALF},
       {at::kInt, nvinfer1::DataType::kINT32},
       {at::kChar, nvinfer1::DataType::kINT8},
+      {at::kByte, nvinfer1::DataType::kINT8},
       {at::kBool, nvinfer1::DataType::kBOOL}};
   return at_trt_type_map;
 }

--- a/cpp/src/compile_spec.cpp
+++ b/cpp/src/compile_spec.cpp
@@ -167,8 +167,11 @@ torchtrt::core::CompileSpec to_internal_compile_spec(CompileSpec external) {
   internal.convert_info.engine_settings.dla_local_dram_size = external.dla_local_dram_size;
   internal.convert_info.engine_settings.dla_global_dram_size = external.dla_global_dram_size;
 
+  internal.partitioning_info.cast_int8_inputs = true;
+
   if (internal.convert_info.engine_settings.enabled_precisions.find(nvinfer1::DataType::kINT8) !=
       internal.convert_info.engine_settings.enabled_precisions.end()) {
+    internal.partitioning_info.cast_int8_inputs = false;
     if (external.ptq_calibrator) {
       internal.convert_info.engine_settings.calibrator = external.ptq_calibrator;
     } else {

--- a/tests/core/partitioning/test_type_auto_conversion.cpp
+++ b/tests/core/partitioning/test_type_auto_conversion.cpp
@@ -107,3 +107,63 @@ TEST(Partitioning, ImplicitAutoConversionCorrectly) {
   }
   ASSERT_TRUE(checkInsertedCastNodeNumber(segmented_blocks[1], 2));
 }
+
+TEST(Partitioning, ExplicitNodeAutoInt8ConversionCorrectly) {
+  const auto graph = R"IR(
+          graph(%x.1 : Tensor,
+                %y.1 : Tensor):
+
+            %26 : int = prim::Constant[value=1]()
+            %21 : bool = prim::Constant[value=0]()
+            %60 : Device = prim::Constant[value="cuda"]()
+            %14 : NoneType = prim::Constant()
+            %3 : int = prim::Constant[value=5]()
+            %19 : int = prim::Constant[value=0]()
+            %29 : int = prim::Constant[value=2]()
+            %13 : int[] = prim::ListConstruct(%3, %3)
+            %k_.1 : Tensor = aten::ones(%13, %19, %14, %60, %14)
+            %20 : int[] = prim::ListConstruct(%19)
+            %k.1 : Tensor = aten::sum(%k_.1, %20, %21, %14)
+            %x.5 : Tensor = aten::add_(%x.1, %y.1, %26)
+            %31 : Tensor = aten::mul(%y.1, %29)
+            %x.9 : Tensor = aten::add_(%x.5, %31, %26)
+            %x.13 : Tensor = aten::add_(%x.9, %k.1, %26)
+            %x.17 : Tensor = aten::sub_(%x.13, %k.1, %26)
+            %x.21 : Tensor = aten::add_(%x.17, %k.1, %26)
+            %x.25 : Tensor = aten::sub_(%x.21, %k.1, %26)
+
+            return (%x.25))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get(), true);
+
+  torch_tensorrt::core::partitioning::PartitioningInfo partitioning_info;
+  partitioning_info.enabled = true;
+  partitioning_info.cast_int8_inputs = true;
+  partitioning_info.forced_fallback_operators = {"aten::ones"};
+  partitioning_info.truncate_long_and_double = true;
+  std::vector<torch_tensorrt::core::ir::Input> inputs;
+  inputs.push_back(torch_tensorrt::core::ir::Input({5, 5}));
+  inputs.push_back(torch_tensorrt::core::ir::Input({5, 5}));
+
+  std::unordered_map<const torch::jit::Value*, std::vector<torch_tensorrt::core::ir::Input>> inputs_map;
+  std::unordered_map<const torch::jit::Value*, std::vector<c10::optional<at::ScalarType>>> input_types;
+  inputs_map.insert({g->inputs()[0], {inputs[0]}});
+  input_types.insert({g->inputs()[0], {{at::kFloat}}});
+  inputs_map.insert({g->inputs()[1], {inputs[1]}});
+  input_types.insert({g->inputs()[1], {{at::kInt}}});
+
+  partitioning_info.collection_input_spec_map = inputs_map;
+  torch_tensorrt::core::partitioning::PartitioningCtx ctx(g->block(), partitioning_info);
+  ctx.input_types_map = input_types;
+  torch_tensorrt::core::partitioning::populateInputIValues(&ctx);
+  torch_tensorrt::core::partitioning::partition(&ctx);
+  auto segmented_blocks = ctx.partitioned_blocks.begin()->second;
+
+  for (auto& seg_block : segmented_blocks) {
+    LOG_DEBUG(seg_block << " cur seg block");
+  }
+
+  // Seeking 1 inserted aten::to converting Byte to Int (%k_.1 is a Byte Tensor)
+  ASSERT_TRUE(checkInsertedCastNodeNumber(segmented_blocks[0], 1));
+}


### PR DESCRIPTION
# Description
- Fix compilation error for GPT-2 model arising from Byte-type inputs fed into TensorRT Engine
- Update translation dictionary between Torch and TensorRT types to include `at::kByte`
- Add field to PartitioningInfo specifying whether to cast Int8 inputs to TensorRT Engines to Int, to avoid error arising from Int8 inputs being fed into non-quantized engines
- Add automatic detection of quantized/calibrated models and disable Int8 => Int32 casting in those cases
- Fix bug where LoweringInfo target device was not being updated for Python API
- Allow `castNode` to force creation of a new node and avoid searching for an existing one to convert
- Add test to ensure cast is inserted in the Torch engine preceding a TensorRT engine, when the Byte tensor is an output of the Torch engine

Error displayed when passing `Int8` inputs to non-quantized TRT Engine:

```python
ERROR: [Torch-TensorRT TorchScript Conversion Context] - 4: input_0: input/output with DataType Int8 in network without Q/DQ layers must have dynamic range set when no calibrator is used.
ERROR: [Torch-TensorRT TorchScript Conversion Context] - 4: [network.cpp::validate::2772] Error Code 4: Internal Error (DataType does not match TensorFormats.)
ERROR: [Torch-TensorRT TorchScript Conversion Context] - 2: [builder.cpp::buildSerializedNetwork::751] Error Code 2: Internal Error (Assertion engine != nullptr failed. )
```

With this PR, GPT-2 now compiles and runs inference successfully.

Fixes #1455 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
