### PR TITLE
feat: support type promotion in aten::cat converter

### DIFF
--- a/core/conversion/converters/converter_util.h
+++ b/core/conversion/converters/converter_util.h
@@ -96,6 +96,8 @@ nvinfer1::ITensor* get_slice_size(
 
 nvinfer1::ITensor* scalar_to_tensor(ConversionCtx* ctx, at::Scalar s);
 
+nvinfer1::DataType promote_types(nvinfer1::DataType type_a, nvinfer1::DataType type_b);
+
 } // namespace converters
 } // namespace conversion
 } // namespace core

--- a/core/conversion/converters/impl/concat.cpp
+++ b/core/conversion/converters/impl/concat.cpp
@@ -1,3 +1,4 @@
+#include "core/conversion/converters/converter_util.h"
 #include "core/conversion/converters/converters.h"
 #include "core/conversion/tensorcontainer/TensorContainer.h"
 #include "core/util/prelude.h"
@@ -24,6 +25,17 @@ auto cat_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns()
                 } else {
                   auto cont = t.toCustomClass<TensorContainer>();
                   tensors.push_back(cont->tensor());
+                }
+              }
+
+              auto promo_dtype = tensors[0]->getType();
+              for(size_t idx = 1UL; idx < tensors.size(); ++idx){
+                promo_dtype = promote_types(promo_dtype, tensors[idx]->getType());
+              }
+
+              for(size_t idx = 0UL; idx < tensors.size(); ++idx){
+                if(tensors[idx]->getType() != promo_dtype){
+                  tensors[idx] = castITensor(ctx, tensors[idx], promo_dtype, util::node_info(n) + "_cast_" + std::to_string(idx));
                 }
               }
 

--- a/tests/core/conversion/converters/test_concat.cpp
+++ b/tests/core/conversion/converters/test_concat.cpp
@@ -29,6 +29,85 @@ TEST(Converters, ATenCatPureTensorConvertsCorrectly) {
       torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
 }
 
+TEST(Converters, ATenCatFloatIntConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor,
+            %1 : Tensor):
+        %2 : Tensor[] = prim::ListConstruct(%0, %1)
+        %3 : int = prim::Constant[value=0]()
+        %4 : Tensor = aten::cat(%2, %3)
+        return (%4))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  auto in1 = at::randint(1, 10, {5}, {at::kCUDA}).to(at::kFloat);
+  auto in2 = at::randint(1, 10, {5}, {at::kCUDA}).to(at::kInt);
+
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in1, in2});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in1, in2});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
+}
+
+TEST(Converters, ATenCatIntHalfIntHalfConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor,
+            %1 : Tensor,
+            %2 : Tensor,
+            %3 : Tensor):
+        %2 : Tensor[] = prim::ListConstruct(%0, %1, %2, %3)
+        %3 : int = prim::Constant[value=0]()
+        %4 : Tensor = aten::cat(%2, %3)
+        return (%4))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  auto in1 = at::randint(1, 10, {5}, {at::kCUDA}).to(at::kInt);
+  auto in2 = at::randint(1, 10, {5}, {at::kCUDA}).to(at::kHalf);
+  auto in3 = at::randint(1, 10, {5}, {at::kCUDA}).to(at::kInt);
+  auto in4 = at::randint(1, 10, {5}, {at::kCUDA}).to(at::kHalf);
+
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in1, in2, in3, in4});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results =
+      torch_tensorrt::tests::util::RunGraphEngine(g, params, {in1, in2, in3, in4}, nvinfer1::DataType::kHALF);
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
+}
+
+TEST(Converters, ATenCatHalfIntFloatConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor,
+            %1 : Tensor,
+            %2 : Tensor):
+        %2 : Tensor[] = prim::ListConstruct(%0, %1, %2)
+        %3 : int = prim::Constant[value=0]()
+        %4 : Tensor = aten::cat(%2, %3)
+        return (%4))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  auto in1 = at::randint(1, 10, {5}, {at::kCUDA}).to(at::kInt);
+  auto in2 = at::randint(1, 10, {5}, {at::kCUDA}).to(at::kHalf);
+  auto in3 = at::randint(1, 10, {5}, {at::kCUDA}).to(at::kFloat);
+
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in1, in2, in3});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in1, in2, in3});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
+}
+
 TEST(Converters, ATenCatDiffTensorConvertsCorrectly) {
   const auto graph = R"IR(
       graph(%0 : Tensor,


### PR DESCRIPTION
# Description

Add support for pytorch style type promotion within the aten::cat converter. Resolves issues with "unsupported type" errors from aten::cat(Int, Float) which is supported by pytorch.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
