### PR TITLE
fix: Add support for `truncate_long_and_double` in FX

### DIFF
--- a/py/torch_tensorrt/fx/fx2trt.py
+++ b/py/torch_tensorrt/fx/fx2trt.py
@@ -41,6 +41,7 @@ class TRTInterpreter(torch.fx.Interpreter):
         explicit_batch_dimension: bool = False,
         explicit_precision: bool = False,
         logger_level=None,
+        truncate_long_and_double=False,
     ):
         super().__init__(module)
 
@@ -70,6 +71,7 @@ class TRTInterpreter(torch.fx.Interpreter):
 
         self.optimization_profiles: Optional[List] = None
         self.input_specs = input_specs
+        self.truncate_long_and_double = truncate_long_and_double
         self.input_specs_iter = 0
         self.validate_input_specs()
         self._cur_node_name: Optional[str] = None
@@ -306,7 +308,9 @@ class TRTInterpreter(torch.fx.Interpreter):
                 self.optimization_profiles[i].set_shape(target, *shape_range)
 
         return self.network.add_input(
-            name=target, shape=tuple(shape), dtype=torch_dtype_to_trt(dtype)
+            name=target,
+            shape=tuple(shape),
+            dtype=torch_dtype_to_trt(dtype, self.truncate_long_and_double),
         )
 
     def call_module(self, target, args, kwargs):

--- a/py/torch_tensorrt/fx/lower.py
+++ b/py/torch_tensorrt/fx/lower.py
@@ -43,6 +43,7 @@ def compile(
     use_experimental_fx_rt=False,
     correctness_atol=1e-1,
     correctness_rtol=1e-1,
+    truncate_long_and_double=False,
 ) -> nn.Module:
     """
     Takes in original module, input and lowering setting, run lowering workflow to turn module
@@ -62,6 +63,7 @@ def compile(
         cuda_graph_batch_size: Cuda graph batch size, default to be -1.
         dynamic_batch: batch dimension (dim=0) is dynamic.
         use_experimental_fx_rt: Uses the next generation TRTModule which supports both Python and TorchScript based execution (including in C++).
+        truncate_long_and_double: Whether to automatically truncate long and double-type tensor inputs to TRT Engines
     Returns:
         A torch.nn.Module lowered by TensorRT.
     """
@@ -85,6 +87,7 @@ def compile(
         use_experimental_rt=use_experimental_fx_rt,
         correctness_atol=correctness_atol,
         correctness_rtol=correctness_rtol,
+        truncate_long_and_double=truncate_long_and_double,
     )
     lowerer = Lowerer.create(lower_setting=lower_setting)
     return lowerer(module, input)
@@ -129,6 +132,7 @@ class LowerTrtInterpreter:
             logger_level=trt.Logger.VERBOSE
             if self.lower_setting.verbose_log
             else trt.Logger.WARNING,
+            truncate_long_and_double=self.lower_setting.truncate_long_and_double,
         )
 
         interp_result: TRTInterpreterResult = interpreter.run(

--- a/py/torch_tensorrt/fx/lower_setting.py
+++ b/py/torch_tensorrt/fx/lower_setting.py
@@ -101,3 +101,4 @@ class LowerSetting(LowerSettingBasic):
     correctness_atol: float = 0.1
     correctness_rtol: float = 0.1
     use_experimental_rt: bool = False
+    truncate_long_and_double: bool = False

--- a/py/torch_tensorrt/fx/test/core/test_trt_module.py
+++ b/py/torch_tensorrt/fx/test/core/test_trt_module.py
@@ -10,8 +10,8 @@ import torch_tensorrt.fx.tracer.acc_tracer.acc_tracer as acc_tracer
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch_tensorrt.fx import InputTensorSpec, TRTInterpreter, TRTModule
 
-# from torch_tensorrt import TRTModuleNext
-# from torch_tensorrt import Device
+from torch_tensorrt import TRTModuleNext
+from torch_tensorrt import Device
 from torch_tensorrt.fx.utils import LowerPrecision
 
 
@@ -58,89 +58,145 @@ class TestTRTModule(TestCase):
         )
 
 
