### PR TITLE
fix: Add version checking for `torch._dynamo` import in `__init__`

### DIFF
--- a/py/torch_tensorrt/__init__.py
+++ b/py/torch_tensorrt/__init__.py
@@ -4,6 +4,7 @@ import os
 import sys
 import platform
 import warnings
+from packaging import version
 from torch_tensorrt._version import (
     __version__,
     __cuda_version__,
@@ -93,8 +94,10 @@ from torch_tensorrt._Device import Device
 from torch_tensorrt._TRTModuleNext import TRTModuleNext
 
 from torch_tensorrt import fx
-from torch_tensorrt import dynamo
-from torch_tensorrt.dynamo import torch_compile
+
+if version.parse(torch.__version__) >= version.parse("2.dev"):
+    from torch_tensorrt import dynamo
+    from torch_tensorrt.dynamo import torch_compile
 
 
 def _register_with_torch():


### PR DESCRIPTION
# Description

- Ensure `torch._dynamo` can be imported by validating Torch version
- Intended to fix legacy CI run

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
