### PR TITLE
Fix: fix float point 16 precision type issue

### DIFF
--- a/core/conversion/converters/impl/activation.cpp
+++ b/core/conversion/converters/impl/activation.cpp
@@ -16,8 +16,9 @@ namespace {
     TORCHTRT_CHECK(new_layer, "Unable to create " #act " layer from node: " << *n);                                  \
                                                                                                                      \
     new_layer->setName(util::node_info(n).c_str());                                                                  \
+    new_layer->setOutputType(0, in->getType());                                                                      \
     ctx->AssociateValueAndTensor(n->outputs()[0], new_layer->getOutput(0));                                          \
-    LOG_DEBUG("Output tensor shape: " << new_layer->getOutput(0)->getDimensions());                                  \
+    LOG_DEBUG("Output tensor: " << new_layer->getOutput(0)->getDimensions() << "/" << in->getType());                \
                                                                                                                      \
     return true;                                                                                                     \
   }                                                                                                                  \
@@ -56,9 +57,10 @@ auto acthardtanh TORCHTRT_UNUSED =
                new_layer->setBeta(max);
 
                new_layer->setName(util::node_info(n).c_str());
+               new_layer->setOutputType(0, in->getType());
                auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], new_layer->getOutput(0));
 
-               LOG_DEBUG("Output shape: " << out_tensor->getDimensions());
+               LOG_DEBUG("Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
                return true;
              }})
         .pattern({// TODO: Remove after functionalization
@@ -75,9 +77,10 @@ auto acthardtanh TORCHTRT_UNUSED =
                     new_layer->setBeta(max);
 
                     new_layer->setName(util::node_info(n).c_str());
+                    new_layer->setOutputType(0, in->getType());
                     auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], new_layer->getOutput(0));
 
-                    LOG_DEBUG("Output shape: " << out_tensor->getDimensions());
+                    LOG_DEBUG("Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
                     return true;
                   }})
         .pattern(
@@ -132,6 +135,7 @@ auto acthardtanh TORCHTRT_UNUSED =
                auto slope_tensor = tensor_to_const(ctx, slopes);
                auto new_layer = ctx->net->addParametricReLU(*in, *slope_tensor);
                new_layer->setName(util::node_info(n).c_str());
+               new_layer->setOutputType(0, in->getType());
                auto out_tensor = new_layer->getOutput(0);
 
                if (to_reshape) {
@@ -144,7 +148,7 @@ auto acthardtanh TORCHTRT_UNUSED =
                }
 
                out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], out_tensor);
-               LOG_DEBUG("Output shape: " << out_tensor->getDimensions());
+               LOG_DEBUG("Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
                return true;
              }})
         .pattern(
@@ -157,9 +161,10 @@ auto acthardtanh TORCHTRT_UNUSED =
                new_layer->setAlpha(negative_slopeScalar);
 
                new_layer->setName(util::node_info(n).c_str());
+               new_layer->setOutputType(0, self->getType());
                auto out_tensor = new_layer->getOutput(0);
                out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], out_tensor);
-               LOG_DEBUG("Output shape: " << out_tensor->getDimensions());
+               LOG_DEBUG("Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
                return true;
              }})
         .pattern(
@@ -171,9 +176,10 @@ auto acthardtanh TORCHTRT_UNUSED =
                auto new_layer = ctx->net->addActivation(*self, nvinfer1::ActivationType::kLEAKY_RELU);
                new_layer->setAlpha(negative_slopeScalar);
                new_layer->setName(util::node_info(n).c_str());
+               new_layer->setOutputType(0, self->getType());
                auto out_tensor = new_layer->getOutput(0);
                out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], out_tensor);
-               LOG_DEBUG("Output shape: " << out_tensor->getDimensions());
+               LOG_DEBUG("Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
                return true;
              }})
         .pattern(
@@ -187,9 +193,10 @@ auto acthardtanh TORCHTRT_UNUSED =
                new_layer->setAlpha(alpha);
 
                new_layer->setName(util::node_info(n).c_str());
+               new_layer->setOutputType(0, in->getType());
 
                auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], new_layer->getOutput(0));
-               LOG_DEBUG("Output shape: " << out_tensor->getDimensions());
+               LOG_DEBUG("Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
                return true;
              }});
 } // namespace