-# TODO add unittest.skip later
-# class TestTRTModuleNext(TestCase):
-#     def test_save_and_load_trt_module(self):
-#         class TestModule(torch.nn.Module):
-#             def forward(self, x):
-#                 return x + x
+class TestTRTModuleInt64Input(TestCase):
+    def test_save_and_load_trt_module(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, x):
+                return x + x
 
-#         inputs = [torch.randn(1, 1)]
-#         mod = TestModule().eval()
-#         ref_output = mod(*inputs)
+        inputs = [torch.randn(5, 5).long()]
+        mod = TestModule().eval()
+        ref_output = mod(*inputs)
 
-#         mod = acc_tracer.trace(mod, inputs)
+        mod = acc_tracer.trace(mod, inputs)
+        interp = TRTInterpreter(
+            mod,
+            input_specs=InputTensorSpec.from_tensors(inputs),
+        )
+        trt_mod = TRTModule(*interp.run(lower_precision=LowerPrecision.FP32))
+        torch.save(trt_mod, "trt.pt")
+        reload_trt_mod = torch.load("trt.pt")
 
-#         interp = TRTInterpreter(
-#             mod,
-#             input_specs=InputTensorSpec.from_tensors(inputs),
-#             explicit_batch_dimension=True,
-#         )
-#         interp_res = interp.run(lower_precision=LowerPrecision.FP32)
+        torch.testing.assert_close(
+            reload_trt_mod(inputs[0].cuda()).cpu(),
+            ref_output,
+            rtol=1e-04,
+            atol=1e-04,
+            check_dtype=False,
+        )
+        os.remove(f"{os.getcwd()}/trt.pt")
 
-#         with io.BytesIO() as engine_bytes:
-#             engine_bytes.write(interp_res.engine.serialize())
-#             engine_str = engine_bytes.getvalue()
+    def test_save_and_load_state_dict(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, x):
+                return x + x
 
-#         trt_mod = TRTModuleNext(
-#             name="TestModule",
-#             serialized_engine=engine_str,
-#             input_binding_names=interp_res.input_names,
-#             output_binding_names=interp_res.output_names,
-#             target_device=Device(f"cuda:{torch.cuda.current_device()}"),
-#         )
+        inputs = [torch.randn(5, 5).long()]
+        mod = TestModule().eval()
+        ref_output = mod(*inputs)
 
-#         torch.save(trt_mod, "trt.pt")
-#         reload_trt_mod = torch.load("trt.pt")
+        mod = acc_tracer.trace(mod, inputs)
+        interp = TRTInterpreter(
+            mod,
+            input_specs=InputTensorSpec.from_tensors(inputs),
+        )
+        trt_mod = TRTModule(*interp.run(lower_precision=LowerPrecision.FP32))
+        st = trt_mod.state_dict()
 
-#         torch.testing.assert_allclose(
-#             reload_trt_mod(inputs[0].cuda()).cpu().reshape_as(ref_output),
-#             ref_output,
-#             rtol=1e-04,
-#             atol=1e-04,
-#         )
-#         os.remove(f"{os.getcwd()}/trt.pt")
+        new_trt_mod = TRTModule()
+        new_trt_mod.load_state_dict(st)
 
-#     def test_save_and_load_state_dict(self):
-#         class TestModule(torch.nn.Module):
-#             def forward(self, x):
-#                 return x + x
+        torch.testing.assert_close(
+            new_trt_mod(inputs[0].cuda()).cpu(),
+            ref_output,
+            rtol=1e-04,
+            atol=1e-04,
+            check_dtype=False,
+        )
 
-#         inputs = [torch.randn(1, 1)]
-#         mod = TestModule().eval()
-#         ref_output = mod(*inputs)
 
