### PR TITLE
infra: Add Torch 1.13.1 testing to nightly CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,15 +524,47 @@ commands:
       - store_artifacts:
           path: /tmp/testlogs
 
-  test-fx_converters:
-    description: "Test the fx converters"
+  test-fx_converters_acc:
+    description: "Test the fx acc converters"
     steps:
       - run:
           name: Run FX converter tests
           command: |
             cd py/torch_tensorrt/fx/test
-            pushd converters/
-            pytest --junitxml=/tmp/artifacts/test_results/fx/converters/test_results.xml
+            pushd converters/acc_op/
+            pytest --junitxml=/tmp/artifacts/test_results/fx/converters/acc_op/test_results.xml
+            popd
+
+      - store_test_results:
+          path: /tmp/artifacts
+      - store_artifacts:
+          path: /tmp/testlogs
+
+  test-fx_converters_aten:
+    description: "Test the fx aten converters"
+    steps:
+      - run:
+          name: Run FX converter tests
+          command: |
+            cd py/torch_tensorrt/fx/test
+            pushd converters/aten_op/
+            pytest --junitxml=/tmp/artifacts/test_results/fx/converters/aten_op/test_results.xml
+            popd
+
+      - store_test_results:
+          path: /tmp/artifacts
+      - store_artifacts:
+          path: /tmp/testlogs
+
+  test-fx_converters_vanilla:
+    description: "Test the fx vanilla converters"
+    steps:
+      - run:
+          name: Run FX converter tests
+          command: |
+            cd py/torch_tensorrt/fx/test
+            pushd converters/vanilla/
+            pytest --junitxml=/tmp/artifacts/test_results/fx/converters/vanilla/test_results.xml
             popd
 
       - store_test_results:
@@ -587,7 +619,7 @@ commands:
           path: /tmp/testlogs
 
   test-fx_tracer:
-    description: "Test the fx tracer"
+    description: "Test all fx tracers"
     steps:
       - run:
           name: Run FX tracer
@@ -595,6 +627,22 @@ commands:
             cd py/torch_tensorrt/fx/test
             pushd tracer
             list_tracer=$(ls | grep -v test_dispatch_*)
+            pytest $list_tracer --junitxml=/tmp/artifacts/test_results/fx/tracer/test_results.xml
+            popd
+      - store_test_results:
+          path: /tmp/artifacts
+      - store_artifacts:
+          path: /tmp/testlogs
+
+  test-fx_tracer_acc:
+    description: "Test the fx acc tracer only"
+    steps:
+      - run:
+          name: Run FX tracer
+          command: |
+            cd py/torch_tensorrt/fx/test
+            pushd tracer
+            list_tracer=$(ls | grep test_acc)
             pytest $list_tracer --junitxml=/tmp/artifacts/test_results/fx/tracer/test_results.xml
             popd
       - store_test_results:
@@ -625,11 +673,33 @@ commands:
           name: Run fx tests
           command: |
             mkdir -p /tmp/artifacts/test_results
-      - test-fx_converters
+      - test-fx_converters_acc
+      - test-fx_converters_aten
+      - test-fx_converters_vanilla
       - test-fx_passes
       - test-fx_tools
       - test-fx_trt_lower
       - test-fx_tracer
+      - test-fx_core
+      - test-fx_quant
+      - store_test_results:
+          path: /tmp/artifacts
+      - store_artifacts:
+          path: /tmp/testlogs
+
+  test-fx-no-aten:
+    description: "Test the fx backend without aten operators"
+    steps:
+      - run:
+          name: Run fx tests without aten ops
+          command: |
+            mkdir -p /tmp/artifacts/test_results
+      - test-fx_converters_acc
+      - test-fx_converters_vanilla
+      - test-fx_passes
+      - test-fx_tools
+      - test-fx_trt_lower
+      - test-fx_tracer_acc
       - test-fx_core
       - test-fx_quant
       - store_test_results:
@@ -781,6 +851,37 @@ jobs:
       # We install torch after torch-trt because pip automatically enforces the version constraint otherwise
       - dump-test-env
       - test-fx
+
+  test-py-fx-x86_64-linux-no-aten:
+    parameters:
+      torch-build:
+        type: string
+      torch-build-index:
+        type: string
+      trt-version-long:
+        type: string
+    machine:
+      image: ubuntu-2004-cuda-11.4:202110-01
+    resource_class: gpu.nvidia.large
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/dist/
+      - install-torch-from-index:
+          torch-build:  << parameters.torch-build >>
+          torch-build-index: << parameters.torch-build-index >>
+      - create-py-env:
+          trt-version-long: << parameters.trt-version-long >>
+      - install-cudnn
+      # - run:
+      #     name: "Set LD_LIBRARY_PATH path to include the installed CUDNN"
+      #     command: export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+      - run:
+          name: "Install torch-tensorrt"
+          command: pip3 install --pre /tmp/dist/x86_64-linux/*cp39-cp39*.whl
+      # We install torch after torch-trt because pip automatically enforces the version constraint otherwise
+      - dump-test-env
+      - test-fx-no-aten
 
   package-x86_64-linux:
     parameters:
@@ -1074,6 +1175,12 @@ parameters:
   torch-build-index:
     type: string
     default: "https://download.pytorch.org/whl/nightly/cu117"
+  torch-build-legacy:
+    type: string
+    default: "1.13.1+cu117"
+  torch-build-index-legacy:
+    type: string
+    default: "https://download.pytorch.org/whl/cu117"
   cudnn-version:
     type: string
     default: "8.5.0.96"
@@ -1127,6 +1234,7 @@ workflows:
                 - release/**/*
     jobs:
       - build-x86_64-linux:
