### PR TITLE
fix: Legacy CI `pip` installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1568,6 +1568,7 @@ workflows:
           torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
           python-version: << pipeline.parameters.python-version >>
           legacy: << pipeline.parameters.enable-legacy >>
+          ci-image: << pipeline.parameters.ci-image-legacy >>
 
       - test-core-cpp-x86_64-linux:
           name: test-core-cpp-x86_64-linux-legacy
@@ -1577,8 +1578,9 @@ workflows:
           trt-version-short: << pipeline.parameters.trt-version-short-legacy >>
           trt-version-long: << pipeline.parameters.trt-version-long-legacy >>
           cudnn-version: << pipeline.parameters.cudnn-version-legacy >>
-          platform: << pipeline.parameters.platform-legacy >>
           python-version: << pipeline.parameters.python-version >>
+          ci-image: << pipeline.parameters.ci-image-legacy >>
+          platform: << pipeline.parameters.platform-legacy >>
           requires:
             - build-x86_64-linux-legacy
 
@@ -1589,6 +1591,7 @@ workflows:
           torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
           trt-version-long: << pipeline.parameters.trt-version-long-legacy >>
           python-version: << pipeline.parameters.python-version >>
+          ci-image: << pipeline.parameters.ci-image-legacy >>
           requires:
             - build-x86_64-linux-legacy
 
@@ -1598,6 +1601,7 @@ workflows:
           torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
           trt-version-long: << pipeline.parameters.trt-version-long-legacy >>
           python-version: << pipeline.parameters.python-version >>
+          ci-image: << pipeline.parameters.ci-image-legacy >>
           requires:
             - build-x86_64-linux-legacy
 
@@ -1655,101 +1659,55 @@ workflows:
 
   on-push:
     jobs:
-      # - build-x86_64-linux:
-      #     cuda-version: << pipeline.parameters.cuda-version >>
-      #     torch-build: << pipeline.parameters.torch-build >>
-      #     torchvision-build: << pipeline.parameters.torchvision-build >>
-      #     torch-build-index: << pipeline.parameters.torch-build-index >>
-      #     python-version: << pipeline.parameters.python-version >>
-
-      # - test-core-cpp-x86_64-linux:
-      #     torch-build: << pipeline.parameters.torch-build >>
-      #     torchvision-build: << pipeline.parameters.torchvision-build >>
-      #     torch-build-index: << pipeline.parameters.torch-build-index >>
-      #     trt-version-short: << pipeline.parameters.trt-version-short >>
-      #     trt-version-long: << pipeline.parameters.trt-version-long >>
-      #     python-version: << pipeline.parameters.python-version >>
-      #     cudnn-version: << pipeline.parameters.cudnn-version >>
-      #     requires:
-      #       - build-x86_64-linux
-
-      # - test-py-ts-x86_64-linux:
-      #     torch-build: << pipeline.parameters.torch-build >>
-      #     torchvision-build: << pipeline.parameters.torchvision-build >>
-      #     torch-build-index: << pipeline.parameters.torch-build-index >>
-      #     trt-version-long: << pipeline.parameters.trt-version-long >>
-      #     python-version: << pipeline.parameters.python-version >>
-      #     requires:
-      #       - build-x86_64-linux
-
-      # - test-py-fx-x86_64-linux:
-      #     torch-build: << pipeline.parameters.torch-build >>
-      #     torchvision-build: << pipeline.parameters.torchvision-build >>
-      #     torch-build-index: << pipeline.parameters.torch-build-index >>
-      #     trt-version-long: << pipeline.parameters.trt-version-long >>
-      #     python-version: << pipeline.parameters.python-version >>
-      #     requires:
-      #       - build-x86_64-linux
-
-      # - test-py-dynamo-x86_64-linux:
-      #     torch-build: << pipeline.parameters.torch-build >>
-      #     torchvision-build: << pipeline.parameters.torchvision-build >>
-      #     torch-build-index: << pipeline.parameters.torch-build-index >>
-      #     trt-version-long: << pipeline.parameters.trt-version-long >>
-      #     python-version: << pipeline.parameters.python-version >>
-      #     requires:
-      #       - build-x86_64-linux
-
-      # - build-x86_64-linux-cmake:
-      #     cuda-version: << pipeline.parameters.cuda-version >>
-      #     torch-build: << pipeline.parameters.torch-build >>
-      #     torch-build-index: << pipeline.parameters.torch-build-index >>
-      #     trt-version-short: << pipeline.parameters.trt-version-short >>
-      #     cudnn-version: << pipeline.parameters.cudnn-version >>
-      #     python-version: << pipeline.parameters.python-version >>
-
       - build-x86_64-linux:
-          name: build-x86_64-linux-legacy
-          cuda-version: << pipeline.parameters.cuda-version-legacy >>
-          torch-build: << pipeline.parameters.torch-build-legacy >>
-          torchvision-build: << pipeline.parameters.torchvision-build-legacy >>
-          torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
+          cuda-version: << pipeline.parameters.cuda-version >>
+          torch-build: << pipeline.parameters.torch-build >>
+          torchvision-build: << pipeline.parameters.torchvision-build >>
+          torch-build-index: << pipeline.parameters.torch-build-index >>
           python-version: << pipeline.parameters.python-version >>
-          legacy: << pipeline.parameters.enable-legacy >>
-          ci-image: << pipeline.parameters.ci-image-legacy >>
-
 
       - test-core-cpp-x86_64-linux:
