### PR TITLE
feat: Add converter for aten::isfinite

### DIFF
--- a/core/conversion/converters/impl/unary.cpp
+++ b/core/conversion/converters/impl/unary.cpp
@@ -49,6 +49,26 @@ auto logical_not_registration TORCHTRT_UNUSED = RegisterNodeConversionPatterns()
        return true;
      }});
 
+auto isfinite_registration TORCHTRT_UNUSED = RegisterNodeConversionPatterns().pattern(
+    {"aten::isfinite(Tensor self) -> Tensor", [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
+       auto in = args[0].ITensorOrFreeze(ctx);
+       // assuming x-x = 0 for all values other than nan/inf/-inf where x-x = nan
+       // x==x for all non-nan values
+       auto inf_test_layer = ctx->net->addElementWise(*in, *in, nvinfer1::ElementWiseOperation::kSUB);
+       TORCHTRT_CHECK(inf_test_layer, "Unable to create sub layer from node: " << *n);
+       inf_test_layer->setName((util::node_info(n) + "_inf_test").c_str());
+       auto inf_test_tensor = inf_test_layer->getOutput(0);
+
+       auto nan_test_layer =
+           ctx->net->addElementWise(*inf_test_tensor, *inf_test_tensor, nvinfer1::ElementWiseOperation::kEQUAL);
+       TORCHTRT_CHECK(nan_test_layer, "Unable to create eq layer from node: " << *n);
+       nan_test_layer->setName((util::node_info(n) + "_nan_test").c_str());
+
+       auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], nan_test_layer->getOutput(0));
+       LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
+       return true;
+     }});
+
 #define convert(unary, trt_type)                                                               \
   auto unary##_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns().pattern(       \
       {"aten::" #unary "(Tensor self) -> Tensor",                                              \

--- a/tests/core/conversion/converters/test_unary.cpp
+++ b/tests/core/conversion/converters/test_unary.cpp
@@ -96,6 +96,27 @@ TEST(Converters, ATenLogicalNotBoolConvertsCorrectly) {
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
 }
 
+TEST(Converters, ATenFiniteConvertsCorrectly) {
+  const auto graph = gen_test_graph("isfinite");
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+  auto in = at::tensor(
+      {float(0),
+       std::nanf(""),
+       float(2),
+       std::numeric_limits<float>::infinity(),
+       float(4),
+       -std::numeric_limits<float>::infinity()},
+      {at::kCUDA});
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
+}
+
 #define test_unary(unary, name)                                                                  \
   TEST(Converters, ATen##name##ConvertsCorrectly) {                                              \
     const auto graph = gen_test_graph(#unary);                                                   \


### PR DESCRIPTION
# Description

Adds a converter to support `aten::isfinite` https://pytorch.org/docs/stable/generated/torch.isfinite.html.

Implemented as `(x-x)==(x-x)`. Relies on the fact that `x-x = NaN` for `NaN`, `inf` and `-inf` and `NaN != NaN`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
