### PR TITLE
fix: Add automatic type promotion for FX elementwise ops

### DIFF
--- a/py/torch_tensorrt/fx/converters/converter_utils.py
+++ b/py/torch_tensorrt/fx/converters/converter_utils.py
@@ -280,6 +280,38 @@ def create_constant(
     return constant.get_output(0)
 
 
+def cast_trt_tensor(
+    network: TRTNetwork,
+    input_val: TRTTensor,
+    dtype: TRTDataType,
+    name: str,
+) -> TRTTensor:
+    """
+    Given a TRT Tensor, convert that Tensor to the specified dtype
+
+    Adds an Identity layer to the network which performs the conversion
+
+    Args:
+        network (TRTNetwork): A TensorRT network
+        input_val (TRTTensor): A TRT Tensor to cast to a new data type
+        dtype (TRTDataType): The TRTDataType to cast the input Tensor to
+        name (str): Name of the calling layer
+
+    Returns:
+        A TensorRT ITensor which has been casted to the specified dtype
+    """
+    #
+    if input_val.dtype != dtype:
+        identity_layer = network.add_identity(input_val)
+        identity_layer.set_output_type(0, dtype)
+        identity_layer.name = (
+            f"Cast ITensor {input_val.name} from {input_val.dtype} to {dtype} - {name}"
+        )
+        return identity_layer.get_output(0)
+    else:
+        return input_val
+
+
 def get_trt_tensor(
     network: TRTNetwork,
     input_val: Any,

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_binary_ops.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_binary_ops.py
@@ -58,6 +58,23 @@ class TestBinaryOpConverters(AccTestCase):
         self.run_test(m, inputs, expected_ops={expected_op})
 
     @parameterized.expand([(op[1].__name__, op[0], op[1]) for op in elementwise_ops])
+    def test_elementwise_ops_mismatched_dtypes(
+        self, name, orig_op: Callable, expected_op
+    ):
+        class TestModule(nn.Module):
+            def __init__(self, orig_op):
+                super().__init__()
+                self.orig_op = orig_op
+
+            def forward(self, x):
+                return self.orig_op(x.int(), x)
+
+        m = TestModule(orig_op)
+        # Avoid dividing by 0.
+        inputs = [2 * torch.rand(1, 1, dtype=torch.float) + 1]
+        self.run_test(m, inputs, expected_ops={expected_op})
+
+    @parameterized.expand([(op[1].__name__, op[0], op[1]) for op in elementwise_ops])
     def test_elementwise_ops_with_one_constant(
         self, name, orig_op: Callable, expected_op
     ):


### PR DESCRIPTION
# Description

- Implement functionality to cast tensors to alternative types
- Add functionality to elementwise ops to promote types and perform necessary casts
- Address issues in FX ops where mixed-precision computations can cause errors
- Add test cases to validate fix

Fixes #1995 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
