### PR TITLE
WIP : Refactoring acc_op converters, adding new aten converters

### DIFF
--- a/py/torch_tensorrt/fx/converters/impl/einsum.py
+++ b/py/torch_tensorrt/fx/converters/impl/einsum.py
@@ -1,0 +1,45 @@
+import numpy as np
+import operator
+import warnings
+from typing import cast, Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+# @manual=//deeplearning/trt/python:py_tensorrt
+import tensorrt as trt
+import torch
+from torch.fx.node import Argument, Target
+
+from ..converter_utils import *  # noqa: F403
+from ...utils import get_dynamic_dims, torch_dtype_from_trt, torch_dtype_to_trt
+
+from torch_tensorrt.fx.types import (
+    TRTNetwork,
+    TRTTensor,
+)
+
+
+def convert_einsum(
+    network: TRTNetwork,
+    target: Target,
+    source_ir: Optional[SourceIR],
+    name: str,
+    input_val,
+    equation,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    assert type(equation) is str, "equation type is not str"
+    const_flag = False
+    for i, input_source in enumerate(input_val):
+        if type(input_source) == torch.Tensor:
+            # const change to TRTensor always output with dtype FLOAT even though stored memory is other type
+            # so we cast to float first. And we need other inputs to be the same float type
+            input_source = input_source.to(torch.float)
+            const_flag = True
+        input_val[i] = get_trt_tensor(network, input_source, name + f"_input_source{i}")
+
+    if const_flag:
+        for i, input_source in enumerate(input_val):
+            if input_source.dtype != trt.float32:
+                input_val[i] = type_cast(
+                    network, target, f"{name}_input_cast{i}", input_source, trt.float32
+                )
+    einsum_layer = network.add_einsum(inputs=input_val, equation=equation)
+    return einsum_layer.get_output(0)

--- a/py/torch_tensorrt/fx/converters/impl/elementwise.py
+++ b/py/torch_tensorrt/fx/converters/impl/elementwise.py
@@ -1,0 +1,73 @@
+import numpy as np
+import operator
+import warnings
+from typing import cast, Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+# @manual=//deeplearning/trt/python:py_tensorrt
+import tensorrt as trt
+import torch
+from torch.fx.node import Argument, Target
+
+from ..converter_utils import *  # noqa: F403
+from ...utils import get_dynamic_dims, torch_dtype_from_trt, torch_dtype_to_trt
+
+from torch_tensorrt.fx.types import (
+    TRTNetwork,
+    TRTTensor,
+)
+
+def add_clamp(network, input, val, op, name):
+    if not len(input.shape):
+        # clamping scalar
+        acc_ops_clamp_trt = get_trt_tensor(
+            network,
+            squeeze_left(torch.tensor([val], dtype=torch_dtype_from_trt(input.dtype))),
+            f"{name}_clamp_{val}",
+        )
+    else:
+        acc_ops_clamp_shape = (1,) * len(input.shape)  # broadcast all dimensions
+        acc_ops_clamp_tensor = (
+            (
+                val
+                * torch.ones(
+                    acc_ops_clamp_shape, dtype=torch_dtype_from_trt(input.dtype)
+                )
+            )
+            .cpu()
+            .numpy()
+        )
+        acc_ops_clamp_trt = network.add_constant(
+            acc_ops_clamp_shape, acc_ops_clamp_tensor
+        ).get_output(0)
+    layer = network.add_elementwise(input, acc_ops_clamp_trt, op)
+    return layer
+
+def convert_clamp(
+        network: TRTNetwork,
+        target: Target,
+        source_ir: Optional[SourceIR],
+        name: str,
+        input_val,
+        min_val = None,
+        max_val = None,
+) -> TRTTensor:
+    if not isinstance(input_val, TRTTensor):
+        raise RuntimeError(
+            f"Clamp received input {input_val} that is not part "
+            "of the TensorRT region!"
+        )
+
+    if min_val is not None:
+        clamp_min_layer = add_clamp(
+            network, input_val, min_val, trt.ElementWiseOperation.MAX, name
+        )
+        set_layer_name(clamp_min_layer, target, f"{name}_clamp_min")
+        input_val = clamp_min_layer.get_output(0)
+    if max_val is not None:
+        clamp_max_layer = add_clamp(
+            network, input_val, max_val, trt.ElementWiseOperation.MIN, name
+        )
+        set_layer_name(clamp_max_layer, target, f"{name}_clamp_max")
+        input_val = clamp_max_layer.get_output(0)
+
+    return input_val

--- a/py/torch_tensorrt/fx/converters/impl/scatter.py
+++ b/py/torch_tensorrt/fx/converters/impl/scatter.py
@@ -1,0 +1,33 @@
+import numpy as np
+import operator
+import warnings
+from typing import cast, Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+# @manual=//deeplearning/trt/python:py_tensorrt
+import tensorrt as trt
+import torch
+from torch.fx.node import Argument, Target
+
+from ..converter_utils import *  # noqa: F403
+from ...utils import get_dynamic_dims, torch_dtype_from_trt, torch_dtype_to_trt
+
+from torch_tensorrt.fx.types import (
+    TRTNetwork,
+    TRTTensor,
+)
+
+
+def convert_scatter(
+        network: TRTNetwork,
+        target: Target,
+        source_ir: Optional[SourceIR],
+        name: str,
+        data,
+        indices,
+        updates,
+        axis,
+        reduction="add",
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    scatter_layer = network.add_scatter(data=data, indices=indices, updates=updates, mode=ScatterMode.ELEMENT)
+    scatter_layer.setAxis(axis)
+    return scatter_layer.get_output(0)

--- a/py/torch_tensorrt/fx/converters/impl/shuffle.py
+++ b/py/torch_tensorrt/fx/converters/impl/shuffle.py
@@ -1,0 +1,127 @@
+import numpy as np
+import operator
+import warnings
+from typing import cast, Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+# @manual=//deeplearning/trt/python:py_tensorrt
+import tensorrt as trt
+import torch
+from torch.fx.node import Argument, Target
+
+from ..converter_utils import *  # noqa: F403
+from ...utils import get_dynamic_dims, torch_dtype_from_trt, torch_dtype_to_trt
+
+from torch_tensorrt.fx.types import (
+    TRTNetwork,
+    TRTTensor,
+)
+
+
+def convert_permute(
+    network: TRTNetwork,
+    target: Target,
+    source_ir: Optional[SourceIR],
+    name: str,
+    input_val: TRTTensor,
+    index: Sequence[TRTTensor],
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    ranks = len(input_val.shape) + (1 if network.has_implicit_batch_dimension else 0)  # type: ignore[union-attr]
+    if len(index) == 1:
+        index = index[0]
+    permutation = [get_positive_dim(i, ranks) for i in cast(Sequence[int], index)]
+
+    if not isinstance(input_val, TRTTensor):
+        raise RuntimeError(
+            f"permute received input {input_val} that is not part "
+            "of the TensorRT region!"
+        )
+
+    if network.has_implicit_batch_dimension:
+        assert permutation[0] == 0, "Can't permute batch dimension when it's implicit."
+        permutation = [i - 1 for i in permutation[1:]]
+
+    layer = network.add_shuffle(input_val)
+    layer.second_transpose = tuple(permutation)
+    set_layer_name(layer, target, name)
+    return layer.get_output(0)
+
+
+def convert_squeeze(
+    network: TRTNetwork,
+    target: Target,
+    source_ir: Optional[SourceIR],
+    name: str,
+    input_val,
+    dim: int,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+
+    if not isinstance(input_val, TRTTensor):
+        raise RuntimeError(
+            f"squeeze received input {input_val} that is not part "
+            "of the TensorRT region!"
+        )
+
+    # Squeeze with dim=None would only work in explicit batch dim mode without any dynamic
+    # dim, which is a very rare case. For now we just claim not supporting dim=None.
+    assert dim is not None, "We don't support dim=None right now for squeeze."
+
+    dim = get_positive_dim(
+        dim, len(input_val.shape) + (1 if network.has_implicit_batch_dimension else 0)
+    )
+    if network.has_implicit_batch_dimension:
+        assert dim != 0, "We don't support squeeze batch dim when it's implicit."
+        dim -= 1
+
+    assert input_val.shape[dim] != -1, "We don't support squeeze dynamic dim."
+    assert (
+        len(get_dynamic_dims(input_val.shape)) <= 1
+    ), "Currently more than one dynamic dim for input to squeeze is not supported."
+
+    output_shape = []
+    for i, s in enumerate(input_val.shape):
+        if i == dim and s == 1:
+            continue
+        output_shape.append(s)
+    layer = network.add_shuffle(input_val)
+    layer.reshape_dims = tuple(output_shape)
+    set_layer_name(layer, target, name)
+    return layer.get_output(0)
+
+
+def convert_unsqueeze(
+    network: TRTNetwork,
+    target: Target,
+    source_ir: Optional[SourceIR],
+    name: str,
+    input_t,
+    dim,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    input_val = get_trt_tensor(network, input_t, f"{name}_input_t")
+    if not isinstance(input_val, TRTTensor):
+        raise RuntimeError(
+            f"unsqueeze received input {input_val} that is not part "
+            "of the TensorRT region!"
+        )
+
+    dim = cast(int, dim)
+    input_shape = input_val.shape
+    input_shape_size = (
+        len(input_val.shape) + 1
+        if network.has_implicit_batch_dimension
+        else len(input_val.shape)
+    )
+    dim = get_positive_dim(dim, input_shape_size + 1)
+
+    if network.has_implicit_batch_dimension:
+        assert dim != 0
+        dim -= 1
+
+    assert (
+        len(get_dynamic_dims(input_val.shape)) <= 1
+    ), "Currently we don't support unsqueeze with more than one dynamic dims."
+    layer = network.add_shuffle(input_val)
+    layer.reshape_dims = (
+        tuple(input_val.shape)[:dim] + (1,) + tuple(input_val.shape)[dim:]
+    )
+    set_layer_name(layer, target, name)
+    return layer.get_output(0)

--- a/py/torch_tensorrt/fx/test/converters/aten_op/test_clamp_aten.py
+++ b/py/torch_tensorrt/fx/test/converters/aten_op/test_clamp_aten.py
@@ -1,0 +1,70 @@
+import torch
+from parameterized import param, parameterized
+from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt.fx.tools.common_fx2trt import DispatchTestCase, InputTensorSpec
+
+
+class TestClampConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            param("default", min=-1, max=0),
+            param("min", min=0.5),
+            param("max", max=0.5),
+            param("minBiggerThanMax", min=1, max=0),
+            param("float32Boundary", min=-3.4028234663852886e38),
+        ]
+    )
+    def test_clamp(
+        self,
+        test_name,
+        min=None,
+        max=None,
+    ):
+        class TestModule(torch.nn.Module):
+            def forward(self, x):
+                return torch.clamp(x, min, max)
+
+        inputs = [torch.randn(3, 4)]
+        self.run_test(TestModule(), inputs, expected_ops={torch.ops.aten.clamp.default})
+
+    @parameterized.expand(
+        [
+            param("default", min=-1, max=0),
+            param("min", min=0.5),
+            param("max", max=0.5),
+            param("minBiggerThanMax", min=1, max=0),
+        ]
+    )
+    def test_clamp_with_dynamic_shape_four_dimensions(
+        self,
+        test_name,
+        min=None,
+        max=None,
+    ):
+        class TestModule(torch.nn.Module):
+            def forward(self, x):
+                return torch.clamp(x, min, max)
+
+        class TestScalarModule(torch.nn.Module):
+            def forward(self, x):
+                y = torch.sum(x)
+                return torch.clamp(y, min, max)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, 3, 3),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 3, 3), (3, 3, 3, 3), (5, 5, 3, 3))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            TestModule(), input_specs, expected_ops={torch.ops.aten.clamp.default}
+        )
+        self.run_test_with_dynamic_shape(
+            TestScalarModule(), input_specs, expected_ops={torch.ops.aten.clamp.default}
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/py/torch_tensorrt/fx/test/converters/aten_op/test_einsum_aten.py
+++ b/py/torch_tensorrt/fx/test/converters/aten_op/test_einsum_aten.py
@@ -1,0 +1,65 @@
+import torch
+import torch.nn as nn
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt.fx.tools.common_fx2trt import DispatchTestCase, InputTensorSpec
+
+
+class TestConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            ("2d_dim", "ij,jk->ik", (2, 3), (3, 4)),
+            ("2d_dim_ext", "ij,kj->ik", (2, 3), (4, 3)),
+            ("3d_dim", "cxd,cyd->cxy", (3, 4, 5), (3, 6, 5)),
+            ("4d_dim", "bcwd,bcdh->bcwh", (2, 3, 4, 5), (2, 3, 5, 6)),
+            ("4d_dim_ext", "bcxd,bcyd->bcxy", (2, 3, 4, 5), (2, 3, 6, 5)),
+            # TRT does not support ellipsis or diagonal operations
+        ]
+    )
+    def test_einsum(self, _, equation, x_size, y_size):
+        class Einsum(nn.Module):
+            def forward(self, x, y):
+                return torch.einsum(equation, x, y)
+
+        inputs = [torch.randn(*x_size), torch.randn(*y_size)]
+        self.run_test(
+            Einsum(),
+            inputs,
+            expected_ops={torch.ops.aten.einsum},
+            # test_implicit_batch_dim=False,
+        )
+
+    @parameterized.expand(
+        [
+            ("4d_dim", "bcwd,bcdh->bcwh", (2, 3, 4, 5), (2, 3, 5, 6)),
+            ("4d_dim_ext", "bcxd,bcyd->bcxy", (2, 3, 4, 5), (2, 3, 6, 5)),
+            # TRT does not support ellipsis or diagonal operations
+        ]
+    )
+    def test_einsum_with_dynamic_shape_four_dimensions(
+        self, _, equation, x_size, y_size
+    ):
+        class Einsum(nn.Module):
+            def forward(self, x, y):
+                return torch.einsum(equation, x, y)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 3, 3), (1, 2, 3, 3), (3, 3, 3, 3))],
+            ),
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 3, 3), (1, 2, 3, 3), (3, 3, 3, 3))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            Einsum(), input_specs, expected_ops={torch.ops.aten.einsum}
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/py/torch_tensorrt/fx/test/converters/aten_op/test_permute_aten.py
+++ b/py/torch_tensorrt/fx/test/converters/aten_op/test_permute_aten.py
@@ -1,0 +1,86 @@
+import torch
+import torch.nn as nn
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt.fx.tools.common_fx2trt import DispatchTestCase, InputTensorSpec
+
+
+class TestPermuteConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            ("positive", [0, 2, 1]),
+            ("negative", [0, -1, -2]),
+        ]
+    )
+    def test_permute_list(self, _, permutation):
+        class Permute(nn.Module):
+            def forward(self, x):
+                return x.permute(permutation)
+
+        inputs = [torch.randn(1, 3, 2)]
+        self.run_test(Permute(), inputs, expected_ops={torch.ops.aten.permute.default})
+
+    @parameterized.expand(
+        [
+            ("positive", [0, 2, 1]),
+            ("negative", [0, -1, -2]),
+        ]
+    )
+    def test_permute(self, _, permutation):
+        class Permute(nn.Module):
+            def forward(self, x):
+                return x.permute(*permutation)
+
+        inputs = [torch.randn(1, 3, 2)]
+        self.run_test(Permute(), inputs, expected_ops={torch.ops.aten.permute.default})
+
+    @parameterized.expand(
+        [
+            ("positive", (1, 2)),
+            ("negative", (-1, -2)),
+        ]
+    )
+    def test_transpose(self, _, dims):
+        class Transpose(nn.Module):
+            def forward(self, x):
+                return x.transpose(*dims)
+
+        inputs = [torch.randn(1, 2, 3)]
+        self.run_test(Transpose(), inputs, expected_ops={torch.ops.aten.transpose.int})
+
+    def test_permute_with_dynamic_shape(self):
+        class Permute(nn.Module):
+            def forward(self, x):
+                return x.permute(1, 2, 0)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 1), (1, 2, 3), (3, 3, 3))],
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            Permute(), input_specs, expected_ops={torch.ops.aten.permute.default}
+        )
+
+    def test_permute_with_dynamic_shape_four_dimensions(self):
+        class Permute(nn.Module):
+            def forward(self, x):
+                return x.permute(1, 2, 3, 0)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 1, 5), (1, 2, 3, 5), (3, 3, 3, 5))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            Permute(), input_specs, expected_ops={torch.ops.aten.permute.default}
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/py/torch_tensorrt/fx/test/converters/aten_op/test_squeeze_aten.py
+++ b/py/torch_tensorrt/fx/test/converters/aten_op/test_squeeze_aten.py
@@ -1,0 +1,40 @@
+import torch
+import torch.nn as nn
+from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt.fx.tools.common_fx2trt import DispatchTestCase, InputTensorSpec
+
+
+class TestSqueeze(DispatchTestCase):
+    def test_squeeze(self):
+        class Squeeze(nn.Module):
+            def forward(self, x):
+                return x.squeeze(2)
+
+        inputs = [torch.randn(1, 2, 1)]
+        self.run_test(Squeeze(), inputs, expected_ops={torch.ops.aten.squeeze.dim})
+
+    # Testing with shape=(-1, -1, -1, -1) results in error:
+    # AssertionError: We don't support squeeze dynamic dim.
+
+    # Testing with more than one dynamic dim results in error:
+    # AssertionError: Currently more than one dynamic dim for input to squeeze is not supported.
+
+    def test_squeeze_with_dynamic_shape(self):
+        class Squeeze(nn.Module):
+            def forward(self, x):
+                return x.squeeze(0)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(1, -1, 2),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 2), (1, 2, 2), (1, 3, 2))],
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            Squeeze(), input_specs, expected_ops={torch.ops.aten.squeeze.dim}
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/py/torch_tensorrt/fx/test/converters/aten_op/test_to_copy_aten.py
+++ b/py/torch_tensorrt/fx/test/converters/aten_op/test_to_copy_aten.py
@@ -1,0 +1,312 @@
+import torch
+
+from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt.fx.tools.common_fx2trt import DispatchTestCase, InputTensorSpec
+from torch_tensorrt.fx.utils import LowerPrecision
+
+
+class TestToConverter(DispatchTestCase):
+    def test_fp16(self):
+        class To(torch.nn.Module):
+            def forward(self, x):
+                return x.to(torch.float16)
+
+        input = torch.randn(2, 2)
+        inputs = [
+            input,
+        ]
+        self.run_test(
+            To(),
+            inputs,
+            expected_ops={torch.ops.aten._to_copy.default},
+            precision=LowerPrecision.FP16,
+        )
+
+    # Testing with shape shape=(-1, -1, -1, -1) results into following error:
+    # Error: assert engine
+    """
+    def test_fp16_with_dynamic_shape_four_dimension(self):
+        class To(torch.nn.Module):
+            def forward(self, x):
+                return x.to(torch.float16)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float16,
+                shape_ranges=[((1, 1, 3, 3), (3, 3, 3, 3), (3, 3, 3, 3))],
+            ).cuda(),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            To(), input_specs, expected_ops={torch.ops.aten._to_copy.default}
+        )
+    """
+
+    def test_fp32(self):
+        class To(torch.nn.Module):
+            def forward(self, x):
+                return x.to(torch.float32)
+
+        input = torch.randn(2, 2).to(torch.float16)
+        inputs = [
+            input,
+        ]
+        self.run_test(
+            To(), inputs, expected_ops={torch.ops.aten._to_copy.default}, 
+        )
+
+    def test_cuda_fp16(self):
+        class To(torch.nn.Module):
+            def forward(self, x):
+                return x.to(torch.device("cuda:0"), torch.float16)
+
+        input = torch.randn(2, 2)
+        inputs = [
+            input,
+        ]
+        self.run_test(
+            To(),
+            inputs,
+            expected_ops={torch.ops.aten._to_copy.default},
+            precision=LowerPrecision.FP16,
+        )
+
+    def test_cuda(self):
+        class To(torch.nn.Module):
+            def forward(self, x):
+                x = x.to(torch.device("cuda"))
+                # append extra layer since to(device) is skipped in TRT
+                return x + torch.randn(2, 2).cuda()
+
+        input = torch.randn(2, 2)
+        inputs = [
+            input,
+        ]
+        self.run_test(
+            To(),
+            inputs,
+            expected_ops={torch.ops.aten._to_copy.default, torch.ops.aten.add.Tensor},
+            precision=LowerPrecision.FP32,
+        )
+
+    def test_cuda_with_dynamic_shape_four_dimensions(self):
+        class To(torch.nn.Module):
+            def forward(self, x):
+                x = x.to(torch.device("cuda"))
+                # append extra layer since to(device) is skipped in TRT
+                return x + torch.randn(3, 3, 3, 3).cuda()
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float16,
+                shape_ranges=[((1, 1, 3, 3), (3, 3, 3, 3), (3, 3, 3, 3))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            To(), input_specs, expected_ops={torch.ops.aten._to_copy.default, torch.ops.aten.add.Tensor}
+        )
+
+    def test_device(self):
+        class To(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = torch.randn(2, 2)
+
+            def forward(self, x):
+                idevice = x.device
+                a = self.a.to(idevice)
+                return x + a
+
+        input = torch.randn(2, 2).cuda()
+        inputs = [
+            input,
+        ]
+        self.run_test(
+            To(),
+            inputs,
+            expected_ops={torch.ops.aten._to_copy.default},
+            precision=LowerPrecision.FP32,
+        )
+
+    def test_device_with_dynamic_shape_four_dimensions(self):
+        class To(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = torch.randn(3, 3, 3, 3)
+
+            def forward(self, x):
+                idevice = x.device
+                a = self.a.to(idevice)
+                return x + a
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float16,
+                shape_ranges=[((1, 1, 3, 3), (3, 3, 3, 3), (3, 3, 3, 3))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            To(), input_specs, expected_ops={torch.ops.aten._to_copy.default, torch.ops.aten.add.Tensor}
+        )
+
+    def test_device_fp16(self):
+        class To(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = torch.randn(2, 2)
+
+            def forward(self, x):
+                idevice = x.device
+                idtype = x.dtype
+                a = self.a.to(idevice)
+                # fx tracer could not handle "to(idevice, torch.float16)"
+                # TypeError: to() received an invalid combination of arguments - got (Attribute, torch.dtype)
+                return a.to(idtype)
+
+        input = torch.randn(2, 2).half().cuda()
+        inputs = [
+            input,
+        ]
+        self.run_test(
+            To(),
+            inputs,
+            expected_ops={torch.ops.aten._to_copy.default},
+            precision=LowerPrecision.FP16,
+        )
+
+    # Testing with shape shape=(-1, -1, -1, -1) results into following error:
+    # Error: assert engine
+    """
+    def test_device_fp16_with_dynamic_shape_four_dimensions(self):
+        class To(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = torch.randn(2, 2)
+
+            def forward(self, x):
+                idevice = x.device
+                idtype = x.dtype
+                a = self.a.to(idevice)
+                # fx tracer could not handle "to(idevice, torch.float16)"
+                # TypeError: to() received an invalid combination of arguments - got (Attribute, torch.dtype)
+                return a.to(idtype)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float16,
+                shape_ranges=[((2, 2, 2, 2), (4, 4, 4, 4), (4, 4, 4, 4))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            To(), input_specs, expected_ops={torch.ops.aten._to_copy.default}
+        )
+    """
+
+    # tensor.float()
+    def test_float(self):
+        class To(torch.nn.Module):
+            def forward(self, x):
+                return x.float()
+
+        input = torch.randn(2, 2).half()
+        inputs = [
+            input,
+        ]
+        self.run_test(
+            To(),
+            inputs,
+            expected_ops={torch.ops.aten._to_copy.default},
+            precision=LowerPrecision.FP32,
+        )
+
+    # tensor.float()
+    def test_float_with_dynamic_shape_four_dimensions(self):
+        class To(torch.nn.Module):
+            def forward(self, x):
+                return x.float()
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 1, 1, 1), (3, 3, 3, 3), (3, 3, 3, 3))],
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            To(), input_specs, expected_ops={torch.ops.aten._to_copy.default}
+        )
+
+    # Half is not suitable for dynamic shape
+    # Error: assert engine
+
+    # tensor.half()
+    def test_half(self):
+        class To(torch.nn.Module):
+            def forward(self, x):
+                return x.half()
+
+        input = torch.randn(2, 2)
+        inputs = [
+            input,
+        ]
+        self.run_test(
+            To(),
+            inputs,
+            expected_ops={torch.ops.aten._to_copy.default},
+            precision=LowerPrecision.FP16,
+        )
+
+    # TODO Open in future. TRT 8.5 does not work for this test
+    # The test is a rare case. We need to remove it in graph maybe.
+    # def test_int(self):
+    #     class To(torch.nn.Module):
+    #         def forward(self, x):
+    #             x = x.int()
+    #             # we do not expect int to be output type, so add an extra layer
+    #             x = x.float()
+    #             return x
+
+    #     input = torch.randn(2, 2)
+    #     inputs = [
+    #         input,
+    #     ]
+    #     self.run_test(
+    #         To(),
+    #         inputs,
+    #         expected_ops={torch.ops.aten._to_copy.default},
+    #         test_implicit_batch_dim=False,
+    #         precision=LowerPrecision.FP32,
+    #     )
+
+    # # tensor.int()
+    # def test_int_with_dynamic_shape_four_dimensions(self):
+    #     class To(torch.nn.Module):
+    #         def forward(self, x):
+    #             x = x.int()
+    #             # we do not expect int to be output type, so add an extra layer
+    #             x = x.float()
+    #             return x
+
+    #     input_specs = [
+    #         InputTensorSpec(
+    #             shape=(-1, -1, -1, -1),
+    #             dtype=torch.int,
+    #             shape_ranges=[((1, 1, 1, 1), (3, 3, 3, 3), (3, 3, 3, 3))],
+    #         ),
+    #     ]
+
+    #     self.run_test_with_dynamic_shape(
+    #         To(), input_specs, expected_ops={torch.ops.aten._to_copy.default}
+    #     )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/py/torch_tensorrt/fx/test/converters/aten_op/test_unsqueeze_aten.py
+++ b/py/torch_tensorrt/fx/test/converters/aten_op/test_unsqueeze_aten.py
@@ -1,0 +1,61 @@
+import torch
+import torch.fx
+import torch.nn as nn
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt.fx.tools.common_fx2trt import DispatchTestCase, InputTensorSpec
+
+
+class TestUnsqueeze(DispatchTestCase):
+    @parameterized.expand(
+        [
+            ("negative_dim", -2),
+            ("positive_dim", 2),
+        ]
+    )
+    def test_unsqueeze(self, _, dim):
+        class Unsqueeze(nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.dim = dim
+
+            def forward(self, x):
+                return torch.unsqueeze(x, self.dim)
+
+        inputs = [torch.randn(1, 2, 3)]
+        self.run_test(
+            Unsqueeze(dim), inputs, expected_ops={torch.ops.aten.unsqueeze.default}
+        )
+
+    # Testing with more than one dynamic dims results in following error:
+    # AssertionError: Currently we don't support unsqueeze with more than one dynamic dims.
+
+    @parameterized.expand(
+        [
+            ("negative_dim_dynamic", -4),
+            ("positive_dim_dynamic", 1),
+        ]
+    )
+    def test_unsqueeze_with_dynamic_shape(self, _, dim):
+        class Unsqueeze(nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.dim = dim
+
+            def forward(self, x):
+                return torch.unsqueeze(x, self.dim)
+
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, 2, 3),
+                dtype=torch.float32,
+                shape_ranges=[((1, 2, 3), (2, 2, 3), (3, 2, 3))],
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            Unsqueeze(dim), input_specs, expected_ops={torch.ops.aten.unsqueeze.default}
+        )
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
# Description

Here is my first stab at refactoring a bunch of converters from acc to aten.
Completed:
torch.ops.aten.squeeze.default
torch.ops.aten.unsqueeze.default
torch.ops.aten.permute.default
torch.ops.aten.transpose.int
torch.ops.aten.clamp.default

WIP:
torch.ops.aten._to_copy.default
torch.ops.aten.scatter_add.default (looks like TRT does not support reduce options yet)

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
