### PR TITLE
Support amax dynamo converter

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -377,3 +377,23 @@ def aten_ops_permute(
         args[0],
         args[1],
     )
+
+@dynamo_tensorrt_converter(torch.ops.aten.amax.default)
+@dynamo_tensorrt_converter(torch.ops.aten.amax.out)
+def aten_ops_amax(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    return impl.amax.amax(
+        network,
+        target,
+        SourceIR.ATEN,
+        name,
+        args[0],
+        args[1],
+        args[2] if len(args) >= 3 else False,
+        kwargs.get("out"),
+    )

--- a/py/torch_tensorrt/dynamo/conversion/impl/__init__.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/__init__.py
@@ -12,3 +12,4 @@ from . import shape
 from . import squeeze
 from . import unsqueeze
 from . import permutation
+from . import amax

--- a/py/torch_tensorrt/dynamo/conversion/impl/amax.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/amax.py
@@ -1,0 +1,46 @@
+from typing import Optional, Union, cast, Any, Tuple
+
+import tensorrt as trt
+
+from torch.fx.node import Target
+
+from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
+from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.fx.converters.converter_utils import (
+    get_axes_for_reduce_op,
+    set_layer_name,
+)
+
+def amax(
+    network: TRTNetwork,
+    target: Target,
+    source_ir: Optional[SourceIR],
+    name: str,
+    input: TRTTensor,
+    dim: Union[int, Tuple[int]],
+    keep_dims: Optional[bool] = False,
+    out: Optional[Any] = None
+) -> TRTTensor:
+    if not isinstance(input, TRTTensor):
+        raise RuntimeError(f"amax received input {input} that is not part of the TensorRT region!"
+    )
+
+    if dim is None:
+        raise ValueError("amax requires specifying dimension(s) (dim).")
+
+    layer = network.add_reduce(
+        input, 
+        trt.ReduceOperation.MAX, 
+        axes=get_axes_for_reduce_op(dim, network.has_implicit_batch_dimension),
+        keep_dims=keep_dims
+    )
+    set_layer_name(layer, target, name)
+    
+    layer_out = layer.get_output(0)
+    if out is not None:
+        if out.shape != layer_out.shape:
+            raise RuntimeError(f"The shape of argument `out` is {out.shape}, which is not same as the layer output shape {layer_out.shape}!")
+        else:
+            out = layer_out
+
+    return layer_out

--- a/tests/py/dynamo/converters/test_amax_aten.py
+++ b/tests/py/dynamo/converters/test_amax_aten.py
@@ -1,0 +1,96 @@
+import torch
+import torch.nn as nn
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt.dynamo.test_utils import DispatchTestCase
+
+
+class TestAmaxConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            ((3, 2, 4), 1, True),
+            ((2, 3, 4, 5), 3, True),
+            ((2, 3, 4, 5), 2, False),
+            ((6, 7, 5, 4, 5), 4, False),
+        ]
+    )
+    def test_amax_dim_int_default(self, input_shape, dim, keep_dims):
+        class Amax(nn.Module):
+            def forward(self, x):
+                return torch.amax(x, dim=dim, keepdim=keep_dims)
+
+        inputs = [torch.randn(*input_shape)]
+        
+        self.run_test(
+            Amax(),
+            inputs,
+            expected_ops={torch.ops.aten.amax.default},
+        )
+        
+    @parameterized.expand(
+        [
+            ((3, 2, 4), 1, True, (3, 1, 4)),
+            ((2, 3, 4, 5), 3, True, (2, 3, 4, 1)),
+            ((2, 3, 4, 5), 2, False, (2, 3, 5)),
+            ((6, 7, 5, 4, 5), 4, False, (6, 7, 5, 4)),
+        ]
+    )
+    def test_amax_dim_int_out(self, input_shape, dim, keep_dims, output_shape):
+        class Amax(nn.Module):
+            def forward(self, x):
+                outputs = torch.randn(*output_shape)
+                return torch.amax(x, dim=dim, keepdim=keep_dims, out=outputs)
+
+        inputs = [torch.randn(*input_shape)]
+        
+        self.run_test(
+            Amax(),
+            inputs,
+            expected_ops={torch.ops.aten.amax.out},
+        )
+
+    @parameterized.expand(
+        [
+            ((3, 2, 4), [1], True),
+            ((2, 1, 4, 5), [0, 3], True),
+            ((2, 3, 4, 5), [0, 1, 2, 3], False),
+            ((6, 7, 5, 4, 5), [1, 3, 4], False),
+        ]
+    )
+    def test_amax_dim_tuple_default(self, input_shape, dim, keep_dims):
+        class Amax(nn.Module):
+            def forward(self, x):
+                return torch.amax(x, dim=dim, keepdim=keep_dims)
+
+        inputs = [torch.randn(*input_shape)]
+        
+        self.run_test(
+            Amax(),
+            inputs,
+            expected_ops={torch.ops.aten.amax.default},
+        )
+        
+    @parameterized.expand(
+        [
+            ((3, 2, 4), [1], True, (3, 1, 4)),
+            ((2, 1, 4, 5), [0, 3], True, (1, 1, 4, 1)),
+            ((2, 3, 4, 5), [0, 1, 2], False, (5,)),
+            ((6, 7, 5, 4, 5), [1, 3, 4], False, (6, 5)),
+        ]
+    )
+    def test_amax_dim_tuple_out(self, input_shape, dim, keep_dims, output_shape):
+        class Amax(nn.Module):
+            def forward(self, x):
+                outputs = torch.randn(*output_shape)
+                return torch.amax(x, dim=dim, keepdim=keep_dims, out=outputs)
+
+        inputs = [torch.randn(*input_shape)]
+        
+        self.run_test(
+            Amax(),
+            inputs,
+            expected_ops={torch.ops.aten.amax.out},
+        )
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
# Description

Support amax dynamo converter.

- Function Schema:
`torch.ops.aten.amax.default`

- Original PyTorch API:
https://pytorch.org/docs/stable/generated/torch.amax.html

Fixes issue #2095 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
