### PR TITLE
tools(opset_coverage): Map default ops to unoverloaded ops

### DIFF
--- a/py/torch_tensorrt/dynamo/tools/opset_coverage.py
+++ b/py/torch_tensorrt/dynamo/tools/opset_coverage.py
@@ -122,14 +122,20 @@ def opset_coverage(
         converter_registry if converter_registry is not None else DYNAMO_CONVERTERS
     )
     converter_registry_targets = {
-        c_registry.qualified_name_or_str(target).removeprefix("torch.ops.")
+        c_registry.qualified_name_or_str(target)
+        .removeprefix("torch.ops.")
+        .replace(".default", "")
         for target in c_registry.keys()
     }
     supported_converted_targets = opset_targets.intersection(converter_registry_targets)
     support_count = 0
     legacy_count = 0
     for target in c_registry.keys():
-        target_str = c_registry.qualified_name_or_str(target).removeprefix("torch.ops.")
+        target_str = (
+            c_registry.qualified_name_or_str(target)
+            .removeprefix("torch.ops.")
+            .replace(".default", "")
+        )
         if target_str in opset_targets:
             _, registry_data = c_registry.get_all_converters_with_target(
                 target, return_registry_info=True
@@ -155,7 +161,9 @@ def opset_coverage(
         else get_decompositions()
     )
     decomp_registry_targets = {
-        c_registry.qualified_name_or_str(target).removeprefix("torch.ops.")
+        c_registry.qualified_name_or_str(target)
+        .removeprefix("torch.ops.")
+        .replace(".default", "")
         for target in l_registry.keys()
     }
     supported_decomp_targets = opset_targets.intersection(decomp_registry_targets)


### PR DESCRIPTION
# Description

Updates the coverage tool to treat converters for default overloads to the root op name

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