+          name: build-x86_64-linux
           torch-build: << pipeline.parameters.torch-build >>
           torch-build-index: << pipeline.parameters.torch-build-index >>
 
@@ -1152,6 +1260,36 @@ workflows:
           trt-version-long: << pipeline.parameters.trt-version-long >>
           requires:
             - build-x86_64-linux
+
+      - build-x86_64-linux:
+          name: build-x86_64-linux-legacy
+          torch-build: << pipeline.parameters.torch-build-legacy >>
+          torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
+
+      - test-core-cpp-x86_64-linux:
+          name: test-core-cpp-x86_64-linux-legacy
+          torch-build: << pipeline.parameters.torch-build-legacy >>
+          torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
+          trt-version-short: << pipeline.parameters.trt-version-short >>
+          trt-version-long: << pipeline.parameters.trt-version-long >>
+          cudnn-version: << pipeline.parameters.cudnn-version >>
+          requires:
+            - build-x86_64-linux-legacy
+
+      - test-py-ts-x86_64-linux:
+          name: test-py-ts-x86_64-linux-legacy
+          torch-build: << pipeline.parameters.torch-build-legacy >>
+          torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
+          trt-version-long: << pipeline.parameters.trt-version-long >>
+          requires:
+            - build-x86_64-linux-legacy
+
+      - test-py-fx-x86_64-linux-no-aten:
+          torch-build: << pipeline.parameters.torch-build-legacy >>
+          torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
+          trt-version-long: << pipeline.parameters.trt-version-long >>
+          requires:
+            - build-x86_64-linux-legacy
 
   release:
     when: << pipeline.parameters.enable-packaging >>

--- a/py/setup.py
+++ b/py/setup.py
@@ -380,7 +380,7 @@ setup(
     long_description=long_description,
     ext_modules=ext_modules,
     install_requires=[
-        "torch>=1.14.0.dev0",
+        "torch>=1.13.1",
     ],
     setup_requires=[],
     cmdclass={

--- a/py/torch_tensorrt/fx/test/quant/test_quant_trt.py
+++ b/py/torch_tensorrt/fx/test/quant/test_quant_trt.py
@@ -696,7 +696,6 @@ class TestQuantizeFxTRTOps(QuantizationTestCase):
             return [extra_input]
 
         conv_add_config = {
-            "pattern_complex_format": (operator.add, torch.nn.Conv2d, MatchAllNode),
             "observation_type": ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT,
             "dtype_configs": [
                 weighted_op_qint8_dtype_config,
@@ -706,6 +705,15 @@ class TestQuantizeFxTRTOps(QuantizationTestCase):
             "root_module": torch.nn.Conv2d,
             "reference_quantized_module_for_root": torch.nn.quantized._reference.Conv2d,
         }
+
+        if torch.__version__.startswith("1"):
+            conv_add_config["pattern"] = (operator.add, torch.nn.Conv2d, MatchAllNode)
+        else:
+            conv_add_config["pattern_complex_format"] = (
+                operator.add,
+                torch.nn.Conv2d,
+                MatchAllNode,
+            )
 
         m = M().eval()
         modified_backend_config_dict = copy.deepcopy(self.trt_backend_config_dict)
@@ -764,10 +772,6 @@ class TestQuantizeFxTRTOps(QuantizationTestCase):
         }
 
         conv_add_config = {
-            "pattern_complex_format": (
-                torch.nn.ReLU,
-                (operator.add, torch.nn.Conv2d, MatchAllNode),
-            ),
             "observation_type": ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT,
             "dtype_configs": [
                 weighted_op_quint8_dtype_config,
@@ -775,6 +779,17 @@ class TestQuantizeFxTRTOps(QuantizationTestCase):
             "root_module": torch.nn.Conv2d,
             # "reference_quantized_module_for_root": torch.nn.quantized._reference.Conv2d,
         }
+
+        if torch.__version__.startswith("1"):
+            conv_add_config["pattern"] = (
+                torch.nn.ReLU,
+                (operator.add, torch.nn.Conv2d, MatchAllNode),
+            )
+        else:
+            conv_add_config["pattern_complex_format"] = (
+                torch.nn.ReLU,
+                (operator.add, torch.nn.Conv2d, MatchAllNode),
+            )
 
         conv_config = {
             "pattern": torch.nn.Conv2d,


### PR DESCRIPTION
# Description
- Add testing for Torch 1.13.1 path in CI across both TS and FX compilation paths
- Disable `aten` tests for 1.13, to resolve Torch Dynamo import/functionality issues
- Add parameter fields to CI to accomodate Torch 1.13.1 version
- Update `dispatch_tracer` function docstrings and imports to avoid naming issue with `torch._dynamo` vs `torchdynamo`

<s>See [this CI run](https://app.circleci.com/pipelines/github/pytorch/TensorRT/2169/workflows/2563cdac-4795-4b97-9bf1-8aec0251e9e7) for a sample of the 1.13.1 run results. Currently the only failing tests are `test_conv_add_standalone_module` from the FX quantization path, and these failures may arise from API usage changes between 1.13 and 2.0.</s>

The CI is now passing with the updates to the FX quantization path. See [this CI run](https://app.circleci.com/pipelines/github/pytorch/TensorRT/2179/workflows/58624d17-529a-43e7-8c7e-6ba89dd4fd6a).

The following tests are disabled for the 1.13.1 CI workflow, due to Dynamo compatibility issues:
- `tracer/test_dispatch_tracer.py`
- `tracer/test_resnet.py`
- `tracer/test_resnet.py`
- `converters/aten_op/*`

Fixes #1716 

## Type of change

Please delete options that are not relevant and/or add your own.

- Infrastructure/CI Change

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
