### PR TITLE
fix: Support dims < -1 in aten::stack converter

### DIFF
--- a/core/conversion/converters/impl/stack.cpp
+++ b/core/conversion/converters/impl/stack.cpp
@@ -19,12 +19,12 @@ auto stack_registrations TORCHTRT_UNUSED = RegisterNodeConversionPatterns().patt
      [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
        auto in = args[0].IValue()->toListRef();
        auto dim = args[1].unwrapToInt();
-       if (-1 == dim) {
+       if (dim < 0) {
          auto first_in = in[0];
          if (first_in.isTensor()) {
-           dim = first_in.toTensor().ndimension();
+           dim = first_in.toTensor().ndimension() + dim + 1;
          } else {
-           dim = first_in.toCustomClass<TensorContainer>()->tensor()->getDimensions().nbDims;
+           dim = first_in.toCustomClass<TensorContainer>()->tensor()->getDimensions().nbDims + dim + 1;
          }
        }
 

--- a/tests/core/conversion/converters/test_stack.cpp
+++ b/tests/core/conversion/converters/test_stack.cpp
@@ -18,8 +18,7 @@ TEST(Converters, ATenStackPureTensorConvertsCorrectly) {
     params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
     auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in1, in2});
 
-    ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(
-        jit_results[0], trt_results[0].reshape_as(jit_results[0]), THRESHOLD_E5));
+    ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], THRESHOLD_E5));
   };
   const auto graph = R"IR(
       graph(%0 : Tensor,
@@ -35,9 +34,17 @@ TEST(Converters, ATenStackPureTensorConvertsCorrectly) {
         %3 : int = prim::Constant[value=-1]()
         %4 : Tensor = aten::stack(%2, %3)
         return (%4))IR";
+  const auto graph3 = R"IR(
+      graph(%0 : Tensor,
+            %1 : Tensor):
+        %2 : Tensor[] = prim::ListConstruct(%0, %1)
+        %3 : int = prim::Constant[value=-2]()
+        %4 : Tensor = aten::stack(%2, %3)
+        return (%4))IR";
 
   TestATenStackPureTensorConvertsCorrectly(graph);
   TestATenStackPureTensorConvertsCorrectly(graph2);
+  TestATenStackPureTensorConvertsCorrectly(graph3);
 }
 
 TEST(Converters, ATenStackPureTensorDynamicConvertsCorrectly) {
@@ -89,8 +96,7 @@ TEST(Converters, ATenStackDiffTensorConvertsCorrectly) {
     params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {in2});
     auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in1});
 
-    ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(
-        jit_results[0], trt_results[0].reshape_as(jit_results[0]), THRESHOLD_E5));
+    ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], THRESHOLD_E5));
   };
   const auto graph = R"IR(
       graph(%0 : Tensor,
@@ -106,6 +112,14 @@ TEST(Converters, ATenStackDiffTensorConvertsCorrectly) {
         %3 : int = prim::Constant[value=-1]()
         %4 : Tensor = aten::stack(%2, %3)
         return (%4))IR";
+  const auto graph3 = R"IR(
+      graph(%0 : Tensor,
+            %1 : Float(4, 4, 4, strides=[16, 4, 1])):
+        %2 : Tensor[] = prim::ListConstruct(%0, %1)
+        %3 : int = prim::Constant[value=-3]()
+        %4 : Tensor = aten::stack(%2, %3)
+        return (%4))IR";
   TestATenStackDiffTensorConvertsCorrectly(graph);
   TestATenStackDiffTensorConvertsCorrectly(graph2);
+  TestATenStackDiffTensorConvertsCorrectly(graph3);
 }


### PR DESCRIPTION
# Description

Handle negative dims arg in aten::stack for values < -1. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
