### PR TITLE
Unsqueeze operator with dynamic inout

### DIFF
--- a/core/conversion/converters/impl/unsqueeze.cpp
+++ b/core/conversion/converters/impl/unsqueeze.cpp
@@ -32,7 +32,7 @@ auto unsqueeze_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns().
 
        auto shuffle_layer = ctx->net->addShuffle(*self);
        TORCHTRT_CHECK(shuffle_layer, "Unable to create shuffle layer from node: " << *n);
-       shuffle_layer->setReshapeDimensions(util::unsqueezeDims(self->getDimensions(), dim));
+       shuffle_layer->setReshapeDimensions(util::unsqueezeDims(self->getDimensions(), dim, 1, false));
 
        auto out = ctx->AssociateValueAndTensor(n->outputs()[0], shuffle_layer->getOutput(0));
 

--- a/tests/core/conversion/converters/test_unsqueeze.cpp
+++ b/tests/core/conversion/converters/test_unsqueeze.cpp
@@ -47,3 +47,25 @@ TEST(Converters, ATenUnsqueezeNegativeDimConvertsCorrectly) {
   ASSERT_TRUE(
       torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
 }
+
+TEST(Converters, ATenUnsqueezeConvertsCorrectlyWithDynamicInput) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor):
+        %1 : int = prim::Constant[value=1]()
+        %2 : Tensor = aten::unsqueeze(%0, %1)
+        return (%2))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  auto in = at::randint(1, 10, {1, 10}, {at::kCUDA});
+
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in});
+
+  ASSERT_TRUE(
+      torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}


### PR DESCRIPTION
The PR consists of the following changes-

1.	Change the use_zeroes parameter to false in shuffle_layer->setReshapeDimensions(), else it is resulting in empty tensor
2.	Test test_unsqueeze.cpp - to test the above changes

In the case of dynamic inputs eg: [1,-1], the util::unsqueezeDims() was changing the dimension [1,1,0] when value 1 was to be inserted at index 1. In shuffle_layer->setReshapeDimensions(), the 0 in the third dimension causes it to get the dimension from input tensor which has length 0 in that dimension. The use_zeroes parameter is set to false so that [1,-1] is reshaped to [1,1,-1] instead.
Fix for issue [1596](https://github.com/pytorch/TensorRT/issues/1596).

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
