### PR TITLE
feat: Added a variant for aten::fake_quant_per_tensor

### DIFF
--- a/tests/core/conversion/converters/test_quantization.cpp
+++ b/tests/core/conversion/converters/test_quantization.cpp
@@ -30,6 +30,40 @@ TEST(Converters, ATenFakeQuantizePerTensorConvertsCorrectly) {
       torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
 }
 
+TEST(Converters, ATenFakeQuantizePerTensorWithParamsConvertsCorrectly) {
+  const auto graph = R"IR(
+    graph(%x.1 : Tensor):
+        %22 : int = prim::Constant[value=-128]()
+        %14 : int = prim::Constant[value=4]()
+        %9 : None = prim::Constant()
+        %35 : Device = prim::Constant[value="cuda:0"]()
+        %6 : int = prim::Constant[value=6]()
+        %7 : int = prim::Constant[value=3]()
+        %3 : int = prim::Constant[value=1]()
+        %5 : float = prim::Constant[value=3.5]()
+        %13 : int = prim::Constant[value=1]()
+        %23 : int = prim::Constant[value=127]()
+        %4 : int[] = prim::ListConstruct(%3)
+        %11 : Tensor = aten::full(%4, %5, %6, %9, %35, %9)
+        %12 : int[] = prim::ListConstruct(%3)
+        %19 : Tensor = aten::full(%12, %13, %7, %9, %35, %9)
+        %quant_input.1 : Tensor = aten::fake_quantize_per_tensor_affine(%x.1, %11, %19, %22, %23)
+        return (%quant_input.1))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, g.get());
+
+  auto in = at::randint(1, 10, {1, 5, 5, 5}, {at::kCUDA}).to(at::kFloat);
+
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {in});
+
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {in}, nvinfer1::DataType::kINT8);
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
+}
+
 TEST(Converters, ATenFakeQuantizePerChannelConvertsCorrectly) {
   const auto graph = R"IR(
     graph(%x.1 : Tensor):


### PR DESCRIPTION
# Description
Added support for fake_quant_per_tensor variant named aten::fake_quantize_per_tensor_affine.tensor_qparams with scale as a Tensor in the schema.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
