### PR TITLE
fix: Add python3 symlink in final container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -94,6 +94,11 @@ RUN bash ./docker/dist-build.sh
 FROM base as torch-tensorrt
 
 COPY . /opt/torch_tensorrt
+
+# Symlink the path pyenv is using for python with the /opt directory for package sourcing
+RUN mkdir -p "/opt/python3/" &&\
+    ln -s "`pyenv which python | xargs dirname | xargs dirname`/lib/python$PYTHON_VERSION/site-packages" "/opt/python3/"
+
 COPY --from=torch-tensorrt-builder  /workspace/torch_tensorrt/src/py/dist/ .
 
 RUN cp /opt/torch_tensorrt/docker/WORKSPACE.docker /opt/torch_tensorrt/WORKSPACE


### PR DESCRIPTION
# Description

- Enable `libtorch` sourcing from WORKSPACE file in Docker container

Addresses #1560

## Type of change

- Container improvement

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
