### PR TITLE
feat: Add lowering of aten::pad to aten::constant_pad_nd

### DIFF
--- a/tests/core/lowering/test_operator_aliasing_pass.cpp
+++ b/tests/core/lowering/test_operator_aliasing_pass.cpp
@@ -45,3 +45,47 @@ TEST(LoweringPasses, LoweringMultiplyCorrectly) {
 
   ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
 }
+
+TEST(LoweringPasses, LoweringPadToConstantPadNdCorrectly) {
+  std::string source_graph = R"IR(
+        graph(%input, %pad, %value):
+            %mode : str = prim::Constant[value="constant"]()
+            %o : Tensor = aten::pad(%input, %pad, %mode, %value)
+            return (%o))IR";
+  std::string target_graph = R"IR(
+        graph(%input, %pad, %value):
+            %o : Tensor = aten::constant_pad_nd(%input, %pad, %value)
+            return (%o))IR";
+
+  auto sg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(source_graph, sg.get());
+  torch_tensorrt::core::lowering::passes::AliasOperators(sg);
+
+  auto tg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(target_graph, tg.get());
+
+  ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
+}
+
+TEST(LoweringPasses, LoweringPadToConstantPadNdNoneInputCorrectly) {
+  std::string source_graph = R"IR(
+        graph(%input, %pad):
+            %none : NoneType = prim::Constant()
+            %mode : str = prim::Constant[value="constant"]()
+            %o : Tensor = aten::pad(%input, %pad, %mode, %none)
+            return (%o))IR";
+  std::string target_graph = R"IR(
+        graph(%input, %pad, %value):
+            %none : NoneType = prim::Constant()
+            %zero : int = prim::Constant[value=0]()
+            %o : Tensor = aten::constant_pad_nd(%input, %pad, %zero)
+            return (%o))IR";
+  auto sg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(source_graph, sg.get());
+  torch_tensorrt::core::lowering::passes::AliasOperators(sg);
+
+  auto tg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(target_graph, tg.get());
+
+  ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
+}


### PR DESCRIPTION
# Description

Adds lowering of aten::pad(mode="constant") to aten::constant_pad_nd. aten::pad supports None as a value which aten::constant_pad_nd so includes legalization of None -> 0.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
