### PR TITLE
fix: Resolve issue in isInputDynamic with mixed static/dynamic shapes

### DIFF
--- a/core/partitioning/partitioning.cpp
+++ b/core/partitioning/partitioning.cpp
@@ -527,16 +527,15 @@ void segmentGraph(PartitioningCtx* ctx, torch::jit::Block* block) {
 
 bool isInputDynamic(PartitioningCtx* ctx) {
   // Check if inputs have dynamic shapes
-  bool input_is_dynamic = true;
   auto inputs_map = ctx->settings.collection_input_spec_map;
   for (auto inputs : inputs_map) {
     for (auto input : inputs.second) {
-      if (!input.input_is_dynamic) {
-        input_is_dynamic = false;
+      if (input.input_is_dynamic) {
+        return true;
       }
     }
   }
-  return input_is_dynamic;
+  return false;
 }
 
 void populateInputIValues(PartitioningCtx* ctx) {


### PR DESCRIPTION
# Description

isInputDynamic previously returned false if any inputs had static shapes. This forced static shape propagation incorrectly when not all input shapes were dynamic.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
