### PR TITLE
Int cast of div converter- <Target: converter_reorg_elementwise>

### DIFF
--- a/py/torch_tensorrt/fx/converters/aten_ops_converters.py
+++ b/py/torch_tensorrt/fx/converters/aten_ops_converters.py
@@ -176,6 +176,21 @@ def aten_ops_div(
         "input": args[0],
         "other": args[1],
     }
+    # If both are TRTTensor, both are cast to float32
+    if isinstance(args[0], TRTTensor) and isinstance(args[1], TRTTensor):
+        kwargs_new["input"], kwargs_new["other"] = cast_int_int_div_trt_tensor(
+            network, kwargs_new["input"], kwargs_new["other"]
+        )
+    # If one is TRTTensor, it is cast to float32
+    elif isinstance(args[0], TRTTensor) and (
+        kwargs_new["input"].dtype == trt.int8 or kwargs_new["input"].dtype == trt.int32
+    ):
+        kwargs_new["input"] = cast_trt_tensor(network, kwargs_new["input"], trt.float32)
+    elif isinstance(args[1], TRTTensor) and (
+        kwargs_new["other"].dtype == trt.int8 or kwargs_new["other"].dtype == trt.int32
+    ):
+        kwargs_new["other"] = cast_trt_tensor(network, kwargs_new["other"], trt.float32)
+
     rounding_mode = kwargs.get("rounding_mode")
     if rounding_mode is None:
         return acc_ops_converters.acc_ops_div(network, target, None, kwargs_new, name)

