### PR TITLE
Broadcast operations in aten::masked_fill and element_wise operations

### DIFF
--- a/core/conversion/converters/converter_util.cpp
+++ b/core/conversion/converters/converter_util.cpp
@@ -161,10 +161,8 @@ nvinfer1::ILayer* add_elementwise(
           canSqueeze = false;
         }
       }
-      LOG_DEBUG("Can the self be squeezed" << canSqueeze);
-      LOG_DEBUG("The size of selfDim" << selfDim.size());
-      LOG_DEBUG("The size of otherDim" << otherDim.size());
       if (canSqueeze) {
+        LOG_WARNING("The self tensor is getting unpadded");
         auto selfShuffle = ctx->net->addShuffle(*self);
         nvinfer1::Dims self_dim = util::toDims(selfDim);
         auto squeezed_self_dim = self_dim;

--- a/core/conversion/converters/impl/select.cpp
+++ b/core/conversion/converters/impl/select.cpp
@@ -705,12 +705,12 @@ auto select_registrations TORCHTRT_UNUSED =
                  int diff = mask->getDimensions().nbDims - self->getDimensions().nbDims;
                  for (int i = 0; i < diff; i++) {
                    if (mask->getDimensions().d[i] != 1) {
-                     LOG_DEBUG("The mask dimension cannot be unpadded to the self dimension");
+                     LOG_ERROR("The mask dimension cannot be unpadded to the self dimension");
                    }
                  }
                  mask = addUnpadding(ctx, n, mask, self->getDimensions().nbDims, false, true);
                } else {
-                 self = addPadding(ctx, n, self, mask->getDimensions().nbDims, false, true);
+                 mask = addPadding(ctx, n, mask, self->getDimensions().nbDims, false, true);
                }
                // mask = addPadding(ctx, n, mask, self->getDimensions().nbDims, false, true);
                auto val = args[2].unwrapToScalar();

--- a/tests/core/conversion/converters/test_masked_fill.cpp
+++ b/tests/core/conversion/converters/test_masked_fill.cpp
@@ -105,6 +105,62 @@ TEST(Converters, ATenMaskedFillMixedTypesFloatIntConvertsCorrectly) {
   ASSERT_TRUE(jit_results[0].dtype() == trt_results[0].dtype());
 }
 
+TEST(Converters, ATenMaskedFillBroadcastMaskPad) {
+  const auto graph = R"IR(
+    graph(%x.1 : Tensor, %x.2 : Tensor):
+      %val : int = prim::Constant[value=4]()
+      %out : Tensor = aten::masked_fill(%x.1, %x.2, %val)
+      return (%out))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(graph, &*g);
+
+  // Input is an integer tensor, filled with a float --> expecting integer tensor out
+  auto in1 = at::rand({2, 3, 5, 7}, {at::kCUDA}).to(torch::kInt32);
+  auto in2 = (2 * at::rand({3, 5, 7}, {at::kCUDA})).to(torch::kBool);
+
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in1, in2});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in1, in2});
+
+  ASSERT_TRUE(
+      torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+
+  // Ensure data types match in outputs
+  ASSERT_TRUE(jit_results[0].dtype() == trt_results[0].dtype());
+}
+
+TEST(Converters, ATenMaskedFillBroadcastSelfPad) {
+  const auto graph = R"IR(
+    graph(%x.1 : Tensor, %x.2 : Tensor):
+      %val : int = prim::Constant[value=4]()
+      %out : Tensor = aten::masked_fill(%x.1, %x.2, %val)
+      return (%out))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(graph, &*g);
+
+  // Input is an integer tensor, filled with a float --> expecting integer tensor out
+  auto in1 = at::rand({3, 5, 7}, {at::kCUDA}).to(torch::kInt32);
+  auto in2 = (2 * at::rand({1, 3, 5, 7}, {at::kCUDA})).to(torch::kBool);
+
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in1, in2});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in1, in2});
+
+  ASSERT_TRUE(
+      torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+
+  // Ensure data types match in outputs
+  ASSERT_TRUE(jit_results[0].dtype() == trt_results[0].dtype());
+}
+
 TEST(Converters, ATenMaskedFillMixedTypesIntFloatConvertsCorrectly) {
   const auto graph = R"IR(
     graph(%x.1 : Tensor, %x.2 : Tensor):


### PR DESCRIPTION
# Description

This PR addresses the broadcasting issue encountered in the NeMo Citrinet model. ([Bug 1573](https://github.com/pytorch/TensorRT/issues/1573)). 


Fixes # (issue)

This PR makes two main changes-
1. The TensorRT broadcast rules are more limited as compared to Torch broadcast rules - [#1629](https://github.com/pytorch/TensorRT/issues/1629). Hence the _aten::masked_fill_ is modified to make mask and self Tensors broadcastable according to TensorRT rules.At present only the mask tensor is padded if its no of dimensions is lesser than the self Tensor, but  not vice versa. 
**Modification** : The mask tensor is unpadded if its dimensions is greater than the self Tensor and it has leading 1 dimensions

2. The _element_wise_ operations broadcasts the two tensors to get to the same dimensions. 
**Modification** : The tensor having extra dimensions is checked if it requires the leading 1 dimensions and accordingly unpadded. Else the other tensor is padded.

The above model fails with the runtime error-RuntimeError: expand(CUDABoolType{[1, 1, 1, 1488]}, size=[1, 256, 1488]): the number of sizes provided (3) must be greater or equal to the number of dimensions in the tensor (4)
 
out dimension = 1, 256, 1488
mask dimension = 1,1,1,1488
Cases with output = out.masked_fill_(mask,2 ) fail while output = torch.masked_fill(mask,2) passes