### PR TITLE
feat: Add tensor type enforcement for converters

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/_ConversionContext.py
+++ b/py/torch_tensorrt/dynamo/conversion/_ConversionContext.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass, field
+
+from torch_tensorrt.dynamo._settings import CompilationSettings
+from torch_tensorrt.fx.types import TRTNetwork
+
+
+@dataclass
+class ConversionContext:
+    """Class representing the context for conversion of a particular network
+
+    Args:
+        net: TensorRT Network being built
+        compilation_settings: Settings selected by the user for compilation
+    """
+
+    net: TRTNetwork
+    compilation_settings: CompilationSettings = field(
+        default_factory=CompilationSettings
+    )

--- a/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
+++ b/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
@@ -345,7 +345,7 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
 
     def get_attr(self, target: str, args: Any, kwargs: Any) -> np.ndarray:
         with _disable_current_modes():
-            from torch_tensorrt.fx.converters import to_numpy
+            from torch_tensorrt.dynamo.conversion.converter_utils import to_numpy
 
             frozen_attr = self.fetch_attr(target)
 

--- a/py/torch_tensorrt/dynamo/conversion/__init__.py
+++ b/py/torch_tensorrt/dynamo/conversion/__init__.py
@@ -1,3 +1,4 @@
+from ._ConversionContext import ConversionContext
 from ._TRTInterpreter import *  # noqa: F403
 from .aten_ops_converters import *  # noqa: F403
 from .conversion import *  # noqa: F403

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -6,6 +6,7 @@ import torch
 from torch.fx.node import Argument, Node, Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
 from torch_tensorrt.dynamo.conversion import impl
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_registry import (
     dynamo_tensorrt_converter,
 )
@@ -13,7 +14,7 @@ from torch_tensorrt.dynamo.conversion.converter_utils import (
     enforce_tensor_types,
     is_only_operator_on_placeholder,
 )
-from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
+from torch_tensorrt.fx.types import TRTTensor
 
 from .converter_utils import dynamic_unsupported_with_args
 