-          name: test-core-cpp-x86_64-linux-legacy
-          torch-build: << pipeline.parameters.torch-build-legacy >>
-          torchvision-build: << pipeline.parameters.torchvision-build-legacy >>
-          torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
-          trt-version-short: << pipeline.parameters.trt-version-short-legacy >>
-          trt-version-long: << pipeline.parameters.trt-version-long-legacy >>
-          cudnn-version: << pipeline.parameters.cudnn-version-legacy >>
+          torch-build: << pipeline.parameters.torch-build >>
+          torchvision-build: << pipeline.parameters.torchvision-build >>
+          torch-build-index: << pipeline.parameters.torch-build-index >>
+          trt-version-short: << pipeline.parameters.trt-version-short >>
+          trt-version-long: << pipeline.parameters.trt-version-long >>
           python-version: << pipeline.parameters.python-version >>
-          ci-image: << pipeline.parameters.ci-image-legacy >>
-          platform: << pipeline.parameters.platform-legacy >>
+          cudnn-version: << pipeline.parameters.cudnn-version >>
           requires:
-            - build-x86_64-linux-legacy
+            - build-x86_64-linux
 
-      # - test-py-ts-x86_64-linux:
-      #     name: test-py-ts-x86_64-linux-legacy
-      #     torch-build: << pipeline.parameters.torch-build-legacy >>
-      #     torchvision-build: << pipeline.parameters.torchvision-build-legacy >>
-      #     torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
-      #     trt-version-long: << pipeline.parameters.trt-version-long-legacy >>
-      #     python-version: << pipeline.parameters.python-version >>
-      #     ci-image: << pipeline.parameters.ci-image-legacy >>
-      #     requires:
-      #       - build-x86_64-linux-legacy
+      - test-py-ts-x86_64-linux:
+          torch-build: << pipeline.parameters.torch-build >>
+          torchvision-build: << pipeline.parameters.torchvision-build >>
+          torch-build-index: << pipeline.parameters.torch-build-index >>
+          trt-version-long: << pipeline.parameters.trt-version-long >>
+          python-version: << pipeline.parameters.python-version >>
+          requires:
+            - build-x86_64-linux
 
-      # - test-py-fx-x86_64-linux-no-aten:
-      #     torch-build: << pipeline.parameters.torch-build-legacy >>
-      #     torchvision-build: << pipeline.parameters.torchvision-build-legacy >>
-      #     torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
-      #     trt-version-long: << pipeline.parameters.trt-version-long-legacy >>
-      #     python-version: << pipeline.parameters.python-version >>
-      #     ci-image: << pipeline.parameters.ci-image-legacy >>
-      #     requires:
-      #       - build-x86_64-linux-legacy
+      - test-py-fx-x86_64-linux:
+          torch-build: << pipeline.parameters.torch-build >>
+          torchvision-build: << pipeline.parameters.torchvision-build >>
+          torch-build-index: << pipeline.parameters.torch-build-index >>
+          trt-version-long: << pipeline.parameters.trt-version-long >>
+          python-version: << pipeline.parameters.python-version >>
+          requires:
+            - build-x86_64-linux
+
+      - test-py-dynamo-x86_64-linux:
+          torch-build: << pipeline.parameters.torch-build >>
+          torchvision-build: << pipeline.parameters.torchvision-build >>
+          torch-build-index: << pipeline.parameters.torch-build-index >>
+          trt-version-long: << pipeline.parameters.trt-version-long >>
+          python-version: << pipeline.parameters.python-version >>
+          requires:
+            - build-x86_64-linux
+
+      - build-x86_64-linux-cmake:
+          cuda-version: << pipeline.parameters.cuda-version >>
+          torch-build: << pipeline.parameters.torch-build >>
+          torch-build-index: << pipeline.parameters.torch-build-index >>
+          trt-version-short: << pipeline.parameters.trt-version-short >>
+          cudnn-version: << pipeline.parameters.cudnn-version >>
+          python-version: << pipeline.parameters.python-version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,7 @@ commands:
             export CUDA_HOME=/usr/local/cuda-<< parameters.cuda-version >>/
             mv toolchains/ci_workspaces/WORKSPACE.<< parameters.platform >> WORKSPACE
             python3 -m pip install pip==22.0.2
-            python3 -m pip wheel --no-deps --verbose --pre . --extra-index-url https://pypi.nvidia.com --extra-index-url << parameters.torch-build-index >> --config-setting="--build-option=--legacy" -w dist
+            python3 -m pip wheel --no-deps --verbose --pre . --extra-index-url https://pypi.nvidia.com --extra-index-url << parameters.torch-build-index >> --global-option="--legacy" -w dist
             python3 -m pip install dist/torch_tensorrt*
             mkdir -p /tmp/dist/builds
             cp dist/torch_tensorrt* /tmp/dist/builds
@@ -1610,54 +1610,10 @@ workflows:
   on-push:
     jobs:
       - build-x86_64-linux:
-          cuda-version: << pipeline.parameters.cuda-version >>
-          torch-build: << pipeline.parameters.torch-build >>
-          torchvision-build: << pipeline.parameters.torchvision-build >>
-          torch-build-index: << pipeline.parameters.torch-build-index >>
+          name: build-x86_64-linux-legacy
+          cuda-version: << pipeline.parameters.cuda-version-legacy >>
+          torch-build: << pipeline.parameters.torch-build-legacy >>
+          torchvision-build: << pipeline.parameters.torchvision-build-legacy >>
+          torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
           python-version: << pipeline.parameters.python-version >>