--- a/core/conversion/converters/impl/batch_norm.cpp
+++ b/core/conversion/converters/impl/batch_norm.cpp
@@ -45,11 +45,12 @@ void _batch_norm(
   auto bn =
       ctx->net->addScaleNd(*input, nvinfer1::ScaleMode::kCHANNEL, bias_weights.data, scale_weights.data, power.data, 1);
   bn->setName(util::node_info(n).c_str());
+  bn->setOutputType(0, input->getType());
 
   // Un-pad bn output if needed
   auto out_tensor = addUnpadding(ctx, n, bn->getOutput(0), orig_shape.nbDims);
   ctx->AssociateValueAndTensor(n->outputs()[0], out_tensor);
-  LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
+  LOG_DEBUG("Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
 }
 
 auto batch_norm_registrations TORCHTRT_UNUSED =
@@ -192,8 +193,10 @@ auto batch_norm_registrations TORCHTRT_UNUSED =
                   ctx->net->addPluginV2(reinterpret_cast<nvinfer1::ITensor* const*>(&input), 1, *instance_norm_plugin);
 
               new_layer->setName(util::node_info(n).c_str());
+              new_layer->setOutputType(0, input->getType());
+
               auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], new_layer->getOutput(0));
-              LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
+              LOG_DEBUG("Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
               return true;
             }});
 } // namespace

--- a/core/conversion/converters/impl/concat.cpp
+++ b/core/conversion/converters/impl/concat.cpp
@@ -45,9 +45,12 @@ auto cat_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns()
 
               auto cat_layer = ctx->net->addConcatenation(tensors.data(), tensors.size());
               cat_layer->setAxis(static_cast<int>(dim));
+              cat_layer->setOutputType(0, promo_dtype);
+
+
               auto cat_out = ctx->AssociateValueAndTensor(n->outputs()[0], cat_layer->getOutput(0));
 
-              LOG_DEBUG("Output tensor shape: " << cat_out->getDimensions());
+              LOG_DEBUG("Output tensor: " << cat_out->getDimensions() << "/" << cat_out->getType());
 
               return true;
             }});

--- a/core/conversion/converters/impl/conv_deconv.cpp
+++ b/core/conversion/converters/impl/conv_deconv.cpp
@@ -123,7 +123,7 @@ bool add_conv_deconv(ConversionCtx* ctx, const torch::jit::Node* n, args& args) 
   }
   auto dims = in->getDimensions();
   auto orig_dims = dims;
-  LOG_DEBUG("Input dims: " << orig_dims);
+  LOG_DEBUG("Input :" << orig_dims << "/" << in->getType());
   LOG_DEBUG("Weights: " << w);
   LOG_DEBUG("stride: " << stride);
   LOG_DEBUG("padding: " << padding);
@@ -253,13 +253,14 @@ bool add_conv_deconv(ConversionCtx* ctx, const torch::jit::Node* n, args& args) 
   }
 
   new_layer->setName(util::node_info(n).c_str());
+  new_layer->setOutputType(0, in->getType());
 
   // Un-expand spatial dims back to 1D if needed
   auto out = addUnpadding(ctx, n, new_layer->getOutput(0), orig_dims.nbDims);
 
   ctx->AssociateValueAndTensor(n->outputs()[0], out);
 
-  LOG_DEBUG("Output tensor shape: " << out->getDimensions());
+  LOG_DEBUG("Output tensor:" << out->getDimensions() << "/" << out->getType());
 
   return true;
 }

--- a/core/conversion/converters/impl/pooling.cpp
+++ b/core/conversion/converters/impl/pooling.cpp
@@ -30,10 +30,11 @@ bool GlobalPoolingConverter(
       /*keepDimensions=*/true);
 
   new_layer->setName(util::node_info(n).c_str());
+  new_layer->setOutputType(0, in->getType());
 
   auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], new_layer->getOutput(0));
 
-  LOG_DEBUG("GlobalPoolingConverter: Output tensor shape: " << out_tensor->getDimensions());
+  LOG_DEBUG("GlobalPoolingConverter: Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
   return true;
 }
 
@@ -103,10 +104,11 @@ bool AdaptivePoolingConverter(
   TORCHTRT_CHECK(new_layer, "Unable to create pooling (interpolation) plugin from node" << *n);
 
   new_layer->setName(util::node_info(n).c_str());
+  new_layer->setOutputType(0, in->getType());
   auto layer_output = new_layer->getOutput(0);
 
   ctx->AssociateValueAndTensor(n->outputs()[0], layer_output);
-  LOG_DEBUG("Output tensor shape: " << layer_output->getDimensions());
+  LOG_DEBUG("Output tensor: " << layer_output->getDimensions() << "/" << layer_output->getType());
 
   return true;
 }
