### PR TITLE
minor fix: Update default minimum torch version for aten tracer

### DIFF
--- a/py/torch_tensorrt/fx/tracer/dispatch_tracer/aten_tracer.py
+++ b/py/torch_tensorrt/fx/tracer/dispatch_tracer/aten_tracer.py
@@ -91,6 +91,7 @@ def setting_python_recursive_limit(limit: int = 10000) -> Generator[None, None, 
         sys.setrecursionlimit(default)
 
 
+@req_torch_version("2.dev")
 def dynamo_trace(
     f: Callable[..., Value],
     # pyre-ignore
@@ -131,11 +132,13 @@ def dynamo_trace(
             ) from exc
 
 
+@req_torch_version("2.dev")
 def trace(f, args, *rest):
     graph_module, guards = dynamo_trace(f, args, True, "symbolic")
     return graph_module, guards
 
 
+@req_torch_version("2.dev")
 def opt_trace(f, args, *rest):
     """
     Optimized trace with necessary passes which re-compose some ops or replace some ops


### PR DESCRIPTION
Minor fix - update defaults to `"2.dev"`