### PR TITLE
fix: Unify layers in Docker Container Cleanup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -104,19 +104,17 @@ RUN mkdir -p "/opt/python3/" &&\
 
 COPY --from=torch-tensorrt-builder  /workspace/torch_tensorrt/src/dist/ .
 
-RUN cp /opt/torch_tensorrt/docker/WORKSPACE.docker /opt/torch_tensorrt/WORKSPACE
-RUN pip install -r /opt/torch_tensorrt/py/requirements.txt
-# Install all dependency wheel files and user-specified TensorRT
-RUN pip install *.whl
-RUN pip install tensorrt==${TENSORRT_VERSION}.*
-
-# Add the Torch-TensorRT wheel file to the dist directory and delete all other .whl files
-RUN rm -fr /workspace/torch_tensorrt/dist/*
-RUN mkdir -p /opt/torch_tensorrt/dist/ && mv torch_tensorrt*.whl /opt/torch_tensorrt/dist/
-RUN rm -fr *.whl
-
-# Remove other cache files if present
-RUN pip cache purge && rm -rf /opt/torch_tensorrt/.mypy_cache
+RUN cp /opt/torch_tensorrt/docker/WORKSPACE.docker /opt/torch_tensorrt/WORKSPACE &&\
+    pip install -r /opt/torch_tensorrt/py/requirements.txt &&\
+    # Install all dependency wheel files and user-specified TensorRT
+    pip install *.whl &&\
+    pip install tensorrt==${TENSORRT_VERSION}.* &&\
+    # Add the Torch-TensorRT wheel file to the dist directory and delete all other .whl files
+    rm -fr /workspace/torch_tensorrt/dist/* &&\
+    mkdir -p /opt/torch_tensorrt/dist/ && mv torch_tensorrt*.whl /opt/torch_tensorrt/dist/ &&\
+    rm -fr *.whl &&\
+    # Remove other cache files if present
+    pip cache purge && rm -rf /opt/torch_tensorrt/.mypy_cache
 
 WORKDIR /opt/torch_tensorrt
 


### PR DESCRIPTION
# Description
- Previously, the Docker container size reduction (#2257) applied across multiple layers, causing the changes to not be reflected in the resultant container
- New container size is 23.8 GB, down from 27.9 GB

## Type of change

Please delete options that are not relevant and/or add your own.

- Container size reduction

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ - ] I have added tests to verify my fix or my feature
  - GHA Build
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
