### PR TITLE
fix: dependency order of inserted long input casts

### DIFF
--- a/tests/core/lowering/BUILD
+++ b/tests/core/lowering/BUILD
@@ -28,6 +28,10 @@ cc_test(
 )
 
 lowering_test(
+    name = "test_autocast_long_inputs",
+)
+
+lowering_test(
     name = "test_conv_pass",
 )
 

--- a/tests/core/lowering/BUILD
+++ b/tests/core/lowering/BUILD
@@ -106,6 +106,7 @@ lowering_test(
 test_suite(
     name = "lowering_tests",
     tests = [
+        ":test_autocast_long_inputs",
         ":test_conv_pass",
         ":test_device_casting",
         ":test_exception_elimination_pass",

--- a/tests/core/lowering/test_autocast_long_inputs.cpp
+++ b/tests/core/lowering/test_autocast_long_inputs.cpp
@@ -1,0 +1,36 @@
+#include <string>
+#include "core/compiler.h"
+#include "core/lowering/passes/passes.h"
+#include "gtest/gtest.h"
+#include "tests/util/util.h"
+#include "torch/csrc/jit/ir/irparser.h"
+#include "torch/csrc/jit/ir/subgraph_matcher.h"
+
+TEST(LoweringPasses, AutocastLongInputs) {
+  std::string source_graph = R"IR(
+    graph(%long_0 : Tensor, %long_1 : Tensor):
+      %res  : Tensor = aten::add(%long_0, %long_1)
+      return (%res))IR";
+  std::string target_graph = R"IR(
+    graph(%long_0 : Tensor, %long_1 : Tensor):
+      %3 : bool = prim::Constant[value=0]()
+      %4 : Device = prim::Constant[value="cuda:0"]()
+      %5 : NoneType = prim::Constant()
+      %6 : int = prim::Constant[value=4]()
+      %7 : Tensor = aten::to[to_compile=0](%long_0, %4, %6, %3, %3, %5)
+      %8 : int = prim::Constant[value=4]()
+      %9 : Tensor = aten::to[to_compile=0](%long_1, %4, %8, %3, %3, %5)
+      %2 : Tensor = aten::add(%7, %9)
+      return (%2))IR";
+
+  auto sg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(source_graph, &*sg);
+  std::unordered_map<const torch::jit::Value*, c10::optional<at::ScalarType>> type_map;
+  type_map[sg->inputs()[0]] = at::kLong;
+  type_map[sg->inputs()[1]] = at::kLong;
+  torch_tensorrt::core::lowering::AutocastLongInputs(sg, type_map, "cuda:0");
+  auto tg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(target_graph, &*tg);
+  ASSERT_TRUE(sg->nodes().front()->kind() == torch::jit::prim::Constant); // confirm constants are added before casts
+  ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
+}


### PR DESCRIPTION
# Description
AutocastLongInputs previously inserted cast nodes before the constant nodes used as inputs to the cast.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