@@ -178,6 +180,7 @@ bool PoolingConverter(ConversionCtx* ctx, const torch::jit::Node* n, args& args,
       ceil_mode ? nvinfer1::PaddingMode::kEXPLICIT_ROUND_UP : nvinfer1::PaddingMode::kEXPLICIT_ROUND_DOWN;
 
   new_layer->setName(util::node_info(n).c_str());
+  new_layer->setOutputType(0, in->getType());
   new_layer->setPaddingMode(padding_mode);
   new_layer->setPaddingNd(padding);
   new_layer->setStrideNd(stride);
@@ -193,7 +196,7 @@ bool PoolingConverter(ConversionCtx* ctx, const torch::jit::Node* n, args& args,
   auto out_tensor = addUnpadding(ctx, n, new_layer->getOutput(0), orig_dims.nbDims, false, true);
   ctx->AssociateValueAndTensor(n->outputs()[0], out_tensor);
 
-  LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
+  LOG_DEBUG("Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
   return true;
 } // namespace
 

--- a/core/conversion/converters/impl/shuffle.cpp
+++ b/core/conversion/converters/impl/shuffle.cpp
@@ -58,10 +58,11 @@ static auto shuffle_registrations TORCHTRT_UNUSED =
                auto shuffle = ctx->net->addShuffle(*in);
                TORCHTRT_CHECK(shuffle, "Unable to create shuffle layer from node: " << *n);
                shuffle->setReshapeDimensions(util::toDims(out_shape));
+               shuffle->setOutputType(0, in->getType());
                shuffle->setName(util::node_info(n).c_str());
 
                auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], shuffle->getOutput(0));
-               LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
+               LOG_DEBUG("Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
                return true;
              }})
         .pattern(
@@ -94,6 +95,8 @@ static auto shuffle_registrations TORCHTRT_UNUSED =
                }
                auto shuffle = ctx->net->addShuffle(*in);
                shuffle->setName(util::node_info(n).c_str());
+               LOG_DEBUG(" setting input type: " << in->getType());
+               shuffle->setOutputType(0, in->getType());
                TORCHTRT_CHECK(shuffle, "Unable to create shuffle layer from node: " << *n);
 
                if (ctx->input_is_dynamic) {
@@ -103,7 +106,7 @@ static auto shuffle_registrations TORCHTRT_UNUSED =
                }
 
                auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], shuffle->getOutput(0));
-               LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
+               LOG_DEBUG("Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
 
                return true;
              }})
@@ -117,9 +120,10 @@ static auto shuffle_registrations TORCHTRT_UNUSED =
                TORCHTRT_CHECK(shuffle, "Unable to create shuffle layer from node: " << *n);
                shuffle->setReshapeDimensions(util::toDims(args[1].unwrapToIntList().vec()));
                shuffle->setName(util::node_info(n).c_str());
+               shuffle->setOutputType(0, in->getType());
 
                auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], shuffle->getOutput(0));
-               LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
+               LOG_DEBUG("Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
 
                return true;
              }})
@@ -138,9 +142,10 @@ static auto shuffle_registrations TORCHTRT_UNUSED =
                std::copy(new_order.begin(), new_order.end(), permute.order);
                shuffle->setSecondTranspose(permute);
                shuffle->setName(util::node_info(n).c_str());
+               shuffle->setOutputType(0, in->getType());
 
                auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], shuffle->getOutput(0));
-               LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
+               LOG_DEBUG("Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
 
                return true;
              }})
@@ -172,9 +177,10 @@ static auto shuffle_registrations TORCHTRT_UNUSED =
 
                shuffle->setSecondTranspose(permute);
                shuffle->setName(util::node_info(n).c_str());
+               shuffle->setOutputType(0, in->getType());
 
                auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], shuffle->getOutput(0));
-               LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
+               LOG_DEBUG("Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
 
                return true;
              }})
@@ -200,9 +206,10 @@ static auto shuffle_registrations TORCHTRT_UNUSED =
                shuffle_layer->setFirstTranspose(firstPerm);
                shuffle_layer->setZeroIsPlaceholder(false);
                shuffle_layer->setName(util::node_info(n).c_str());
+               shuffle_layer->setOutputType(0, in->getType());
 
                auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], shuffle_layer->getOutput(0));
-               LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
+               LOG_DEBUG("Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
 
                return true;
              }})
@@ -275,9 +282,10 @@ static auto shuffle_registrations TORCHTRT_UNUSED =
                TORCHTRT_CHECK(last_view_layer, "Unable to create shuffle layer from node: " << *n);
                last_view_layer->setReshapeDimensions(util::toDims(final_shape));
                last_view_layer->setName(util::node_info(n).c_str());
+               last_view_layer->setOutputType(0, self->getType());
 
                auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], last_view_layer->getOutput(0));
-               LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
+               LOG_DEBUG("Output tensor: " << out_tensor->getDimensions() << "/" << out_tensor->getType());
 
                return true;
              }});


### PR DESCRIPTION
# Description
For some networks running with FP16, some bugs like 
```
Expected input tensors to have type Half, found type float
```
are observed. 
This PR fixes the bug that output type may not match to the input type
in converters. Some of the converters should make sure that the input
tensor and output tensor have the same date type.


## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