@@ -28,14 +29,14 @@ def args_bounds_check(
 
 @dynamo_tensorrt_converter(torch.ops.aten.batch_norm)
 def aten_ops_batch_norm(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.normalization.batch_norm(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -71,14 +72,14 @@ def embedding_param_validator(embedding_node: Node) -> bool:
     torch.ops.aten.embedding.default, capability_validator=embedding_param_validator
 )
 def aten_ops_embedding(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.embedding.embedding(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -93,25 +94,25 @@ def aten_ops_embedding(
 @dynamo_tensorrt_converter(torch.ops.aten.fmod.Scalar)
 @dynamo_tensorrt_converter(torch.ops.aten.fmod.Tensor)
 def aten_ops_fmod(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
-    return impl.elementwise.fmod(network, target, SourceIR.ATEN, name, args[0], args[1])
+    return impl.elementwise.fmod(ctx, target, SourceIR.ATEN, name, args[0], args[1])
 
 
 @dynamo_tensorrt_converter(torch.ops.aten.relu.default)
 def aten_ops_relu(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.activation.relu(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -121,14 +122,14 @@ def aten_ops_relu(
 
 @dynamo_tensorrt_converter(torch.ops.aten.sigmoid.default)
 def aten_ops_sigmoid(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.activation.sigmoid(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -138,14 +139,14 @@ def aten_ops_sigmoid(
 
 @dynamo_tensorrt_converter(torch.ops.aten.tanh.default)
 def aten_ops_tanh(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.activation.tanh(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -155,14 +156,14 @@ def aten_ops_tanh(
 
 @dynamo_tensorrt_converter(torch.ops.aten.leaky_relu.default)
 def aten_ops_leaky_relu(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.activation.leaky_relu(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -173,14 +174,14 @@ def aten_ops_leaky_relu(
 
 @dynamo_tensorrt_converter(torch.ops.aten.elu.default)
 def aten_ops_elu(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.activation.elu(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -192,14 +193,14 @@ def aten_ops_elu(
 
 @dynamo_tensorrt_converter(torch.ops.aten.softplus.default)
 def aten_ops_softplus(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.activation.softplus(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -210,14 +211,14 @@ def aten_ops_softplus(
 
 @dynamo_tensorrt_converter(torch.ops.aten.clip.default)
 def aten_ops_clip(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.activation.clip(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -229,14 +230,14 @@ def aten_ops_clip(
 
 @dynamo_tensorrt_converter(torch.ops.aten.hardsigmoid.default)
 def aten_ops_hard_sigmoid(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.activation.hard_sigmoid(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -251,14 +252,14 @@ def aten_ops_hard_sigmoid(
 @dynamo_tensorrt_converter(torch.ops.aten.mv.default)
 @dynamo_tensorrt_converter(torch.ops.aten.bmm.default)
 def aten_ops_matmul(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.matmul.matrix_multiply(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -269,14 +270,14 @@ def aten_ops_matmul(
 
 @dynamo_tensorrt_converter(torch.ops.aten.layer_norm.default)
 def aten_ops_layernorm(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.normalization.layer_norm(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -290,14 +291,14 @@ def aten_ops_layernorm(
 
 @dynamo_tensorrt_converter(torch.ops.aten.rsqrt.default)
 def aten_ops_rsqrt(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.elementwise.rsqrt(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -307,14 +308,14 @@ def aten_ops_rsqrt(
 
 @dynamo_tensorrt_converter(torch.ops.aten.neg.default)
 def aten_ops_neg(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.neg(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -325,25 +326,25 @@ def aten_ops_neg(
 @dynamo_tensorrt_converter(torch.ops.aten.squeeze.dim)
 @dynamo_tensorrt_converter(torch.ops.aten.squeeze.dims)
 def aten_ops_squeeze(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
-    return impl.squeeze.squeeze(network, target, SourceIR.ATEN, name, args[0], args[1])
+    return impl.squeeze.squeeze(ctx, target, SourceIR.ATEN, name, args[0], args[1])
 
 
 @dynamo_tensorrt_converter(torch.ops.aten.erf.default)
 def aten_ops_erf(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.erf(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -353,27 +354,27 @@ def aten_ops_erf(
 
 @dynamo_tensorrt_converter(torch.ops.aten.unsqueeze.default)
 def aten_ops_unsqueeze(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unsqueeze.unsqueeze(
-        network, target, SourceIR.ATEN, name, input_t=args[0], dim=args[1]
+        ctx, target, SourceIR.ATEN, name, input_t=args[0], dim=args[1]
     )
 
 
 @dynamo_tensorrt_converter(torch.ops.aten._softmax.default)
 def aten_ops_softmax(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.normalization.softmax(
-        network, target, SourceIR.ATEN, name, args[0], args[1]
+        ctx, target, SourceIR.ATEN, name, args[0], args[1]
     )
 
 
@@ -388,14 +389,14 @@ def aten_ops_softmax(
     capability_validator=dynamic_unsupported_with_args([1]),
 )
 def aten_ops_split(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.split.split(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -407,14 +408,14 @@ def aten_ops_split(
 
 @dynamo_tensorrt_converter(torch.ops.aten.where.self)
 def aten_ops_where(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.condition.where(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -426,14 +427,14 @@ def aten_ops_where(
 
 @dynamo_tensorrt_converter(torch.ops.aten.clamp.default)
 def aten_ops_clamp(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.elementwise.clamp(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -445,27 +446,27 @@ def aten_ops_clamp(
 
 @dynamo_tensorrt_converter(torch.ops.aten.select.int)
 def aten_ops_select(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.select.select(
-        network, target, SourceIR.ATEN, name, args[0], args[1], args[2]
+        ctx, target, SourceIR.ATEN, name, args[0], args[1], args[2]
     )
 
 
 @dynamo_tensorrt_converter(torch.ops.aten.slice.Tensor)
 def aten_ops_slice(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.slice.slice_op(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -484,14 +485,14 @@ def aten_ops_slice(
     }
 )
 def aten_ops_permute(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.permutation.permute(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -553,14 +554,14 @@ def to_copy_dtype_validator(placeholder_only: bool) -> Callable[[Node], bool]:
     capability_validator=to_copy_dtype_validator(placeholder_only=False),
 )
 def aten_ops_clone_copy_dtype(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.cast.to_copy(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -579,7 +580,7 @@ def aten_ops_clone_copy_dtype(
     capability_validator=to_copy_dtype_validator(placeholder_only=True),
 )
 def aten_ops_clone_copy_placeholder(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
@@ -589,7 +590,7 @@ def aten_ops_clone_copy_placeholder(
     # we need to force cast to ensure a layer is added to the TRT engine
     # since TRT engine inputs cannot also be TRT engine outputs
     return impl.cast.to_copy(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -601,14 +602,14 @@ def aten_ops_clone_copy_placeholder(
 
 @dynamo_tensorrt_converter(torch.ops.aten.expand.default)
 def aten_ops_expand(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.slice.expand(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -631,14 +632,14 @@ def amax_param_validator(amax_node: Node) -> bool:
     torch.ops.aten.amax.default, capability_validator=amax_param_validator
 )
 def aten_ops_amax(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.reduce.amax(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -651,14 +652,14 @@ def aten_ops_amax(
 @dynamo_tensorrt_converter(torch.ops.aten.sum.default)
 @dynamo_tensorrt_converter(torch.ops.aten.sum.dim_IntList)
 def aten_ops_sum(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.reduce.sum(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -670,14 +671,14 @@ def aten_ops_sum(
 
 @dynamo_tensorrt_converter(torch.ops.aten.exp.default)
 def aten_ops_exp(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.exp(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -687,14 +688,14 @@ def aten_ops_exp(
 
 @dynamo_tensorrt_converter(torch.ops.aten.log.default)
 def aten_ops_log(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.log(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -704,14 +705,14 @@ def aten_ops_log(
 
 @dynamo_tensorrt_converter(torch.ops.aten.sqrt.default)
 def aten_ops_sqrt(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.sqrt(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -721,14 +722,14 @@ def aten_ops_sqrt(
 
 @dynamo_tensorrt_converter(torch.ops.aten.reciprocal.default)
 def aten_ops_recip(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.recip(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -738,14 +739,14 @@ def aten_ops_recip(
 
 @dynamo_tensorrt_converter(torch.ops.aten.abs.default)
 def aten_ops_abs(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.abs(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -755,14 +756,14 @@ def aten_ops_abs(
 
 @dynamo_tensorrt_converter(torch.ops.aten.sin.default)
 def aten_ops_sin(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.sin(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -772,14 +773,14 @@ def aten_ops_sin(
 
 @dynamo_tensorrt_converter(torch.ops.aten.cos.default)
 def aten_ops_cos(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.cos(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -789,14 +790,14 @@ def aten_ops_cos(
 
 @dynamo_tensorrt_converter(torch.ops.aten.tan.default)
 def aten_ops_tan(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.tan(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -806,14 +807,14 @@ def aten_ops_tan(
 
 @dynamo_tensorrt_converter(torch.ops.aten.sinh.default)
 def aten_ops_sinh(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.sinh(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -823,14 +824,14 @@ def aten_ops_sinh(
 
 @dynamo_tensorrt_converter(torch.ops.aten.cosh.default)
 def aten_ops_cosh(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.cosh(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -840,14 +841,14 @@ def aten_ops_cosh(
 
 @dynamo_tensorrt_converter(torch.ops.aten.asin.default)
 def aten_ops_asin(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.asin(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -857,14 +858,14 @@ def aten_ops_asin(
 
 @dynamo_tensorrt_converter(torch.ops.aten.acos.default)
 def aten_ops_acos(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.acos(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -874,14 +875,14 @@ def aten_ops_acos(
 
 @dynamo_tensorrt_converter(torch.ops.aten.atan.default)
 def aten_ops_atan(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.atan(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -891,14 +892,14 @@ def aten_ops_atan(
 
 @dynamo_tensorrt_converter(torch.ops.aten.asinh.default)
 def aten_ops_asinh(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.asinh(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -908,14 +909,14 @@ def aten_ops_asinh(
 
 @dynamo_tensorrt_converter(torch.ops.aten.acosh.default)
 def aten_ops_acosh(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.acosh(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -925,14 +926,14 @@ def aten_ops_acosh(
 
 @dynamo_tensorrt_converter(torch.ops.aten.atanh.default)
 def aten_ops_atanh(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.atanh(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -942,14 +943,14 @@ def aten_ops_atanh(
 
 @dynamo_tensorrt_converter(torch.ops.aten.ceil.default)
 def aten_ops_ceil(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.ceil(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -959,14 +960,14 @@ def aten_ops_ceil(
 
 @dynamo_tensorrt_converter(torch.ops.aten.floor.default)
 def aten_ops_floor(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.floor(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -976,14 +977,14 @@ def aten_ops_floor(
 
 @dynamo_tensorrt_converter(torch.ops.aten.logical_not.default)
 def aten_ops_logical_not(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.logical_not(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -993,14 +994,14 @@ def aten_ops_logical_not(
 
 @dynamo_tensorrt_converter(torch.ops.aten.sign.default)
 def aten_ops_sign(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.sign(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1010,14 +1011,14 @@ def aten_ops_sign(
 
 @dynamo_tensorrt_converter(torch.ops.aten.round.default)
 def aten_ops_round(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.round(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1027,14 +1028,14 @@ def aten_ops_round(
 
 @dynamo_tensorrt_converter(torch.ops.aten.isinf.default)
 def aten_ops_isinf(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.unary.isinf(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1045,7 +1046,7 @@ def aten_ops_isinf(
 @dynamo_tensorrt_converter(torch.ops.aten.add.Tensor)
 @dynamo_tensorrt_converter(torch.ops.aten.add.Scalar)
 def aten_ops_add(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
@@ -1056,7 +1057,7 @@ def aten_ops_add(
 
     if alpha != 1:
         other = impl.elementwise.mul(
-            network,
+            ctx,
             target,
             SourceIR.ATEN,
             name,
@@ -1065,7 +1066,7 @@ def aten_ops_add(
         )
 
     return impl.elementwise.add(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1077,14 +1078,14 @@ def aten_ops_add(
 @dynamo_tensorrt_converter(torch.ops.aten.mul.Tensor)
 @dynamo_tensorrt_converter(torch.ops.aten.mul.Scalar)
 def aten_ops_mul(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.elementwise.mul(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1095,14 +1096,14 @@ def aten_ops_mul(
 
 @dynamo_tensorrt_converter(torch.ops.aten.maximum.default)
 def aten_ops_max(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.elementwise.max(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1113,14 +1114,14 @@ def aten_ops_max(
 
 @dynamo_tensorrt_converter(torch.ops.aten.minimum.default)
 def aten_ops_min(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.elementwise.min(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1132,7 +1133,7 @@ def aten_ops_min(
 @dynamo_tensorrt_converter(torch.ops.aten.sub.Tensor)
 @dynamo_tensorrt_converter(torch.ops.aten.sub.Scalar)
 def aten_ops_sub(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
@@ -1143,7 +1144,7 @@ def aten_ops_sub(
 
     if alpha != 1:
         other = impl.elementwise.mul(
-            network,
+            ctx,
             target,
             SourceIR.ATEN,
             name,
@@ -1152,7 +1153,7 @@ def aten_ops_sub(
         )
 
     return impl.elementwise.sub(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1166,7 +1167,7 @@ def aten_ops_sub(
 @dynamo_tensorrt_converter(torch.ops.aten.div.Scalar)
 @dynamo_tensorrt_converter(torch.ops.aten.div.Scalar_mode)
 def aten_ops_div(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
@@ -1176,7 +1177,7 @@ def aten_ops_div(
 
     if rounding_mode is None:
         return impl.elementwise.div(
-            network,
+            ctx,
             target,
             SourceIR.ATEN,
             name,
@@ -1185,7 +1186,7 @@ def aten_ops_div(
         )
     elif rounding_mode == "floor":
         return impl.elementwise.floor_divide(
-            network,
+            ctx,
             target,
             SourceIR.ATEN,
             name,
@@ -1194,7 +1195,7 @@ def aten_ops_div(
         )
     elif rounding_mode == "trunc":
         return impl.elementwise.trunc_div(
-            network,
+            ctx,
             target,
             SourceIR.ATEN,
             name,
@@ -1211,14 +1212,14 @@ def aten_ops_div(
 @dynamo_tensorrt_converter(torch.ops.aten.pow.Scalar)
 @dynamo_tensorrt_converter(torch.ops.aten.pow.Tensor_Scalar)
 def aten_ops_pow(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.elementwise.pow(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1230,14 +1231,14 @@ def aten_ops_pow(
 @dynamo_tensorrt_converter(torch.ops.aten.floor_divide.default)
 @dynamo_tensorrt_converter(torch.ops.aten.floor_divide.Scalar)
 def aten_ops_floor_div(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.elementwise.floor_divide(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1248,14 +1249,14 @@ def aten_ops_floor_div(
 
 @dynamo_tensorrt_converter(torch.ops.aten.logical_and.default)
 def aten_ops_logical_and(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.elementwise.logical_and(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1266,14 +1267,14 @@ def aten_ops_logical_and(
 
 @dynamo_tensorrt_converter(torch.ops.aten.logical_or.default)
 def aten_ops_logical_or(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.elementwise.logical_or(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1284,14 +1285,14 @@ def aten_ops_logical_or(
 
 @dynamo_tensorrt_converter(torch.ops.aten.logical_xor.default)
 def aten_ops_logical_xor(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.elementwise.logical_xor(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1303,14 +1304,14 @@ def aten_ops_logical_xor(
 @dynamo_tensorrt_converter(torch.ops.aten.eq.Tensor)
 @dynamo_tensorrt_converter(torch.ops.aten.eq.Scalar)
 def aten_ops_equal(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.elementwise.eq(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1322,14 +1323,14 @@ def aten_ops_equal(
 @dynamo_tensorrt_converter(torch.ops.aten.gt.Tensor)
 @dynamo_tensorrt_converter(torch.ops.aten.gt.Scalar)
 def aten_ops_greater(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.elementwise.gt(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1341,14 +1342,14 @@ def aten_ops_greater(
 @dynamo_tensorrt_converter(torch.ops.aten.lt.Tensor)
 @dynamo_tensorrt_converter(torch.ops.aten.lt.Scalar)
 def aten_ops_less(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.elementwise.lt(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1372,7 +1373,7 @@ def conv_param_validator(conv_node: Node) -> bool:
     }
 )
 def aten_ops_convolution(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
@@ -1381,7 +1382,7 @@ def aten_ops_convolution(
     is_transposed = args[6]
     if not is_transposed:
         return impl.conv.convNd(
-            network,
+            ctx,
             target,
             source_ir=SourceIR.ATEN,
             name=name,
@@ -1396,7 +1397,7 @@ def aten_ops_convolution(
         )
     else:
         return impl.deconv.deconvNd(
-            network,
+            ctx,
             target,
             source_ir=SourceIR.ATEN,
             name=name,
@@ -1414,14 +1415,14 @@ def aten_ops_convolution(
 @dynamo_tensorrt_converter(torch.ops.aten.linear.default)
 @dynamo_tensorrt_converter(torch.ops.aten.linear)
 def aten_ops_linear(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.linear.linear(
-        network,
+        ctx,
         target,
         SourceIR.ATEN,
         name,
@@ -1455,14 +1456,14 @@ def avg_pool_param_validator(pool_node: Node) -> bool:
 @dynamo_tensorrt_converter(torch.ops.aten.avg_pool2d.default, capability_validator=avg_pool_param_validator)  # type: ignore[misc]
 @dynamo_tensorrt_converter(torch.ops.aten.avg_pool3d.default, capability_validator=avg_pool_param_validator)  # type: ignore[misc]
 def aten_ops_avg_pool(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.pool.avg_poolNd(
-        network,
+        ctx,
         target,
         source_ir=SourceIR.ATEN,
         name=name,
@@ -1498,14 +1499,14 @@ def max_pool_param_validator(pool_node: Node) -> bool:
 @dynamo_tensorrt_converter(torch.ops.aten.max_pool2d.default, capability_validator=max_pool_param_validator)  # type: ignore[misc]
 @dynamo_tensorrt_converter(torch.ops.aten.max_pool3d.default, capability_validator=max_pool_param_validator)  # type: ignore[misc]
 def aten_ops_max_pool(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.pool.max_poolNd(
-        network,
+        ctx,
         target,
         source_ir=SourceIR.ATEN,
         name=name,

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -1,16 +1,20 @@
 import logging
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
 
+import numpy as np
 import torch
 from torch.fx.node import Argument, Node, Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
 from torch_tensorrt.dynamo.conversion import impl
+from torch_tensorrt.dynamo.conversion.converter_registry import (
+    dynamo_tensorrt_converter,
+)
 from torch_tensorrt.dynamo.conversion.converter_utils import (
+    enforce_tensor_types,
     is_only_operator_on_placeholder,
 )
 from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
 
-from .converter_registry import dynamo_tensorrt_converter
 from .converter_utils import dynamic_unsupported_with_args
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -22,7 +26,7 @@ def args_bounds_check(
     return args[i] if len(args) > i else replacement
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.batch_norm)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.batch_norm)
 def aten_ops_batch_norm(
     network: TRTNetwork,
     target: Target,
@@ -65,7 +69,7 @@ def embedding_param_validator(embedding_node: Node) -> bool:
 
 @dynamo_tensorrt_converter(
     torch.ops.aten.embedding.default, capability_validator=embedding_param_validator
-)  # type: ignore[misc]
+)
 def aten_ops_embedding(
     network: TRTNetwork,
     target: Target,
@@ -86,8 +90,8 @@ def aten_ops_embedding(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.fmod.Scalar)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.fmod.Tensor)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.fmod.Scalar)
+@dynamo_tensorrt_converter(torch.ops.aten.fmod.Tensor)
 def aten_ops_fmod(
     network: TRTNetwork,
     target: Target,
@@ -98,7 +102,7 @@ def aten_ops_fmod(
     return impl.elementwise.fmod(network, target, SourceIR.ATEN, name, args[0], args[1])
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.relu.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.relu.default)
 def aten_ops_relu(
     network: TRTNetwork,
     target: Target,
@@ -115,7 +119,7 @@ def aten_ops_relu(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.sigmoid.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.sigmoid.default)
 def aten_ops_sigmoid(
     network: TRTNetwork,
     target: Target,
@@ -132,7 +136,7 @@ def aten_ops_sigmoid(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.tanh.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.tanh.default)
 def aten_ops_tanh(
     network: TRTNetwork,
     target: Target,
@@ -149,7 +153,7 @@ def aten_ops_tanh(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.leaky_relu.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.leaky_relu.default)
 def aten_ops_leaky_relu(
     network: TRTNetwork,
     target: Target,
@@ -167,7 +171,7 @@ def aten_ops_leaky_relu(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.elu.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.elu.default)
 def aten_ops_elu(
     network: TRTNetwork,
     target: Target,
@@ -186,7 +190,7 @@ def aten_ops_elu(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.softplus.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.softplus.default)
 def aten_ops_softplus(
     network: TRTNetwork,
     target: Target,
@@ -204,7 +208,7 @@ def aten_ops_softplus(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.clip.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.clip.default)
 def aten_ops_clip(
     network: TRTNetwork,
     target: Target,
@@ -223,7 +227,7 @@ def aten_ops_clip(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.hardsigmoid.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.hardsigmoid.default)
 def aten_ops_hard_sigmoid(
     network: TRTNetwork,
     target: Target,
@@ -242,10 +246,10 @@ def aten_ops_hard_sigmoid(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.matmul)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.mm.default)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.mv.default)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.bmm.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.matmul)
+@dynamo_tensorrt_converter(torch.ops.aten.mm.default)
+@dynamo_tensorrt_converter(torch.ops.aten.mv.default)
+@dynamo_tensorrt_converter(torch.ops.aten.bmm.default)
 def aten_ops_matmul(
     network: TRTNetwork,
     target: Target,
@@ -263,7 +267,7 @@ def aten_ops_matmul(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.layer_norm.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.layer_norm.default)
 def aten_ops_layernorm(
     network: TRTNetwork,
     target: Target,
@@ -284,7 +288,7 @@ def aten_ops_layernorm(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.rsqrt.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.rsqrt.default)
 def aten_ops_rsqrt(
     network: TRTNetwork,
     target: Target,
@@ -301,7 +305,7 @@ def aten_ops_rsqrt(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.neg.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.neg.default)
 def aten_ops_neg(
     network: TRTNetwork,
     target: Target,
@@ -318,8 +322,8 @@ def aten_ops_neg(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.squeeze.dim)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.squeeze.dims)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.squeeze.dim)
+@dynamo_tensorrt_converter(torch.ops.aten.squeeze.dims)
 def aten_ops_squeeze(
     network: TRTNetwork,
     target: Target,
@@ -330,7 +334,7 @@ def aten_ops_squeeze(
     return impl.squeeze.squeeze(network, target, SourceIR.ATEN, name, args[0], args[1])
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.erf.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.erf.default)
 def aten_ops_erf(
     network: TRTNetwork,
     target: Target,
@@ -347,7 +351,7 @@ def aten_ops_erf(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.unsqueeze.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.unsqueeze.default)
 def aten_ops_unsqueeze(
     network: TRTNetwork,
     target: Target,
@@ -360,7 +364,7 @@ def aten_ops_unsqueeze(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten._softmax.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten._softmax.default)
 def aten_ops_softmax(
     network: TRTNetwork,
     target: Target,
@@ -375,14 +379,14 @@ def aten_ops_softmax(
 
 @dynamo_tensorrt_converter(
     torch.ops.aten.split.Tensor, capability_validator=dynamic_unsupported_with_args([1])
-)  # type: ignore[misc]
+)
 @dynamo_tensorrt_converter(
     torch.ops.aten.split.sizes, capability_validator=dynamic_unsupported_with_args([1])
-)  # type: ignore[misc]
+)
 @dynamo_tensorrt_converter(
     torch.ops.aten.split_with_sizes.default,
     capability_validator=dynamic_unsupported_with_args([1]),
-)  # type: ignore[misc]
+)
 def aten_ops_split(
     network: TRTNetwork,
     target: Target,
@@ -401,7 +405,7 @@ def aten_ops_split(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.where.self)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.where.self)
 def aten_ops_where(
     network: TRTNetwork,
     target: Target,
@@ -420,7 +424,7 @@ def aten_ops_where(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.clamp.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.clamp.default)
 def aten_ops_clamp(
     network: TRTNetwork,
     target: Target,
@@ -439,7 +443,7 @@ def aten_ops_clamp(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.select.int)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.select.int)
 def aten_ops_select(
     network: TRTNetwork,
     target: Target,
@@ -452,7 +456,7 @@ def aten_ops_select(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.slice.Tensor)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.slice.Tensor)
 def aten_ops_slice(
     network: TRTNetwork,
     target: Target,
@@ -473,7 +477,12 @@ def aten_ops_slice(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.permute.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.permute.default)
+@enforce_tensor_types(
+    {
+        0: (TRTTensor,),
+    }
+)
 def aten_ops_permute(
     network: TRTNetwork,
     target: Target,
@@ -538,11 +547,11 @@ def to_copy_dtype_validator(placeholder_only: bool) -> Callable[[Node], bool]:
 @dynamo_tensorrt_converter(
     torch.ops.aten.clone.default,
     capability_validator=lambda node: not is_only_operator_on_placeholder(node),
-)  # type: ignore[misc]
+)
 @dynamo_tensorrt_converter(
     torch.ops.aten._to_copy.default,
     capability_validator=to_copy_dtype_validator(placeholder_only=False),
-)  # type: ignore[misc]
+)
 def aten_ops_clone_copy_dtype(
     network: TRTNetwork,
     target: Target,
@@ -564,11 +573,11 @@ def aten_ops_clone_copy_dtype(
 @dynamo_tensorrt_converter(
     torch.ops.aten.clone.default,
     capability_validator=is_only_operator_on_placeholder,
-)  # type: ignore[misc]
+)
 @dynamo_tensorrt_converter(
     torch.ops.aten._to_copy.default,
     capability_validator=to_copy_dtype_validator(placeholder_only=True),
-)  # type: ignore[misc]
+)
 def aten_ops_clone_copy_placeholder(
     network: TRTNetwork,
     target: Target,
@@ -590,7 +599,7 @@ def aten_ops_clone_copy_placeholder(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.expand.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.expand.default)
 def aten_ops_expand(
     network: TRTNetwork,
     target: Target,
@@ -620,7 +629,7 @@ def amax_param_validator(amax_node: Node) -> bool:
 
 @dynamo_tensorrt_converter(
     torch.ops.aten.amax.default, capability_validator=amax_param_validator
-)  # type: ignore[misc]
+)
 def aten_ops_amax(
     network: TRTNetwork,
     target: Target,
@@ -639,8 +648,8 @@ def aten_ops_amax(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.sum.default)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.sum.dim_IntList)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.sum.default)
+@dynamo_tensorrt_converter(torch.ops.aten.sum.dim_IntList)
 def aten_ops_sum(
     network: TRTNetwork,
     target: Target,
@@ -659,7 +668,7 @@ def aten_ops_sum(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.exp.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.exp.default)
 def aten_ops_exp(
     network: TRTNetwork,
     target: Target,
@@ -676,7 +685,7 @@ def aten_ops_exp(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.log.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.log.default)
 def aten_ops_log(
     network: TRTNetwork,
     target: Target,
@@ -693,7 +702,7 @@ def aten_ops_log(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.sqrt.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.sqrt.default)
 def aten_ops_sqrt(
     network: TRTNetwork,
     target: Target,
@@ -710,7 +719,7 @@ def aten_ops_sqrt(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.reciprocal.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.reciprocal.default)
 def aten_ops_recip(
     network: TRTNetwork,
     target: Target,
@@ -727,7 +736,7 @@ def aten_ops_recip(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.abs.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.abs.default)
 def aten_ops_abs(
     network: TRTNetwork,
     target: Target,
@@ -744,7 +753,7 @@ def aten_ops_abs(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.sin.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.sin.default)
 def aten_ops_sin(
     network: TRTNetwork,
     target: Target,
@@ -761,7 +770,7 @@ def aten_ops_sin(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.cos.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.cos.default)
 def aten_ops_cos(
     network: TRTNetwork,
     target: Target,
@@ -778,7 +787,7 @@ def aten_ops_cos(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.tan.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.tan.default)
 def aten_ops_tan(
     network: TRTNetwork,
     target: Target,
@@ -795,7 +804,7 @@ def aten_ops_tan(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.sinh.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.sinh.default)
 def aten_ops_sinh(
     network: TRTNetwork,
     target: Target,
@@ -812,7 +821,7 @@ def aten_ops_sinh(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.cosh.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.cosh.default)
 def aten_ops_cosh(
     network: TRTNetwork,
     target: Target,
@@ -829,7 +838,7 @@ def aten_ops_cosh(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.asin.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.asin.default)
 def aten_ops_asin(
     network: TRTNetwork,
     target: Target,
@@ -846,7 +855,7 @@ def aten_ops_asin(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.acos.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.acos.default)
 def aten_ops_acos(
     network: TRTNetwork,
     target: Target,
@@ -863,7 +872,7 @@ def aten_ops_acos(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.atan.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.atan.default)
 def aten_ops_atan(
     network: TRTNetwork,
     target: Target,
@@ -880,7 +889,7 @@ def aten_ops_atan(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.asinh.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.asinh.default)
 def aten_ops_asinh(
     network: TRTNetwork,
     target: Target,
@@ -897,7 +906,7 @@ def aten_ops_asinh(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.acosh.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.acosh.default)
 def aten_ops_acosh(
     network: TRTNetwork,
     target: Target,
@@ -914,7 +923,7 @@ def aten_ops_acosh(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.atanh.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.atanh.default)
 def aten_ops_atanh(
     network: TRTNetwork,
     target: Target,
@@ -931,7 +940,7 @@ def aten_ops_atanh(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.ceil.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.ceil.default)
 def aten_ops_ceil(
     network: TRTNetwork,
     target: Target,
@@ -948,7 +957,7 @@ def aten_ops_ceil(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.floor.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.floor.default)
 def aten_ops_floor(
     network: TRTNetwork,
     target: Target,
@@ -965,7 +974,7 @@ def aten_ops_floor(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.logical_not.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.logical_not.default)
 def aten_ops_logical_not(
     network: TRTNetwork,
     target: Target,
@@ -982,7 +991,7 @@ def aten_ops_logical_not(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.sign.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.sign.default)
 def aten_ops_sign(
     network: TRTNetwork,
     target: Target,
@@ -999,7 +1008,7 @@ def aten_ops_sign(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.round.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.round.default)
 def aten_ops_round(
     network: TRTNetwork,
     target: Target,
@@ -1016,7 +1025,7 @@ def aten_ops_round(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.isinf.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.isinf.default)
 def aten_ops_isinf(
     network: TRTNetwork,
     target: Target,
@@ -1033,8 +1042,8 @@ def aten_ops_isinf(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.add.Tensor)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.add.Scalar)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.add.Tensor)
+@dynamo_tensorrt_converter(torch.ops.aten.add.Scalar)
 def aten_ops_add(
     network: TRTNetwork,
     target: Target,
@@ -1065,8 +1074,8 @@ def aten_ops_add(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.mul.Tensor)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.mul.Scalar)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.mul.Tensor)
+@dynamo_tensorrt_converter(torch.ops.aten.mul.Scalar)
 def aten_ops_mul(
     network: TRTNetwork,
     target: Target,
@@ -1084,7 +1093,7 @@ def aten_ops_mul(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.maximum.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.maximum.default)
 def aten_ops_max(
     network: TRTNetwork,
     target: Target,
@@ -1102,7 +1111,7 @@ def aten_ops_max(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.minimum.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.minimum.default)
 def aten_ops_min(
     network: TRTNetwork,
     target: Target,
@@ -1120,8 +1129,8 @@ def aten_ops_min(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.sub.Tensor)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.sub.Scalar)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.sub.Tensor)
+@dynamo_tensorrt_converter(torch.ops.aten.sub.Scalar)
 def aten_ops_sub(
     network: TRTNetwork,
     target: Target,
@@ -1152,10 +1161,10 @@ def aten_ops_sub(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.div.Tensor)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.div.Tensor_mode)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.div.Scalar)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.div.Scalar_mode)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.div.Tensor)
+@dynamo_tensorrt_converter(torch.ops.aten.div.Tensor_mode)
+@dynamo_tensorrt_converter(torch.ops.aten.div.Scalar)
+@dynamo_tensorrt_converter(torch.ops.aten.div.Scalar_mode)
 def aten_ops_div(
     network: TRTNetwork,
     target: Target,
@@ -1198,9 +1207,9 @@ def aten_ops_div(
         )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.pow.Tensor_Tensor)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.pow.Scalar)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.pow.Tensor_Scalar)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.pow.Tensor_Tensor)
+@dynamo_tensorrt_converter(torch.ops.aten.pow.Scalar)
+@dynamo_tensorrt_converter(torch.ops.aten.pow.Tensor_Scalar)
 def aten_ops_pow(
     network: TRTNetwork,
     target: Target,
@@ -1218,8 +1227,8 @@ def aten_ops_pow(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.floor_divide.default)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.floor_divide.Scalar)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.floor_divide.default)
+@dynamo_tensorrt_converter(torch.ops.aten.floor_divide.Scalar)
 def aten_ops_floor_div(
     network: TRTNetwork,
     target: Target,
@@ -1237,7 +1246,7 @@ def aten_ops_floor_div(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.logical_and.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.logical_and.default)
 def aten_ops_logical_and(
     network: TRTNetwork,
     target: Target,
@@ -1255,7 +1264,7 @@ def aten_ops_logical_and(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.logical_or.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.logical_or.default)
 def aten_ops_logical_or(
     network: TRTNetwork,
     target: Target,
@@ -1273,7 +1282,7 @@ def aten_ops_logical_or(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.logical_xor.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.logical_xor.default)
 def aten_ops_logical_xor(
     network: TRTNetwork,
     target: Target,
@@ -1291,8 +1300,8 @@ def aten_ops_logical_xor(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.eq.Tensor)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.eq.Scalar)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.eq.Tensor)
+@dynamo_tensorrt_converter(torch.ops.aten.eq.Scalar)
 def aten_ops_equal(
     network: TRTNetwork,
     target: Target,
@@ -1310,8 +1319,8 @@ def aten_ops_equal(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.gt.Tensor)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.gt.Scalar)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.gt.Tensor)
+@dynamo_tensorrt_converter(torch.ops.aten.gt.Scalar)
 def aten_ops_greater(
     network: TRTNetwork,
     target: Target,
@@ -1329,8 +1338,8 @@ def aten_ops_greater(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.lt.Tensor)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.lt.Scalar)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.lt.Tensor)
+@dynamo_tensorrt_converter(torch.ops.aten.lt.Scalar)
 def aten_ops_less(
     network: TRTNetwork,
     target: Target,
@@ -1354,7 +1363,14 @@ def conv_param_validator(conv_node: Node) -> bool:
 
 @dynamo_tensorrt_converter(
     torch.ops.aten.convolution.default, capability_validator=conv_param_validator
-)  # type: ignore[misc]
+)
+@enforce_tensor_types(
+    {
+        0: (TRTTensor,),
+        1: (TRTTensor, np.ndarray, torch.Tensor),
+        2: (TRTTensor, np.ndarray, torch.Tensor),
+    }
+)
 def aten_ops_convolution(
     network: TRTNetwork,
     target: Target,
@@ -1395,8 +1411,8 @@ def aten_ops_convolution(
         )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.linear.default)  # type: ignore[misc]
-@dynamo_tensorrt_converter(torch.ops.aten.linear)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.linear.default)
+@dynamo_tensorrt_converter(torch.ops.aten.linear)
 def aten_ops_linear(
     network: TRTNetwork,
     target: Target,

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -27,7 +27,7 @@ def args_bounds_check(
     return args[i] if len(args) > i else replacement
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.batch_norm)
+@dynamo_tensorrt_converter(torch.ops.aten.batch_norm)  # type: ignore[misc]
 def aten_ops_batch_norm(
     ctx: ConversionContext,
     target: Target,
@@ -70,7 +70,7 @@ def embedding_param_validator(embedding_node: Node) -> bool:
 
 @dynamo_tensorrt_converter(
     torch.ops.aten.embedding.default, capability_validator=embedding_param_validator
-)
+)  # type: ignore[misc]
 def aten_ops_embedding(
     ctx: ConversionContext,
     target: Target,
@@ -91,8 +91,8 @@ def aten_ops_embedding(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.fmod.Scalar)
-@dynamo_tensorrt_converter(torch.ops.aten.fmod.Tensor)
+@dynamo_tensorrt_converter(torch.ops.aten.fmod.Scalar)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.fmod.Tensor)  # type: ignore[misc]
 def aten_ops_fmod(
     ctx: ConversionContext,
     target: Target,
@@ -103,7 +103,7 @@ def aten_ops_fmod(
     return impl.elementwise.fmod(ctx, target, SourceIR.ATEN, name, args[0], args[1])
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.relu.default)
+@dynamo_tensorrt_converter(torch.ops.aten.relu.default)  # type: ignore[misc]
 def aten_ops_relu(
     ctx: ConversionContext,
     target: Target,
@@ -120,7 +120,7 @@ def aten_ops_relu(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.sigmoid.default)
+@dynamo_tensorrt_converter(torch.ops.aten.sigmoid.default)  # type: ignore[misc]
 def aten_ops_sigmoid(
     ctx: ConversionContext,
     target: Target,
@@ -137,7 +137,7 @@ def aten_ops_sigmoid(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.tanh.default)
+@dynamo_tensorrt_converter(torch.ops.aten.tanh.default)  # type: ignore[misc]
 def aten_ops_tanh(
     ctx: ConversionContext,
     target: Target,
@@ -154,7 +154,7 @@ def aten_ops_tanh(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.leaky_relu.default)
+@dynamo_tensorrt_converter(torch.ops.aten.leaky_relu.default)  # type: ignore[misc]
 def aten_ops_leaky_relu(
     ctx: ConversionContext,
     target: Target,
@@ -172,7 +172,7 @@ def aten_ops_leaky_relu(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.elu.default)
+@dynamo_tensorrt_converter(torch.ops.aten.elu.default)  # type: ignore[misc]
 def aten_ops_elu(
     ctx: ConversionContext,
     target: Target,
@@ -191,7 +191,7 @@ def aten_ops_elu(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.softplus.default)
+@dynamo_tensorrt_converter(torch.ops.aten.softplus.default)  # type: ignore[misc]
 def aten_ops_softplus(
     ctx: ConversionContext,
     target: Target,
@@ -209,7 +209,7 @@ def aten_ops_softplus(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.clip.default)
+@dynamo_tensorrt_converter(torch.ops.aten.clip.default)  # type: ignore[misc]
 def aten_ops_clip(
     ctx: ConversionContext,
     target: Target,
@@ -228,7 +228,7 @@ def aten_ops_clip(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.hardsigmoid.default)
+@dynamo_tensorrt_converter(torch.ops.aten.hardsigmoid.default)  # type: ignore[misc]
 def aten_ops_hard_sigmoid(
     ctx: ConversionContext,
     target: Target,
@@ -247,10 +247,10 @@ def aten_ops_hard_sigmoid(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.matmul)
-@dynamo_tensorrt_converter(torch.ops.aten.mm.default)
-@dynamo_tensorrt_converter(torch.ops.aten.mv.default)
-@dynamo_tensorrt_converter(torch.ops.aten.bmm.default)
+@dynamo_tensorrt_converter(torch.ops.aten.matmul)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.mm.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.mv.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.bmm.default)  # type: ignore[misc]
 def aten_ops_matmul(
     ctx: ConversionContext,
     target: Target,
@@ -268,7 +268,7 @@ def aten_ops_matmul(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.layer_norm.default)
+@dynamo_tensorrt_converter(torch.ops.aten.layer_norm.default)  # type: ignore[misc]
 def aten_ops_layernorm(
     ctx: ConversionContext,
     target: Target,
@@ -289,7 +289,7 @@ def aten_ops_layernorm(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.rsqrt.default)
+@dynamo_tensorrt_converter(torch.ops.aten.rsqrt.default)  # type: ignore[misc]
 def aten_ops_rsqrt(
     ctx: ConversionContext,
     target: Target,
@@ -306,7 +306,7 @@ def aten_ops_rsqrt(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.neg.default)
+@dynamo_tensorrt_converter(torch.ops.aten.neg.default)  # type: ignore[misc]
 def aten_ops_neg(
     ctx: ConversionContext,
     target: Target,
@@ -323,8 +323,8 @@ def aten_ops_neg(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.squeeze.dim)
-@dynamo_tensorrt_converter(torch.ops.aten.squeeze.dims)
+@dynamo_tensorrt_converter(torch.ops.aten.squeeze.dim)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.squeeze.dims)  # type: ignore[misc]
 def aten_ops_squeeze(
     ctx: ConversionContext,
     target: Target,
@@ -335,7 +335,7 @@ def aten_ops_squeeze(
     return impl.squeeze.squeeze(ctx, target, SourceIR.ATEN, name, args[0], args[1])
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.erf.default)
+@dynamo_tensorrt_converter(torch.ops.aten.erf.default)  # type: ignore[misc]
 def aten_ops_erf(
     ctx: ConversionContext,
     target: Target,
@@ -352,7 +352,7 @@ def aten_ops_erf(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.unsqueeze.default)
+@dynamo_tensorrt_converter(torch.ops.aten.unsqueeze.default)  # type: ignore[misc]
 def aten_ops_unsqueeze(
     ctx: ConversionContext,
     target: Target,
@@ -365,7 +365,7 @@ def aten_ops_unsqueeze(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten._softmax.default)
+@dynamo_tensorrt_converter(torch.ops.aten._softmax.default)  # type: ignore[misc]
 def aten_ops_softmax(
     ctx: ConversionContext,
     target: Target,
@@ -380,14 +380,14 @@ def aten_ops_softmax(
 
 @dynamo_tensorrt_converter(
     torch.ops.aten.split.Tensor, capability_validator=dynamic_unsupported_with_args([1])
-)
+)  # type: ignore[misc]
 @dynamo_tensorrt_converter(
     torch.ops.aten.split.sizes, capability_validator=dynamic_unsupported_with_args([1])
-)
+)  # type: ignore[misc]
 @dynamo_tensorrt_converter(
     torch.ops.aten.split_with_sizes.default,
     capability_validator=dynamic_unsupported_with_args([1]),
-)
+)  # type: ignore[misc]
 def aten_ops_split(
     ctx: ConversionContext,
     target: Target,
@@ -406,7 +406,7 @@ def aten_ops_split(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.where.self)
+@dynamo_tensorrt_converter(torch.ops.aten.where.self)  # type: ignore[misc]
 def aten_ops_where(
     ctx: ConversionContext,
     target: Target,
@@ -425,7 +425,7 @@ def aten_ops_where(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.clamp.default)
+@dynamo_tensorrt_converter(torch.ops.aten.clamp.default)  # type: ignore[misc]
 def aten_ops_clamp(
     ctx: ConversionContext,
     target: Target,
@@ -444,7 +444,7 @@ def aten_ops_clamp(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.select.int)
+@dynamo_tensorrt_converter(torch.ops.aten.select.int)  # type: ignore[misc]
 def aten_ops_select(
     ctx: ConversionContext,
     target: Target,
@@ -457,7 +457,7 @@ def aten_ops_select(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.slice.Tensor)
+@dynamo_tensorrt_converter(torch.ops.aten.slice.Tensor)  # type: ignore[misc]
 def aten_ops_slice(
     ctx: ConversionContext,
     target: Target,
@@ -478,12 +478,12 @@ def aten_ops_slice(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.permute.default)
+@dynamo_tensorrt_converter(torch.ops.aten.permute.default)  # type: ignore[misc]
 @enforce_tensor_types(
     {
         0: (TRTTensor,),
     }
-)
+)  # type: ignore[misc]
 def aten_ops_permute(
     ctx: ConversionContext,
     target: Target,
@@ -548,11 +548,11 @@ def to_copy_dtype_validator(placeholder_only: bool) -> Callable[[Node], bool]:
 @dynamo_tensorrt_converter(
     torch.ops.aten.clone.default,
     capability_validator=lambda node: not is_only_operator_on_placeholder(node),
-)
+)  # type: ignore[misc]
 @dynamo_tensorrt_converter(
     torch.ops.aten._to_copy.default,
     capability_validator=to_copy_dtype_validator(placeholder_only=False),
-)
+)  # type: ignore[misc]
 def aten_ops_clone_copy_dtype(
     ctx: ConversionContext,
     target: Target,
@@ -574,11 +574,11 @@ def aten_ops_clone_copy_dtype(
 @dynamo_tensorrt_converter(
     torch.ops.aten.clone.default,
     capability_validator=is_only_operator_on_placeholder,
-)
+)  # type: ignore[misc]
 @dynamo_tensorrt_converter(
     torch.ops.aten._to_copy.default,
     capability_validator=to_copy_dtype_validator(placeholder_only=True),
-)
+)  # type: ignore[misc]
 def aten_ops_clone_copy_placeholder(
     ctx: ConversionContext,
     target: Target,
@@ -600,7 +600,7 @@ def aten_ops_clone_copy_placeholder(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.expand.default)
+@dynamo_tensorrt_converter(torch.ops.aten.expand.default)  # type: ignore[misc]
 def aten_ops_expand(
     ctx: ConversionContext,
     target: Target,
@@ -630,7 +630,7 @@ def amax_param_validator(amax_node: Node) -> bool:
 
 @dynamo_tensorrt_converter(
     torch.ops.aten.amax.default, capability_validator=amax_param_validator
-)
+)  # type: ignore[misc]
 def aten_ops_amax(
     ctx: ConversionContext,
     target: Target,
@@ -649,8 +649,8 @@ def aten_ops_amax(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.sum.default)
-@dynamo_tensorrt_converter(torch.ops.aten.sum.dim_IntList)
+@dynamo_tensorrt_converter(torch.ops.aten.sum.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.sum.dim_IntList)  # type: ignore[misc]
 def aten_ops_sum(
     ctx: ConversionContext,
     target: Target,
@@ -669,7 +669,7 @@ def aten_ops_sum(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.exp.default)
+@dynamo_tensorrt_converter(torch.ops.aten.exp.default)  # type: ignore[misc]
 def aten_ops_exp(
     ctx: ConversionContext,
     target: Target,
@@ -686,7 +686,7 @@ def aten_ops_exp(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.log.default)
+@dynamo_tensorrt_converter(torch.ops.aten.log.default)  # type: ignore[misc]
 def aten_ops_log(
     ctx: ConversionContext,
     target: Target,
@@ -703,7 +703,7 @@ def aten_ops_log(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.sqrt.default)
+@dynamo_tensorrt_converter(torch.ops.aten.sqrt.default)  # type: ignore[misc]
 def aten_ops_sqrt(
     ctx: ConversionContext,
     target: Target,
@@ -720,7 +720,7 @@ def aten_ops_sqrt(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.reciprocal.default)
+@dynamo_tensorrt_converter(torch.ops.aten.reciprocal.default)  # type: ignore[misc]
 def aten_ops_recip(
     ctx: ConversionContext,
     target: Target,
@@ -737,7 +737,7 @@ def aten_ops_recip(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.abs.default)
+@dynamo_tensorrt_converter(torch.ops.aten.abs.default)  # type: ignore[misc]
 def aten_ops_abs(
     ctx: ConversionContext,
     target: Target,
@@ -754,7 +754,7 @@ def aten_ops_abs(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.sin.default)
+@dynamo_tensorrt_converter(torch.ops.aten.sin.default)  # type: ignore[misc]
 def aten_ops_sin(
     ctx: ConversionContext,
     target: Target,
@@ -771,7 +771,7 @@ def aten_ops_sin(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.cos.default)
+@dynamo_tensorrt_converter(torch.ops.aten.cos.default)  # type: ignore[misc]
 def aten_ops_cos(
     ctx: ConversionContext,
     target: Target,
@@ -788,7 +788,7 @@ def aten_ops_cos(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.tan.default)
+@dynamo_tensorrt_converter(torch.ops.aten.tan.default)  # type: ignore[misc]
 def aten_ops_tan(
     ctx: ConversionContext,
     target: Target,
@@ -805,7 +805,7 @@ def aten_ops_tan(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.sinh.default)
+@dynamo_tensorrt_converter(torch.ops.aten.sinh.default)  # type: ignore[misc]
 def aten_ops_sinh(
     ctx: ConversionContext,
     target: Target,
@@ -822,7 +822,7 @@ def aten_ops_sinh(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.cosh.default)
+@dynamo_tensorrt_converter(torch.ops.aten.cosh.default)  # type: ignore[misc]
 def aten_ops_cosh(
     ctx: ConversionContext,
     target: Target,
@@ -839,7 +839,7 @@ def aten_ops_cosh(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.asin.default)
+@dynamo_tensorrt_converter(torch.ops.aten.asin.default)  # type: ignore[misc]
 def aten_ops_asin(
     ctx: ConversionContext,
     target: Target,
@@ -856,7 +856,7 @@ def aten_ops_asin(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.acos.default)
+@dynamo_tensorrt_converter(torch.ops.aten.acos.default)  # type: ignore[misc]
 def aten_ops_acos(
     ctx: ConversionContext,
     target: Target,
@@ -873,7 +873,7 @@ def aten_ops_acos(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.atan.default)
+@dynamo_tensorrt_converter(torch.ops.aten.atan.default)  # type: ignore[misc]
 def aten_ops_atan(
     ctx: ConversionContext,
     target: Target,
@@ -890,7 +890,7 @@ def aten_ops_atan(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.asinh.default)
+@dynamo_tensorrt_converter(torch.ops.aten.asinh.default)  # type: ignore[misc]
 def aten_ops_asinh(
     ctx: ConversionContext,
     target: Target,
@@ -907,7 +907,7 @@ def aten_ops_asinh(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.acosh.default)
+@dynamo_tensorrt_converter(torch.ops.aten.acosh.default)  # type: ignore[misc]
 def aten_ops_acosh(
     ctx: ConversionContext,
     target: Target,
@@ -924,7 +924,7 @@ def aten_ops_acosh(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.atanh.default)
+@dynamo_tensorrt_converter(torch.ops.aten.atanh.default)  # type: ignore[misc]
 def aten_ops_atanh(
     ctx: ConversionContext,
     target: Target,
@@ -941,7 +941,7 @@ def aten_ops_atanh(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.ceil.default)
+@dynamo_tensorrt_converter(torch.ops.aten.ceil.default)  # type: ignore[misc]
 def aten_ops_ceil(
     ctx: ConversionContext,
     target: Target,
@@ -958,7 +958,7 @@ def aten_ops_ceil(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.floor.default)
+@dynamo_tensorrt_converter(torch.ops.aten.floor.default)  # type: ignore[misc]
 def aten_ops_floor(
     ctx: ConversionContext,
     target: Target,
@@ -975,7 +975,7 @@ def aten_ops_floor(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.logical_not.default)
+@dynamo_tensorrt_converter(torch.ops.aten.logical_not.default)  # type: ignore[misc]
 def aten_ops_logical_not(
     ctx: ConversionContext,
     target: Target,
@@ -992,7 +992,7 @@ def aten_ops_logical_not(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.sign.default)
+@dynamo_tensorrt_converter(torch.ops.aten.sign.default)  # type: ignore[misc]
 def aten_ops_sign(
     ctx: ConversionContext,
     target: Target,
@@ -1009,7 +1009,7 @@ def aten_ops_sign(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.round.default)
+@dynamo_tensorrt_converter(torch.ops.aten.round.default)  # type: ignore[misc]
 def aten_ops_round(
     ctx: ConversionContext,
     target: Target,
@@ -1026,7 +1026,7 @@ def aten_ops_round(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.isinf.default)
+@dynamo_tensorrt_converter(torch.ops.aten.isinf.default)  # type: ignore[misc]
 def aten_ops_isinf(
     ctx: ConversionContext,
     target: Target,
@@ -1043,8 +1043,8 @@ def aten_ops_isinf(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.add.Tensor)
-@dynamo_tensorrt_converter(torch.ops.aten.add.Scalar)
+@dynamo_tensorrt_converter(torch.ops.aten.add.Tensor)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.add.Scalar)  # type: ignore[misc]
 def aten_ops_add(
     ctx: ConversionContext,
     target: Target,
@@ -1075,8 +1075,8 @@ def aten_ops_add(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.mul.Tensor)
-@dynamo_tensorrt_converter(torch.ops.aten.mul.Scalar)
+@dynamo_tensorrt_converter(torch.ops.aten.mul.Tensor)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.mul.Scalar)  # type: ignore[misc]
 def aten_ops_mul(
     ctx: ConversionContext,
     target: Target,
@@ -1094,7 +1094,7 @@ def aten_ops_mul(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.maximum.default)
+@dynamo_tensorrt_converter(torch.ops.aten.maximum.default)  # type: ignore[misc]
 def aten_ops_max(
     ctx: ConversionContext,
     target: Target,
@@ -1112,7 +1112,7 @@ def aten_ops_max(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.minimum.default)
+@dynamo_tensorrt_converter(torch.ops.aten.minimum.default)  # type: ignore[misc]
 def aten_ops_min(
     ctx: ConversionContext,
     target: Target,
@@ -1130,8 +1130,8 @@ def aten_ops_min(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.sub.Tensor)
-@dynamo_tensorrt_converter(torch.ops.aten.sub.Scalar)
+@dynamo_tensorrt_converter(torch.ops.aten.sub.Tensor)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.sub.Scalar)  # type: ignore[misc]
 def aten_ops_sub(
     ctx: ConversionContext,
     target: Target,
@@ -1162,10 +1162,10 @@ def aten_ops_sub(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.div.Tensor)
-@dynamo_tensorrt_converter(torch.ops.aten.div.Tensor_mode)
-@dynamo_tensorrt_converter(torch.ops.aten.div.Scalar)
-@dynamo_tensorrt_converter(torch.ops.aten.div.Scalar_mode)
+@dynamo_tensorrt_converter(torch.ops.aten.div.Tensor)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.div.Tensor_mode)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.div.Scalar)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.div.Scalar_mode)  # type: ignore[misc]
 def aten_ops_div(
     ctx: ConversionContext,
     target: Target,
@@ -1208,9 +1208,9 @@ def aten_ops_div(
         )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.pow.Tensor_Tensor)
-@dynamo_tensorrt_converter(torch.ops.aten.pow.Scalar)
-@dynamo_tensorrt_converter(torch.ops.aten.pow.Tensor_Scalar)
+@dynamo_tensorrt_converter(torch.ops.aten.pow.Tensor_Tensor)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.pow.Scalar)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.pow.Tensor_Scalar)  # type: ignore[misc]
 def aten_ops_pow(
     ctx: ConversionContext,
     target: Target,
@@ -1228,8 +1228,8 @@ def aten_ops_pow(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.floor_divide.default)
-@dynamo_tensorrt_converter(torch.ops.aten.floor_divide.Scalar)
+@dynamo_tensorrt_converter(torch.ops.aten.floor_divide.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.floor_divide.Scalar)  # type: ignore[misc]
 def aten_ops_floor_div(
     ctx: ConversionContext,
     target: Target,
@@ -1247,7 +1247,7 @@ def aten_ops_floor_div(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.logical_and.default)
+@dynamo_tensorrt_converter(torch.ops.aten.logical_and.default)  # type: ignore[misc]
 def aten_ops_logical_and(
     ctx: ConversionContext,
     target: Target,
@@ -1265,7 +1265,7 @@ def aten_ops_logical_and(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.logical_or.default)
+@dynamo_tensorrt_converter(torch.ops.aten.logical_or.default)  # type: ignore[misc]
 def aten_ops_logical_or(
     ctx: ConversionContext,
     target: Target,
@@ -1283,7 +1283,7 @@ def aten_ops_logical_or(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.logical_xor.default)
+@dynamo_tensorrt_converter(torch.ops.aten.logical_xor.default)  # type: ignore[misc]
 def aten_ops_logical_xor(
     ctx: ConversionContext,
     target: Target,
@@ -1301,8 +1301,8 @@ def aten_ops_logical_xor(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.eq.Tensor)
-@dynamo_tensorrt_converter(torch.ops.aten.eq.Scalar)
+@dynamo_tensorrt_converter(torch.ops.aten.eq.Tensor)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.eq.Scalar)  # type: ignore[misc]
 def aten_ops_equal(
     ctx: ConversionContext,
     target: Target,
@@ -1320,8 +1320,8 @@ def aten_ops_equal(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.gt.Tensor)
-@dynamo_tensorrt_converter(torch.ops.aten.gt.Scalar)
+@dynamo_tensorrt_converter(torch.ops.aten.gt.Tensor)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.gt.Scalar)  # type: ignore[misc]
 def aten_ops_greater(
     ctx: ConversionContext,
     target: Target,
@@ -1339,8 +1339,8 @@ def aten_ops_greater(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.lt.Tensor)
-@dynamo_tensorrt_converter(torch.ops.aten.lt.Scalar)
+@dynamo_tensorrt_converter(torch.ops.aten.lt.Tensor)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.lt.Scalar)  # type: ignore[misc]
 def aten_ops_less(
     ctx: ConversionContext,
     target: Target,
@@ -1364,14 +1364,14 @@ def conv_param_validator(conv_node: Node) -> bool:
 
 @dynamo_tensorrt_converter(
     torch.ops.aten.convolution.default, capability_validator=conv_param_validator
-)
+)  # type: ignore[misc]
 @enforce_tensor_types(
     {
         0: (TRTTensor,),
-        1: (TRTTensor, np.ndarray, torch.Tensor),
-        2: (TRTTensor, np.ndarray, torch.Tensor),
+        1: (np.ndarray, torch.Tensor, TRTTensor),
+        2: (np.ndarray, torch.Tensor, TRTTensor),
     }
-)
+)  # type: ignore[misc]
 def aten_ops_convolution(
     ctx: ConversionContext,
     target: Target,
@@ -1412,8 +1412,8 @@ def aten_ops_convolution(
         )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.linear.default)
-@dynamo_tensorrt_converter(torch.ops.aten.linear)
+@dynamo_tensorrt_converter(torch.ops.aten.linear.default)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.linear)  # type: ignore[misc]
 def aten_ops_linear(
     ctx: ConversionContext,
     target: Target,

--- a/py/torch_tensorrt/dynamo/conversion/conversion.py
+++ b/py/torch_tensorrt/dynamo/conversion/conversion.py
@@ -39,6 +39,7 @@ def convert_module(
         Input.from_tensors(inputs, disable_memory_format_check=True),
         logger_level=(trt.Logger.VERBOSE if settings.debug else trt.Logger.WARNING),
         output_dtypes=output_dtypes,
+        compilation_settings=settings,
     )
     interpreter_result = interpreter.run(
         workspace_size=settings.workspace_size,

--- a/py/torch_tensorrt/dynamo/conversion/converter_registry.py
+++ b/py/torch_tensorrt/dynamo/conversion/converter_registry.py
@@ -18,12 +18,13 @@ from typing import (
 
 from torch._ops import OpOverloadPacket
 from torch.fx.node import Argument, Node, Target, _get_qualified_name
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.fx.converter_registry import CONVERTERS
 from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
 
 logger = logging.getLogger(__name__)
 
-ConverterImplSignature = Callable[
+LegacyConverterImplSignature = Callable[
     [
         TRTNetwork,
         Target,
@@ -34,12 +35,34 @@ ConverterImplSignature = Callable[
     Union[TRTTensor, Sequence[TRTTensor]],
 ]
 
+DynamoConverterImplSignature = Callable[
+    [
+        ConversionContext,
+        Target,
+        Tuple[Argument, ...],
+        Dict[str, Argument],
+        str,
+    ],
+    Union[TRTTensor, Sequence[TRTTensor]],
+]
+
+ConverterImplSignature = Union[
+    LegacyConverterImplSignature, DynamoConverterImplSignature
+]
+
 
 class ConverterPriority(Enum):
     """Enum to set a converter's priority in the registry"""
 
     STANDARD = auto()
     HIGH = auto()
+
+
+class CallingConvention(Enum):
+    """Enum representing a converter's calling convention"""
+
+    LEGACY = auto()  # Legacy FX converters
+    CTX = auto()  # New Dynamo converters
 
 
 @dataclass(frozen=True)
@@ -156,7 +179,10 @@ class ConverterRegistry:
         registries: List of dictionaries representing converter registries.
             The order of the provided dictionaries is the order in which they
             will be traversed. This is only significant when using non-validated
-            methods.
+            methods
+        registry_names: Optional list of names for each registry
+        registry_calling_conventions: Optional list of calling conventions
+            for each registry
     """
 
     def __init__(
@@ -165,6 +191,7 @@ class ConverterRegistry:
             Dict[Target, Union[Callable[..., Any], Sequence[ConverterSupport]]]
         ],
         registry_names: Optional[Sequence[str]] = None,
+        registry_calling_conventions: Optional[Sequence[CallingConvention]] = None,
     ):
         # Copy reference to each dictionary object into attribute list
         self.registries = list(registries)
@@ -175,6 +202,14 @@ class ConverterRegistry:
         else:
             self.registry_names = [
                 f"Registry {i + 1}" for i in range(len(self.registries))
+            ]
+
+        if registry_calling_conventions is not None:
+            assert len(self.registries) == len(registry_calling_conventions)
+            self.registry_calling_conventions = list(registry_calling_conventions)
+        else:
+            self.registry_calling_conventions = [
+                CallingConvention.CTX for _ in range(len(self.registries))
             ]
 
         self.validate_invariants()
@@ -202,12 +237,13 @@ class ConverterRegistry:
 
     def __getitem_without_validation__(
         self, key: Target
-    ) -> (
-        Any
-    ):  # TODO: Narrow to ConverterImplSignature this when we can remove FX converters
+    ) -> Tuple[
+        Any, CallingConvention
+    ]:  # TODO: Narrow to ConverterImplSignature this when we can remove FX converters
         """Get the first-found converter in any registry
 
-        Searches all registries in order and returns the first converter encountered
+        Searches all registries in order and returns the first converter encountered,
+        along with the calling convention of the registry the converter was sourced from
         """
         if isinstance(key, Node):
             raise KeyError(
@@ -218,26 +254,29 @@ class ConverterRegistry:
         self.validate_invariants()
 
         # Iterate over all registries and return the first converter found
-        for registry in self.registries:
+        for registry, calling_convention in zip(
+            self.registries, self.registry_calling_conventions
+        ):
             if key in registry:
                 converters = registry[key]
 
                 if isinstance(converters, (list, tuple)):
-                    return converters[0].converter_implementation
+                    return converters[0].converter_implementation, calling_convention
                 else:
-                    return converters
+                    return converters, calling_convention
 
         raise KeyError(f"None of the converter registries have an entry for {key}")
 
     def __getitem__(
         self, node: Node
-    ) -> (
-        Any
-    ):  # TODO: Narrow to ConverterImplSignature this when we can remove FX converters
+    ) -> Tuple[
+        Any, CallingConvention
+    ]:  # TODO: Narrow to ConverterImplSignature this when we can remove FX converters
         """Get the first-found validated converter in any registry
 
-        Searches all registries in order and returns the first converter
-        which passes validation on the input node
+        Searches all registries in order and returns the first converter which passes
+        validation on the input node, along with the calling convention of the
+        registry the converter was sourced from
         """
         if not isinstance(node, Node):
             raise KeyError(
@@ -251,16 +290,21 @@ class ConverterRegistry:
 
         # Iterate over all registries, validating the converter on the input node
         # If no capability_validator function is found, assume full coverage
-        for registry in self.registries:
+        for registry, calling_convention in zip(
+            self.registries, self.registry_calling_conventions
+        ):
             if key in registry:
                 converters = registry[key]
 
                 if isinstance(converters, (list, tuple)):
                     for candidate in converters:
                         if candidate.capability_validator(node):
-                            return candidate.converter_implementation
+                            return (
+                                candidate.converter_implementation,
+                                calling_convention,
+                            )
                 else:
-                    return converters
+                    return converters, calling_convention
 
         raise KeyError(
             f"None of the converter registries have a validated entry for {key}, with node {node}"
@@ -272,9 +316,9 @@ class ConverterRegistry:
 
     def get_unvalidated(
         self, key: Target, value: Optional[ConverterImplSignature] = None
-    ) -> (
-        Any
-    ):  # TODO: Narrow to ConverterImplSignature this when we can remove FX converters
+    ) -> Union[
+        Any, Tuple[Any, CallingConvention]
+    ]:  # TODO: Narrow to ConverterImplSignature this when we can remove FX converters
         """Get unvalidated converter for input target with a default return"""
         try:
             return self.__getitem_without_validation__(key)
@@ -283,9 +327,9 @@ class ConverterRegistry:
 
     def get(
         self, node: Node, value: Optional[ConverterImplSignature] = None
-    ) -> (
-        Any
-    ):  # TODO: Narrow to ConverterImplSignature this when we can remove FX converters
+    ) -> Union[
+        Any, Tuple[Any, CallingConvention]
+    ]:  # TODO: Narrow to ConverterImplSignature this when we can remove FX converters
         """Get validated converter for input node with a default return"""
         try:
             return self.__getitem__(node)
@@ -398,5 +442,6 @@ class ConverterRegistry:
 # Note the Dynamo registry is listed first, for precedence
 DYNAMO_CONVERTERS: ConverterRegistry = ConverterRegistry(
     [DYNAMO_ATEN_CONVERTERS, CONVERTERS],  # type: ignore[list-item]
-    ["Dynamo ATen Converters Registry", "FX ATen Converters Registry"],
+    ["Dynamo ATen Converters Registry", "FX Legacy ATen Converters Registry"],
+    [CallingConvention.CTX, CallingConvention.LEGACY],
 )

--- a/py/torch_tensorrt/dynamo/conversion/converter_registry.py
+++ b/py/torch_tensorrt/dynamo/conversion/converter_registry.py
@@ -67,7 +67,7 @@ def dynamo_tensorrt_converter(
     enabled: bool = True,
     capability_validator: Optional[Callable[[Node], bool]] = None,
     priority: ConverterPriority = ConverterPriority.STANDARD,
-) -> Callable[[Any], Union[TRTTensor, Sequence[TRTTensor]]]:
+) -> Callable[[ConverterImplSignature], ConverterImplSignature]:
     """Decorator for Dynamo TensorRT Converter
 
     Registers the decorated function in the DYNAMO_ATEN_CONVERTERS registry

--- a/py/torch_tensorrt/dynamo/conversion/impl/condition/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/condition/ops.py
@@ -4,17 +4,18 @@ import tensorrt as trt
 import torch
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import (
     broadcastable,
     get_trt_tensor,
 )
 from torch_tensorrt.dynamo.conversion.impl.slice import expand
 from torch_tensorrt.fx.converters.converter_utils import broadcast, set_layer_name
-from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
+from torch_tensorrt.fx.types import TRTTensor
 
 
 def where(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -39,10 +40,10 @@ def where(
     # purpose of this is to bring input and other rank same as
     # output_shape to input it to the add_expand operation
     # condition will have dimension of either input or other
-    input, other = broadcast(network, input, other, f"{name}_x", f"{name}_y")
+    input, other = broadcast(ctx.net, input, other, f"{name}_x", f"{name}_y")
     if len(tuple(condition.shape)) != len(tuple(input.shape)):
         condition, input = broadcast(
-            network, condition, input, f"{name}_condition", f"{name}_x"
+            ctx.net, condition, input, f"{name}_condition", f"{name}_x"
         )
 
     x_shape = list(input.shape)
@@ -56,8 +57,8 @@ def where(
         if condition_shape != output_shape:
             condition.expand(output_shape)
         condition = condition.to(torch.int32)
-        condition_const = get_trt_tensor(network, condition, f"{name}_condition")
-        condition_layer = network.add_identity(condition_const)
+        condition_const = get_trt_tensor(ctx, condition, f"{name}_condition")
+        condition_layer = ctx.net.add_identity(condition_const)
         condition_layer.set_output_type(0, trt.bool)
         set_layer_name(condition_layer, target, f"{name}_condition")
         condition_val = condition_layer.get_output(0)
@@ -65,7 +66,7 @@ def where(
         assert condition.dtype == trt.bool, "mask dtype is not bool!"
         if len(condition_shape) != condition_dim:
             condition_val = expand(
-                network, target, source_ir, f"{name}_expand", condition, output_shape
+                ctx, target, source_ir, f"{name}_expand", condition, output_shape
             )
         else:
             condition_val = condition
@@ -76,12 +77,12 @@ def where(
             if len(input.shape) == 0:
                 input = input.unsqueeze(0)
             input = input.expand(output_shape)
-        x_val = get_trt_tensor(network, input, f"{name}_x")
+        x_val = get_trt_tensor(ctx, input, f"{name}_x")
     else:
         x_val = input
         if x_shape != output_shape:
             x_val = expand(
-                network, target, source_ir, f"{name}_x_expand", input, output_shape
+                ctx, target, source_ir, f"{name}_x_expand", input, output_shape
             )
 
     if type(other) != TRTTensor:
@@ -90,15 +91,15 @@ def where(
             if len(other.shape) == 0:
                 other = other.unsqueeze(0)
             other = other.expand(output_shape)
-        y_val = get_trt_tensor(network, other, f"{name}_y")
+        y_val = get_trt_tensor(ctx, other, f"{name}_y")
     else:
         y_val = other
         if y_shape != output_shape:
             y_val = expand(
-                network, target, source_ir, f"{name}_y_expand", y_val, output_shape
+                ctx, target, source_ir, f"{name}_y_expand", y_val, output_shape
             )
 
-    select_layer = network.add_select(condition_val, x_val, y_val)
+    select_layer = ctx.net.add_select(condition_val, x_val, y_val)
 
     set_layer_name(select_layer, target, f"{name}_select")
 

--- a/py/torch_tensorrt/dynamo/conversion/impl/conv.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/conv.py
@@ -7,6 +7,7 @@ import tensorrt as trt
 import torch
 from torch.fx.node import Target
 from torch_tensorrt.dynamo.conversion import impl
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import (
     extend_attr_to_tuple,
     get_trt_tensor,
@@ -19,11 +20,11 @@ from torch_tensorrt.fx.converters.converter_utils import (
     set_layer_name,
     to_numpy,
 )
-from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
+from torch_tensorrt.fx.types import TRTTensor
 
 
 def convNd(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Union[Target, str],
     source_ir: Optional[SourceIR],
     name: str,
@@ -44,7 +45,7 @@ def convNd(
     if is_conv1d:
         # Apply an unsqueeze operation to transform the conv1d problem into conv2d
         input = impl.unsqueeze.unsqueeze(
-            network, target, source_ir, name + "_unsqueeze_conv1d", input, -1
+            ctx, target, source_ir, name + "_unsqueeze_conv1d", input, -1
         )
 
     # Process bias terms
@@ -53,7 +54,7 @@ def convNd(
         bias = to_numpy(bias)
 
     elif isinstance(bias, TRTTensor):
-        bias = get_trt_tensor(network, bias, f"{name}_bias")
+        bias = get_trt_tensor(ctx, bias, f"{name}_bias")
 
     elif bias is not None:
         raise RuntimeError(
@@ -61,12 +62,12 @@ def convNd(
         )
 
     # Process weight terms
-    if network.has_explicit_precision or isinstance(weight, TRTTensor):
-        weight = get_trt_tensor(network, weight, f"{name}_weight")
+    if ctx.net.has_explicit_precision or isinstance(weight, TRTTensor):
+        weight = get_trt_tensor(ctx, weight, f"{name}_weight")
         # Append new dimension (unsqueeze) if the convolution is 1d
         if is_conv1d:
             input = impl.unsqueeze.unsqueeze(
-                network, target, source_ir, name + "_unsqueeze_weight", weight, -1
+                ctx, target, source_ir, name + "_unsqueeze_weight", weight, -1
             )
 
     elif isinstance(weight, (torch.Tensor, np.ndarray)):
@@ -83,7 +84,7 @@ def convNd(
         )
 
     # add conv layer
-    conv_layer = network.add_convolution_nd(
+    conv_layer = ctx.net.add_convolution_nd(
         input=input,
         num_output_maps=weight.shape[0],
         kernel_shape=weight.shape[2:],
@@ -134,7 +135,7 @@ def convNd(
     if is_conv1d:
         # Apply a squeeze operation to transform the conv2d problem back into conv1d
         result = impl.squeeze.squeeze(
-            network, target, source_ir, name + "_squeeze_conv1d", result, -1
+            ctx, target, source_ir, name + "_squeeze_conv1d", result, -1
         )
 
     return result

--- a/py/torch_tensorrt/dynamo/conversion/impl/conv.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/conv.py
@@ -9,16 +9,16 @@ from torch.fx.node import Target
 from torch_tensorrt.dynamo.conversion import impl
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import (
+    SourceIR,
     extend_attr_to_tuple,
     get_trt_tensor,
+    to_numpy,
 )
 from torch_tensorrt.fx.converters.converter_utils import (
-    SourceIR,
     get_dyn_range,
     has_dynamic_shape,
     mark_as_int8_layer,
     set_layer_name,
-    to_numpy,
 )
 from torch_tensorrt.fx.types import TRTTensor
 

--- a/py/torch_tensorrt/dynamo/conversion/impl/deconv.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/deconv.py
@@ -11,6 +11,7 @@ from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContex
 from torch_tensorrt.dynamo.conversion.converter_utils import (
     extend_attr_to_tuple,
     get_trt_tensor,
+    to_numpy,
 )
 from torch_tensorrt.fx.converters.converter_utils import (
     SourceIR,
@@ -18,7 +19,6 @@ from torch_tensorrt.fx.converters.converter_utils import (
     has_dynamic_shape,
     mark_as_int8_layer,
     set_layer_name,
-    to_numpy,
 )
 from torch_tensorrt.fx.types import TRTTensor
 

--- a/py/torch_tensorrt/dynamo/conversion/impl/elementwise/base.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/elementwise/base.py
@@ -7,12 +7,13 @@ import tensorrt as trt
 import torch
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import (
     cast_trt_tensor,
     get_trt_tensor,
 )
 from torch_tensorrt.fx.converters.converter_utils import broadcast, set_layer_name
-from torch_tensorrt.fx.types import TRTElementWiseOp, TRTNetwork, TRTTensor
+from torch_tensorrt.fx.types import TRTElementWiseOp, TRTTensor
 from torch_tensorrt.fx.utils import Frameworks, unified_dtype_converter
 
 
@@ -52,7 +53,7 @@ def get_python_op_from_trt_elementwise_op(
 
 
 def convert_binary_elementwise(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -73,7 +74,7 @@ def convert_binary_elementwise(
     tensor are not allowed to have larger ranks than the trt tensor operand.
 
     Args:
-        network (TRTNetwork): TensorRT network object.
+        ctx (ConversionContext): TensorRT ConversionContext object.
         target (Target): Target of fx node.
         source_ir (SourceIR): The IR that is calling the function.
         name (str): The name we want to assign to the created TensorRT layer.
@@ -128,8 +129,8 @@ def convert_binary_elementwise(
             [lhs_val], dtype=unified_dtype_converter(rhs_dtype, Frameworks.NUMPY)
         )
 
-    lhs_val = get_trt_tensor(network, lhs_val, f"{name}_lhs", lhs_dtype)
-    rhs_val = get_trt_tensor(network, rhs_val, f"{name}_rhs", rhs_dtype)
+    lhs_val = get_trt_tensor(ctx, lhs_val, f"{name}_lhs", lhs_dtype)
+    rhs_val = get_trt_tensor(ctx, rhs_val, f"{name}_rhs", rhs_dtype)
 
     promoted_type = torch.promote_types(
         unified_dtype_converter(lhs_val.dtype, Frameworks.TORCH),
@@ -139,15 +140,15 @@ def convert_binary_elementwise(
 
     if trt_promoted_type != lhs_val.dtype:
         lhs_val = cast_trt_tensor(
-            network, lhs_val, trt_promoted_type, name, target, source_ir
+            ctx, lhs_val, trt_promoted_type, name, target, source_ir
         )
     if trt_promoted_type != rhs_val.dtype:
         rhs_val = cast_trt_tensor(
-            network, rhs_val, trt_promoted_type, name, target, source_ir
+            ctx, rhs_val, trt_promoted_type, name, target, source_ir
         )
 
     # Check the limitation in the doc string.
-    if network.has_implicit_batch_dimension:
+    if ctx.net.has_implicit_batch_dimension:
         if is_lhs_trt_tensor and not is_rhs_trt_tensor:
             assert len(lhs_val.shape) >= len(
                 rhs_val.shape
@@ -158,9 +159,9 @@ def convert_binary_elementwise(
             ), f"{rhs_val.shape} >= {lhs_val.shape}"
 
     lhs_val, rhs_val = broadcast(
-        network, lhs_val, rhs_val, f"{name}_lhs", f"{name}_rhs"
+        ctx.net, lhs_val, rhs_val, f"{name}_lhs", f"{name}_rhs"
     )
-    layer = network.add_elementwise(lhs_val, rhs_val, op_type)
+    layer = ctx.net.add_elementwise(lhs_val, rhs_val, op_type)
     set_layer_name(layer, target, name, source_ir)
     output = layer.get_output(0)
     kind: str = str(target.__name__) if callable(target) else target

--- a/py/torch_tensorrt/dynamo/conversion/impl/elementwise/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/elementwise/ops.py
@@ -4,6 +4,7 @@ import numpy as np
 import tensorrt as trt
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import (
     cast_int_int_div_trt_tensor,
     cast_int_or_float_to_bool,
@@ -15,12 +16,12 @@ from torch_tensorrt.dynamo.conversion.impl.elementwise.base import (
 from torch_tensorrt.dynamo.conversion.impl.unary import sign
 from torch_tensorrt.dynamo.conversion.impl.unary.base import convert_unary
 from torch_tensorrt.fx.converters.converter_utils import set_layer_name, squeeze_left
-from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
+from torch_tensorrt.fx.types import TRTTensor
 from torch_tensorrt.fx.utils import Frameworks, unified_dtype_converter
 
 
 def trunc_div(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -33,7 +34,7 @@ def trunc_div(
     it will be ceil round. Example: [2.1, 0.8, -3.2] -> [2, 0, -3].
 
     Args:
-        network: INetworkDefinition.
+        ctx: ConversionContext.
         target: node target
         source_ir (SourceIR): Source IR calling the function.
         name: namespace for the op
@@ -44,7 +45,7 @@ def trunc_div(
         A TensorRT tensor represent the result of trunc divide.
     """
     prod_output = convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         f"{name}_prod",
@@ -54,7 +55,7 @@ def trunc_div(
     )
 
     sign_output = sign(
-        network,
+        ctx,
         target,
         source_ir,
         name,
@@ -63,17 +64,17 @@ def trunc_div(
 
     # Convert constant input into ITensor for UnaryOperation
     if not isinstance(input, trt.tensorrt.ITensor):
-        input = get_trt_tensor(network, input, f"{name}_input")
+        input = get_trt_tensor(ctx, input, f"{name}_input")
     if not isinstance(other, trt.tensorrt.ITensor):
         other = get_trt_tensor(
-            network,
+            ctx,
             other,
             f"{name}_other",
             dtype=unified_dtype_converter(input.dtype, Frameworks.TORCH),
         )
 
     abs_input_output = convert_unary(
-        network,
+        ctx,
         target,
         source_ir,
         f"{name}_abs_input",
@@ -81,7 +82,7 @@ def trunc_div(
         input,
     )
     abs_other_output = convert_unary(
-        network,
+        ctx,
         target,
         source_ir,
         f"{name}_abs_other",
@@ -89,7 +90,7 @@ def trunc_div(
         other,
     )
     abs_floor_output = convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         f"{name}_floor_div",
@@ -98,7 +99,7 @@ def trunc_div(
         abs_other_output,
     )
     output = convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         f"{name}_output",
@@ -111,14 +112,14 @@ def trunc_div(
 
 
 def rsqrt(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
     input: TRTTensor,
 ) -> TRTTensor:
     sqrt_trt_output = convert_unary(
-        network,
+        ctx,
         target,
         source_ir,
         f"{name}_sqrt",
@@ -127,7 +128,7 @@ def rsqrt(
     )
 
     output = convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         f"{name}_output",
@@ -140,7 +141,7 @@ def rsqrt(
 
 
 def fmod(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -149,7 +150,7 @@ def fmod(
 ) -> TRTTensor:
     # NOTE: TRT doesnt currently implement fmod so we need multiple operations to perform it
     trunc_div_value = trunc_div(
-        network,
+        ctx,
         target,
         source_ir,
         name + "_trunc_div",
@@ -157,7 +158,7 @@ def fmod(
         other,
     )
     prod_value = convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         name + "_prod",
@@ -166,7 +167,7 @@ def fmod(
         other,
     )
     sub_value = convert_binary_elementwise(
-        network,
+        ctx,
         target,
         SourceIR.ACC,
         name + "_sub",
@@ -178,7 +179,7 @@ def fmod(
 
 
 def clamp(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -193,7 +194,7 @@ def clamp(
         )
 
     def _add_layer(
-        network: TRTNetwork,
+        ctx: ConversionContext,
         input: TRTTensor,
         val: float,
         op: trt.ElementWiseOperation,
@@ -204,7 +205,7 @@ def clamp(
         if not len(input.shape):
             # clamping scalar
             acc_ops_clamp_trt = get_trt_tensor(
-                network,
+                ctx,
                 squeeze_left(
                     np.array(
                         [val],
@@ -220,21 +221,21 @@ def clamp(
                 val,
                 dtype=unified_dtype_converter(input.dtype, Frameworks.NUMPY),
             )
-            acc_ops_clamp_trt = network.add_constant(
+            acc_ops_clamp_trt = ctx.net.add_constant(
                 acc_ops_clamp_shape, acc_ops_clamp_tensor
             ).get_output(0)
-        layer = network.add_elementwise(input, acc_ops_clamp_trt, op)
+        layer = ctx.net.add_elementwise(input, acc_ops_clamp_trt, op)
         return layer
 
     if min_val is not None:
         clamp_min_layer = _add_layer(
-            network, input_val, min_val, trt.ElementWiseOperation.MAX, name
+            ctx, input_val, min_val, trt.ElementWiseOperation.MAX, name
         )
         set_layer_name(clamp_min_layer, target, f"{name}_clamp_min")
         input_val = clamp_min_layer.get_output(0)
     if max_val is not None:
         clamp_max_layer = _add_layer(
-            network, input_val, max_val, trt.ElementWiseOperation.MIN, name
+            ctx, input_val, max_val, trt.ElementWiseOperation.MIN, name
         )
         set_layer_name(clamp_max_layer, target, f"{name}_clamp_max")
         input_val = clamp_max_layer.get_output(0)
@@ -243,7 +244,7 @@ def clamp(
 
 
 def add(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -251,12 +252,12 @@ def add(
     rhs_val: Union[TRTTensor, int, float],
 ) -> TRTTensor:
     return convert_binary_elementwise(
-        network, target, source_ir, name, trt.ElementWiseOperation.SUM, lhs_val, rhs_val
+        ctx, target, source_ir, name, trt.ElementWiseOperation.SUM, lhs_val, rhs_val
     )
 
 
 def mul(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -264,7 +265,7 @@ def mul(
     rhs_val: Union[TRTTensor, int, float],
 ) -> TRTTensor:
     return convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         name,
@@ -275,7 +276,7 @@ def mul(
 
 
 def max(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -283,12 +284,12 @@ def max(
     rhs_val: Union[TRTTensor, int, float],
 ) -> TRTTensor:
     return convert_binary_elementwise(
-        network, target, source_ir, name, trt.ElementWiseOperation.MAX, lhs_val, rhs_val
+        ctx, target, source_ir, name, trt.ElementWiseOperation.MAX, lhs_val, rhs_val
     )
 
 
 def min(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -296,12 +297,12 @@ def min(
     rhs_val: Union[TRTTensor, int, float],
 ) -> TRTTensor:
     return convert_binary_elementwise(
-        network, target, source_ir, name, trt.ElementWiseOperation.MIN, lhs_val, rhs_val
+        ctx, target, source_ir, name, trt.ElementWiseOperation.MIN, lhs_val, rhs_val
     )
 
 
 def sub(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -309,12 +310,12 @@ def sub(
     rhs_val: Union[TRTTensor, int, float],
 ) -> TRTTensor:
     return convert_binary_elementwise(
-        network, target, source_ir, name, trt.ElementWiseOperation.SUB, lhs_val, rhs_val
+        ctx, target, source_ir, name, trt.ElementWiseOperation.SUB, lhs_val, rhs_val
     )
 
 
 def div(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -322,15 +323,15 @@ def div(
     rhs_val: Union[TRTTensor, int, float],
 ) -> TRTTensor:
     if isinstance(lhs_val, TRTTensor) and isinstance(rhs_val, TRTTensor):
-        lhs_val, rhs_val = cast_int_int_div_trt_tensor(network, lhs_val, rhs_val, name)
+        lhs_val, rhs_val = cast_int_int_div_trt_tensor(ctx, lhs_val, rhs_val, name)
 
     return convert_binary_elementwise(
-        network, target, source_ir, name, trt.ElementWiseOperation.DIV, lhs_val, rhs_val
+        ctx, target, source_ir, name, trt.ElementWiseOperation.DIV, lhs_val, rhs_val
     )
 
 
 def pow(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -338,15 +339,15 @@ def pow(
     rhs_val: Union[TRTTensor, int, float],
 ) -> TRTTensor:
     if isinstance(lhs_val, TRTTensor) and isinstance(rhs_val, TRTTensor):
-        lhs_val, rhs_val = cast_int_int_div_trt_tensor(network, lhs_val, rhs_val, name)
+        lhs_val, rhs_val = cast_int_int_div_trt_tensor(ctx, lhs_val, rhs_val, name)
 
     return convert_binary_elementwise(
-        network, target, source_ir, name, trt.ElementWiseOperation.POW, lhs_val, rhs_val
+        ctx, target, source_ir, name, trt.ElementWiseOperation.POW, lhs_val, rhs_val
     )
 
 
 def floor_divide(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -354,7 +355,7 @@ def floor_divide(
     rhs_val: Union[TRTTensor, int, float],
 ) -> TRTTensor:
     return convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         name,
@@ -365,7 +366,7 @@ def floor_divide(
 
 
 def logical_and(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -373,18 +374,18 @@ def logical_and(
     rhs_val: Union[TRTTensor, int, float],
 ) -> TRTTensor:
     if isinstance(lhs_val, TRTTensor):
-        lhs_val = cast_int_or_float_to_bool(network, name, lhs_val)
+        lhs_val = cast_int_or_float_to_bool(ctx, name, lhs_val)
 
     if isinstance(rhs_val, TRTTensor):
-        rhs_val = cast_int_or_float_to_bool(network, name, rhs_val)
+        rhs_val = cast_int_or_float_to_bool(ctx, name, rhs_val)
 
     return convert_binary_elementwise(
-        network, target, source_ir, name, trt.ElementWiseOperation.AND, lhs_val, rhs_val
+        ctx, target, source_ir, name, trt.ElementWiseOperation.AND, lhs_val, rhs_val
     )
 
 
 def logical_or(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -392,18 +393,18 @@ def logical_or(
     rhs_val: Union[TRTTensor, int, float],
 ) -> TRTTensor:
     if isinstance(lhs_val, TRTTensor):
-        lhs_val = cast_int_or_float_to_bool(network, name, lhs_val)
+        lhs_val = cast_int_or_float_to_bool(ctx, name, lhs_val)
 
     if isinstance(rhs_val, TRTTensor):
-        rhs_val = cast_int_or_float_to_bool(network, name, rhs_val)
+        rhs_val = cast_int_or_float_to_bool(ctx, name, rhs_val)
 
     return convert_binary_elementwise(
-        network, target, source_ir, name, trt.ElementWiseOperation.OR, lhs_val, rhs_val
+        ctx, target, source_ir, name, trt.ElementWiseOperation.OR, lhs_val, rhs_val
     )
 
 
 def logical_xor(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -411,18 +412,18 @@ def logical_xor(
     rhs_val: Union[TRTTensor, int, float],
 ) -> TRTTensor:
     if isinstance(lhs_val, TRTTensor):
-        lhs_val = cast_int_or_float_to_bool(network, name, lhs_val)
+        lhs_val = cast_int_or_float_to_bool(ctx, name, lhs_val)
 
     if isinstance(rhs_val, TRTTensor):
-        rhs_val = cast_int_or_float_to_bool(network, name, rhs_val)
+        rhs_val = cast_int_or_float_to_bool(ctx, name, rhs_val)
 
     return convert_binary_elementwise(
-        network, target, source_ir, name, trt.ElementWiseOperation.XOR, lhs_val, rhs_val
+        ctx, target, source_ir, name, trt.ElementWiseOperation.XOR, lhs_val, rhs_val
     )
 
 
 def eq(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -430,7 +431,7 @@ def eq(
     rhs_val: Union[TRTTensor, int, float],
 ) -> TRTTensor:
     return convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         name,
@@ -441,7 +442,7 @@ def eq(
 
 
 def gt(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -449,7 +450,7 @@ def gt(
     rhs_val: Union[TRTTensor, int, float],
 ) -> TRTTensor:
     return convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         name,
@@ -460,7 +461,7 @@ def gt(
 
 
 def lt(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -468,7 +469,7 @@ def lt(
     rhs_val: Union[TRTTensor, int, float],
 ) -> TRTTensor:
     return convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         name,

--- a/py/torch_tensorrt/dynamo/conversion/impl/matmul.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/matmul.py
@@ -3,14 +3,15 @@ from typing import Optional
 import tensorrt as trt
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import get_trt_tensor
 from torch_tensorrt.fx.converters.converter_utils import broadcast, set_layer_name
-from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
+from torch_tensorrt.fx.types import TRTTensor
 from torch_tensorrt.fx.utils import Frameworks, unified_dtype_converter
 
 
 def matrix_multiply(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -20,10 +21,10 @@ def matrix_multiply(
     other_matrix_op: trt.MatrixOperation = trt.MatrixOperation.NONE,
 ) -> TRTTensor:
     if not isinstance(input, trt.tensorrt.ITensor):
-        input = get_trt_tensor(network, input, f"{name}_input")
+        input = get_trt_tensor(ctx, input, f"{name}_input")
     if not isinstance(other, trt.tensorrt.ITensor):
         other = get_trt_tensor(
-            network,
+            ctx,
             other,
             f"{name}_other",
             dtype=unified_dtype_converter(input.dtype, Frameworks.TORCH),
@@ -40,8 +41,8 @@ def matrix_multiply(
         other_matrix_op = trt.MatrixOperation.VECTOR
 
     input, other = broadcast(
-        network, input, other, f"{name}_input", f"{name}_other", preset_diff
+        ctx.net, input, other, f"{name}_input", f"{name}_other", preset_diff
     )
-    layer = network.add_matrix_multiply(input, input_matrix_op, other, other_matrix_op)
+    layer = ctx.net.add_matrix_multiply(input, input_matrix_op, other, other_matrix_op)
     set_layer_name(layer, target, name, source_ir)
     return layer.get_output(0)

--- a/py/torch_tensorrt/dynamo/conversion/impl/normalization/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/normalization/ops.py
@@ -7,7 +7,7 @@ import torch
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
-from torch_tensorrt.dynamo.conversion.converter_utils import get_positive_dim
+from torch_tensorrt.dynamo.conversion.converter_utils import get_positive_dim, to_numpy
 from torch_tensorrt.dynamo.conversion.impl.elementwise.base import (
     convert_binary_elementwise,
 )
@@ -16,7 +16,6 @@ from torch_tensorrt.fx.converters.converter_utils import (
     get_trt_plugin,
     has_dynamic_shape,
     set_layer_name,
-    to_numpy,
 )
 from torch_tensorrt.fx.types import TRTTensor
 from torch_tensorrt.fx.utils import get_dynamic_dims

--- a/py/torch_tensorrt/dynamo/conversion/impl/normalization/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/normalization/ops.py
@@ -6,6 +6,7 @@ import tensorrt as trt
 import torch
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import get_positive_dim
 from torch_tensorrt.dynamo.conversion.impl.elementwise.base import (
     convert_binary_elementwise,
@@ -17,14 +18,14 @@ from torch_tensorrt.fx.converters.converter_utils import (
     set_layer_name,
     to_numpy,
 )
-from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
+from torch_tensorrt.fx.types import TRTTensor
 from torch_tensorrt.fx.utils import get_dynamic_dims
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
 def batch_norm(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -55,11 +56,11 @@ def batch_norm(
 
     # For BatchNorm1d, reshape 1d to 2d
     output_shape = input.shape
-    if not network.has_implicit_batch_dimension and len(input.shape) < 4:
+    if not ctx.net.has_implicit_batch_dimension and len(input.shape) < 4:
         assert (
             len(get_dynamic_dims(input.shape)) <= 1
         ), "BatchNorm1D with more than one dynamic dims is not currently supported."
-        reshape_layer = network.add_shuffle(input)
+        reshape_layer = ctx.net.add_shuffle(input)
         if len(input.shape) == 2:
             reshape_layer.reshape_dims = (input.shape[0], input.shape[1], 1, 1)
         else:  # len(input_val.shape) == 3
@@ -71,12 +72,12 @@ def batch_norm(
             )
         set_layer_name(reshape_layer, target, f"{name}_reshape_2d")
         input = reshape_layer.get_output(0)
-    layer = network.add_scale(input, trt.ScaleMode.CHANNEL, bias, scale, power)
+    layer = ctx.net.add_scale(input, trt.ScaleMode.CHANNEL, bias, scale, power)
     set_layer_name(layer, target, name)
 
     # For BatchNorm1d, reshape output back to 1d
-    if not network.has_implicit_batch_dimension and len(output_shape) < 4:
-        reshape_output_layer = network.add_shuffle(layer.get_output(0))
+    if not ctx.net.has_implicit_batch_dimension and len(output_shape) < 4:
+        reshape_output_layer = ctx.net.add_shuffle(layer.get_output(0))
         reshape_output_layer.reshape_dims = tuple(output_shape)
         set_layer_name(reshape_output_layer, target, f"{name}_reshape_1d")
         layer = reshape_output_layer
@@ -84,7 +85,7 @@ def batch_norm(
 
 
 def layer_norm(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -127,7 +128,7 @@ def layer_norm(
     )
 
     try:
-        if network.has_implicit_batch_dimension:
+        if ctx.net.has_implicit_batch_dimension:
             plugin = get_trt_plugin("layer_norm", field_collection, "1", "fx2trt")
         else:
             plugin = get_trt_plugin("LayerNormDynamic", field_collection, "1", "fx2trt")
@@ -136,15 +137,15 @@ def layer_norm(
             "Unable to find layer norm plugin, fall back to TensorRT implementation."
         )
         return layer_norm_no_plugin(
-            network, target, source_ir, name, input, normalized_shape, weight, bias, eps
+            ctx, target, source_ir, name, input, normalized_shape, weight, bias, eps
         )
-    layer = network.add_plugin_v2([input], plugin)
+    layer = ctx.net.add_plugin_v2([input], plugin)
     layer.name = name
     return layer.get_output(0)
 
 
 def layer_norm_no_plugin(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -170,14 +171,14 @@ def layer_norm_no_plugin(
         axes |= 1 << (len(input.shape) - d - 1)
 
     # E[x]
-    mean_expected_layer = network.add_reduce(
+    mean_expected_layer = ctx.net.add_reduce(
         input, trt.ReduceOperation.AVG, axes, keep_dims=True
     )
     set_layer_name(mean_expected_layer, target, f"{name}_mean_expected")
 
     # X-E[x]
     sub_trt = convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         f"{name}_sub",
@@ -186,13 +187,13 @@ def layer_norm_no_plugin(
         mean_expected_layer.get_output(0),
     )
     # Variance = mean(pow(x_sub_mean,2))
-    pow_tensor = network.add_constant(
+    pow_tensor = ctx.net.add_constant(
         (1,) * len(input.shape),
         trt.Weights(np.ascontiguousarray([2.0], dtype=np.float32)),
     )
     pow_tensor.name = f"{name}_power"
     pow_var = convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         f"{name}_pow_var",
@@ -200,18 +201,18 @@ def layer_norm_no_plugin(
         sub_trt,
         pow_tensor.get_output(0),
     )
-    mean_trt_layer = network.add_reduce(
+    mean_trt_layer = ctx.net.add_reduce(
         pow_var, trt.ReduceOperation.AVG, axes, keep_dims=True
     )
     set_layer_name(mean_trt_layer, target, f"{name}_mean")
     # Variance + eps
-    eps_tensor = network.add_constant(
+    eps_tensor = ctx.net.add_constant(
         (1,) * len(input.shape),
         trt.Weights(np.ascontiguousarray([eps], dtype=np.float32)),
     )
     eps_tensor.name = f"{name}_eps"
     add_trt = convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         f"{name}_add",
@@ -221,7 +222,7 @@ def layer_norm_no_plugin(
     )
     # SQRT((Var + eps))
     sqrt_trt = convert_unary(
-        network,
+        ctx,
         target,
         source_ir,
         f"{name}_sqrt",
@@ -230,7 +231,7 @@ def layer_norm_no_plugin(
     )
     # (x - E[x]) / sqrt((var + eps))
     div_trt = convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         f"{name}_div_trt",
@@ -240,18 +241,18 @@ def layer_norm_no_plugin(
     )
 
     assert gamma is not None
-    gamma_tensor = network.add_constant(
+    gamma_tensor = ctx.net.add_constant(
         gamma.shape, trt.Weights(np.ascontiguousarray(gamma))
     )
     gamma_tensor.name = f"{name}_gamma"
     assert beta is not None
-    beta_tensor = network.add_constant(
+    beta_tensor = ctx.net.add_constant(
         gamma.shape, trt.Weights(np.ascontiguousarray(beta))
     )
     beta_tensor.name = f"{name}_beta"
     # y * gamma + beta
     scale_layer = convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         f"{name}_scale",
@@ -260,7 +261,7 @@ def layer_norm_no_plugin(
         gamma_tensor.get_output(0),
     )
     return convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         name,
@@ -271,14 +272,14 @@ def layer_norm_no_plugin(
 
 
 def softmax(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
     input: TRTTensor,
     dim: Optional[Any] = None,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
-    input_ranks = len(input.shape) + (1 if network.has_implicit_batch_dimension else 0)
+    input_ranks = len(input.shape) + (1 if ctx.net.has_implicit_batch_dimension else 0)
 
     if not isinstance(input, TRTTensor):
         raise RuntimeError(
@@ -300,11 +301,11 @@ def softmax(
         dim = cast(int, dim)
 
     dim = get_positive_dim(dim, input_ranks)
-    if network.has_implicit_batch_dimension:
+    if ctx.net.has_implicit_batch_dimension:
         assert dim != 0, "Can't apply softmax on batch dimension when it's implicit."
         dim -= 1
 
-    layer = network.add_softmax(input)
+    layer = ctx.net.add_softmax(input)
     layer.axes = 1 << dim
     set_layer_name(layer, target, name)
     return layer.get_output(0)

--- a/py/torch_tensorrt/dynamo/conversion/impl/permutation.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/permutation.py
@@ -2,13 +2,14 @@ from typing import Optional, Sequence
 
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import get_positive_dim
 from torch_tensorrt.fx.converters.converter_utils import set_layer_name
-from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
+from torch_tensorrt.fx.types import TRTTensor
 
 
 def permute(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -22,7 +23,7 @@ def permute(
 
     permutation = get_positive_dim(permutation, len(input.shape))
 
-    layer = network.add_shuffle(input)
+    layer = ctx.net.add_shuffle(input)
     layer.second_transpose = tuple(permutation)
     set_layer_name(layer, target, name, source_ir)
     return layer.get_output(0)

--- a/py/torch_tensorrt/dynamo/conversion/impl/pool.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/pool.py
@@ -3,16 +3,17 @@ from typing import Optional, Sequence, Union
 import tensorrt as trt
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import extend_attr_to_tuple
 from torch_tensorrt.fx.converters.converter_utils import (
     has_dynamic_shape,
     set_layer_name,
 )
-from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
+from torch_tensorrt.fx.types import TRTTensor
 
 
 def avg_poolNd(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Union[Target, str],
     source_ir: Optional[SourceIR],
     name: str,
@@ -45,7 +46,7 @@ def avg_poolNd(
     padding = extend_attr_to_tuple(padding, dim)
 
     # add average pooling layer
-    pool_layer = network.add_pooling_nd(
+    pool_layer = ctx.net.add_pooling_nd(
         input=input,
         type=trt.PoolingType.AVERAGE,
         window_size=kernel_size,
@@ -60,7 +61,7 @@ def avg_poolNd(
 
 
 def max_poolNd(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Union[Target, str],
     source_ir: Optional[SourceIR],
     name: str,
@@ -92,7 +93,7 @@ def max_poolNd(
     padding = extend_attr_to_tuple(padding, dim)
 
     # add max pooling layer
-    pool_layer = network.add_pooling_nd(
+    pool_layer = ctx.net.add_pooling_nd(
         input=input,
         type=trt.PoolingType.MAX,
         window_size=kernel_size,

--- a/py/torch_tensorrt/dynamo/conversion/impl/reduce.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/reduce.py
@@ -3,17 +3,18 @@ from typing import Optional, Sequence, Union
 import tensorrt as trt
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import (
     cast_trt_tensor,
     get_axes_for_reduce_op,
     get_positive_dim,
 )
 from torch_tensorrt.fx.converters.converter_utils import set_layer_name
-from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
+from torch_tensorrt.fx.types import TRTTensor
 
 
 def amax(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -24,9 +25,9 @@ def amax(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
-    layer = network.add_reduce(
+    layer = ctx.net.add_reduce(
         input_val,
         trt.ReduceOperation.MAX,
         axes=get_axes_for_reduce_op(get_positive_dim(dim, len(input_val.shape))),
@@ -37,7 +38,7 @@ def amax(
 
 
 def sum(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -48,11 +49,11 @@ def sum(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     if dim is None:
         dim = tuple(range(len(input_val.shape)))
-    layer = network.add_reduce(
+    layer = ctx.net.add_reduce(
         input_val,
         trt.ReduceOperation.SUM,
         axes=get_axes_for_reduce_op(get_positive_dim(dim, len(input_val.shape))),

--- a/py/torch_tensorrt/dynamo/conversion/impl/shape.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/shape.py
@@ -8,10 +8,11 @@ import torch
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
+from torch_tensorrt.dynamo.conversion.converter_utils import to_numpy
 from torch_tensorrt.dynamo.conversion.impl.elementwise.base import (
     convert_binary_elementwise,
 )
-from torch_tensorrt.fx.converters.converter_utils import set_layer_name, to_numpy
+from torch_tensorrt.fx.converters.converter_utils import set_layer_name
 from torch_tensorrt.fx.types import TRTTensor
 
 

--- a/py/torch_tensorrt/dynamo/conversion/impl/shape.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/shape.py
@@ -3,20 +3,20 @@ from __future__ import annotations
 from typing import List, Optional, Tuple
 
 import numpy as np
+import tensorrt as trt
 import torch
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.impl.elementwise.base import (
     convert_binary_elementwise,
 )
 from torch_tensorrt.fx.converters.converter_utils import set_layer_name, to_numpy
-from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
-
-import tensorrt as trt
+from torch_tensorrt.fx.types import TRTTensor
 
 
 def get_shape_with_dynamic_shape(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -37,7 +37,7 @@ def get_shape_with_dynamic_shape(
         5. output shape with actual batch_size as [2048, 128, 256]
 
     Args:
-        network (TRTNetwork): TensorRT network object.
+        ctx (ConversionContext): TensorRT ConversionContext object.
         shape: calculated shape of the expected output tensor
         input_val (TRTTensor): A TensorRT ITensor.
         target (Target): Target of fx node.
@@ -46,22 +46,22 @@ def get_shape_with_dynamic_shape(
         TensorRT ITensors that represents the actual shape of the input_val
     """
     # Ger real shape info for input_val
-    input_shape = network.add_shape(input_val).get_output(0)
+    input_shape = ctx.net.add_shape(input_val).get_output(0)
 
-    scale_layer = network.add_constant(
+    scale_layer = ctx.net.add_constant(
         input_shape.shape, np.ascontiguousarray(shape, dtype=np.int32)
     )
     set_layer_name(scale_layer, target, f"{name}_scale")
     scale_res = scale_layer.get_output(0)
 
     length = input_shape.shape[0]
-    zero_layer = network.add_constant(
+    zero_layer = ctx.net.add_constant(
         input_shape.shape, to_numpy(torch.zeros((length), dtype=torch.int32))
     )
     set_layer_name(zero_layer, target, f"{name}_zeros")
 
     condition_val = convert_binary_elementwise(
-        network,
+        ctx,
         target,
         source_ir,
         f"{name}_shape",
@@ -69,6 +69,6 @@ def get_shape_with_dynamic_shape(
         scale_res,
         zero_layer.get_output(0),
     )
-    select_layer = network.add_select(condition_val, input_shape, scale_res)
+    select_layer = ctx.net.add_select(condition_val, input_shape, scale_res)
     set_layer_name(select_layer, target, f"{name}_select")
     return select_layer.get_output(0)

--- a/py/torch_tensorrt/dynamo/conversion/impl/slice/base.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/slice/base.py
@@ -2,16 +2,17 @@ from typing import Optional
 
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.impl.shape import get_shape_with_dynamic_shape
 from torch_tensorrt.fx.converters.converter_utils import (
     has_dynamic_shape,
     set_layer_name,
 )
-from torch_tensorrt.fx.types import Shape, TRTNetwork, TRTTensor
+from torch_tensorrt.fx.types import Shape, TRTTensor
 
 
 def slice(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -22,10 +23,8 @@ def slice(
 ) -> TRTTensor:
     dynamic_shape = has_dynamic_shape(input.shape)
     if dynamic_shape:
-        shape = get_shape_with_dynamic_shape(
-            network, target, source_ir, name, shape, input
-        )
-    layer = network.add_slice(
+        shape = get_shape_with_dynamic_shape(ctx, target, source_ir, name, shape, input)
+    layer = ctx.net.add_slice(
         input,
         start=start,
         shape=[] if dynamic_shape else shape,

--- a/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import get_positive_dim
 from torch_tensorrt.dynamo.conversion.impl.slice.base import slice
 from torch_tensorrt.fx.converters.converter_utils import (
@@ -10,11 +11,11 @@ from torch_tensorrt.fx.converters.converter_utils import (
     prepend_ones,
     set_layer_name,
 )
-from torch_tensorrt.fx.types import Shape, TRTNetwork, TRTTensor
+from torch_tensorrt.fx.types import Shape, TRTTensor
 
 
 def slice_op(  # TODO: This should be slice not whatever is in base
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -30,10 +31,10 @@ def slice_op(  # TODO: This should be slice not whatever is in base
             "of the TensorRT region!"
         )
 
-    ranks = len(input.shape) + (1 if network.has_implicit_batch_dimension else 0)
+    ranks = len(input.shape) + (1 if ctx.net.has_implicit_batch_dimension else 0)
     dim = get_positive_dim(dim, ranks)
     dynamic_shape = has_dynamic_shape(input.shape)
-    if network.has_implicit_batch_dimension:
+    if ctx.net.has_implicit_batch_dimension:
         if dim == 0:
             raise RuntimeError(
                 f"We do not support slice_tensor at batch dim when it's implicit, got {dim}!"
@@ -56,12 +57,12 @@ def slice_op(  # TODO: This should be slice not whatever is in base
     output_shape[dim] = math.ceil((stop_int - start_int) / step_int)
 
     return slice(
-        network, target, source_ir, name, input, start_slice, output_shape, stride_slice
+        ctx, target, source_ir, name, input, start_slice, output_shape, stride_slice
     )
 
 
 def expand(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -79,7 +80,7 @@ def expand(
     # If the rank of the input tensor is less than the shape's rank, pad with ones
     if initial_tensor_rank < shape_rank:
         input_t = prepend_ones(
-            network,
+            ctx.net,
             input_t,
             name + "_expand_broadcast",
             shape_rank - initial_tensor_rank,
@@ -105,6 +106,6 @@ def expand(
     stride = tuple(
         [int(i == o) for i, o in zip(input_tensor_shape, shape)]
     )  # stride == 1 if dimensions match, 0 otherwise
-    layer = network.add_slice(input_t, start=start, shape=shape, stride=stride)
+    layer = ctx.net.add_slice(input_t, start=start, shape=shape, stride=stride)
     set_layer_name(layer, target, name, source_ir)
     return layer.get_output(0)

--- a/py/torch_tensorrt/dynamo/conversion/impl/unary/base.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/unary/base.py
@@ -1,15 +1,15 @@
 from typing import Optional
 
+import tensorrt as trt
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.fx.converters.converter_utils import set_layer_name
-from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
-
-import tensorrt as trt
+from torch_tensorrt.fx.types import TRTTensor
 
 
 def convert_unary(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -20,7 +20,7 @@ def convert_unary(
     Add a TensorRT Unary layer to `network`.
 
     Args:
-        network (TRTNetwork): TensorRT network object.
+        ctx (ConversionContext): TensorRT ConversionContext object.
         input_val (TRTTensor): Input to the unary op. Must be a TensorRT tensor.
         op_type (trt.ElementWiseOperation): Type of the TensorRT unary operation.
         target (Target): Target of fx node.
@@ -34,7 +34,7 @@ def convert_unary(
             f"{operation_type} received input {input_val} that is not part "
             "of the TensorRT region!"
         )
-    layer = network.add_unary(input_val, operation_type)
+    layer = ctx.net.add_unary(input_val, operation_type)
     set_layer_name(layer, target, name, source_ir)
     output = layer.get_output(0)
     kind: str = str(target.__name__) if callable(target) else target

--- a/py/torch_tensorrt/dynamo/conversion/impl/unary/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/unary/ops.py
@@ -3,13 +3,14 @@ from typing import Optional
 import tensorrt as trt
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import cast_trt_tensor
 from torch_tensorrt.dynamo.conversion.impl.unary.base import convert_unary
-from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
+from torch_tensorrt.fx.types import TRTTensor
 
 
 def exp(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -17,7 +18,7 @@ def exp(
 ) -> TRTTensor:
     """
     Args:
-        network (TRTNetwork): TensorRT network object.
+        ctx (ConversionContext): TensorRT ConversionContext object.
         target (Target): fx node target.
         source_ir (SourceIR): Source IR calling the function
         name (str): Name of the fx node with optional suffix.
@@ -29,15 +30,15 @@ def exp(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.EXP, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.EXP, input_val
     )
 
 
 def log(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -46,15 +47,15 @@ def log(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.LOG, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.LOG, input_val
     )
 
 
 def sqrt(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -63,15 +64,15 @@ def sqrt(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.SQRT, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.SQRT, input_val
     )
 
 
 def recip(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -80,27 +81,27 @@ def recip(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.RECIP, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.RECIP, input_val
     )
 
 
 def abs(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
     input_val: TRTTensor,
 ) -> TRTTensor:
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.ABS, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.ABS, input_val
     )
 
 
 def sin(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -109,15 +110,15 @@ def sin(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.SIN, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.SIN, input_val
     )
 
 
 def cos(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -126,15 +127,15 @@ def cos(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.COS, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.COS, input_val
     )
 
 
 def tan(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -143,15 +144,15 @@ def tan(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.TAN, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.TAN, input_val
     )
 
 
 def sinh(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -160,15 +161,15 @@ def sinh(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.SINH, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.SINH, input_val
     )
 
 
 def cosh(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -177,15 +178,15 @@ def cosh(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.COSH, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.COSH, input_val
     )
 
 
 def asin(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -194,15 +195,15 @@ def asin(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.ASIN, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.ASIN, input_val
     )
 
 
 def acos(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -211,15 +212,15 @@ def acos(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.ACOS, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.ACOS, input_val
     )
 
 
 def atan(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -228,15 +229,15 @@ def atan(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.ATAN, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.ATAN, input_val
     )
 
 
 def asinh(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -245,15 +246,15 @@ def asinh(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.ASINH, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.ASINH, input_val
     )
 
 
 def acosh(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -262,15 +263,15 @@ def acosh(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.ACOSH, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.ACOSH, input_val
     )
 
 
 def atanh(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -279,15 +280,15 @@ def atanh(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.ATANH, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.ATANH, input_val
     )
 
 
 def ceil(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -296,15 +297,15 @@ def ceil(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.CEIL, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.CEIL, input_val
     )
 
 
 def floor(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -313,30 +314,30 @@ def floor(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.FLOOR, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.FLOOR, input_val
     )
 
 
 def logical_not(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
     input_val: TRTTensor,
 ) -> TRTTensor:
     if (isinstance(input_val, TRTTensor)) and input_val.dtype != trt.bool:
-        input_val = cast_trt_tensor(network, input_val, trt.bool, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.bool, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.NOT, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.NOT, input_val
     )
 
 
 def sign(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -345,15 +346,15 @@ def sign(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.SIGN, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.SIGN, input_val
     )
 
 
 def round(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -362,15 +363,15 @@ def round(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.ROUND, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.ROUND, input_val
     )
 
 
 def isinf(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -379,15 +380,15 @@ def isinf(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.ISINF, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.ISINF, input_val
     )
 
 
 def neg(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -396,15 +397,15 @@ def neg(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.NEG, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.NEG, input_val
     )
 
 
 def erf(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
@@ -413,8 +414,8 @@ def erf(
     if (isinstance(input_val, TRTTensor)) and (
         input_val.dtype == trt.int8 or input_val.dtype == trt.int32
     ):
-        input_val = cast_trt_tensor(network, input_val, trt.float32, name)
+        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
 
     return convert_unary(
-        network, target, source_ir, name, trt.UnaryOperation.ERF, input_val
+        ctx, target, source_ir, name, trt.UnaryOperation.ERF, input_val
     )

--- a/py/torch_tensorrt/dynamo/conversion/impl/unsqueeze.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/unsqueeze.py
@@ -2,24 +2,25 @@ from typing import Optional, cast
 
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import (
     get_positive_dim,
     get_trt_tensor,
 )
 from torch_tensorrt.fx.converters.converter_utils import set_layer_name
-from torch_tensorrt.fx.types import Shape, TRTNetwork, TRTTensor
+from torch_tensorrt.fx.types import Shape, TRTTensor
 from torch_tensorrt.fx.utils import get_dynamic_dims
 
 
 def unsqueeze(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
     input_t: TRTTensor,
     dim: Shape,
 ) -> TRTTensor:
-    input_val = get_trt_tensor(network, input_t, f"{name}_input_t")
+    input_val = get_trt_tensor(ctx, input_t, f"{name}_input_t")
     if not isinstance(input_val, TRTTensor):
         raise RuntimeError(
             f"unsqueeze received input {input_val} that is not part "
@@ -30,19 +31,19 @@ def unsqueeze(
 
     input_shape_size = (
         len(input_val.shape) + 1
-        if network.has_implicit_batch_dimension
+        if ctx.net.has_implicit_batch_dimension
         else len(input_val.shape)
     )
     dim = get_positive_dim(dim, input_shape_size + 1)
 
-    if network.has_implicit_batch_dimension:
+    if ctx.net.has_implicit_batch_dimension:
         assert dim != 0
         dim -= 1
 
     assert (
         len(get_dynamic_dims(input_val.shape)) <= 1
     ), "Currently we don't support unsqueeze with more than one dynamic dims."
-    layer = network.add_shuffle(input_val)
+    layer = ctx.net.add_shuffle(input_val)
     layer.reshape_dims = (
         tuple(input_val.shape)[:dim] + (1,) + tuple(input_val.shape)[dim:]
     )

--- a/py/torch_tensorrt/dynamo/conversion/op_evaluators.py
+++ b/py/torch_tensorrt/dynamo/conversion/op_evaluators.py
@@ -3,7 +3,8 @@ import operator
 from typing import Dict, Sequence, Tuple, Union
 
 from torch.fx.node import Argument, Node, Target
-from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
+from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
+from torch_tensorrt.fx.types import TRTTensor
 
 from .converter_registry import ConverterRegistry, dynamo_tensorrt_converter
 
@@ -20,7 +21,7 @@ def getitem_validator(getitem_node: Node) -> bool:
 # TODO: Subsequent evaluators should be registered here with their own validators
 @dynamo_tensorrt_converter(operator.getitem, capability_validator=getitem_validator)
 def generic_evaluator(
-    network: TRTNetwork,
+    ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
     kwargs: Dict[str, Argument],

--- a/py/torch_tensorrt/dynamo/lowering/substitutions/maxpool1d.py
+++ b/py/torch_tensorrt/dynamo/lowering/substitutions/maxpool1d.py
@@ -65,7 +65,7 @@ def maxpool1d_generic(
 #               "bias": bias,
 #               ...
 #
-@register_substitution(torch.nn.MaxPool1d, torch.ops.tensorrt.maxpool1d)  # type: ignore
+@register_substitution(torch.nn.MaxPool1d, torch.ops.tensorrt.maxpool1d)  # type: ignore[misc]
 def maxpool1d_insertion_fn(
     gm: torch.fx.GraphModule,
     node: torch.fx.Node,

--- a/tests/py/dynamo/backend/test_specialized_models.py
+++ b/tests/py/dynamo/backend/test_specialized_models.py
@@ -222,6 +222,7 @@ class TestTensorFreezing(TestCase):
             inputs,
             min_block_size=1,
             pass_through_build_failures=True,
+            truncate_long_and_double=True,
         )
         optimized_model_results = optimized_model(*inputs).detach().cpu()
         torch_model_results = fx_graph(*inputs).detach().cpu()

--- a/tests/py/dynamo/conversion/harness.py
+++ b/tests/py/dynamo/conversion/harness.py
@@ -8,6 +8,7 @@ import torch_tensorrt.fx.tracer.dispatch_tracer.aten_tracer as aten_tracer
 from torch.fx.passes.infra.pass_base import PassResult
 from torch.testing._internal.common_utils import TestCase
 from torch_tensorrt import Input
+from torch_tensorrt.dynamo._settings import CompilationSettings
 
 # Use interpreter, input spec, and test case from fx_ts_compat to test Dynamo Converter Registry
 from torch_tensorrt.dynamo.conversion import TRTInterpreter
@@ -282,10 +283,15 @@ class DispatchTestCase(TRTTestCase):
             pass_tracer = chain_passes(*apply_passes)
             mod = pass_tracer(mod, inputs)
 
+        # Previous instance of the interpreter auto-casted 64-bit inputs
+        # We replicate this behavior here
+        compilation_settings = CompilationSettings(truncate_long_and_double=True)
+
         interp = TRTInterpreter(
             mod,
             Input.from_tensors(inputs),
             output_dtypes=output_dtypes,
+            compilation_settings=compilation_settings,
         )
         super().run_test(
             mod,
@@ -321,10 +327,15 @@ class DispatchTestCase(TRTTestCase):
             disable_passes=disable_passes,
         )
 
+        # Previous instance of the interpreter auto-casted 64-bit inputs
+        # We replicate this behavior here
+        compilation_settings = CompilationSettings(truncate_long_and_double=True)
+
         interp = TRTInterpreter(
             mod,
             input_specs,
             output_dtypes=output_dtypes,
+            compilation_settings=compilation_settings,
         )
         # Since the lowering is based on optimal shape. We need to test with
         # different shape(for ex. max shape) for testing dynamic shape

--- a/tests/py/dynamo/conversion/test_converter_utils.py
+++ b/tests/py/dynamo/conversion/test_converter_utils.py
@@ -1,0 +1,41 @@
+import numpy as np
+import torch
+from torch.testing._internal.common_utils import TestCase, run_tests
+from torch_tensorrt.dynamo.conversion.converter_utils import enforce_tensor_types
+from torch_tensorrt.fx.types import TRTTensor
+
+from ..testing_utilities import DECIMALS_OF_AGREEMENT, lower_graph_testing
+
+
+class TestTensorTypeEnforcement(TestCase):
+    def test_valid_type_no_promotion(self):
+        @enforce_tensor_types({0: (np.ndarray, torch.Tensor)}, promote=False)
+        def fake_converter(network, target, args, kwargs, name):
+            self.assertIsInstance(args[0], np.ndarray)
+            return
+
+        fake_converter(None, None, (np.ones((4, 4)),), {}, "fake")
+
+    def test_different_type_no_promotion(self):
+        @enforce_tensor_types({0: (TRTTensor,)}, promote=False)
+        def fake_converter(network, target, args, kwargs, name):
+            return
+
+        with self.assertRaises(AssertionError):
+            fake_converter(None, None, (np.ones((4, 4)),), {}, "fake")
+
+    def test_different_type_with_promotion(self):
+        @enforce_tensor_types({"sample": (np.ndarray,)}, promote=True)
+        def fake_converter(network, target, args, kwargs, name):
+            self.assertIsInstance(kwargs["sample"], np.ndarray)
+            return
+
+        fake_converter(None, None, tuple(), {"sample": torch.ones((4, 4))}, "fake")
+
+    def test_invalid_invocation_type(self):
+        with self.assertRaises(AssertionError):
+            enforce_tensor_types({0: (int, bool)})
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
# Description

- Add utilities to enforce tensor types for aten converters via direct reference
- Add robust testing for utilities
- Update decorator schemas throughout code

Fixes #2306

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
