### PR TITLE
feat: Support int inputs to aten::max/min and aten::argmax/argmin

### DIFF
--- a/core/conversion/converters/impl/max.cpp
+++ b/core/conversion/converters/impl/max.cpp
@@ -22,6 +22,11 @@ bool min_max_dim(ConversionCtx* ctx, const torch::jit::Node* n, args& args, nvin
   if (dim < 0) {
     dim = selfDim.size() + dim;
   }
+  bool int_input = self->getType() == nvinfer1::DataType::kINT32;
+  if (int_input) {
+    LOG_DEBUG("topk layer does not support int32 inputs, adding cast to float");
+    self = castITensor(ctx, self, nvinfer1::DataType::kFLOAT, util::node_info(n) + "_input");
+  }
   uint32_t reduce_axes_mask = 1 << dim;
   auto topk_layer = ctx->net->addTopK(*self, topKOperation, 1, reduce_axes_mask);
   TORCHTRT_CHECK(topk_layer, "Unable to create topk layer from node: " << *n);
@@ -44,7 +49,10 @@ bool min_max_dim(ConversionCtx* ctx, const torch::jit::Node* n, args& args, nvin
     out0 = ctx->AssociateValueAndTensor(n->outputs()[0], topk_layer->getOutput(0));
     out1 = ctx->AssociateValueAndTensor(n->outputs()[1], topk_layer->getOutput(1));
   }
-
+  if (int_input) {
+    LOG_DEBUG("Adding cast of topK layer output back to int32");
+    out0 = castITensor(ctx, out0, nvinfer1::DataType::kINT32, util::node_info(n) + "_output");
+  }
   LOG_DEBUG("Output tensor(0) shape: " << out0->getDimensions());
   LOG_DEBUG("Output tensor(1) shape: " << out1->getDimensions());
 
@@ -58,6 +66,10 @@ bool arg_min_max(ConversionCtx* ctx, const torch::jit::Node* n, args& args, nvin
   auto selfDim = util::toVec(self->getDimensions());
   if (dim < 0) {
     dim = selfDim.size() + dim;
+  }
+  if (self->getType() == nvinfer1::DataType::kINT32) {
+    LOG_DEBUG("topk layer does not support int32 inputs, adding cast to float");
+    self = castITensor(ctx, self, nvinfer1::DataType::kFLOAT, util::node_info(n) + "_input");
   }
   uint32_t reduce_axes_mask = 1 << dim;
   auto topk_layer = ctx->net->addTopK(*self, topKOperation, 1, reduce_axes_mask);

--- a/tests/core/conversion/converters/test_max.cpp
+++ b/tests/core/conversion/converters/test_max.cpp
@@ -29,6 +29,29 @@ TEST(Converters, ATenMaxDimConvertsCorrectly) {
       torch_tensorrt::tests::util::almostEqual(jit_results[1], trt_results[1].reshape_as(jit_results[1]), 2e-6));
 }
 
+TEST(Converters, ATenMaxDimIntInputConvertsCorrectly) {
+  const auto graph = R"IR(
+    graph(%x.1 : Tensor):
+      %2 : int = prim::Constant[value=0]()
+      %3 : bool = prim::Constant[value=0]()
+      %4 : Tensor, %5 : Tensor = aten::max(%x.1, %2, %3)
+      return (%4, %5))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  auto in = at::randint(-5, 5, {5, 5}, {at::kCUDA});
+
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[1], trt_results[1], 2e-6));
+}
+
 TEST(Converters, ATenMinDimConvertsCorrectly) {
   const auto graph = R"IR(
     graph(%x.1 : Tensor):
@@ -75,6 +98,28 @@ TEST(Converters, ATenArgMaxConvertsCorrectly) {
 
   ASSERT_TRUE(
       torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}
+
+TEST(Converters, ATenArgMaxIntInputConvertsCorrectly) {
+  const auto graph = R"IR(
+    graph(%x.1 : Tensor):
+      %2 : int = prim::Constant[value=0]()
+      %3 : bool = prim::Constant[value=0]()
+      %4 : Tensor = aten::argmax(%x.1, %2, %3)
+      return (%4))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  auto in = at::randint(-5, 5, {5, 5}, {at::kCUDA});
+
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
 }
 
 TEST(Converters, ATenArgMaxKeepdimConvertsCorrectly) {


### PR DESCRIPTION
# Description

aten::max/min and aten::argmax/min currently error out with int inputs on the topk layer which only supports activation types. Add a cast to float to support int inputs.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
