### PR TITLE
Corrected a typo, which was raising an error

### DIFF
--- a/docsrc/tutorials/use_from_pytorch.rst
+++ b/docsrc/tutorials/use_from_pytorch.rst
@@ -33,7 +33,7 @@ at the documentation for the Torch-TensorRT ``TensorRTCompileSpec`` API.
 
     spec = {
         "forward": torch_tensorrt.ts.TensorRTCompileSpec(
-            {
+            **{
                 "inputs": [torch_tensorrt.Input([1, 3, 300, 300])],
                 "enabled_precisions": {torch.float, torch.half},
                 "refit": False,


### PR DESCRIPTION
# Description

Corrected a typo in the Using Torch-TensorRT Directly From PyTorch tutorial which was causing an error

Fixes #1688

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