-
-      - test-core-cpp-x86_64-linux:
-          torch-build: << pipeline.parameters.torch-build >>
-          torchvision-build: << pipeline.parameters.torchvision-build >>
-          torch-build-index: << pipeline.parameters.torch-build-index >>
-          trt-version-short: << pipeline.parameters.trt-version-short >>
-          trt-version-long: << pipeline.parameters.trt-version-long >>
-          python-version: << pipeline.parameters.python-version >>
-          cudnn-version: << pipeline.parameters.cudnn-version >>
-          requires:
-            - build-x86_64-linux
-
-      - test-py-ts-x86_64-linux:
-          torch-build: << pipeline.parameters.torch-build >>
-          torchvision-build: << pipeline.parameters.torchvision-build >>
-          torch-build-index: << pipeline.parameters.torch-build-index >>
-          trt-version-long: << pipeline.parameters.trt-version-long >>
-          python-version: << pipeline.parameters.python-version >>
-          requires:
-            - build-x86_64-linux
-
-      - test-py-fx-x86_64-linux:
-          torch-build: << pipeline.parameters.torch-build >>
-          torchvision-build: << pipeline.parameters.torchvision-build >>
-          torch-build-index: << pipeline.parameters.torch-build-index >>
-          trt-version-long: << pipeline.parameters.trt-version-long >>
-          python-version: << pipeline.parameters.python-version >>
-          requires:
-            - build-x86_64-linux
-
-      - test-py-dynamo-x86_64-linux:
-          torch-build: << pipeline.parameters.torch-build >>
-          torchvision-build: << pipeline.parameters.torchvision-build >>
-          torch-build-index: << pipeline.parameters.torch-build-index >>
-          trt-version-long: << pipeline.parameters.trt-version-long >>
-          python-version: << pipeline.parameters.python-version >>
-          requires:
-            - build-x86_64-linux
-
-      - build-x86_64-linux-cmake:
-          cuda-version: << pipeline.parameters.cuda-version >>
-          torch-build: << pipeline.parameters.torch-build >>
-          torch-build-index: << pipeline.parameters.torch-build-index >>
-          trt-version-short: << pipeline.parameters.trt-version-short >>
-          cudnn-version: << pipeline.parameters.cudnn-version >>
-          python-version: << pipeline.parameters.python-version >>
+          legacy: << pipeline.parameters.enable-legacy >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,8 +319,9 @@ commands:
             export CUDA_HOME=/usr/local/cuda-<< parameters.cuda-version >>/
             mv toolchains/ci_workspaces/WORKSPACE.<< parameters.platform >> WORKSPACE
             python3 -m pip install pip==22.0.2
-            python3 -m pip wheel --no-deps --verbose --pre . --extra-index-url https://pypi.nvidia.com --extra-index-url << parameters.torch-build-index >> --global-option="--legacy" -w dist
-            python3 -m pip install dist/torch_tensorrt*
+            python3 -m pip install -r py/requirements.txt
+            python3 setup.py bdist_wheel --legacy
+            python3 setup.py install --legacy
             mkdir -p /tmp/dist/builds
             cp dist/torch_tensorrt* /tmp/dist/builds
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,7 @@ commands:
           name: Build torch-tensorrt python legacy release (pre-cxx11-abi)
           command: |
             export CUDA_HOME=/usr/local/cuda-<< parameters.cuda-version >>/
-            mv toolchains/ci_workspaces/WORKSPACE.<< parameters.platform >> WORKSPACE
+            mv toolchains/ci_workspaces/WORKSPACE.<< parameters.platform >>.legacy WORKSPACE
             python3 -m pip install wheel setuptools pyyaml
             python3 -m pip install pybind11==2.6.2
             python3 setup.py bdist_wheel --legacy
@@ -1434,7 +1434,7 @@ parameters:
   # Legacy platform config
   cuda-version-legacy:
     type: string
-    default: "11.7"
+    default: "11.8"
   torch-build-legacy:
     type: string
     default: "1.13.1+cu117"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,10 +318,11 @@ commands:
           command: |
             export CUDA_HOME=/usr/local/cuda-<< parameters.cuda-version >>/
             mv toolchains/ci_workspaces/WORKSPACE.<< parameters.platform >>.legacy WORKSPACE
+            mv toolchains/legacy/pyproject.toml pyproject.toml
             python3 -m pip install wheel setuptools pyyaml
             python3 -m pip install pybind11==2.6.2
             python3 setup.py bdist_wheel --legacy
-            python3 setup.py install --legacy
+            python3 -m pip install dist/torch_tensorrt*
             mkdir -p /tmp/dist/builds
             cp dist/torch_tensorrt* /tmp/dist/builds
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -839,8 +839,11 @@ jobs:
       legacy:
         type: boolean
         default: false
+      ci-image:
+        type: string
+        default: "linux-cuda-12:2023.05.1"
     machine:
-      image: linux-cuda-12:2023.05.1
+      image: << parameters.ci-image >>
     resource_class: gpu.nvidia.small
     steps:
       - checkout
@@ -906,8 +909,11 @@ jobs:
         type: string
       cudnn-version:
         type: string
+      ci-image:
+        type: string
+        default: "linux-cuda-12:2023.05.1"
     machine:
-      image: linux-cuda-12:2023.05.1
+      image: << parameters.ci-image >>
     resource_class: gpu.nvidia.medium
     parallelism: 4
     steps:
@@ -946,8 +952,11 @@ jobs:
         type: string
       python-version:
         type: string
+      ci-image:
+        type: string
+        default: "linux-cuda-12:2023.05.1"
     machine:
-      image: linux-cuda-12:2023.05.1
+      image: << parameters.ci-image >>
     resource_class: gpu.nvidia.medium
     steps:
       - checkout
@@ -979,9 +988,12 @@ jobs:
         type: string
       python-version:
         type: string
+      ci-image:
+        type: string
+        default: "linux-cuda-12:2023.05.1"
     parallelism: 8
     machine:
-      image: linux-cuda-12:2023.05.1
+      image: << parameters.ci-image >>
     resource_class: gpu.nvidia.medium
     steps:
       - checkout
@@ -1015,9 +1027,12 @@ jobs:
         type: string
       python-version:
         type: string
+      ci-image:
+        type: string
+        default: "linux-cuda-12:2023.05.1"
     parallelism: 8
     machine:
-      image: linux-cuda-12:2023.05.1
+      image: << parameters.ci-image >>
     resource_class: gpu.nvidia.medium
     steps:
       - checkout
