### PR TITLE
fix: Repair argument passing in both Dynamo paths

### DIFF
--- a/py/torch_tensorrt/dynamo/backend/__init__.py
+++ b/py/torch_tensorrt/dynamo/backend/__init__.py
@@ -45,6 +45,7 @@ def compile(
     min_block_size=MIN_BLOCK_SIZE,
     torch_executed_ops=[],
     torch_executed_modules=[],
+    pass_through_build_failures=PASS_THROUGH_BUILD_FAILURES,
     **kwargs,
 ):
     if debug:
@@ -86,6 +87,7 @@ def compile(
         workspace_size=workspace_size,
         min_block_size=min_block_size,
         torch_executed_ops=torch_executed_ops,
+        pass_through_build_failures=pass_through_build_failures,
         **kwargs,
     )
 

--- a/py/torch_tensorrt/dynamo/backend/conversion.py
+++ b/py/torch_tensorrt/dynamo/backend/conversion.py
@@ -36,7 +36,6 @@ def convert_module(
     interpreter = TRTInterpreter(
         module,
         InputTensorSpec.from_tensors(inputs),
-        explicit_batch_dimension=True,
         logger_level=(trt.Logger.VERBOSE if settings.debug else trt.Logger.WARNING),
         output_dtypes=output_dtypes,
     )

--- a/py/torch_tensorrt/dynamo/fx_ts_compat/fx2trt.py
+++ b/py/torch_tensorrt/dynamo/fx_ts_compat/fx2trt.py
@@ -38,8 +38,6 @@ class TRTInterpreter(torch.fx.Interpreter):
         self,
         module: torch.fx.GraphModule,
         input_specs: List[InputTensorSpec],
-        explicit_batch_dimension: bool = True,
-        explicit_precision: bool = False,
         logger_level=None,
         output_dtypes=None,
     ):
@@ -49,17 +47,11 @@ class TRTInterpreter(torch.fx.Interpreter):
         self.builder = trt.Builder(self.logger)
 
         flag = 0
-        if explicit_batch_dimension:
-            EXPLICIT_BATCH = 1 << (int)(
-                trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH
-            )
-            flag |= EXPLICIT_BATCH
 
-        if explicit_precision:
-            EXPLICIT_PRECISION = 1 << (int)(
-                trt.NetworkDefinitionCreationFlag.EXPLICIT_PRECISION
-            )
-            flag |= EXPLICIT_PRECISION
+        # It is deprecated to not use this flag
+        EXPLICIT_BATCH = 1 << (int)(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
+        flag |= EXPLICIT_BATCH
+
         self.network = self.builder.create_network(flag)
 
         missing_ops = self.validate_conversion()

--- a/py/torch_tensorrt/dynamo/fx_ts_compat/lower_setting.py
+++ b/py/torch_tensorrt/dynamo/fx_ts_compat/lower_setting.py
@@ -44,7 +44,6 @@ class LowerSetting(LowerSettingBasic):
     Args:
     input_specs: Specs for inputs to engine, can either be a single size or a
     range defined by Min, Optimal, Max sizes.
-    explicit_precision: Use explicit precision during lowering.
     workspace_size: The maximum workspace size. The maximum GPU temporary
     memory which the TensorRT engine can use at execution time.
     strict_type_constraints: Require TensorRT engine to strictly follow data type
@@ -76,8 +75,6 @@ class LowerSetting(LowerSettingBasic):
     """
 
     input_specs: List[InputTensorSpec] = dc.field(default_factory=list)
-    explicit_batch_dimension: bool = True
-    explicit_precision: bool = False
     workspace_size: int = 0
     strict_type_constraints: bool = False
     customized_fuse_pass: PassManager = dc.field(


### PR DESCRIPTION
# Description

- Pass-through new TRT args in export
- Fix bug in `fx_ts_compat` where `explicit_batch_dimension` did not exist in input args
- Pass-through build failures arg in compile

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
