### PR TITLE
Torch version check change for imports

### DIFF
--- a/py/torch_tensorrt/dynamo/backend/backends.py
+++ b/py/torch_tensorrt/dynamo/backend/backends.py
@@ -20,7 +20,7 @@ from torch_tensorrt.dynamo.utils import parse_dynamo_kwargs, set_log_level
 from packaging import version
 
 # Modify import location of utilities based on Torch version
-if version.parse(sanitized_torch_version()) < version.parse("2.1.1"):
+if version.parse(sanitized_torch_version()) <= version.parse("2.1.0.dev20230902"):
     from torch._inductor.freezing import ConstantFolder, replace_node_with_constant
 else:
     from torch._inductor.constant_folding import (


### PR DESCRIPTION
The snippet throws error for torch= 2.1.0.dev20230905+cu121
This PR changes the python version check for the inductor import.