@@ -1054,9 +1069,12 @@ jobs:
         type: string
       python-version:
         type: string
+      ci-image:
+        type: string
+        default: "linux-cuda-12:2023.05.1"
     parallelism: 4
     machine:
-      image: linux-cuda-12:2023.05.1
+      image: << parameters.ci-image >>
     resource_class: gpu.nvidia.medium
     steps:
       - checkout
@@ -1093,9 +1111,12 @@ jobs:
         type: string
       torch-build-index:
         type: string
+      ci-image:
+        type: string
+        default: "linux-cuda-12:2023.05.1"
     parallelism: 4
     machine:
-      image: linux-cuda-12:2023.05.1
+      image: << parameters.ci-image >>
     resource_class: gpu.nvidia.small
     steps:
       - when:
@@ -1143,8 +1164,11 @@ jobs:
         type: string
       torch-build-index:
         type: string
+      ci-image:
+        type: string
+        default: "linux-cuda-12:2023.05.1"
     machine:
-      image: linux-cuda-12:2023.05.1
+      image: << parameters.ci-image >>
     resource_class: gpu.nvidia.small
     steps:
       - when:
@@ -1279,8 +1303,11 @@ jobs:
         type: string
       python-version:
         type: string
+      ci-image:
+        type: string
+        default: "linux-cuda-12:2023.05.1"
     machine:
-      image: linux-cuda-12:2023.05.1
+      image: << parameters.ci-image >>
     resource_class: gpu.nvidia.small
     steps:
       - checkout
@@ -1316,8 +1343,11 @@ jobs:
     parameters:
       torch-base-image:
         type: string
+      ci-image:
+        type: string
+        default: "linux-cuda-12:2023.05.1"
     machine:
-      image: linux-cuda-12:2023.05.1
+      image: << parameters.ci-image >>
     resource_class: gpu.nvidia.small
     steps:
       - checkout
@@ -1344,8 +1374,11 @@ jobs:
         default: false
       torch-base-image:
         type: string
+      ci-image:
+        type: string
+        default: "linux-cuda-12:2023.05.1"
     machine:
-      image: linux-cuda-12:2023.05.1
+      image: << parameters.ci-image >>
     resource_class: gpu.nvidia.small
     steps:
       - when:
@@ -1420,6 +1453,9 @@ parameters:
   trt-version-long-legacy:
     type: string
     default: "8.6.1"
+  ci-image-legacy:
+    type: string
+    default: "linux-cuda-11:2023.02.1"
 
   # Jetson platform config
   cuda-jetson-version:
@@ -1618,3 +1654,4 @@ workflows:
           torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
           python-version: << pipeline.parameters.python-version >>
           legacy: << pipeline.parameters.enable-legacy >>
+          ci-image: << pipeline.parameters.ci-image-legacy >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,7 +318,7 @@ commands:
           command: |
             export CUDA_HOME=/usr/local/cuda-<< parameters.cuda-version >>/
             mv toolchains/ci_workspaces/WORKSPACE.<< parameters.platform >> WORKSPACE
-            python3 -m pip install wheel setuptools
+            python3 -m pip install wheel setuptools pyyaml
             python3 -m pip install pybind11==2.6.2
             python3 setup.py bdist_wheel --legacy
             python3 setup.py install --legacy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,8 +318,8 @@ commands:
           command: |
             export CUDA_HOME=/usr/local/cuda-<< parameters.cuda-version >>/
             mv toolchains/ci_workspaces/WORKSPACE.<< parameters.platform >> WORKSPACE
-            python3 -m pip install pip==22.0.2
-            python3 -m pip install -r py/requirements.txt
+            python3 -m pip install wheel setuptools
+            python3 -m pip install pybind11==2.6.2
             python3 setup.py bdist_wheel --legacy
             python3 setup.py install --legacy
             mkdir -p /tmp/dist/builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1647,6 +1647,59 @@ workflows:
   on-push:
     jobs:
       - build-x86_64-linux:
+          cuda-version: << pipeline.parameters.cuda-version >>
+          torch-build: << pipeline.parameters.torch-build >>
+          torchvision-build: << pipeline.parameters.torchvision-build >>
+          torch-build-index: << pipeline.parameters.torch-build-index >>
+          python-version: << pipeline.parameters.python-version >>
+
+      - test-core-cpp-x86_64-linux:
+          torch-build: << pipeline.parameters.torch-build >>
+          torchvision-build: << pipeline.parameters.torchvision-build >>
+          torch-build-index: << pipeline.parameters.torch-build-index >>
+          trt-version-short: << pipeline.parameters.trt-version-short >>
+          trt-version-long: << pipeline.parameters.trt-version-long >>
+          python-version: << pipeline.parameters.python-version >>
+          cudnn-version: << pipeline.parameters.cudnn-version >>
+          requires:
+            - build-x86_64-linux
+
+      - test-py-ts-x86_64-linux:
+          torch-build: << pipeline.parameters.torch-build >>
+          torchvision-build: << pipeline.parameters.torchvision-build >>
+          torch-build-index: << pipeline.parameters.torch-build-index >>
+          trt-version-long: << pipeline.parameters.trt-version-long >>
+          python-version: << pipeline.parameters.python-version >>
+          requires:
+            - build-x86_64-linux
+
+      - test-py-fx-x86_64-linux:
+          torch-build: << pipeline.parameters.torch-build >>
+          torchvision-build: << pipeline.parameters.torchvision-build >>
+          torch-build-index: << pipeline.parameters.torch-build-index >>
+          trt-version-long: << pipeline.parameters.trt-version-long >>
+          python-version: << pipeline.parameters.python-version >>
+          requires:
+            - build-x86_64-linux
+
+      - test-py-dynamo-x86_64-linux:
+          torch-build: << pipeline.parameters.torch-build >>
+          torchvision-build: << pipeline.parameters.torchvision-build >>
+          torch-build-index: << pipeline.parameters.torch-build-index >>
+          trt-version-long: << pipeline.parameters.trt-version-long >>
+          python-version: << pipeline.parameters.python-version >>
+          requires:
+            - build-x86_64-linux
+
+      - build-x86_64-linux-cmake:
+          cuda-version: << pipeline.parameters.cuda-version >>
+          torch-build: << pipeline.parameters.torch-build >>
+          torch-build-index: << pipeline.parameters.torch-build-index >>
+          trt-version-short: << pipeline.parameters.trt-version-short >>
+          cudnn-version: << pipeline.parameters.cudnn-version >>
+          python-version: << pipeline.parameters.python-version >>
+
+      - build-x86_64-linux:
           name: build-x86_64-linux-legacy
           cuda-version: << pipeline.parameters.cuda-version-legacy >>
           torch-build: << pipeline.parameters.torch-build-legacy >>
