### PR TITLE
None: Replace the Tensor Layer name from "Unnamed Layer #" to its original name

### DIFF
--- a/py/torch_tensorrt/fx/converters/converter_utils.py
+++ b/py/torch_tensorrt/fx/converters/converter_utils.py
@@ -122,7 +122,12 @@ def set_layer_name(
         if isinstance(target, str)
         else f"{source_ir}_ops.{target.__name__}"
     )
-    layer.name = f"[{layer.type.name}]-[{target_name}]-[{name}]"
+    layer.name = f"[{layer.type.name}]-[{target_name}]-[{name}]-[#_of_outputs_{layer.num_outputs}]"
+
+    for i in range(layer.num_outputs):
+        output = layer.get_output(i)
+        layer.name.append(f"-[{output.name}]")
+
 
 
 def extend_attr_to_tuple(


### PR DESCRIPTION
# Description

To improve the debuggability, we try to set the layer name for each myelin output for a more meaningful naming so that we can replace the "Unnamed Layer #" with its original name. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