-#         mod = acc_tracer.trace(mod, inputs)
-#         interp = TRTInterpreter(
-#             mod,
-#             input_specs=InputTensorSpec.from_tensors(inputs),
-#             explicit_batch_dimension=True,
-#         )
-#         interp_res = interp.run(lower_precision=LowerPrecision.FP32)
+class TestTRTModuleNext(TestCase):
+    def test_save_and_load_trt_module(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, x):
+                return x + x
 
-#         with io.BytesIO() as engine_bytes:
-#             engine_bytes.write(interp_res.engine.serialize())
-#             engine_str = engine_bytes.getvalue()
+        inputs = [torch.randn(1, 1)]
+        mod = TestModule().eval()
+        ref_output = mod(*inputs)
 
-#         trt_mod = TRTModuleNext(
-#             name="TestModule",
-#             serialized_engine=engine_str,
-#             input_binding_names=interp_res.input_names,
-#             output_binding_names=interp_res.output_names,
-#             target_device=Device(f"cuda:{torch.cuda.current_device()}"),
-#         )
+        mod = acc_tracer.trace(mod, inputs)
 
-#         st = trt_mod.state_dict()
+        interp = TRTInterpreter(
+            mod,
+            input_specs=InputTensorSpec.from_tensors(inputs),
+            explicit_batch_dimension=True,
+        )
+        interp_res = interp.run(lower_precision=LowerPrecision.FP32)
 
-#         new_trt_mod = TRTModuleNext()
-#         new_trt_mod.load_state_dict(st)
+        with io.BytesIO() as engine_bytes:
+            engine_bytes.write(interp_res.engine.serialize())
+            engine_str = engine_bytes.getvalue()
 
-#         torch.testing.assert_allclose(
-#             new_trt_mod(inputs[0].cuda()).cpu().reshape_as(ref_output),
-#             ref_output,
-#             rtol=1e-04,
-#             atol=1e-04,
-#         )
+        trt_mod = TRTModuleNext(
+            name="TestModule",
+            serialized_engine=engine_str,
+            input_binding_names=interp_res.input_names,
+            output_binding_names=interp_res.output_names,
+            target_device=Device(f"cuda:{torch.cuda.current_device()}"),
+        )
+
+        torch.save(trt_mod, "trt.pt")
+        reload_trt_mod = torch.load("trt.pt")
+
+        torch.testing.assert_allclose(
+            reload_trt_mod(inputs[0].cuda()).cpu().reshape_as(ref_output),
+            ref_output,
+            rtol=1e-04,
+            atol=1e-04,
+        )
+        os.remove(f"{os.getcwd()}/trt.pt")
+
+    def test_save_and_load_state_dict(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, x):
+                return x + x
+
+        inputs = [torch.randn(1, 1)]
+        mod = TestModule().eval()
+        ref_output = mod(*inputs)
+
+        mod = acc_tracer.trace(mod, inputs)
+        interp = TRTInterpreter(
+            mod,
+            input_specs=InputTensorSpec.from_tensors(inputs),
+            explicit_batch_dimension=True,
+        )
+        interp_res = interp.run(lower_precision=LowerPrecision.FP32)
+
+        with io.BytesIO() as engine_bytes:
+            engine_bytes.write(interp_res.engine.serialize())
+            engine_str = engine_bytes.getvalue()
+
+        trt_mod = TRTModuleNext(
+            name="TestModule",
+            serialized_engine=engine_str,
+            input_binding_names=interp_res.input_names,
+            output_binding_names=interp_res.output_names,
+            target_device=Device(f"cuda:{torch.cuda.current_device()}"),
+        )
+
+        st = trt_mod.state_dict()
+
+        new_trt_mod = TRTModuleNext()
+        new_trt_mod.load_state_dict(st)
+
+        torch.testing.assert_allclose(
+            new_trt_mod(inputs[0].cuda()).cpu().reshape_as(ref_output),
+            ref_output,
+            rtol=1e-04,
+            atol=1e-04,
+        )
 
 
 if __name__ == "__main__":

--- a/py/torch_tensorrt/fx/trt_module.py
+++ b/py/torch_tensorrt/fx/trt_module.py
@@ -156,6 +156,15 @@ class TRTModule(torch.nn.Module):
                         inputs = (
                             inputs[:i] + (inputs[i].to(torch.int32),) + inputs[i + 1 :]
                         )
