### PR TITLE
fix: Out-Of-Bounds bug in Unsqueeze

### DIFF
--- a/core/util/trt_util.cpp
+++ b/core/util/trt_util.cpp
@@ -161,8 +161,14 @@ nvinfer1::Dims unpadDims(const nvinfer1::Dims& d) {
 }
 
 nvinfer1::Dims unsqueezeDims(const nvinfer1::Dims& d, int pos, int val, bool use_zeros) {
-  // acceptable range for pos is [0, d.nbDims]
-  TORCHTRT_ASSERT(pos >= 0 && pos <= d.nbDims, "ERROR: Index to unsqueeze is out of bounds.");
+  // Acceptable range for pos is [-d.nbDims - 1, d.nbDims]
+  TORCHTRT_ASSERT(
+      pos >= (-d.nbDims - 1) && pos <= d.nbDims,
+      "ERROR: Index to unsqueeze is out of bounds. "
+          << "Expected value in range [" << (-d.nbDims - 1) << ", " << d.nbDims << "], but got " << pos);
+
+  // Unsqueeze with negative dimensions creates a new dimension at that index
+  pos = (pos < 0) ? (pos + d.nbDims + 1) : pos;
 
   nvinfer1::Dims dims;
   for (int i = 0, j = 0; j <= d.nbDims; j++) {


### PR DESCRIPTION
# Description

- Implement support for negative-indexing in unsqueeze, in accordance with the `torch.unsqueeze` function
- Fix bug for TFT model in PyTorch, which requires negative indexing in unsqueeze
- Update core utility logic and comments

Desired Behavior:
```python
torch.unsqueeze(torch.ones(4, 4), -1).shape
>>> (4, 4, 1)

torch.unsqueeze(torch.ones(4, 4), -3).shape
>>> (1, 4, 4)
```

Fixes #1779

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
