### PR TITLE
fix: fix the inappropriate lowering pass of aten::to

### DIFF
--- a/core/lowering/passes/reduce_to.cpp
+++ b/core/lowering/passes/reduce_to.cpp
@@ -8,16 +8,6 @@ namespace lowering {
 namespace passes {
 
 void ReduceToOperation(std::shared_ptr<torch::jit::Graph>& graph) {
-  std::string to_dtype_layout_pattern = R"IR(
-        graph(%x, %dtype, %layout, %device, %pm, %nb, %copy, %format):
-            %out : Tensor = aten::to(%x, %dtype, %layout, %device, %pm, %nb, %copy, %format)
-            return (%out))IR";
-
-  std::string to_dtype_multi_input_pattern = R"IR(
-        graph(%x, %dtype, %layout, %device, %pm, %nb, %copy, %format):
-            %out : Tensor = aten::to(%x, %device, %dtype, %nb, %copy, %format)
-            return (%out))IR";
-
   std::string to_type_as_pattern = R"IR(
         graph(%input, %other):
             %out : Tensor = aten::type_as(%input, %other)
@@ -29,11 +19,6 @@ void ReduceToOperation(std::shared_ptr<torch::jit::Graph>& graph) {
             %6 : None = prim::Constant()
             %out : Tensor = aten::to(%input, %other, %5, %5, %6)
             return (%out))IR";
-
-  // replace aten::to.dtype_layout with aten::to.dtype
-  torch::jit::SubgraphRewriter map_aten_dtype_layout;
-  map_aten_dtype_layout.RegisterRewritePattern(to_dtype_layout_pattern, to_dtype_multi_input_pattern);
-  map_aten_dtype_layout.runOnGraph(graph);
 
   // replace aten::type_as with aten::to.other
   torch::jit::SubgraphRewriter map_aten_type_as_to_other;

--- a/tests/core/lowering/test_reduce_to_pass.cpp
+++ b/tests/core/lowering/test_reduce_to_pass.cpp
@@ -6,28 +6,6 @@
 #include "torch/csrc/jit/ir/irparser.h"
 #include "torch/csrc/jit/ir/subgraph_matcher.h"
 
-TEST(LoweringPasses, ReduceToDtypeLayoutCorrectly) {
-  std::string source_graph = R"IR(
-    graph(%x, %dtype, %layout, %device, %pm, %nb, %copy, %format):
-        %out : Tensor = aten::to(%x, %dtype, %layout, %device, %pm, %nb, %copy, %format)
-        return (%out))IR";
-  std::string target_graph = R"IR(
-    graph(%x, %dtype, %layout, %device, %pm, %nb, %copy, %format):
-        %out : Tensor = aten::to(%x, %device, %dtype, %nb, %copy, %format)
-        return (%out))IR";
-
-  torch_tensorrt::core::util::logging::get_logger().set_reportable_log_level(
-      torch_tensorrt::core::util::logging::LogLevel::kGRAPH);
-  auto sg = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(source_graph, &*sg);
-  torch_tensorrt::core::lowering::passes::ReduceToOperation(sg);
-
-  auto tg = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(target_graph, &*tg);
-
-  ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
-}
-
 TEST(LoweringPasses, ReduceAtenTypeAsCorrectly) {
   std::string source_graph = R"IR(
     graph(%input, %other):


### PR DESCRIPTION
# Description
When there is a aten::to operation in the model as: 
```
sizes = sizes.to(device=boxes.device)
```
like what happens here: https://github.com/facebookresearch/detectron2/blob/58e472e076a5d861fdcf773d9254a3664e045bf8/detectron2/modeling/poolers.py#L65, What this operation does is setting the device for sizes variable, since all the other parameters for aten::to op is not explicitly set, this results in an aten::to op in graph as:
```
 %sizes0.2 : Tensor = aten::to(%1954, %80, %80, %1955, %80, %6, %6, %80)
```
where:
```
%80 : NoneType = prim::Constant()
```
The NoneType is valid for aten::to candidate form:
```
aten::to.dtype_layout(Tensor(a) self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)
```
but not valid for the other forms, and in our lowering pass we convert the form above into other forms in this line: https://github.com/pytorch/TensorRT/blob/a3436504714dc40885e80f70c93478d263eb1df1/core/lowering/passes/reduce_to.cpp#L35
That's why this error message was printed : 
```
RuntimeError: 0 INTERNAL ASSERT FAILED at "../torch/csrc/jit/ir/alias_analysis.cpp":608, please report a bug to PyTorch. We don't have an op for aten::to but it isn't a special case.  Argument types: Tensor, Device, NoneType, bool, bool, NoneType, 
```


Fixes #1530 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
