### PR TITLE
Update test_flatten_aten and test_reshape_aten due to PT2.0 changed tracer behavior for these ops

### DIFF
--- a/py/torch_tensorrt/fx/test/converters/aten_op/test_flatten_aten.py
+++ b/py/torch_tensorrt/fx/test/converters/aten_op/test_flatten_aten.py
@@ -27,7 +27,7 @@ class TestFlattenConverter(DispatchTestCase):
         self.run_test(
             Flatten(start_dim, end_dim),
             inputs,
-            expected_ops={torch.ops.aten._reshape_alias.default},
+            expected_ops={torch.ops.aten.view.default},
             test_implicit_batch_dim=(start_dim != 0),
         )
 

--- a/py/torch_tensorrt/fx/test/converters/aten_op/test_reshape_aten.py
+++ b/py/torch_tensorrt/fx/test/converters/aten_op/test_reshape_aten.py
@@ -25,7 +25,7 @@ class TestReshapeConverter(DispatchTestCase):
         self.run_test(
             TestModule(target_shape),
             inputs,
-            expected_ops={torch.ops.aten._reshape_alias.default},
+            expected_ops={torch.ops.aten.view.default},
         )
 
     ## TODO: proxytensor tracer does not support output size containing -1. If dim=0 is set to -1 for dynamic batch,


### PR DESCRIPTION
# Description

Fixed unit test failure. #1528 

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
