### PR TITLE
fix: Remove references to `_native_batch_norm_legit_no_training` for PyTorch 2.0 Stable

### DIFF
--- a/py/torch_tensorrt/fx/passes/lower_basic_pass_aten.py
+++ b/py/torch_tensorrt/fx/passes/lower_basic_pass_aten.py
@@ -165,7 +165,6 @@ def replace_aten_op_with_indices(module: torch.fx.GraphModule) -> torch.fx.Graph
             torch.ops.aten.max_pool3d_with_indices.default,
             torch.ops.aten.native_batch_norm.default,
             torch.ops.aten._native_batch_norm_legit.default,
-            torch.ops.aten._native_batch_norm_legit_no_training.default,
         ):
             modified = True
             if len(n.users) != 1:
@@ -185,16 +184,6 @@ def replace_aten_op_with_indices(module: torch.fx.GraphModule) -> torch.fx.Graph
                 new_op = torch.ops.aten.batch_norm
                 new_args = list(n.args)
                 new_args.append(False)
-                new_args = tuple(new_args)
-            elif (
-                n.target == torch.ops.aten._native_batch_norm_legit_no_training.default
-            ):
-                new_op = torch.ops.aten.batch_norm
-                new_args = list(n.args)
-                new_args.append(False)
-                # _native_batch_norm_legit_no_training doesn't take in a training arg (assumed to be false)
-                # but batchnorm takes in a training arg at position 5.
-                new_args.insert(5, False)
                 new_args = tuple(new_args)
 
             getitem_node = next(iter(n.users))


### PR DESCRIPTION
# Description
- Remove references for PyTorch 2.0 stable

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ - ] I have added tests to verify my fix or my feature
  - CI-Tested
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
