### PR TITLE
[feat] Add converter support for index_select

### DIFF
--- a/tests/core/conversion/converters/test_select.cpp
+++ b/tests/core/conversion/converters/test_select.cpp
@@ -165,6 +165,60 @@ TEST(Converters, ATenSelectEmptyTensorConvertsCorrectly) {
   ASSERT_TRUE(torch_tensorrt::tests::util::sameShape(jit_results[0], trt_results[0]));
 }
 
+TEST(Converters, ATenIndexSelectConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor, %index : Int (2)):
+        %2 : int = prim::Constant[value=0]()
+        %3 : Tensor = aten::index_select(%0, %2, %index)
+        return (%3))IR";
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+  auto in = at::randint(1, 10, {4, 4, 4}, {at::kCUDA});
+  auto index = at::randint(0, 4, {2}, {at::kCUDA}).to(torch::kI32);
+
+  auto jit_in = at::clone(in);
+  auto jit_index = at::clone(index);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {jit_index});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  auto trt_index = at::clone(index);
+  auto trt_params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {trt_index});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, trt_params, {trt_in});
+
+  auto trt = trt_results[0].reshape(jit_results[0].sizes());
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}
+
+TEST(Converters, ATenIndexSelectNegativeDimConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor, %index : Int (5)):
+        %2 : int = prim::Constant[value=-1]()
+        %3 : Tensor = aten::index_select(%0, %2, %index)
+        return (%3))IR";
+  auto g = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(graph, g.get());
+
+  auto in = at::randint(1, 10, {5, 3, 9}, {at::kCUDA});
+  auto index = at::randint(0, 9, {5}, {at::kCUDA}).to(torch::kI32);
+
+  auto jit_in = at::clone(in);
+  auto jit_index = at::clone(index);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {jit_index});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  auto trt_index = at::clone(index);
+  auto trt_params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {trt_index});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, trt_params, {trt_in});
+
+  auto trt = trt_results[0].reshape(jit_results[0].sizes());
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}
+
 TEST(Converters, ATenNarrowStartScalarConvertsCorrectly) {
   const auto graph = R"IR(
       graph(%x.1 : Tensor):


### PR DESCRIPTION
# Description

Adds a converter for aten::index_select  https://pytorch.org/docs/stable/generated/torch.index_select.html

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
