### PR TITLE
fix: Repair invalid schema arising from lowering pass

### DIFF
--- a/tests/core/lowering/test_remove_unnecessary_casts.cpp
+++ b/tests/core/lowering/test_remove_unnecessary_casts.cpp
@@ -5,6 +5,8 @@
 #include "tests/util/util.h"
 #include "torch/csrc/jit/ir/irparser.h"
 #include "torch/csrc/jit/ir/subgraph_matcher.h"
+#include "torch/csrc/jit/passes/canonicalize.h"
+#include "torch/csrc/jit/passes/constant_pooling.h"
 
 TEST(LoweringPasses, RemoveUnnecessaryCastIntCorrectly) {
   std::string source_graph = R"IR(
@@ -253,6 +255,155 @@ TEST(LoweringPasses, RemoveSingleUse0DTensorsFloorDivIntValuesAgree) {
   auto jit_post_results = torch_tensorrt::tests::util::EvaluateGraphJIT(g_out, {});
 
   ASSERT_TRUE(torch_tensorrt::tests::util::exactlyEqual(jit_pre_results[0].toTensor(), jit_post_results[0].toTensor()));
+}
+
+TEST(LoweringPasses, RemoveSingleUse0DTensorsDivTruncIntValuesAgree) {
+  // Ensure the source and target graphs have equivalent outputs
+  // (Source and Target are computing equivalent values)
+  std::string source_graph_no_inputs = R"IR(
+    graph():
+      %0: int = prim::Constant[value=2]()
+      %11: int = prim::Constant[value=-3]()
+      %234 : str = prim::Constant[value="trunc"]()
+      %3: Tensor = prim::NumToTensor(%0)
+      %1: Tensor = prim::NumToTensor(%11)
+      %4: Tensor = aten::div(%1, %3, %234)
+      %50: int = aten::Int(%4)
+      %5: Tensor = prim::NumToTensor(%50)
+      return (%5))IR";
+  std::string target_graph_no_inputs = R"IR(
+    graph():
+      %0: int = prim::Constant[value=2]()
+      %1: int = prim::Constant[value=-3]()
+      %40: float = aten::div(%1, %0)
+      %41: int = aten::Int(%40)
+      %4: Tensor = prim::NumToTensor(%41)
+      return (%4))IR";
+
+  auto g_in = std::make_shared<torch::jit::Graph>();
+  auto g_out = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(source_graph_no_inputs, g_in.get());
+  torch::jit::parseIR(target_graph_no_inputs, g_out.get());
+
+  auto jit_pre_results = torch_tensorrt::tests::util::EvaluateGraphJIT(g_in, {});
+  auto jit_post_results = torch_tensorrt::tests::util::EvaluateGraphJIT(g_out, {});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::exactlyEqual(jit_pre_results[0].toTensor(), jit_post_results[0].toTensor()));
+
+  // Ensure the lowering pass transforms the first graph into the second
+  std::string source_graph = R"IR(
+    graph(%0: int):
+      %1: Tensor = prim::Constant[value=[8]]()
+      %3: Tensor = prim::NumToTensor(%0)
+      %234: str = prim::Constant[value="trunc"]()
+      %4: Tensor = aten::div(%3, %1, %234)
+      %5: int = aten::Int(%4)
+      return (%5))IR";
+
+  std::string target_graph = R"IR(
+    graph(%0 : int):
+      %1 : str = prim::Constant[value="trunc"]()
+      %2 : int = prim::Constant[value=8]()
+      %3 : float = aten::div(%0, %2)
+      %4 : int = aten::Int(%3)
+      return (%4))IR";
+
+  auto sg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(source_graph, &*sg);
+
+  auto first_op = *(sg->block()->nodes().begin());
+  torch::jit::Value* r = sg->insertConstant(c10::scalar_to_tensor(8), c10::nullopt, first_op->scope());
+  r->copyMetadata(first_op->output());
+  r->setType(c10::TensorType::get());
+  first_op->output()->replaceAllUsesWith(r);
+  first_op->destroy();
+
+  torch_tensorrt::core::lowering::passes::RemoveSingleUse0DTensors(sg);
+  torch::jit::ConstantPooling(sg);
+  sg = torch::jit::Canonicalize(sg, false);
+
+  auto tg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(target_graph, &*tg);
+  torch::jit::ConstantPooling(tg);
+  tg = torch::jit::Canonicalize(tg, false);
+
+  // Validate identical graphs after pooling constants and canonicalizing
+  ASSERT_TRUE((tg->toString() == sg->toString()));
+}
+
+TEST(LoweringPasses, RemoveSingleUse0DTensorsDivFloorIntValuesAgree) {
+  // Ensure the source and target graphs have equivalent outputs
+  // (Source and Target are computing equivalent values)
+  std::string source_graph_no_inputs = R"IR(
+    graph():
+      %0: int = prim::Constant[value=2]()
+      %11: int = prim::Constant[value=-3]()
+      %234 : str = prim::Constant[value="floor"]()
+      %3: Tensor = prim::NumToTensor(%0)
+      %1: Tensor = prim::NumToTensor(%11)
+      %4: Tensor = aten::div(%1, %3, %234)
+      %50: int = aten::Int(%4)
+      %5: Tensor = prim::NumToTensor(%50)
+      return (%5))IR";
+  std::string target_graph_no_inputs = R"IR(
+    graph():
+      %0: int = prim::Constant[value=2]()
+      %1: int = prim::Constant[value=-3]()
+      %40: int = aten::floordiv(%1, %0)
+      %41: int = aten::Int(%40)
+      %4: Tensor = prim::NumToTensor(%41)
+      return (%4))IR";
+
+  auto g_in = std::make_shared<torch::jit::Graph>();
+  auto g_out = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(source_graph_no_inputs, g_in.get());
+  torch::jit::parseIR(target_graph_no_inputs, g_out.get());
+
+  auto jit_pre_results = torch_tensorrt::tests::util::EvaluateGraphJIT(g_in, {});
+  auto jit_post_results = torch_tensorrt::tests::util::EvaluateGraphJIT(g_out, {});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::exactlyEqual(jit_pre_results[0].toTensor(), jit_post_results[0].toTensor()));
+
+  // Ensure the lowering pass transforms the first graph into the second
+  std::string source_graph = R"IR(
+    graph(%0: int):
+      %1: Tensor = prim::Constant[value=[8]]()
+      %3: Tensor = prim::NumToTensor(%0)
+      %234: str = prim::Constant[value="floor"]()
+      %4: Tensor = aten::div(%3, %1, %234)
+      %5: int = aten::Int(%4)
+      return (%5))IR";
+
+  std::string target_graph = R"IR(
+    graph(%0 : int):
+      %1 : str = prim::Constant[value="floor"]()
+      %2 : int = prim::Constant[value=8]()
+      %3 : int = aten::floordiv(%0, %2)
+      return (%3))IR";
+
+  auto sg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(source_graph, &*sg);
+
+  auto first_op = *(sg->block()->nodes().begin());
+  torch::jit::Value* r = sg->insertConstant(c10::scalar_to_tensor(8), c10::nullopt, first_op->scope());
+  r->copyMetadata(first_op->output());
+  r->setType(c10::TensorType::get());
+  first_op->output()->replaceAllUsesWith(r);
+  first_op->destroy();
+
+  torch_tensorrt::core::lowering::passes::RemoveSingleUse0DTensors(sg);
+  torch::jit::ConstantPooling(sg);
+  sg = torch::jit::Canonicalize(sg, false);
+
+  auto tg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(target_graph, &*tg);
+  torch::jit::ConstantPooling(tg);
+  tg = torch::jit::Canonicalize(tg, false);
+
+  // Validate identical graphs after pooling constants and canonicalizing
+  ASSERT_TRUE((tg->toString() == sg->toString()));
 }
 
 TEST(LoweringPasses, RemoveSingleUse0DTensorsFloorDivFloatValuesAgree) {


### PR DESCRIPTION
# Description
- When `remove_unnecessary_casts` replaces both tensors in an `aten::div` call with the corresponding scalars, and the rounding mode (third argument) is specified, the schema becomes invalid
- To avoid this, we intercept the call and split the result based on what the third argument in the input was, either delegating the result to `aten::Int(aten::div(...))`, for "trunc" or `aten::floordiv(...)` for "floor"
- Update lowering pass to incorporate the above change, with appropriate documentation
- Add testing to verify catching and correctly handling these edge cases

Fixes #1780 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
