### PR TITLE
fix: TRTInterpreter output lacks return value

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/trt_interpreter.py
+++ b/py/torch_tensorrt/dynamo/conversion/trt_interpreter.py
@@ -356,3 +356,5 @@ class TRTInterpreter(torch.fx.Interpreter):
             elif self.output_fp16 and output.dtype == trt.float32:
                 output.dtype = trt.float16
             self._output_names.append(name)
+
+        return list(outputs)


### PR DESCRIPTION
# Description

- Fixes error causing PyTree failures during Dynamo tracing for new converters returning lists of Tensors

The following error is encountered when testing converters:
```python
Traceback (most recent call last):
  File "~/python_virtual_environments/torch_trt_venv/lib/python3.10/site-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "~/TensorRT/py/torch_tensorrt/dynamo/converters/test/test_split.py", line 25, in test_split
    self.run_test(
  File "~/TensorRT/py/torch_tensorrt/dynamo/converters/test_utils.py", line 102, in run_test
    super().run_test(
  File "~/TensorRT/py/torch_tensorrt/dynamo/fx_ts_compat/tools/common_fx2trt.py", line 84, in run_test
    interpreter_result = interpreter.run(lower_precision=precision)
  File "~/TensorRT/py/torch_tensorrt/dynamo/fx_ts_compat/fx2trt.py", line 212, in run
    super().run()
  File "~/python_virtual_environments/torch_trt_venv/lib/python3.10/site-packages/torch/fx/interpreter.py", line 155, in run
    return self.module.graph.process_outputs(output_val) if enable_io_processing else output_val
  File "~/python_virtual_environments/torch_trt_venv/lib/python3.10/site-packages/torch/fx/graph.py", line 858, in process_outputs
    return self._codegen.process_outputs(out)
  File "~/python_virtual_environments/torch_trt_venv/lib/python3.10/site-packages/torch/fx/graph.py", line 620, in process_outputs
    return pytree.tree_unflatten(out, self.pytree_info.out_spec)
  File "~/python_virtual_environments/torch_trt_venv/lib/python3.10/site-packages/torch/utils/_pytree.py", line 301, in tree_unflatten
    raise ValueError(
ValueError: tree_unflatten(values, spec): `values` has length 1 but the spec refers to a pytree that holds 2 items (TreeSpec(tuple, None, [*,
  *])).
```

The TorchGen output verifier, [invoked here](https://github.com/pytorch/pytorch/blob/46104882d720bf369ace6b0d744f5452c361388d/torch/fx/interpreter.py#L153-L155), requires the outputs to be a list of values. The `TRTInterpreter` was not returning any values, causing the first error, then was returning `tuple` values, causing the second issue. The cast introduced in this PR resolves those. 

Related to: https://github.com/pytorch/TensorRT/issues/1828#issuecomment-1520728382

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ]  I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
