### PR TITLE
Var_mean lowering pass <Target: converter_reorg_elementwise>

### DIFF
--- a/py/torch_tensorrt/dynamo/backend/test/test_decompositions.py
+++ b/py/torch_tensorrt/dynamo/backend/test/test_decompositions.py
@@ -129,14 +129,6 @@ class TestLowering(TestCase):
                 1,
                 1,
             ).cuda(),
-            torch.rand(
-                7,
-                8,
-            ).cuda(),
-            torch.rand(
-                8,
-                9,
-            ).cuda(),
         ]
 
         fx_graph = torch.fx.symbolic_trace(AddMM())
@@ -178,6 +170,188 @@ class TestLowering(TestCase):
             DECIMALS_OF_AGREEMENT,
             f"AddMM TRT outputs don't match with the original model.",
         )
+
+    def test_lowering_var_mean(self):
+        class var_mean(torch.nn.Module):
+            def forward(self, x):
+                return torch.var_mean(x)
+
+        # Operations expected to be included in the traced graph after decompositions
+        expected_ops = {
+            torch.ops.aten.mean.Tensor,
+            torch.ops.aten.pow.Tensor,
+            torch.ops.aten.sub.default,
+        }
+        unexpected_ops = {torch.ops.aten.var_mean.default}
+
+        inputs = [
+            torch.rand(
+                3,
+                4,
+            ).cuda(),
+        ]
+
+        fx_graph = torch.fx.symbolic_trace(var_mean())
+        unexpected_ops_seen, expected_ops_unseen = lower_graph_testing(
+            fx_graph,
+            inputs,
+            expected_ops=expected_ops,
+            unexpected_ops=unexpected_ops,
+            min_block_size=1,
+        )
+
+        self.assertEquals(
+            len(unexpected_ops_seen),
+            0,
+            f"The following unexpected ops were encountered: {unexpected_ops_seen}",
+        )
+
+        self.assertEquals(
+            len(expected_ops_unseen),
+            0,
+            f"The following expected ops were not encountered: {expected_ops_unseen}",
+        )
+
+        torch._dynamo.reset()
+
+        # Validate that the results between Torch and Torch-TRT are similar
+        optimized_model = compile(
+            fx_graph, inputs, min_block_size=1, pass_through_build_failures=True
+        )
+        optimized_model_results = optimized_model(*inputs).detach().cpu()
+        torch_model_results = fx_graph(*inputs).detach().cpu()
+
+        max_diff = float(
+            torch.max(torch.abs(optimized_model_results - torch_model_results))
+        )
+        self.assertAlmostEqual(
+            max_diff,
+            0,
+            DECIMALS_OF_AGREEMENT,
+            f"var_mean TRT outputs don't match with the original model.",
+        )
+
+
+def test_lowering_var_mean_dim(self):
+    class var_mean(torch.nn.Module):
+        def forward(self, x):
+            return torch.var_mean(x, [1])
+
+    # Operations expected to be included in the traced graph after decompositions
+    expected_ops = {
+        torch.ops.aten.mean.Tensor,
+        torch.ops.aten.pow.Tensor,
+        torch.ops.aten.sub.default,
+    }
+    unexpected_ops = {torch.ops.aten.var_mean.default}
+
+    inputs = [
+        torch.rand(
+            3,
+            4,
+        ).cuda(),
+    ]
+
+    fx_graph = torch.fx.symbolic_trace(var_mean())
+    unexpected_ops_seen, expected_ops_unseen = lower_graph_testing(
+        fx_graph,
+        inputs,
+        expected_ops=expected_ops,
+        unexpected_ops=unexpected_ops,
+        min_block_size=1,
+    )
+
+    self.assertEquals(
+        len(unexpected_ops_seen),
+        0,
+        f"The following unexpected ops were encountered: {unexpected_ops_seen}",
+    )
+
+    self.assertEquals(
+        len(expected_ops_unseen),
+        0,
+        f"The following expected ops were not encountered: {expected_ops_unseen}",
+    )
+
+    torch._dynamo.reset()
+
+    # Validate that the results between Torch and Torch-TRT are similar
+    optimized_model = compile(
+        fx_graph, inputs, min_block_size=1, pass_through_build_failures=True
+    )
+    optimized_model_results = optimized_model(*inputs).detach().cpu()
+    torch_model_results = fx_graph(*inputs).detach().cpu()
+
+    max_diff = float(
+        torch.max(torch.abs(optimized_model_results - torch_model_results))
+    )
+    self.assertAlmostEqual(
+        max_diff,
+        0,
+        DECIMALS_OF_AGREEMENT,
+        f"var_mean TRT outputs don't match with the original model.",
+    )
+
+
+def test_lowering_var_mean(self):
+    class var_mean(torch.nn.Module):
+        def forward(self, x):
+            return torch.var_mean(x, [1], 1)
+
+    # Operations expected to be included in the traced graph after decompositions
+    expected_ops = {
+        torch.ops.aten.mean.Tensor,
+        torch.ops.aten.pow.Tensor,
+        torch.ops.aten.sub.default,
+    }
+    unexpected_ops = {torch.ops.aten.var_mean.default}
+
+    inputs = [
+        torch.rand(
+            3,
+            4,
+        ).cuda(),
+    ]
+
+    fx_graph = torch.fx.symbolic_trace(var_mean())
+    unexpected_ops_seen, expected_ops_unseen = lower_graph_testing(
+        fx_graph,
+        inputs,
+        expected_ops=expected_ops,
+        unexpected_ops=unexpected_ops,
+        min_block_size=1,
+    )
+
+    self.assertEquals(
+        len(unexpected_ops_seen),
+        0,
+        f"The following unexpected ops were encountered: {unexpected_ops_seen}",
+    )
+
+    self.assertEquals(
+        len(expected_ops_unseen),
+        0,
+        f"The following expected ops were not encountered: {expected_ops_unseen}",
+    )
+
+    torch._dynamo.reset()
+
+    # Validate that the results between Torch and Torch-TRT are similar
+    optimized_model = compile(
+        fx_graph, inputs, min_block_size=1, pass_through_build_failures=True
+    )
+    optimized_model_results = optimized_model(*inputs).detach().cpu()
+    torch_model_results = fx_graph(*inputs).detach().cpu()
+
+    max_diff = float(
+        torch.max(torch.abs(optimized_model_results - torch_model_results))
+    )
+    self.assertAlmostEqual(
+        max_diff,
+        0,
+        DECIMALS_OF_AGREEMENT,
+        f"var_mean TRT outputs don't match with the original model.",
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Lowering pass for var_mean converter #1793. Covers three cases
1. var_mean(Tensor self, bool unbiased=True)
2. var_mean.dim(Tensor self, int[1]? dim, bool unbiased=True, bool keepdim=False)
3. var_mean.correction(Tensor self, int[1]? dim=None, *, Scalar? correction=None, bool keepdim=False)
