### PR TITLE
Support new FX Legacy Registry in opset coverage tool

### DIFF
--- a/py/torch_tensorrt/dynamo/tools/opset_coverage.py
+++ b/py/torch_tensorrt/dynamo/tools/opset_coverage.py
@@ -48,6 +48,10 @@ TAGS_YAML_PATH = (
     Path(os.path.dirname(torchgen.__file__)) / "packaged/ATen/native/tags.yaml"
 )
 
+DYNAMO_REGISTRY_NAME = "Dynamo ATen Converters Registry"
+FX_REGISTRY_NAME = "FX ATen Converters Registry"
+FX_LEGACY_REGISTRY_NAME = "FX Legacy ATen Converters Registry"
+
 
 def get_aten_ops() -> List[Tuple[str, str]]:
     parsed_yaml = parse_native_yaml(NATIVE_FUNCTION_YAML_PATH, TAGS_YAML_PATH)
@@ -140,11 +144,12 @@ def opset_coverage(
             _, registry_data = c_registry.get_all_converters_with_target(
                 target, return_registry_info=True
             )
+
             if registry_data is not None:
-                if registry_data["Dynamo ATen Converters Registry"] >= 1:
+                if DYNAMO_REGISTRY_NAME in registry_data and registry_data[DYNAMO_REGISTRY_NAME] >= 1:
                     status = SupportStatus.CONVERTED
                     support_count += 1
-                elif registry_data["FX ATen Converters Registry"] >= 1:
+                elif (FX_REGISTRY_NAME in registry_data and registry_data[FX_REGISTRY_NAME] >= 1) or (FX_LEGACY_REGISTRY_NAME in registry_data and registry_data[FX_LEGACY_REGISTRY_NAME] >= 1):
                     status = SupportStatus.LEGACY_CONVERTED
                     legacy_count += 1
 

--- a/py/torch_tensorrt/dynamo/tools/opset_coverage.py
+++ b/py/torch_tensorrt/dynamo/tools/opset_coverage.py
@@ -147,14 +147,14 @@ def opset_coverage(
 
             if registry_data is not None:
                 if (
-                        DYNAMO_REGISTRY_NAME in registry_data
-                        and registry_data[DYNAMO_REGISTRY_NAME] >= 1
+                    DYNAMO_REGISTRY_NAME in registry_data
+                    and registry_data[DYNAMO_REGISTRY_NAME] >= 1
                 ):
                     status = SupportStatus.CONVERTED
                     support_count += 1
                 elif (
-                        FX_REGISTRY_NAME in registry_data
-                        and registry_data[FX_REGISTRY_NAME] >= 1
+                    FX_REGISTRY_NAME in registry_data
+                    and registry_data[FX_REGISTRY_NAME] >= 1
                 ) or (
                     FX_LEGACY_REGISTRY_NAME in registry_data
                     and registry_data[FX_LEGACY_REGISTRY_NAME] >= 1

--- a/py/torch_tensorrt/dynamo/tools/opset_coverage.py
+++ b/py/torch_tensorrt/dynamo/tools/opset_coverage.py
@@ -146,10 +146,19 @@ def opset_coverage(
             )
 
             if registry_data is not None:
-                if DYNAMO_REGISTRY_NAME in registry_data and registry_data[DYNAMO_REGISTRY_NAME] >= 1:
+                if (
+                        DYNAMO_REGISTRY_NAME in registry_data
+                        and registry_data[DYNAMO_REGISTRY_NAME] >= 1
+                ):
                     status = SupportStatus.CONVERTED
                     support_count += 1
-                elif (FX_REGISTRY_NAME in registry_data and registry_data[FX_REGISTRY_NAME] >= 1) or (FX_LEGACY_REGISTRY_NAME in registry_data and registry_data[FX_LEGACY_REGISTRY_NAME] >= 1):
+                elif (
+                        FX_REGISTRY_NAME in registry_data
+                        and registry_data[FX_REGISTRY_NAME] >= 1
+                ) or (
+                    FX_LEGACY_REGISTRY_NAME in registry_data
+                    and registry_data[FX_LEGACY_REGISTRY_NAME] >= 1
+                ):
                     status = SupportStatus.LEGACY_CONVERTED
                     legacy_count += 1
                 else:

--- a/py/torch_tensorrt/dynamo/tools/opset_coverage.py
+++ b/py/torch_tensorrt/dynamo/tools/opset_coverage.py
@@ -152,6 +152,8 @@ def opset_coverage(
                 elif (FX_REGISTRY_NAME in registry_data and registry_data[FX_REGISTRY_NAME] >= 1) or (FX_LEGACY_REGISTRY_NAME in registry_data and registry_data[FX_LEGACY_REGISTRY_NAME] >= 1):
                     status = SupportStatus.LEGACY_CONVERTED
                     legacy_count += 1
+                else:
+                    raise Exception(f"Op belongs to unknown registry: {registry_data}")
 
                 support_status[target_str] = {
                     "schema": f"{target_str.split('.')[0]}.{opset_schemas[target_str]}",


### PR DESCRIPTION
# Description

The opset_coverage.py tool was failing with the following error:

```
Traceback (most recent call last):
  File "/opt/torch_tensorrt/py/torch_tensorrt/dynamo/tools/opset_coverage.py", line 213, in <module>
    find_coverage_status(ATEN_OPS, "ATen")
  File "/opt/torch_tensorrt/py/torch_tensorrt/dynamo/tools/opset_coverage.py", line 199, in find_coverage_status
    coverage = opset_coverage(opset)
  File "/opt/torch_tensorrt/py/torch_tensorrt/dynamo/tools/opset_coverage.py", line 147, in opset_coverage
    elif registry_data["FX ATen Converters Registry"] >= 1:
KeyError: 'FX ATen Converters Registry'
```

For some reason, some ATen and Prims ops appear with the registry name "FX Legacy ATen Converters Registry"

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
