### PR TITLE
fix: Issue in non-Tensor Input Resolution

### DIFF
--- a/core/partitioning/partitioning.cpp
+++ b/core/partitioning/partitioning.cpp
@@ -74,7 +74,7 @@ void setExplicitFallbackNodes(PartitioningCtx* ctx, torch::jit::Block* block) {
       continue;
     }
 
-    if (n->kind() == torch::jit::prim::Loop && checkLoopEvaluatable) {
+    if (n->kind() == torch::jit::prim::Loop && checkLoopEvaluatable(n)) {
       ctx->setNodeExecutorDecision(n, NodeExecutorDecision::kCONVERT);
     } else if (!conversion::OpSupported(n)) {
       // If the op is not supported by the conversion phase it should run in PyTorch

--- a/core/partitioning/partitioning.cpp
+++ b/core/partitioning/partitioning.cpp
@@ -273,34 +273,22 @@ void resolveTRTNonTensorInputs(PartitioningCtx* ctx, torch::jit::Block* block) {
   PartitionedGraph& cur_partitioned_block = ctx->partitioned_blocks[block];
   for (size_t i = 0; i < cur_partitioned_block.size(); ++i) {
     if (cur_partitioned_block[i].target() == SegmentedBlock::kTensorRT) {
-      // Store current number of inputs to block, and number of inputs after one round
-      // of reductions
-      auto current_input_size = cur_partitioned_block[i].inputs().size();
-      auto reduced_input_size = current_input_size;
-
-      // While the number of inputs to the block is strictly decreasing, continue to resolve inputs
-      do {
-        current_input_size = reduced_input_size;
-        std::vector<torch::jit::Value*> inputs_to_resolve;
-        for (auto input : cur_partitioned_block[i].raw_inputs()) {
-          if (!isTensor(input)) {
-            inputs_to_resolve.push_back(input);
-          }
+      std::vector<torch::jit::Value*> inputs_to_resolve;
+      for (auto input : cur_partitioned_block[i].raw_inputs()) {
+        if (!isTensor(input)) {
+          inputs_to_resolve.push_back(input);
         }
-        if (!inputs_to_resolve.empty()) {
-          std::vector<torch::jit::Node*> dependency_nodes =
-              getDependencyNodes(inputs_to_resolve, cur_partitioned_block[i]);
-          dependency_nodes.insert(
-              dependency_nodes.end(),
-              cur_partitioned_block[i].raw_nodes().begin(),
-              cur_partitioned_block[i].raw_nodes().end());
-          cur_partitioned_block[i] =
-              SegmentedBlock(cur_partitioned_block[i].get_id(), SegmentedBlock::kTensorRT, dependency_nodes);
-        }
-        // Update reduced number of inputs to be current inputs to block
-        reduced_input_size = cur_partitioned_block[i].inputs().size();
-        // If number of inputs has not decreased, all dependencies have been resolved
-      } while (current_input_size != reduced_input_size);
+      }
+      if (!inputs_to_resolve.empty()) {
+        std::vector<torch::jit::Node*> dependency_nodes =
+            getDependencyNodes(inputs_to_resolve, cur_partitioned_block[i]);
+        dependency_nodes.insert(
+            dependency_nodes.end(),
+            cur_partitioned_block[i].raw_nodes().begin(),
+            cur_partitioned_block[i].raw_nodes().end());
+        cur_partitioned_block[i] =
+            SegmentedBlock(cur_partitioned_block[i].get_id(), SegmentedBlock::kTensorRT, dependency_nodes);
+      }
     }
   }
 }

--- a/core/partitioning/segmentedblock/SegmentedBlock.h
+++ b/core/partitioning/segmentedblock/SegmentedBlock.h
@@ -98,6 +98,9 @@ struct SegmentedBlock {
     return in_types_;
   }
 
+  BlockID get_id() {
+    return id_;
+  }
   void update_id(BlockID new_id) {
     id_ = new_id;
   }


### PR DESCRIPTION
# Description

- <s>In certain TensorRT-executed blocks, multiple non-Tensor inputs originate from the same parent Tensor in another Torch block, so a single pass of resolveTRTNonTensorInputs does not resolve all non-Tensor inputs, causing failures at compile-time</s>
- Issue was determined to trace to the use of `prim::Loop` in the TensorRT block and is fixed in PR #1691 
- Add function to `SegmentedBlock` to get the ID of a block, so re-inserted blocks retain the same ID as the previous block being replaced
- Add regression test case to elicit behavior

## Failure Case
### Before Non-Tensor Input Resolution
```python
DEBUG: [Torch-TensorRT - Debug Build] - Finalizing in progress TensorRT block
DEBUG: [Torch-TensorRT - Debug Build] - Segment Block @2:
    Target: TensorRT

    Graph: graph(%1 : int,
      %9 : int[],
      %12 : Tensor):
```
### After 1 Round of Non-Tensor Input Resolution
```python
GRAPH: [Torch-TensorRT - Debug Build] - Running shape analysis on block Segment Block @2:
    Target: TensorRT

    Graph: graph(%1 : int[],
      %3 : Tensor):
```

### After 2 Rounds of Non-Tensor Input Resolution
```python
INFO: [Torch-TensorRT - Debug Build] - Segment Block @2:
    Target: TensorRT

    Graph: graph(%1 : Tensor):
```

Fixes #1612 
Related to: #1613 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