+                    elif (
+                        inputs[i].dtype == torch.float64
+                        and self.input_dtypes[i] == torch.float32
+                    ):
+                        inputs = (
+                            inputs[:i]
+                            + (inputs[i].to(torch.float32),)
+                            + inputs[i + 1 :]
+                        )
 
                     assert (
                         inputs[i].dtype == self.input_dtypes[i]

--- a/py/torch_tensorrt/fx/utils.py
+++ b/py/torch_tensorrt/fx/utils.py
@@ -5,6 +5,7 @@ from packaging import version
 # @manual=//deeplearning/trt/python:py_tensorrt
 import tensorrt as trt
 import torch
+import logging
 from functorch import make_fx
 from functorch.experimental import functionalize
 from torch_tensorrt.fx.passes.lower_basic_pass import (
@@ -13,6 +14,9 @@ from torch_tensorrt.fx.passes.lower_basic_pass import (
 )
 
 from .types import Shape, TRTDataType
+
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
 class LowerPrecision(Enum):
@@ -50,6 +54,11 @@ def torch_dtype_to_trt(dtype: torch.dtype) -> TRTDataType:
     elif dtype == torch.int8:
         return trt.int8
     elif dtype == torch.int32:
+        return trt.int32
+    elif dtype == torch.int64:
+        _LOGGER.warn(
+            "Detected Int64 Input, Casting to Int32 for TRT Engine Compatibility"
+        )
         return trt.int32
     elif dtype == torch.float16:
         return trt.float16

--- a/py/torch_tensorrt/fx/utils.py
+++ b/py/torch_tensorrt/fx/utils.py
@@ -39,7 +39,9 @@ class LowerPrecision(Enum):
             return None
 
 
-def torch_dtype_to_trt(dtype: torch.dtype) -> TRTDataType:
+def torch_dtype_to_trt(
+    dtype: torch.dtype, truncate_long_and_double: bool = False
+) -> TRTDataType:
     """
     Convert PyTorch data types to TensorRT data types.
 
@@ -56,14 +58,31 @@ def torch_dtype_to_trt(dtype: torch.dtype) -> TRTDataType:
     elif dtype == torch.int32:
         return trt.int32
     elif dtype == torch.int64:
-        _LOGGER.warn(
-            "Detected Int64 Input, Casting to Int32 for TRT Engine Compatibility"
-        )
-        return trt.int32
+        if truncate_long_and_double:
+            _LOGGER.warn(
+                "Detected Int64 Input, Casting to Int32 for TRT Engine Compatibility"
+            )
+            return trt.int32
+        else:
+            raise TypeError(
+                "Detected Int64 Input which is not supported by tensorrt, enable compilation"
+                + "option truncate_long_and_double=True to cast input to Int32 for TRT Engine"
+            )
     elif dtype == torch.float16:
         return trt.float16
     elif dtype == torch.float32:
         return trt.float32
+    elif dtype == torch.float64:
+        if truncate_long_and_double:
+            _LOGGER.warn(
+                "Detected Float64 Input, Casting to Float32 for TRT Engine Compatibility"
+            )
+            return trt.float32
+        else:
+            raise TypeError(
+                "Detected Float64 Input which is not supported by tensorrt, enable compilation"
+                + "option truncate_long_and_double=True to cast input to Float32 for TRT Engine"
+            )
     else:
         raise TypeError("%s is not supported by tensorrt" % dtype)
 


### PR DESCRIPTION
# Description

- Add utility capabilities for accepting int64 and float64 inputs to TRTModules to support multiple use cases
- Support cases include situations where internal tensors in split modules are int64 (generally used for indexing torch Tensors)
- This also supports cases where the user wants to input long or double tensors as forward inputs
- Add test cases to verify functionality and accuracy
- Enable tests for TRTModuleNext, which are now fully supported on main

Fixes #1864 
Addresses #1740 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
