### PR TITLE
Unsqueeze op set dim

### DIFF
--- a/core/conversion/converters/impl/conv_deconv.cpp
+++ b/core/conversion/converters/impl/conv_deconv.cpp
@@ -14,9 +14,9 @@ bool add_conv_deconv(ConversionCtx* ctx, const torch::jit::Node* n, args& args) 
   // Input to conv/deconv
   auto in = args[0].ITensor();
   if (in->getType() == nvinfer1::DataType::kINT32) {
-    LOG_DEBUG(
-      "Found type  " << in->getType() << " in aten::convolution, casting to "
-      << nvinfer1::DataType::kFLOAT << " for compatibility.");
+    LOG_WARNING(
+        "Found type  " << in->getType() << "in aten::convolution, casting to" << nvinfer1::DataType::kFLOAT
+                       << " for compatibility.");
     in = castITensor(ctx, in, nvinfer1::DataType::kFLOAT);
   }
   // Conv /deconv parameters

--- a/core/conversion/converters/impl/conv_deconv.cpp
+++ b/core/conversion/converters/impl/conv_deconv.cpp
@@ -13,7 +13,12 @@ namespace {
 bool add_conv_deconv(ConversionCtx* ctx, const torch::jit::Node* n, args& args) {
   // Input to conv/deconv
   auto in = args[0].ITensor();
-
+  // if (in->getType() == nvinfer1::DataType::kINT32) {
+  //   LOG_DEBUG(
+  //     "Found type  " << in->getType() << " in aten::convolution, casting to "
+  //     << nvinfer1::DataType::kFLOAT << " for compatibility.");
+  //   in = castITensor(ctx, in, nvinfer1::DataType::kFLOAT);
+  // }
   // Conv /deconv parameters
   auto stride = util::toDims(args[3].unwrapToIntList());
   auto padding = util::toDims(args[4].unwrapToIntList());

--- a/core/conversion/converters/impl/conv_deconv.cpp
+++ b/core/conversion/converters/impl/conv_deconv.cpp
@@ -13,12 +13,12 @@ namespace {
 bool add_conv_deconv(ConversionCtx* ctx, const torch::jit::Node* n, args& args) {
   // Input to conv/deconv
   auto in = args[0].ITensor();
-  // if (in->getType() == nvinfer1::DataType::kINT32) {
-  //   LOG_DEBUG(
-  //     "Found type  " << in->getType() << " in aten::convolution, casting to "
-  //     << nvinfer1::DataType::kFLOAT << " for compatibility.");
-  //   in = castITensor(ctx, in, nvinfer1::DataType::kFLOAT);
-  // }
+  if (in->getType() == nvinfer1::DataType::kINT32) {
+    LOG_DEBUG(
+      "Found type  " << in->getType() << " in aten::convolution, casting to "
+      << nvinfer1::DataType::kFLOAT << " for compatibility.");
+    in = castITensor(ctx, in, nvinfer1::DataType::kFLOAT);
+  }
   // Conv /deconv parameters
   auto stride = util::toDims(args[3].unwrapToIntList());
   auto padding = util::toDims(args[4].unwrapToIntList());

--- a/core/conversion/converters/impl/unsqueeze.cpp
+++ b/core/conversion/converters/impl/unsqueeze.cpp
@@ -32,7 +32,7 @@ auto unsqueeze_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns().
 
        auto shuffle_layer = ctx->net->addShuffle(*self);
        TORCHTRT_CHECK(shuffle_layer, "Unable to create shuffle layer from node: " << *n);
-       shuffle_layer->setReshapeDimensions(util::unsqueezeDims(self->getDimensions(), dim));
+       shuffle_layer->setReshapeDimensions(util::unsqueezeDims(self->getDimensions(), dim, 1, false));
 
        auto out = ctx->AssociateValueAndTensor(n->outputs()[0], shuffle_layer->getOutput(0));
 


### PR DESCRIPTION
# Description

The PR consists of the following changes-
1. Change the _use_zeroes_ parameter to false in _shuffle_layer->setReshapeDimensions()_, else it is resulting in empty tensor
2. Test _test_unsqueeze.cpp_ - to test the above changes

 In the case of dynamic inputs eg: [1,-1], the _util::unsqueezeDims()_ was changing the dimension [1,1,0] when value 1 was to be inserted at index 1. In _shuffle_layer->setReshapeDimensions()_, the 0 in the third dimension causes it to get the dimension from input tensor which has length 0 in that dimension. The _use_zeroes_ parameter is set to false so that [1,-1] is reshaped to [1,1,-1] instead
Fix for issue [1596](https://github.com/pytorch/TensorRT/issues/1596).

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