@@ -1655,3 +1708,38 @@ workflows:
           python-version: << pipeline.parameters.python-version >>
           legacy: << pipeline.parameters.enable-legacy >>
           ci-image: << pipeline.parameters.ci-image-legacy >>
+
+
+      - test-core-cpp-x86_64-linux:
+          name: test-core-cpp-x86_64-linux-legacy
+          torch-build: << pipeline.parameters.torch-build-legacy >>
+          torchvision-build: << pipeline.parameters.torchvision-build-legacy >>
+          torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
+          trt-version-short: << pipeline.parameters.trt-version-short-legacy >>
+          trt-version-long: << pipeline.parameters.trt-version-long-legacy >>
+          cudnn-version: << pipeline.parameters.cudnn-version-legacy >>
+          python-version: << pipeline.parameters.python-version >>
+          ci-image: << pipeline.parameters.ci-image-legacy >>
+          requires:
+            - build-x86_64-linux-legacy
+
+      - test-py-ts-x86_64-linux:
+          name: test-py-ts-x86_64-linux-legacy
+          torch-build: << pipeline.parameters.torch-build-legacy >>
+          torchvision-build: << pipeline.parameters.torchvision-build-legacy >>
+          torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
+          trt-version-long: << pipeline.parameters.trt-version-long-legacy >>
+          python-version: << pipeline.parameters.python-version >>
+          ci-image: << pipeline.parameters.ci-image-legacy >>
+          requires:
+            - build-x86_64-linux-legacy
+
+      - test-py-fx-x86_64-linux-no-aten:
+          torch-build: << pipeline.parameters.torch-build-legacy >>
+          torchvision-build: << pipeline.parameters.torchvision-build-legacy >>
+          torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
+          trt-version-long: << pipeline.parameters.trt-version-long-legacy >>
+          python-version: << pipeline.parameters.python-version >>
+          ci-image: << pipeline.parameters.ci-image-legacy >>
+          requires:
+            - build-x86_64-linux-legacy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -913,6 +913,9 @@ jobs:
       ci-image:
         type: string
         default: "linux-cuda-12:2023.05.1"
+      platform:
+        type: string
+        default: "x86_64"
     machine:
       image: << parameters.ci-image >>
     resource_class: gpu.nvidia.medium