--- a/py/torch_tensorrt/fx/converters/converter_utils.py
+++ b/py/torch_tensorrt/fx/converters/converter_utils.py
@@ -280,6 +280,38 @@ def create_constant(
     return constant.get_output(0)
 
 
+def cast_trt_tensor(
+    network: TRTNetwork,
+    input_val: TRTTensor,
+    dtype: TRTDataType,
+    name: str,
+) -> TRTTensor:
+    """
+    Given a TRT Tensor, convert that Tensor to the specified dtype
+
+    Adds an Identity layer to the network which performs the conversion
+
+    Args:
+        network (TRTNetwork): A TensorRT network
+        input_val (TRTTensor): A TRT Tensor to cast to a new data type
+        dtype (TRTDataType): The TRTDataType to cast the input Tensor to
+        name (str): Name of the calling layer
+
+    Returns:
+        A TensorRT ITensor which has been casted to the specified dtype
+    """
+    #
+    if input_val.dtype != dtype:
+        identity_layer = network.add_identity(input_val)
+        identity_layer.set_output_type(0, dtype)
+        identity_layer.name = (
+            f"Cast ITensor {input_val.name} from {input_val.dtype} to {dtype} - {name}"
+        )
+        return identity_layer.get_output(0)
+    else:
+        return input_val
+
+
 def get_trt_tensor(
     network: TRTNetwork,
     input_val: Any,

--- a/py/torch_tensorrt/fx/converters/converter_utils.py
+++ b/py/torch_tensorrt/fx/converters/converter_utils.py
@@ -312,6 +312,30 @@ def cast_trt_tensor(
         return input_val
 
 
+def cast_int_int_div_trt_tensor(
+    network: TRTNetwork,
+    lhs_val: TRTTensor,
+    rhs_val: TRTTensor,
+) -> List[TRTTensor]:
+    """
+    Given two `int` data type TRT Tensor to div operation, cast the TRT Tensor to float type
+
+    Args:
+        network (TRTNetwork): A TensorRT network
+        lhs_val (TRTTensor): A TRT Tensor numerator
+        rhs_val (TRTTensor): A TRT Tensor numerator
+
+    Returns:
+        A list of lhs_val and rhs_val casted to the approriate datatype
+    """
+    if (lhs_val.dtype == trt.int8 or lhs_val.dtype == trt.int32) and (
+        rhs_val.dtype == trt.int8 or rhs_val.dtype == trt.int32
+    ):
+        lhs_val = cast_trt_tensor(network, lhs_val, trt.float32)
+        rhs_val = cast_trt_tensor(network, rhs_val, trt.float32)
+    return list((lhs_val, rhs_val))
+
+
 def get_trt_tensor(
     network: TRTNetwork,
     input_val: Any,

--- a/py/torch_tensorrt/fx/converters/impl/elementwise/base.py
+++ b/py/torch_tensorrt/fx/converters/impl/elementwise/base.py
@@ -129,7 +129,8 @@ def convert_binary_elementwise(
     rhs_val = get_trt_tensor(network, rhs_val, f"{name}_rhs", rhs_dtype)
 
     promoted_type = torch.promote_types(
-        unified_dtype_converter(lhs_val.dtype, Frameworks.TORCH), unified_dtype_converter(rhs_val.dtype, Frameworks.TORCH)
+        unified_dtype_converter(lhs_val.dtype, Frameworks.TORCH),
+        unified_dtype_converter(rhs_val.dtype, Frameworks.TORCH),
     )
     trt_promoted_type = unified_dtype_converter(promoted_type, Frameworks.TRT)
 

--- a/py/torch_tensorrt/fx/converters/impl/elementwise/base.py
+++ b/py/torch_tensorrt/fx/converters/impl/elementwise/base.py
@@ -17,6 +17,7 @@ from torch_tensorrt.fx.converters.converter_utils import (
     broadcast,
     squeeze_left,
     get_trt_tensor,
+    cast_trt_tensor,
 )
 
 
@@ -52,6 +53,7 @@ def convert_binary_elementwise(
     introduce constant via .size() op. Other scenario should be const folded first.
     If any operand is not a trt tensor, we make it a trt constant layer while preserve
     its dtype. Then we broadcast these two inputs to have the same number of dimensions.
+    We also promote the types of the two tensors to avoid dtype errors in TRT.
 
     Limitation:
         If we are using implicit batch dim mode, the operand that is not a trt
@@ -125,6 +127,16 @@ def convert_binary_elementwise(
 
     lhs_val = get_trt_tensor(network, lhs_val, f"{name}_lhs", lhs_dtype)
     rhs_val = get_trt_tensor(network, rhs_val, f"{name}_rhs", rhs_dtype)
+
+    promoted_type = torch.promote_types(
+        unified_dtype_converter(lhs_val.dtype, Frameworks.TORCH), unified_dtype_converter(rhs_val.dtype, Frameworks.TORCH)
+    )
+    trt_promoted_type = unified_dtype_converter(promoted_type, Frameworks.TRT)
+
+    if trt_promoted_type != lhs_val.dtype:
+        lhs_val = cast_trt_tensor(network, lhs_val, trt_promoted_type, name)
+    if trt_promoted_type != rhs_val.dtype:
+        rhs_val = cast_trt_tensor(network, rhs_val, trt_promoted_type, name)
 
     # Check the limitation in the doc string.
     if network.has_implicit_batch_dimension:

--- a/py/torch_tensorrt/fx/test/converters/acc_op/test_binary_ops.py
+++ b/py/torch_tensorrt/fx/test/converters/acc_op/test_binary_ops.py
@@ -58,6 +58,23 @@ class TestBinaryOpConverters(AccTestCase):
         self.run_test(m, inputs, expected_ops={expected_op})
 
     @parameterized.expand([(op[1].__name__, op[0], op[1]) for op in elementwise_ops])
+    def test_elementwise_ops_mismatched_dtypes(
+        self, name, orig_op: Callable, expected_op
+    ):
+        class TestModule(nn.Module):
+            def __init__(self, orig_op):
+                super().__init__()
+                self.orig_op = orig_op
+
+            def forward(self, x):
+                return self.orig_op(x.int(), x)
+
+        m = TestModule(orig_op)
+        # Avoid dividing by 0.
+        inputs = [2 * torch.rand(1, 1, dtype=torch.float) + 1]
+        self.run_test(m, inputs, expected_ops={expected_op})
+
+    @parameterized.expand([(op[1].__name__, op[0], op[1]) for op in elementwise_ops])
     def test_elementwise_ops_with_one_constant(
         self, name, orig_op: Callable, expected_op
     ):


### PR DESCRIPTION
This PR addresses input casting for aten::div cases in which both the inputs are integer