### PR TITLE
feat: Add support for device compilation setting

### DIFF
--- a/py/torch_tensorrt/_Device.py
+++ b/py/torch_tensorrt/_Device.py
@@ -8,11 +8,10 @@ else:
 
 import warnings
 
-import torch
-from torch_tensorrt import logging
-
 # from torch_tensorrt import _enums
 import tensorrt as trt
+import torch
+from torch_tensorrt import logging
 
 try:
     from torch_tensorrt import _C
@@ -119,6 +118,9 @@ class Device(object):
                 self.dla_core, self.allow_gpu_fallback
             )
         )
+
+    def __repr__(self) -> str:
+        return self.__str__()
 
     def _to_internal(self) -> _C.Device:
         internal_dev = _C.Device()

--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -209,12 +209,12 @@ def compile(
         import collections.abc
 
         from torch_tensorrt import Device
-        from torch_tensorrt.dynamo.utils import prepare_device, prepare_inputs
+        from torch_tensorrt.dynamo.utils import prepare_inputs, to_torch_device
 
         if not isinstance(inputs, collections.abc.Sequence):
             inputs = [inputs]
         device = kwargs.get("device", Device._current_device())
-        torchtrt_inputs, torch_inputs = prepare_inputs(inputs, prepare_device(device))
+        torchtrt_inputs, torch_inputs = prepare_inputs(inputs, to_torch_device(device))
         module = torch_tensorrt.dynamo.trace(module, torch_inputs, **kwargs)
         compiled_aten_module: torch.fx.GraphModule = dynamo_compile(
             module,

--- a/py/torch_tensorrt/dynamo/_defaults.py
+++ b/py/torch_tensorrt/dynamo/_defaults.py
@@ -1,7 +1,9 @@
 import torch
+from torch_tensorrt._Device import Device
 
 PRECISION = torch.float32
 DEBUG = False
+DEVICE = None
 WORKSPACE_SIZE = 0
 MIN_BLOCK_SIZE = 5
 PASS_THROUGH_BUILD_FAILURES = False
@@ -12,3 +14,7 @@ TRUNCATE_LONG_AND_DOUBLE = False
 USE_PYTHON_RUNTIME = False
 USE_FAST_PARTITIONER = True
 ENABLE_EXPERIMENTAL_DECOMPOSITIONS = False
+
+
+def default_device() -> Device:
+    return Device(gpu_id=torch.cuda.current_device())

--- a/py/torch_tensorrt/dynamo/_settings.py
+++ b/py/torch_tensorrt/dynamo/_settings.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Set
 
 import torch
+from torch_tensorrt._Device import Device
 from torch_tensorrt.dynamo._defaults import (
     DEBUG,
     ENABLE_EXPERIMENTAL_DECOMPOSITIONS,
@@ -15,6 +16,7 @@ from torch_tensorrt.dynamo._defaults import (
     USE_PYTHON_RUNTIME,
     VERSION_COMPATIBLE,
     WORKSPACE_SIZE,
+    default_device,
 )
 
 
@@ -54,3 +56,4 @@ class CompilationSettings:
     truncate_long_and_double: bool = TRUNCATE_LONG_AND_DOUBLE
     use_fast_partitioner: bool = USE_FAST_PARTITIONER
     enable_experimental_decompositions: bool = ENABLE_EXPERIMENTAL_DECOMPOSITIONS
+    device: Device = field(default_factory=default_device)

--- a/py/torch_tensorrt/dynamo/compile.py
+++ b/py/torch_tensorrt/dynamo/compile.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import collections.abc
 import logging
-from typing import Any, List, Optional, Sequence, Set, Tuple
+from typing import Any, List, Optional, Sequence, Set, Tuple, Union
 
 import torch
 import torch_tensorrt
@@ -13,6 +13,7 @@ from torch_tensorrt._enums import (  # TODO: Should probabably be the TRT Engine
 from torch_tensorrt.dynamo import CompilationSettings, partitioning
 from torch_tensorrt.dynamo._defaults import (
     DEBUG,
+    DEVICE,
     ENABLE_EXPERIMENTAL_DECOMPOSITIONS,
     MAX_AUX_STREAMS,
     MIN_BLOCK_SIZE,
@@ -29,7 +30,11 @@ from torch_tensorrt.dynamo.conversion import (
     convert_module,
     repair_long_or_double_inputs,
 )
-from torch_tensorrt.dynamo.utils import prepare_device, prepare_inputs
+from torch_tensorrt.dynamo.utils import (
+    prepare_inputs,
+    to_torch_device,
+    to_torch_tensorrt_device,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +43,7 @@ def compile(
     gm: Any,
     inputs: Any,
     *,
-    device: Device = Device._current_device(),
+    device: Optional[Union[Device, torch.device, str]] = DEVICE,
     disable_tf32: bool = False,
     sparse_weights: bool = False,
     enabled_precisions: Set[torch.dtype] | Tuple[torch.dtype] = (torch.float32,),
@@ -82,7 +87,9 @@ def compile(
     if not isinstance(inputs, collections.abc.Sequence):
         inputs = [inputs]
 
-    _, torch_inputs = prepare_inputs(inputs, prepare_device(device))
+    device = to_torch_tensorrt_device(device)
+
+    _, torch_inputs = prepare_inputs(inputs, to_torch_device(device))
 
     if (
         torch.float16 in enabled_precisions
@@ -105,6 +112,7 @@ def compile(
     compilation_options = {
         "precision": precision,
         "debug": debug,
+        "device": device,
         "workspace_size": workspace_size,
         "min_block_size": min_block_size,
         "torch_executed_ops": torch_executed_ops

--- a/py/torch_tensorrt/dynamo/conversion/conversion.py
+++ b/py/torch_tensorrt/dynamo/conversion/conversion.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 import io
 from typing import Sequence
 
+import tensorrt as trt
 import torch
 from torch_tensorrt._Input import Input
 from torch_tensorrt.dynamo import CompilationSettings
 from torch_tensorrt.dynamo.conversion import TRTInterpreter
 from torch_tensorrt.dynamo.runtime import PythonTorchTensorRTModule, TorchTensorRTModule
-
-import tensorrt as trt
 
 
 def convert_module(
@@ -72,4 +71,5 @@ def convert_module(
             name=name,
             input_binding_names=list(interpreter_result.input_names),
             output_binding_names=list(interpreter_result.output_names),
+            target_device=settings.device,
         )

--- a/tests/py/dynamo/backend/test_compiler_utils.py
+++ b/tests/py/dynamo/backend/test_compiler_utils.py
@@ -1,24 +1,59 @@
-from torch_tensorrt.dynamo.utils import prepare_device, prepare_inputs
-from utils import same_output_format
-import torch_tensorrt
 import unittest
+
 import torch
+import torch_tensorrt
+from torch_tensorrt.dynamo.utils import (
+    prepare_inputs,
+    to_torch_device,
+    to_torch_tensorrt_device,
+)
+from utils import same_output_format
 
 
-class TestPrepareDevice(unittest.TestCase):
-    def test_prepare_cuda_device(self):
+class TestToTorchDevice(unittest.TestCase):
+    def test_cast_cuda_device(self):
         gpu_id = 0
         device = torch.device(f"cuda:{gpu_id}")
-        prepared_device = prepare_device(device)
+        prepared_device = to_torch_device(device)
         self.assertTrue(isinstance(prepared_device, torch.device))
         self.assertTrue(prepared_device.index == gpu_id)
 
-    def test_prepare_trt_device(self):
+    def test_cast_trt_device(self):
         gpu_id = 4
         device = torch_tensorrt.Device(gpu_id=gpu_id)
-        prepared_device = prepare_device(device)
+        prepared_device = to_torch_device(device)
         self.assertTrue(isinstance(prepared_device, torch.device))
         self.assertTrue(prepared_device.index == gpu_id)
+
+    def test_cast_str_device(self):
+        gpu_id = 2
+        device = f"cuda:{2}"
+        prepared_device = to_torch_device(device)
+        self.assertTrue(isinstance(prepared_device, torch.device))
+        self.assertTrue(prepared_device.index == gpu_id)
+
+
+class TestToTorchTRTDevice(unittest.TestCase):
+    def test_cast_cuda_device(self):
+        gpu_id = 0
+        device = torch.device(f"cuda:{gpu_id}")
+        prepared_device = to_torch_tensorrt_device(device)
+        self.assertTrue(isinstance(prepared_device, torch_tensorrt.Device))
+        self.assertTrue(prepared_device.gpu_id == gpu_id)
+
+    def test_cast_trt_device(self):
+        gpu_id = 4
+        device = torch_tensorrt.Device(gpu_id=gpu_id)
+        prepared_device = to_torch_tensorrt_device(device)
+        self.assertTrue(isinstance(prepared_device, torch_tensorrt.Device))
+        self.assertTrue(prepared_device.gpu_id == gpu_id)
+
+    def test_cast_str_device(self):
+        gpu_id = 2
+        device = f"cuda:{2}"
+        prepared_device = to_torch_tensorrt_device(device)
+        self.assertTrue(isinstance(prepared_device, torch_tensorrt.Device))
+        self.assertTrue(prepared_device.gpu_id == gpu_id)
 
 
 class TestPrepareInputs(unittest.TestCase):


### PR DESCRIPTION
# Description
- Enables support for device compilation settings in Dynamo paths
- Developed in a way such that extensions for multiple gpus can be made in a straightforward fashion
  - Default device type/format can be customized
- Defaults to current present device, with context-aware switching, enable the following workflow for torch compile:
```python
    with torch.cuda.device(1):
        model = models.resnet18(pretrained=True).eval().cuda()
        input = torch.randn((1, 3, 224, 224)).cuda()

        compile_spec = {
            "inputs": [
                torchtrt.Input(
                    input.shape, dtype=torch.float, format=torch.contiguous_format
                )
            ],
            "enabled_precisions": {torch.float},
            "debug": True,
            "ir": "torch_compile",
        }

        trt_mod = torchtrt.compile(model, **compile_spec)
```

Fixes #2172 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
