### PR TITLE
fix: Repair null bindings issue in TRT Engines

### DIFF
--- a/py/torch_tensorrt/dynamo/backend/backends.py
+++ b/py/torch_tensorrt/dynamo/backend/backends.py
@@ -121,6 +121,9 @@ def _compile_module(
         torch_executed_ops=settings.torch_executed_ops,
     )
 
+    # Store TRT replicas of Torch subgraphs
+    trt_modules = {}
+
     # Iterate over all components that can be accelerated
     # Generate the corresponding TRT Module for those
     for name, _ in partitioned_module.named_children():
@@ -138,7 +141,10 @@ def _compile_module(
             settings=settings,
         )
 
-        # Replace FX Module with TRT Module
+        trt_modules[name] = trt_mod
+
+    # Replace all FX Modules with TRT Modules
+    for name, trt_mod in trt_modules.items():
         setattr(partitioned_module, name, trt_mod)
 
     return partitioned_module


### PR DESCRIPTION
# Description

- Caused by passing Fake Tensor objects into TRT engines mid-compilation
- Resolved by replacing all FX modules with TRT equivalents after all TRT compilation is complete. This way, modules are not run on FakeTensors generated during compilation

Fixes #2072

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
