### PR TITLE
Pass detailed unique layer name to the TRT engine

### DIFF
--- a/py/torch_tensorrt/dynamo/fx_ts_compat/fx2trt.py
+++ b/py/torch_tensorrt/dynamo/fx_ts_compat/fx2trt.py
@@ -297,7 +297,7 @@ class TRTInterpreter(torch.fx.Interpreter):
         # The call stack contains a detailed name of the module
         # which shows exactly where the module is located in the
         # network architecture.
-        stack_item =  node.meta.get("nn_module_stack", None)
+        stack_item = node.meta.get("nn_module_stack", None)
         # The current node is the last item in the stack
         mod_stack = stack_item.popitem() if stack_item else ""
         node_name = str(node)
@@ -306,7 +306,11 @@ class TRTInterpreter(torch.fx.Interpreter):
             # Clean up the module name
             mod_name = re.sub("^.*__self", "", mod_name)
             mod_name = re.sub("_(\d+)$", "/\g<1>", mod_name)
-            node_name = mod_name + '/' + node_name
+            node_name = mod_name + "/" + node_name
+        else:
+            # Try an alternative way to get the module info
+            # like the node.meta['source_fn'] attr
+            pass
 
         _LOGGER.debug(f"Node meta name {node_name}")
         return node_name

--- a/py/torch_tensorrt/fx/fx2trt.py
+++ b/py/torch_tensorrt/fx/fx2trt.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import warnings
 from datetime import datetime
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Sequence
@@ -270,8 +271,27 @@ class TRTInterpreter(torch.fx.Interpreter):
             engine, self._input_names, self._output_names, serialized_cache
         )
 
+    def get_node_name(self, node):
+        # nn_module_stack preserves the call stack of pytorch nn.modules
+        # The call stack contains a detailed name of the module
+        # which shows exactly where the module is located in the
+        # network architecture.
+        stack_item =  node.meta.get("nn_module_stack", None)
+        # The current node is the last item in the stack
+        mod_stack = stack_item.popitem() if stack_item else ""
+        node_name = str(node)
+        if mod_stack:
+            mod_name = str(mod_stack[0]).replace("___", "/")
+            # Clean up the module name
+            mod_name = re.sub("^.*__self", "", mod_name)
+            mod_name = re.sub("_(\d+)$", "/\g<1>", mod_name)
+            node_name = mod_name + '/' + node_name
+
+        _LOGGER.debug(f"Node meta name {node_name}")
+        return node_name
+
     def run_node(self, n):
-        self._cur_node_name = str(n)
+        self._cur_node_name = self.get_node_name(n)
         # add "_itensor_to_tensor_meta"
         kwargs = dict(n.kwargs)
         kwargs["_itensor_to_tensor_meta"] = self._itensor_to_tensor_meta

--- a/py/torch_tensorrt/fx/fx2trt.py
+++ b/py/torch_tensorrt/fx/fx2trt.py
@@ -276,7 +276,7 @@ class TRTInterpreter(torch.fx.Interpreter):
         # The call stack contains a detailed name of the module
         # which shows exactly where the module is located in the
         # network architecture.
-        stack_item =  node.meta.get("nn_module_stack", None)
+        stack_item = node.meta.get("nn_module_stack", None)
         # The current node is the last item in the stack
         mod_stack = stack_item.popitem() if stack_item else ""
         node_name = str(node)
@@ -285,7 +285,7 @@ class TRTInterpreter(torch.fx.Interpreter):
             # Clean up the module name
             mod_name = re.sub("^.*__self", "", mod_name)
             mod_name = re.sub("_(\d+)$", "/\g<1>", mod_name)
-            node_name = mod_name + '/' + node_name
+            node_name = mod_name + "/" + node_name
 
         _LOGGER.debug(f"Node meta name {node_name}")
         return node_name


### PR DESCRIPTION
PyTorch provides a way to retrieve a detailed unique layer name from framework.  The name is derived from the module class hierarchy so details of the network architecture is encoded in the name.  This information is really useful for performance analysis and for a basic understanding of the network architecture.  The goal is to pass this name from PyTorch to TRT, torch-TRT is effectively just a pass through stage. 

# Description
Each layer in pytorch is defined by classes which inherit from nn.module.  The fx graph represents the network as a sequence of nn.module instances along with the pytorch operators which implement the forward method for each class.  Each of these operators can be made unique by prefixing them with the module name they appear in.  The fx graph maintains the module name in the node.meta['nn_module_stack'] attribute.  This change just fetches the 'nn_module_stack' cleans up the name and prefixes it to the operator name, then it gets passed to the TRT engine IR.

Fixes #2069

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
