### PR TITLE
fix: Issue in TS dimension-squeeze utility

### DIFF
--- a/core/util/trt_util.cpp
+++ b/core/util/trt_util.cpp
@@ -216,7 +216,7 @@ nvinfer1::Dims squeezeDims(const nvinfer1::Dims& d, int pos, bool use_zeros, boo
       // Replace all instances of -1, indicating dynamic dimension
       // with 0, indicating copy the dimension from another tensor
       // (Generally used for reshape operations)
-      if (use_zeros && d.d[i] == -1) {
+      if (use_zeros && d.d[i] == -1 && i < pos) {
         dims.d[j] = 0;
         // If zeros already exist in the dimensions (empty tensor),
         // Replace all instances of 0, indicating empty dimension


### PR DESCRIPTION
# Description
- Add condition to dynamic-dimension insertion for using zero dimension in place of dynamic (-1)
  - This effectively enables 2 non-contiguous dynamic dimensions. For more than two, an additional fix/overhaul of the dimension squeeze system is needed
- Add regression test case to catch similar scenarios

Fixes #2331

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x  ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
