### PR TITLE
Get windows build working

### DIFF
--- a/core/plugins/CMakeLists.txt
+++ b/core/plugins/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(${lib_name}
         TensorRT::nvinfer_plugin
         torch
         core_util
+        cuDNN::cuDNN
     PRIVATE
         Threads::Threads
 )

--- a/core/runtime/CMakeLists.txt
+++ b/core/runtime/CMakeLists.txt
@@ -33,8 +33,14 @@ target_link_libraries(${lib_name}
         TensorRT::nvinfer
         torch
         core_util
-        #stdc++fs
 )
+
+if(NOT WIN32)
+    target_link_libraries(${lib_name}
+        PUBLIC
+            stdc++fs
+    )
+endif(NOT WIN32)
 
 # Install
 install(FILES ${HEADER_FILES} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/torch_tensorrt/core/runtime")

--- a/core/runtime/CMakeLists.txt
+++ b/core/runtime/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries(${lib_name}
         TensorRT::nvinfer
         torch
         core_util
-        stdc++fs
+        #stdc++fs
 )
 
 # Install

--- a/core/runtime/TRTEngine.h
+++ b/core/runtime/TRTEngine.h
@@ -25,7 +25,7 @@ struct TRTEngine : torch::CustomClassHolder {
   std::string name;
   RTDevice device_info;
 
-  std::string profile_path_prefix = std::experimental::filesystem::temp_directory_path();
+  std::string profile_path_prefix = std::experimental::filesystem::temp_directory_path().string();
 
   std::unordered_map<uint64_t, uint64_t> in_binding_map = {}; // TRT IDX -> PYT IDX
   std::unordered_map<uint64_t, uint64_t> out_binding_map = {}; // TRT IDX -> PYT IDX

--- a/core/runtime/TRTEngineProfiler.cpp
+++ b/core/runtime/TRTEngineProfiler.cpp
@@ -1,7 +1,7 @@
 #include <algorithm>
 #include <fstream>
-#include <sstream>
 #include <iomanip>
+#include <sstream>
 
 #include "core/runtime/TRTEngineProfiler.h"
 

--- a/core/runtime/TRTEngineProfiler.cpp
+++ b/core/runtime/TRTEngineProfiler.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <fstream>
+#include <sstream>
 #include <iomanip>
 
 #include "core/runtime/TRTEngineProfiler.h"


### PR DESCRIPTION
# Description

Initial PR for #1563. Fixes Windows CMAKE build.

Finally had time to come back to this - build on a fresh Windows11 machine, all steps to setup/reproduce included.

The change to `core/plugins/CMakeLists.txt` seems like it should be unrelated to this. I was unable to build because 'cudnn.h' was required, but the include path was not being passed to the compiler as the `cuDNN` module wasn't specified. This might not be a problem in other targets because commonly the cudnn files are just installed in to the cuda include/lib/bin dirs.

Also note - windows is generally case insensitive. The normal output dir is `build/` but that doesn't work on Windows as there is a `BUILD` file. So I'm using `out/` as the output. But that isn't in the `.gitignore`, and I haven't included a change for that in this PR.

## Type of change

- Bug fix (incomplete and probably breaks other build targets)
- This change requires a documentation update

# Notes to reproduce with Visual Studio Code (I didn't want to pull down the whole Visual Studio)
- [ ] Install Visual Studio Code
- [ ] Install Build Tools for Visual Studio 2022
    - Select "Desktop Development with C++"
        - Currently, this installs MSVC v143 - 2022. There are also options to install previous 2019/2017/2015 editions of MSVC
    - License term "1b Build Tools additional use right" allows using Build Tools to compile Open Source Dependencies
    - Also allows using Build Tools to develop and test Open Source Dependencies, to the minor extend of ensuring compatibility with Build Tools
- [ ] Install CUDA 11.7.1
- [ ] Install CuDNN 8.5.0.96
    - Set `cuDNN_ROOT_DIR`
- [ ] Install TensorRT 8.5.1.7
    - Set `TensorRT_ROOT`
    - Add `TensorRT_ROOT\lib` to PATH
- [ ] Install "libtorch-win-shared-with-deps-latest.zip" 
    - Select the CUDA 11.7 version
    - Set `Torch_DIR`
    - Add `Torch_DIR\lib` to PATH
- [ ] Clone TensorRT repo
- [ ] Install C++ and CMake Tools extensions from MS
    - Change build to RelWithDebInfo
- [ ] Update `.vscode\settings.json`
- [ ] Clean, configure, build

`/.vscode/settings.json`
```json
{
    "cmake.generator": "Ninja",
    "cmake.configureSettings": {
        "CMAKE_MODULE_PATH": {
            "type": "FILEPATH",
            "value": "$PWD\\cmake\\Modules"
        },
        "CMAKE_CXX_FLAGS": {
            "type": "STRING",
            "value": "-D_SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING"
        },
        "Torch_DIR": {
            "type": "FILEPATH",
            "value": "X:\\libtorch\\share\\cmake\\Torch"
        },
        "TensorRT_ROOT": {
            "type": "FILEPATH",
            "value": "X:\\path\\to\\tensorrt"
        },
        "cuDNN_ROOT_DIR": {
            "type": "FILEPATH",
            "value": "X:\\path\\to\\cudnn"
        },
        "CMAKE_CUDA_FLAGS": "-allow-unsupported-compiler"
    },
    "cmake.buildDirectory": "${workspaceFolder}/out"
}
```
