### PR TITLE
feat: allow specifying output_dtypes in tests

### DIFF
--- a/tests/py/dynamo/converters/harness.py
+++ b/tests/py/dynamo/converters/harness.py
@@ -266,6 +266,7 @@ class DispatchTestCase(TRTTestCase):
         precision=torch.float,
         check_dtype=True,
         disable_passes=False,
+        output_dtypes=None,
     ):
         mod.eval()
         mod = self.generate_graph(
@@ -284,6 +285,7 @@ class DispatchTestCase(TRTTestCase):
         interp = TRTInterpreter(
             mod,
             Input.from_tensors(inputs),
+            output_dtypes=output_dtypes,
         )
         super().run_test(
             mod,
@@ -306,6 +308,7 @@ class DispatchTestCase(TRTTestCase):
         rtol=1e-03,
         atol=1e-03,
         disable_passes=False,
+        output_dtypes=None,
     ):
         mod.eval()
         inputs = [spec.example_tensor("opt_shape") for spec in input_specs]
@@ -321,6 +324,7 @@ class DispatchTestCase(TRTTestCase):
         interp = TRTInterpreter(
             mod,
             input_specs,
+            output_dtypes=output_dtypes,
         )
         # Since the lowering is based on optimal shape. We need to test with
         # different shape(for ex. max shape) for testing dynamic shape


### PR DESCRIPTION
# Description

Allow specifying output_dtypes in run_test(). For some ops whose output is type `float` but it should be `bool` to match with pytorch in test. Thus, we need this arg to specify output type.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
