### PR TITLE
[fix] aten::stack with dynamic inputs

### DIFF
--- a/core/conversion/converters/impl/stack.cpp
+++ b/core/conversion/converters/impl/stack.cpp
@@ -43,10 +43,9 @@ auto stack_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns().patt
            auto cont = t.toCustomClass<TensorContainer>();
            itensor = cont->tensor();
          }
-
          auto shuffle_layer = ctx->net->addShuffle(*itensor);
          TORCHTRT_CHECK(shuffle_layer, "Unable to create shuffle layer from node: " << *n);
-         shuffle_layer->setReshapeDimensions(util::unsqueezeDims(itensor->getDimensions(), dim));
+         shuffle_layer->setReshapeDimensions(util::unsqueezeDims(itensor->getDimensions(), dim, 1, false));
 
          tensors.push_back(shuffle_layer->getOutput(0));
        }

--- a/tests/core/conversion/converters/test_stack.cpp
+++ b/tests/core/conversion/converters/test_stack.cpp
@@ -40,6 +40,41 @@ TEST(Converters, ATenStackPureTensorConvertsCorrectly) {
   TestATenStackPureTensorConvertsCorrectly(graph2);
 }
 
+TEST(Converters, ATenStackPureTensorDynamicConvertsCorrectly) {
+  auto TestATenStackPureTensorConvertsCorrectly = [](const std::string& graph) {
+    auto g = std::make_shared<torch::jit::Graph>();
+    torch::jit::parseIR(graph, g.get());
+
+    auto in1 = at::randint(1, 10, {4, 4, 4}, {at::kCUDA});
+    auto in2 = at::randint(1, 10, {4, 4, 4}, {at::kCUDA});
+
+    auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+    auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in1, in2});
+
+    params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+    auto trt_results = torch_tensorrt::tests::util::RunGraphEngineDynamic(g, params, {in1, in2});
+
+    ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], THRESHOLD_E5));
+  };
+  const auto graph = R"IR(
+      graph(%0 : Tensor,
+            %1 : Tensor):
+        %2 : Tensor[] = prim::ListConstruct(%0, %1)
+        %3 : int = prim::Constant[value=1]()
+        %4 : Tensor = aten::stack(%2, %3)
+        return (%4))IR";
+  const auto graph2 = R"IR(
+      graph(%0 : Tensor,
+            %1 : Tensor):
+        %2 : Tensor[] = prim::ListConstruct(%0, %1)
+        %3 : int = prim::Constant[value=-1]()
+        %4 : Tensor = aten::stack(%2, %3)
+        return (%4))IR";
+
+  TestATenStackPureTensorConvertsCorrectly(graph);
+  TestATenStackPureTensorConvertsCorrectly(graph2);
+}
+
 TEST(Converters, ATenStackDiffTensorConvertsCorrectly) {
   auto TestATenStackDiffTensorConvertsCorrectly = [](const std::string& graph) {
     auto g = std::make_shared<torch::jit::Graph>();


### PR DESCRIPTION
# Description

Resolves error preventing aten::stack from converting correctly with dynamic shapes. Unsqueezed dims used 0 for dynamic dimension which was not aligned correctly with the dynamic dim in the input, switch to using -1.
Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
