### PR TITLE
chore: Add parallelism to Dynamo tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1053,6 +1053,7 @@ jobs:
         type: string
       python-version:
         type: string
+    parallelism: 4
     machine:
       image: linux-cuda-12:2023.05.1
     resource_class: gpu.nvidia.medium


### PR DESCRIPTION
# Description

- Reduce testing time on CircleCI by over 15 mins
- Tests currently are only split by file, not by individual test cases since these are managed by two different commands (CircleCI vs PyTest)

Fixes #2139 

## Type of change

- CI fix

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