@@ -939,7 +942,8 @@ jobs:
           name: "Install torch-tensorrt"
           command: pip3 install /tmp/dist/x86_64-linux/*cp310-cp310*.whl
       - dump-test-env
-      - test-ts-core
+      - test-ts-core:
+        platform: << parameters.platform >>
 
   test-py-ts-x86_64-linux:
     parameters:
@@ -1457,6 +1461,9 @@ parameters:
   ci-image-legacy:
     type: string
     default: "linux-cuda-11:2023.02.1"
+  platform-legacy:
+    type: string
+    default: "x86_64.legacy"
 
   # Jetson platform config
   cuda-jetson-version:
@@ -1570,6 +1577,7 @@ workflows:
           trt-version-short: << pipeline.parameters.trt-version-short-legacy >>
           trt-version-long: << pipeline.parameters.trt-version-long-legacy >>
           cudnn-version: << pipeline.parameters.cudnn-version-legacy >>
+          platform: << pipeline.parameters.platform-legacy >>
           python-version: << pipeline.parameters.python-version >>
           requires:
             - build-x86_64-linux-legacy
@@ -1719,6 +1727,7 @@ workflows:
           trt-version-short: << pipeline.parameters.trt-version-short-legacy >>
           trt-version-long: << pipeline.parameters.trt-version-long-legacy >>
           cudnn-version: << pipeline.parameters.cudnn-version-legacy >>
+          platform: << pipeline.parameters.platform-legacy >>
           python-version: << pipeline.parameters.python-version >>
           ci-image: << pipeline.parameters.ci-image-legacy >>
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -943,7 +943,7 @@ jobs:
           command: pip3 install /tmp/dist/x86_64-linux/*cp310-cp310*.whl
       - dump-test-env
       - test-ts-core:
-        platform: << parameters.platform >>
+          platform: << parameters.platform >>
 
   test-py-ts-x86_64-linux:
     parameters:
@@ -1655,58 +1655,58 @@ workflows:
 
   on-push:
     jobs:
-      - build-x86_64-linux:
-          cuda-version: << pipeline.parameters.cuda-version >>
-          torch-build: << pipeline.parameters.torch-build >>
-          torchvision-build: << pipeline.parameters.torchvision-build >>
-          torch-build-index: << pipeline.parameters.torch-build-index >>
-          python-version: << pipeline.parameters.python-version >>
+      # - build-x86_64-linux:
+      #     cuda-version: << pipeline.parameters.cuda-version >>
+      #     torch-build: << pipeline.parameters.torch-build >>
+      #     torchvision-build: << pipeline.parameters.torchvision-build >>
+      #     torch-build-index: << pipeline.parameters.torch-build-index >>
+      #     python-version: << pipeline.parameters.python-version >>
 
-      - test-core-cpp-x86_64-linux:
-          torch-build: << pipeline.parameters.torch-build >>
-          torchvision-build: << pipeline.parameters.torchvision-build >>
-          torch-build-index: << pipeline.parameters.torch-build-index >>
-          trt-version-short: << pipeline.parameters.trt-version-short >>
-          trt-version-long: << pipeline.parameters.trt-version-long >>
-          python-version: << pipeline.parameters.python-version >>
-          cudnn-version: << pipeline.parameters.cudnn-version >>
-          requires:
-            - build-x86_64-linux
+      # - test-core-cpp-x86_64-linux:
+      #     torch-build: << pipeline.parameters.torch-build >>
+      #     torchvision-build: << pipeline.parameters.torchvision-build >>
+      #     torch-build-index: << pipeline.parameters.torch-build-index >>
+      #     trt-version-short: << pipeline.parameters.trt-version-short >>
+      #     trt-version-long: << pipeline.parameters.trt-version-long >>
+      #     python-version: << pipeline.parameters.python-version >>
+      #     cudnn-version: << pipeline.parameters.cudnn-version >>
+      #     requires:
+      #       - build-x86_64-linux
 
-      - test-py-ts-x86_64-linux:
-          torch-build: << pipeline.parameters.torch-build >>
-          torchvision-build: << pipeline.parameters.torchvision-build >>
-          torch-build-index: << pipeline.parameters.torch-build-index >>
-          trt-version-long: << pipeline.parameters.trt-version-long >>
-          python-version: << pipeline.parameters.python-version >>
-          requires:
-            - build-x86_64-linux
+      # - test-py-ts-x86_64-linux:
+      #     torch-build: << pipeline.parameters.torch-build >>
+      #     torchvision-build: << pipeline.parameters.torchvision-build >>
+      #     torch-build-index: << pipeline.parameters.torch-build-index >>
+      #     trt-version-long: << pipeline.parameters.trt-version-long >>
+      #     python-version: << pipeline.parameters.python-version >>
+      #     requires:
+      #       - build-x86_64-linux
 
-      - test-py-fx-x86_64-linux:
-          torch-build: << pipeline.parameters.torch-build >>
-          torchvision-build: << pipeline.parameters.torchvision-build >>
-          torch-build-index: << pipeline.parameters.torch-build-index >>
-          trt-version-long: << pipeline.parameters.trt-version-long >>
-          python-version: << pipeline.parameters.python-version >>
-          requires:
-            - build-x86_64-linux
+      # - test-py-fx-x86_64-linux:
+      #     torch-build: << pipeline.parameters.torch-build >>
+      #     torchvision-build: << pipeline.parameters.torchvision-build >>
+      #     torch-build-index: << pipeline.parameters.torch-build-index >>
+      #     trt-version-long: << pipeline.parameters.trt-version-long >>
+      #     python-version: << pipeline.parameters.python-version >>
+      #     requires:
+      #       - build-x86_64-linux
 
-      - test-py-dynamo-x86_64-linux:
-          torch-build: << pipeline.parameters.torch-build >>
-          torchvision-build: << pipeline.parameters.torchvision-build >>
-          torch-build-index: << pipeline.parameters.torch-build-index >>
-          trt-version-long: << pipeline.parameters.trt-version-long >>
-          python-version: << pipeline.parameters.python-version >>
-          requires:
-            - build-x86_64-linux
+      # - test-py-dynamo-x86_64-linux:
+      #     torch-build: << pipeline.parameters.torch-build >>
+      #     torchvision-build: << pipeline.parameters.torchvision-build >>
+      #     torch-build-index: << pipeline.parameters.torch-build-index >>
+      #     trt-version-long: << pipeline.parameters.trt-version-long >>
+      #     python-version: << pipeline.parameters.python-version >>
+      #     requires:
+      #       - build-x86_64-linux
 
-      - build-x86_64-linux-cmake:
-          cuda-version: << pipeline.parameters.cuda-version >>
-          torch-build: << pipeline.parameters.torch-build >>
-          torch-build-index: << pipeline.parameters.torch-build-index >>
-          trt-version-short: << pipeline.parameters.trt-version-short >>
-          cudnn-version: << pipeline.parameters.cudnn-version >>
-          python-version: << pipeline.parameters.python-version >>
+      # - build-x86_64-linux-cmake:
+      #     cuda-version: << pipeline.parameters.cuda-version >>
+      #     torch-build: << pipeline.parameters.torch-build >>
+      #     torch-build-index: << pipeline.parameters.torch-build-index >>
+      #     trt-version-short: << pipeline.parameters.trt-version-short >>
+      #     cudnn-version: << pipeline.parameters.cudnn-version >>
+      #     python-version: << pipeline.parameters.python-version >>
 
       - build-x86_64-linux:
           name: build-x86_64-linux-legacy
@@ -1727,29 +1727,29 @@ workflows:
           trt-version-short: << pipeline.parameters.trt-version-short-legacy >>
           trt-version-long: << pipeline.parameters.trt-version-long-legacy >>
           cudnn-version: << pipeline.parameters.cudnn-version-legacy >>
+          python-version: << pipeline.parameters.python-version >>
+          ci-image: << pipeline.parameters.ci-image-legacy >>
           platform: << pipeline.parameters.platform-legacy >>
-          python-version: << pipeline.parameters.python-version >>
-          ci-image: << pipeline.parameters.ci-image-legacy >>
           requires:
             - build-x86_64-linux-legacy
 
-      - test-py-ts-x86_64-linux:
-          name: test-py-ts-x86_64-linux-legacy
-          torch-build: << pipeline.parameters.torch-build-legacy >>
-          torchvision-build: << pipeline.parameters.torchvision-build-legacy >>
-          torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
-          trt-version-long: << pipeline.parameters.trt-version-long-legacy >>
-          python-version: << pipeline.parameters.python-version >>
-          ci-image: << pipeline.parameters.ci-image-legacy >>
-          requires:
-            - build-x86_64-linux-legacy
+      # - test-py-ts-x86_64-linux:
+      #     name: test-py-ts-x86_64-linux-legacy
+      #     torch-build: << pipeline.parameters.torch-build-legacy >>
+      #     torchvision-build: << pipeline.parameters.torchvision-build-legacy >>
+      #     torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
+      #     trt-version-long: << pipeline.parameters.trt-version-long-legacy >>
+      #     python-version: << pipeline.parameters.python-version >>
+      #     ci-image: << pipeline.parameters.ci-image-legacy >>
+      #     requires:
+      #       - build-x86_64-linux-legacy
 
-      - test-py-fx-x86_64-linux-no-aten:
-          torch-build: << pipeline.parameters.torch-build-legacy >>
-          torchvision-build: << pipeline.parameters.torchvision-build-legacy >>
-          torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
-          trt-version-long: << pipeline.parameters.trt-version-long-legacy >>
-          python-version: << pipeline.parameters.python-version >>
-          ci-image: << pipeline.parameters.ci-image-legacy >>
-          requires:
-            - build-x86_64-linux-legacy
+      # - test-py-fx-x86_64-linux-no-aten:
+      #     torch-build: << pipeline.parameters.torch-build-legacy >>
+      #     torchvision-build: << pipeline.parameters.torchvision-build-legacy >>
+      #     torch-build-index: << pipeline.parameters.torch-build-index-legacy >>
+      #     trt-version-long: << pipeline.parameters.trt-version-long-legacy >>
+      #     python-version: << pipeline.parameters.python-version >>
+      #     ci-image: << pipeline.parameters.ci-image-legacy >>
+      #     requires:
+      #       - build-x86_64-linux-legacy

--- a/toolchains/ci_workspaces/WORKSPACE.x86_64.legacy
+++ b/toolchains/ci_workspaces/WORKSPACE.x86_64.legacy
@@ -1,0 +1,99 @@
+workspace(name = "Torch-TensorRT")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_python",
+    sha256 = "863ba0fa944319f7e3d695711427d9ad80ba92c6edd0b7c7443b84e904689539",
+    strip_prefix = "rules_python-0.22.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.22.0/rules_python-0.22.0.tar.gz",
+)
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
+
+http_archive(
+    name = "rules_pkg",
+    sha256 = "8f9ee2dc10c1ae514ee599a8b42ed99fa262b757058f65ad3c384289ff70c4b8",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
+    ],
+)
+
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()
+
+http_archive(
+    name = "googletest",
+    sha256 = "755f9a39bc7205f5a0c428e920ddad092c33c8a1b46997def3f1d4a82aded6e1",
+    strip_prefix = "googletest-5ab508a01f9eb089207ee87fd547d290da39d015",
+    urls = ["https://github.com/google/googletest/archive/5ab508a01f9eb089207ee87fd547d290da39d015.zip"],
+)
+
+# External dependency for torch_tensorrt if you already have precompiled binaries.
+local_repository(
+    name = "torch_tensorrt",
+    path = "/opt/circleci/.pyenv/versions/3.10.9/lib/python3.10/site-packages/torch_tensorrt"
+)
+
+# CUDA should be installed on the system locally
+new_local_repository(
+    name = "cuda",
+    build_file = "@//third_party/cuda:BUILD",
+    path = "/usr/local/cuda-11.8/",
+)
+
+new_local_repository(
+    name = "cublas",
+    build_file = "@//third_party/cublas:BUILD",
+    path = "/usr",
+)
+
+####################################################################################
+# Locally installed dependencies (use in cases of custom dependencies or aarch64)
+####################################################################################
+
+# NOTE: In the case you are using just the pre-cxx11-abi path or just the cxx11 abi path
+# with your local libtorch, just point deps at the same path to satisfy bazel.
+
+# NOTE: NVIDIA's aarch64 PyTorch (python) wheel file uses the CXX11 ABI unlike PyTorch's standard
+# x86_64 python distribution. If using NVIDIA's version just point to the root of the package
+# for both versions here and do not use --config=pre-cxx11-abi
+
+new_local_repository(
+    name = "libtorch",
+    path = "/opt/circleci/.pyenv/versions/3.10.9/lib/python3.10/site-packages/torch",
+    build_file = "third_party/libtorch/BUILD"
+)
+
+new_local_repository(
+    name = "libtorch_pre_cxx11_abi",
+    path = "/opt/circleci/.pyenv/versions/3.10.9/lib/python3.10/site-packages/torch",
+    build_file = "third_party/libtorch/BUILD"
+)
+
+new_local_repository(
+    name = "cudnn",
+    path = "/usr/",
+    build_file = "@//third_party/cudnn/local:BUILD"
+)
+
+new_local_repository(
+   name = "tensorrt",
+   path = "/usr/",
+   build_file = "@//third_party/tensorrt/local:BUILD"
+)
+
+load("@rules_python//python:pip.bzl", "pip_parse")
+
+pip_parse(
+    name = "devtools_deps",
+    requirements = "//:requirements-dev.txt",
+)
+
+load("@devtools_deps//:requirements.bzl", "install_deps")
+
+install_deps()

--- a/toolchains/legacy/pyproject.toml
+++ b/toolchains/legacy/pyproject.toml
@@ -1,0 +1,218 @@
+[build-system]
+requires = [
+    "setuptools>=68.0.0",
+    "packaging>=23.1",
+    "wheel>=0.40.0",
+    "ninja>=1.11.0",
+    "pyyaml>=6.0",
+    "cffi>=1.15.1",
+    "typing-extensions>=4.7.0",
+    "future>=0.18.3",
+    "tensorrt>=8.6,<8.7",
+    "torch>=1.13.0,<2.0",
+    "pybind11==2.6.2",
+    "numpy",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "torch_tensorrt"
+authors = [
+    {name="NVIDIA Corporation", email="narens@nvidia.com"}
+]
+description = "Torch-TensorRT is a package which allows users to automatically compile PyTorch and TorchScript modules to TensorRT while remaining in PyTorch"
+license = {file = "LICENSE"}
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: GPU :: NVIDIA CUDA",
+    "License :: OSI Approved :: BSD License",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: C++",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Libraries",
+]
+readme = {file = "py/README.md", content-type = "text/markdown"}
+requires-python = ">=3.8"
+keywords = ["pytorch", "torch", "tensorrt", "trt", "ai", "artificial intelligence", "ml", "machine learning", "dl", "deep learning", "compiler", "dynamo", "torchscript", "inference"]
+dependencies = [
+    "torch>=1.13.0,<2.0",
+    "tensorrt>=8.6,<8.7",
+    "packaging>=23",
+    "numpy",
+    "typing-extensions>=4.7.0",
+]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+torchvision = ["torchvision >=0.14.0,<0.15.0"]
+
+[project.urls]
+Homepage = "https://pytorch.org/tensorrt"
+Documentation = "https://pytorch.org/tensorrt"
+Repository = "https://github.com/pytorch/tensorrt.git"
+Changelog = "https://github.com/pytorch/tensorrt/releases"
+
+[tool.setuptools]
+package-dir = {"" = "py"}
+include-package-data = false
+
+[tool.ruff]
+# NOTE: Synchoronize the ignores with .flake8
+ignore = [
+    # these ignores are from flake8-bugbear; please fix!
+    "B007", "B008", "B017",
+    "B018", # Useless expression
+    "B019", "B020",
+    "B023", "B024", "B026",
+    "B028", # No explicit `stacklevel` keyword argument found
+    "B904", "B905",
+    "E402",
+    "C408", # C408 ignored because we like the dict keyword argument syntax
+    "E501", # E501 is not flexible enough, we're using B950 instead
+    "E721",
+    "E731", # Assign lambda expression
+    "E741",
+    "EXE001",
+    "F405",
+    "F821",
+    "F841",
+    # these ignores are from flake8-logging-format; please fix!
+    "G101", "G201", "G202", "G003", "G004",
+    # these ignores are from RUFF perf; please fix!
+    "PERF203", "PERF4",
+    "SIM102", "SIM103", "SIM112", # flake8-simplify code styles
+    "SIM105", # these ignores are from flake8-simplify. please fix or ignore with commented reason
+    "SIM108",
+    "SIM110",
+    "SIM114", # Combine `if` branches using logical `or` operator
+    "SIM115",
+    "SIM116", # Disable Use a dictionary instead of consecutive `if` statements
+    "SIM117",
+    "SIM118",
+]
+#line-length = 120
+select = [
+    "B",
+    "C4",
+    "G",
+    "E",
+    "F",
+    "SIM1",
+    "W",
+    # Not included in flake8
+    "PERF",
+    "PLE",
+    "TRY302",
+]
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+target-version = "py311"
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = [
+    "A","B","C","D","E","F","G",
+    "I","N","Q","S","T","W",
+    "ANN", "ARG", "BLE", "COM", "DJ",
+    "DTZ", "EM", "ERA", "EXE", "FBT",
+    "ICN", "INP", "ISC", "NPY", "PD",
+    "PGH", "PIE", "PL", "PT", "PTH",
+    "PYI", "RET", "RSE", "RUF", "SIM",
+    "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
+unfixable = []
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+    "env",
+    "py/torch_tensorrt/fx",
+    ".github",
+    "examples",
+    "tests",
+    "tools",
+    "docs",
+    "docsrc",
+    "tests",
+    "setup.py",
+    "noxfile.py",
+    "__init__.py"
+]
+
+[tool.ruff.mccabe]
+# Unlike Flake8, default to a complexity level of 10.
+max-complexity = 10
+
+[tool.isort]
+profile = "black"
+py_version = 311
+skip = [
+    "py/torch_tensorrt/fx",
+]
+
+[tool.black]
+#line-length = 120
+target-versions = ["py38", "py39", "py310", "py311", "py312"]
+force-exclude = """
+elu_converter/setup.py
+"""
+
+[tool.mypy]
+strict = true
+ignore_missing_imports = true
+show_error_codes = true
+disable_error_code = "attr-defined"
+no_implicit_optional = true
+exclude = [
+    "^py/torch_tensorrt/fx",
+    "py/torch_tensorrt/fx",
+    "torch_tensorrt/fx",
+    "py/torch_tensorrt/_C.so",
+    "examples",
+    "docs",
+    "docsrc",
+    "tests",
+    "setup.py",
+    "noxfile.py"
+]
+python_version = "3.11"
+
+follow_imports = "skip"
+
+[[tool.mypy.overrides]]
+module = "torch_tensorrt.dynamo.conversion.aten_converters"
+disable_error_code = "arg-type"
+
+[[tool.mypy.overrides]]
+module = "torch_tensorrt.dynamo.lowering._decompositions"
+disallow_untyped_calls = false
+
+[[tool.mypy.overrides]]
+module = "torch_tensorrt.fx.*"
+ignore_errors = true
+follow_imports = "skip"


### PR DESCRIPTION
- Update `config.yaml` to support legacy CI testing, including upgraded `.toml` and `WORKSPACE` files built specifically for the legacy version
- Add parameters to the configuration file to allow switching CUDA versions for the legacy build
- Update default in `compile()` to be TorchScript in the legacy install