### PR TITLE
chore: remove compose_bmm pass as it is not decomposed anymore

### DIFF
--- a/py/torch_tensorrt/fx/tracer/dispatch_tracer/aten_tracer.py
+++ b/py/torch_tensorrt/fx/tracer/dispatch_tracer/aten_tracer.py
@@ -140,7 +140,6 @@ def opt_trace(f, args, *rest):
     These passes should be general and functional purpose
     """
     passes_list = [
-        compose_bmm,
         compose_chunk,
         compose_getitem_slice,
         replace_aten_reshape_alias_with_replace,


### PR DESCRIPTION
# Description

remove compose_bmm pass as it is not decomposed anymore

Fixes https://github.com/pytorch/TensorRT/pull/1821

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
