### PR TITLE
fix: Repair input range on BERT inputs for CI

### DIFF
--- a/tests/py/models/test_models.py
+++ b/tests/py/models/test_models.py
@@ -86,7 +86,7 @@ class TestModels(unittest.TestCase):
 
     def test_bert_base_uncased(self):
         self.model = cm.BertModule().cuda()
-        self.input = torch.randint(0, 5, (1, 14), dtype=torch.int32).to("cuda")
+        self.input = torch.randint(0, 2, (1, 14), dtype=torch.int32).to("cuda")
 
         compile_spec = {
             "inputs": [


### PR DESCRIPTION
# Description

- Update range on BERT module inputs to respect input/embedding indexing restrictions
- Fix failing CI test with BERT on TorchScript path

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ - ] I have added tests to verify my fix or my feature
  - CI validation
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
