### PR TITLE
small fix: Packaging version switch

### DIFF
--- a/py/torch_tensorrt/dynamo/backend/backends.py
+++ b/py/torch_tensorrt/dynamo/backend/backends.py
@@ -20,7 +20,7 @@ from torch_tensorrt.dynamo.utils import parse_dynamo_kwargs
 from packaging import version
 
 # Modify import location of utilities based on Torch version
-if version.parse(torch_tensorrt.sanitized_torch_version()) <= version.parse("2.1.0"):
+if version.parse(torch_tensorrt.sanitized_torch_version()) < version.parse("2.1.1"):
     from torch._inductor.freezing import ConstantFolder, replace_node_with_constant
 else:
     from torch._inductor.constant_folding import (


### PR DESCRIPTION
- Versioning does not recognize `2.1.0+cu118` as equal to `2.1.0`. Switch implementation to use less-than comparison