### PR TITLE
fix: Add support for default dimension in `aten.cat`

### DIFF
--- a/py/torch_tensorrt/fx/converters/aten_ops_converters.py
+++ b/py/torch_tensorrt/fx/converters/aten_ops_converters.py
@@ -358,7 +358,7 @@ def aten_ops_cat(
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     kwargs_new = {
         "tensors": args[0],
-        "dim": args[1],
+        "dim": args[1] if len(args) >= 2 else 0,
     }
     return acc_ops_converters.acc_ops_cat(network, target, None, kwargs_new, name)
 

--- a/py/torch_tensorrt/fx/test/converters/aten_op/test_cat_aten.py
+++ b/py/torch_tensorrt/fx/test/converters/aten_op/test_cat_aten.py
@@ -9,7 +9,7 @@ class TestCatConverter(DispatchTestCase):
     @parameterized.expand(
         [
             ("pos", 1),
-            # ("neg", -2), #dim can not have dynamic input
+            ("neg", -2),
         ]
     )
     def test_cat(self, _, dim):
@@ -27,7 +27,7 @@ class TestCatConverter(DispatchTestCase):
     @parameterized.expand(
         [
             ("pos", 1),
-            # ("neg", -2), #dim can not have dynamic input
+            ("neg", -2),
         ]
     )
     def test_cat_dynamic_shape(self, _, dim):
@@ -45,6 +45,41 @@ class TestCatConverter(DispatchTestCase):
                 shape=(16, -1, 3),
                 dtype=torch.float32,
                 shape_ranges=[((16, 2, 3), (16, 16, 3), (16, 32, 3))],
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            Cat(),
+            input_specs,
+            expected_ops={torch.ops.aten.cat.default},
+        )
+
+    def test_cat_no_dim(self):
+        class Cat(nn.Module):
+            def forward(self, x, y, z):
+                return torch.cat((x, y, z))
+
+        inputs = [torch.randn(2, 1, 3), torch.randn(1, 1, 3), torch.randn(3, 1, 3)]
+        self.run_test(
+            Cat(),
+            inputs,
+            expected_ops={torch.ops.aten.cat.default},
+        )
+
+    def test_cat_dynamic_shape_no_dim(self):
+        class Cat(nn.Module):
+            def forward(self, x, y):
+                return torch.cat((x, y))
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, 16, 3),
+                dtype=torch.float32,
+                shape_ranges=[((2, 16, 3), (3, 16, 3), (32, 16, 3))],
+            ),
+            InputTensorSpec(
+                shape=(-1, 16, 3),
+                dtype=torch.float32,
+                shape_ranges=[((2, 16, 3), (3, 16, 3), (32, 16, 3))],
             ),
         ]
         self.run_test_with_dynamic_shape(


### PR DESCRIPTION
# Description

- Add default `dim=0` to concatenation operator for use cases which do not have a specific concatenation dimension specified
- T5 encounters this error during compilation
- Add test cases to elicit error with default dimension

Fixes #1862
Addresses #1740 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
