### PR TITLE
feat: Wrap ExportedPrograms transformations with an API, allow dynamo.compile to accept graphmodules.

### DIFF
--- a/docsrc/user_guide/saving_models.rst
+++ b/docsrc/user_guide/saving_models.rst
@@ -22,8 +22,8 @@ The following code illustrates this approach.
     model = MyModel().eval().cuda()
     inputs = torch.randn((1, 3, 224, 224)).cuda()
     trt_gm = torch_tensorrt.compile(model, ir="dynamo", inputs) # Output is a torch.fx.GraphModule
-    trt_script_model = torch.jit.trace(trt_gm, inputs)
-    torch.jit.save(trt_script_model, "trt_model.ts")
+    trt_traced_model = torchtrt.dynamo.serialize(trt_gm, inputs)
+    torch.jit.save(trt_traced_model, "trt_model.ts")
 
     # Later, you can load it and run inference
     model = torch.jit.load("trt_model.ts").cuda()
@@ -42,7 +42,7 @@ b) ExportedProgram
     inputs = torch.randn((1, 3, 224, 224)).cuda()
     trt_gm = torch_tensorrt.compile(model, ir="dynamo", inputs) # Output is a torch.fx.GraphModule
     # Transform and create an exported program
-    trt_exp_program = torch_tensorrt.dynamo.transform(trt_gm, inputs, call_spec)
+    trt_exp_program = torch_tensorrt.dynamo.serialize(trt_gm, inputs, call_spec, ir="exported_program")
     torch.export.save(trt_exp_program, "trt_model.ep")
 
     # Later, you can load it and run inference 

--- a/docsrc/user_guide/saving_models.rst
+++ b/docsrc/user_guide/saving_models.rst
@@ -37,21 +37,19 @@ b) ExportedProgram
 
     import torch
     import torch_tensorrt
-    from torch_tensorrt.dynamo.export import transform, create_exported_program
 
     model = MyModel().eval().cuda()
     inputs = torch.randn((1, 3, 224, 224)).cuda()
     trt_gm = torch_tensorrt.compile(model, ir="dynamo", inputs) # Output is a torch.fx.GraphModule
     # Transform and create an exported program
-    trt_gm = transform(trt_gm, inputs)
-    trt_exp_program = create_exported_program(trt_gm, call_spec, trt_gm.state_dict())
-    torch._export.save(trt_exp_program, "trt_model.ep")
+    trt_exp_program = torch_tensorrt.dynamo.transform(trt_gm, inputs, call_spec)
+    torch.export.save(trt_exp_program, "trt_model.ep")
 
     # Later, you can load it and run inference 
-    model = torch._export.load("trt_model.ep")
+    model = torch.export.load("trt_model.ep")
     model(inputs)
 
-`torch_tensorrt.dynamo.export.transform` inlines the submodules within a GraphModule to their corresponding nodes and stiches all the nodes together. 
+`torch_tensorrt.dynamo.transform` inlines the submodules within a GraphModule to their corresponding nodes, stiches all the nodes together and creates an ExportedProgram. 
 This is needed as `torch._export` serialization cannot handle serializing and deserializing of submodules (`call_module` nodes). 
 
 NOTE: This way of saving the models using `ExportedProgram` is experimental. Here is a known issue : https://github.com/pytorch/TensorRT/issues/2341

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -1,9 +1,8 @@
 numpy
 packaging
 pybind11==2.6.2
---extra-index-url https://download.pytorch.org/whl/nightly/cu121
-torch>=2.1.0,<2.2.0
-torchvision>=0.16.0,<0.17.0
+torch==2.1.0
+torchvision==0.16.0
 --extra-index-url https://pypi.ngc.nvidia.com
 tensorrt==8.6.1
 pyyaml

--- a/py/torch_tensorrt/dynamo/__init__.py
+++ b/py/torch_tensorrt/dynamo/__init__.py
@@ -16,3 +16,4 @@ if version.parse(sanitized_torch_version()) >= version.parse("2.1.dev"):
         DYNAMO_CONVERTERS,
         dynamo_tensorrt_converter,
     )
+    from .export import transform

--- a/py/torch_tensorrt/dynamo/__init__.py
+++ b/py/torch_tensorrt/dynamo/__init__.py
@@ -16,4 +16,4 @@ if version.parse(sanitized_torch_version()) >= version.parse("2.1.dev"):
         DYNAMO_CONVERTERS,
         dynamo_tensorrt_converter,
     )
-    from .export import transform
+    from .export import serialize

--- a/py/torch_tensorrt/dynamo/compile.py
+++ b/py/torch_tensorrt/dynamo/compile.py
@@ -86,7 +86,15 @@ def compile(
     inputs = prepare_inputs(inputs)
     device = to_torch_tensorrt_device(device)
 
-    gm = exported_program.module()
+    if isinstance(exported_program, torch.fx.GraphModule):
+        gm = exported_program
+    elif isinstance(exported_program, ExportedProgram):
+        gm = exported_program.module()
+    else:
+        raise AssertionError(
+            f"Input graph should either be an ExportedProgram or a GraphModule but got type {type(exported_program)}"
+        )
+
     logger.debug("Input graph: " + str(gm.graph))
 
     # Apply lowering on the graph module

--- a/py/torch_tensorrt/dynamo/compile.py
+++ b/py/torch_tensorrt/dynamo/compile.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 
 def compile(
-    exported_program: ExportedProgram,
+    exported_program: Union[torch.fx.GraphModule, ExportedProgram],
     inputs: Any,
     *,
     device: Optional[Union[Device, torch.device, str]] = DEVICE,

--- a/py/torch_tensorrt/dynamo/export.py
+++ b/py/torch_tensorrt/dynamo/export.py
@@ -44,7 +44,7 @@ def serialize(
         return exp_program
     else:
         raise ValueError(
-            "Invalid ir provided for serialization. Select among torchscript | exported_program"
+            "Invalid ir : {ir} provided for serialization. Options include torchscript | exported_program"
         )
 
 

--- a/tests/py/dynamo/models/test_export_serde.py
+++ b/tests/py/dynamo/models/test_export_serde.py
@@ -44,7 +44,9 @@ def test_base_full_compile(ir):
 
     exp_program = torchtrt.dynamo.trace(model, **compile_spec)
     trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
-    trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
+    trt_exp_program = torchtrt.dynamo.serialize(
+        trt_gm, [input], call_spec=exp_program.call_spec, ir="exported_program"
+    )
     serialized_prog = serialize(trt_exp_program)
     deserialized_prog = deserialize(*serialized_prog)
 
@@ -96,7 +98,9 @@ def test_base_full_compile_multiple_outputs(ir):
 
     exp_program = torchtrt.dynamo.trace(model, **compile_spec)
     trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
-    trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
+    trt_exp_program = torchtrt.dynamo.serialize(
+        trt_gm, [input], call_spec=exp_program.call_spec, ir="exported_program"
+    )
     serialized_prog = serialize(trt_exp_program)
     deserialized_prog = deserialize(*serialized_prog)
     # Check Pyt and TRT exported program outputs
@@ -153,7 +157,9 @@ def test_base_full_compile_save_load(ir):
 
     exp_program = torchtrt.dynamo.trace(model, **compile_spec)
     trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
-    trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
+    trt_exp_program = torchtrt.dynamo.serialize(
+        trt_gm, [input], call_spec=exp_program.call_spec, ir="exported_program"
+    )
     torch._export.save(trt_exp_program, "/tmp/trt.ep")
     deser_trt_exp_program = torch._export.load("/tmp/trt.ep")
 
@@ -212,7 +218,9 @@ def test_hybrid_relu_fallback(ir):
 
     exp_program = torchtrt.dynamo.trace(model, **compile_spec)
     trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
-    trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
+    trt_exp_program = torchtrt.dynamo.serialize(
+        trt_gm, [input], call_spec=exp_program.call_spec, ir="exported_program"
+    )
     torch._export.save(trt_exp_program, "/tmp/trt.ep")
     deser_trt_exp_program = torch._export.load("/tmp/trt.ep")
 
@@ -254,7 +262,9 @@ def test_resnet18_save_load(ir):
 
     exp_program = torchtrt.dynamo.trace(model, **compile_spec)
     trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
-    trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
+    trt_exp_program = torchtrt.dynamo.serialize(
+        trt_gm, [input], call_spec=exp_program.call_spec, ir="exported_program"
+    )
     torch._export.save(trt_exp_program, "/tmp/trt.ep")
     deser_trt_exp_program = torch._export.load("/tmp/trt.ep")
 

--- a/tests/py/dynamo/models/test_export_serde.py
+++ b/tests/py/dynamo/models/test_export_serde.py
@@ -6,299 +6,182 @@ import torch
 import torch_tensorrt as torchtrt
 import torchvision.models as models
 from torch._export.serde.serialize import deserialize, serialize
-from torch_tensorrt.dynamo.export import create_trt_exp_program, transform
 from torch_tensorrt.dynamo.utils import COSINE_THRESHOLD, cosine_similarity
 
 assertions = unittest.TestCase()
 
 
-@pytest.mark.unit
-def test_base_full_compile(ir):
-    """
-    This tests export serde functionality on a base model
-    which is fully TRT convertible
-    """
-
-    class MyModule(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.conv = torch.nn.Conv2d(3, 16, 3, stride=1, bias=True)
-            self.relu = torch.nn.ReLU()
-
-        def forward(self, x):
-            out = self.conv(x)
-            out = self.relu(out)
-            return out
-
-    model = MyModule().eval().cuda()
-    input = torch.randn((1, 3, 224, 224)).to("cuda")
-
-    compile_spec = {
-        "inputs": [
-            torchtrt.Input(
-                input.shape, dtype=torch.float, format=torch.contiguous_format
-            )
-        ],
-        "ir": ir,
-        "min_block_size": 1,
-    }
-
-    exp_program = torchtrt.dynamo.trace(model, **compile_spec)
-    trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
-    trt_gm = transform(trt_gm, [input])
-    trt_exp_program = create_trt_exp_program(
-        trt_gm, exp_program.call_spec, trt_gm.state_dict()
-    )
-    serialized_prog = serialize(trt_exp_program)
-    deserialized_prog = deserialize(*serialized_prog)
-
-    # Check Pyt and TRT exported program outputs
-    cos_sim = cosine_similarity(model(input), trt_exp_program(input))
-    assertions.assertTrue(
-        cos_sim > COSINE_THRESHOLD,
-        msg=f"test_base_model_full_compile TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-    )
-    # Check Pyt and deserialized TRT exported program outputs
-    cos_sim = cosine_similarity(model(input), deserialized_prog(input))
-    assertions.assertTrue(
-        cos_sim > COSINE_THRESHOLD,
-        msg=f"test_base_model_full_compile TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-    )
-
-
-@pytest.mark.unit
-def test_base_full_compile_multiple_outputs(ir):
-    """
-    This tests export serde functionality on a base model
-    with multiple outputs which is fully TRT convertible
-    """
-
-    class MyModule(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.conv = torch.nn.Conv2d(3, 16, 3, stride=1, bias=True)
-            self.relu = torch.nn.ReLU()
-
-        def forward(self, x):
-            conv = self.conv(x)
-            conv = conv * 0.5
-            relu = self.relu(conv)
-            return conv, relu
-
-    model = MyModule().eval().cuda()
-    input = torch.randn((1, 3, 224, 224)).to("cuda")
-
-    compile_spec = {
-        "inputs": [
-            torchtrt.Input(
-                input.shape, dtype=torch.float, format=torch.contiguous_format
-            )
-        ],
-        "ir": ir,
-        "min_block_size": 1,
-    }
-
-    exp_program = torchtrt.dynamo.trace(model, **compile_spec)
-    trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
-    trt_gm = transform(trt_gm, [input])
-    trt_exp_program = create_trt_exp_program(
-        trt_gm, exp_program.call_spec, trt_gm.state_dict()
-    )
-
-    serialized_prog = serialize(trt_exp_program)
-    deserialized_prog = deserialize(*serialized_prog)
-    # Check Pyt and TRT exported program outputs
-    outputs_pyt = model(input)
-    outputs_trt = trt_exp_program(input)
-    for idx in range(len(outputs_pyt)):
-        cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt[idx])
-        assertions.assertTrue(
-            cos_sim > COSINE_THRESHOLD,
-            msg=f"test_base_full_compile_multiple_outputs TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-        )
-
-    # Check Pyt and deserialized TRT exported program outputs
-    outputs_trt_deser = deserialized_prog(input)
-    for idx in range(len(outputs_pyt)):
-        cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt_deser[idx])
-        assertions.assertTrue(
-            cos_sim > COSINE_THRESHOLD,
-            msg=f"test_base_full_compile_multiple_outputs TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-        )
-
-
-@pytest.mark.unit
-def test_base_full_compile_save_load(ir):
-    """
-    This tests export save and load functionality on a base model
-    with multiple outputs which is fully TRT convertible
-    """
-
-    class MyModule(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.conv = torch.nn.Conv2d(3, 16, 3, stride=1, bias=True)
-            self.relu = torch.nn.ReLU()
-
-        def forward(self, x):
-            conv = self.conv(x)
-            conv = conv * 0.5
-            relu = self.relu(conv)
-            return conv, relu
-
-    model = MyModule().eval().cuda()
-    input = torch.randn((1, 3, 224, 224)).to("cuda")
-
-    compile_spec = {
-        "inputs": [
-            torchtrt.Input(
-                input.shape, dtype=torch.float, format=torch.contiguous_format
-            )
-        ],
-        "ir": ir,
-        "min_block_size": 1,
-    }
-
-    exp_program = torchtrt.dynamo.trace(model, **compile_spec)
-    trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
-    trt_gm = transform(trt_gm, [input])
-    trt_exp_program = create_trt_exp_program(
-        trt_gm, exp_program.call_spec, trt_gm.state_dict()
-    )
-
-    torch._export.save(trt_exp_program, "/tmp/trt.ep")
-    deser_trt_exp_program = torch._export.load("/tmp/trt.ep")
-
-    outputs_pyt = model(input)
-    outputs_trt = trt_exp_program(input)
-    # Check Pyt and TRT exported program outputs
-    for idx in range(len(outputs_pyt)):
-        cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt[idx])
-        assertions.assertTrue(
-            cos_sim > COSINE_THRESHOLD,
-            msg=f"test_base_full_compile_multiple_outputs TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-        )
-    # Check Pyt and deserialized TRT exported program outputs
-    outputs_trt_deser = deser_trt_exp_program(input)
-    for idx in range(len(outputs_pyt)):
-        cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt_deser[idx])
-        assertions.assertTrue(
-            cos_sim > COSINE_THRESHOLD,
-            msg=f"test_base_full_compile_save_load TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-        )
-
-
-@pytest.mark.unit
-def test_hybrid_relu_fallback(ir):
-    """
-    This tests export save and load functionality on a hybrid
-    model with Pytorch and TRT segments. Relu (unweighted) layer is forced to
-    fallback
-    """
-
-    class MyModule(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.conv = torch.nn.Conv2d(3, 16, 3, stride=1, bias=True)
-            self.relu = torch.nn.ReLU()
-
-        def forward(self, x):
-            conv = self.conv(x)
-            relu = self.relu(conv)
-            mul = relu * 0.5
-            return mul
-
-    model = MyModule().eval().cuda()
-    input = torch.randn((1, 3, 224, 224)).to("cuda")
-
-    compile_spec = {
-        "inputs": [
-            torchtrt.Input(
-                input.shape, dtype=torch.float, format=torch.contiguous_format
-            )
-        ],
-        "ir": ir,
-        "min_block_size": 1,
-        "torch_executed_ops": "torch.ops.aten.relu.default",
-    }
-
-    exp_program = torchtrt.dynamo.trace(model, **compile_spec)
-    trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
-    trt_gm = transform(trt_gm, [input])
-    trt_exp_program = create_trt_exp_program(
-        trt_gm, exp_program.call_spec, trt_gm.state_dict()
-    )
-
-    torch._export.save(trt_exp_program, "/tmp/trt.ep")
-    deser_trt_exp_program = torch._export.load("/tmp/trt.ep")
-
-    outputs_pyt = model(input)
-    outputs_trt = trt_exp_program(input)
-    for idx in range(len(outputs_pyt)):
-        cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt[idx])
-        assertions.assertTrue(
-            cos_sim > COSINE_THRESHOLD,
-            msg=f"test_base_full_compile_multiple_outputs TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-        )
-
-    outputs_trt_deser = deser_trt_exp_program(input)
-    for idx in range(len(outputs_pyt)):
-        cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt_deser[idx])
-        assertions.assertTrue(
-            cos_sim > COSINE_THRESHOLD,
-            msg=f"test_base_full_compile_save_load TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-        )
-
-
-@pytest.mark.unit
-def test_resnet18_save_load(ir):
-    """
-    This tests export save and load functionality on Resnet18 model
-    """
-    model = models.resnet18().eval().cuda()
-    input = torch.randn((1, 3, 224, 224)).to("cuda")
-
-    compile_spec = {
-        "inputs": [
-            torchtrt.Input(
-                input.shape, dtype=torch.float, format=torch.contiguous_format
-            )
-        ],
-        "ir": ir,
-        "min_block_size": 1,
-    }
-
-    exp_program = torchtrt.dynamo.trace(model, **compile_spec)
-    trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
-    trt_gm = transform(trt_gm, [input])
-    trt_exp_program = create_trt_exp_program(
-        trt_gm, exp_program.call_spec, trt_gm.state_dict()
-    )
-    torch._export.save(trt_exp_program, "/tmp/trt.ep")
-    deser_trt_exp_program = torch._export.load("/tmp/trt.ep")
-
-    outputs_pyt = model(input)
-    outputs_trt = trt_exp_program(input)
-    cos_sim = cosine_similarity(outputs_pyt, outputs_trt)
-    assertions.assertTrue(
-        cos_sim > COSINE_THRESHOLD,
-        msg=f"test_resnet18_save_load TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-    )
-
-    outputs_trt_deser = deser_trt_exp_program(input)
-    cos_sim = cosine_similarity(outputs_pyt, outputs_trt_deser)
-    assertions.assertTrue(
-        cos_sim > COSINE_THRESHOLD,
-        msg=f"test_resnet18_save_load TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-    )
-
-
-# Enable this test once this issue is resolved https://github.com/pytorch/TensorRT/issues/2341
 # @pytest.mark.unit
-# def test_hybrid_conv_fallback(ir):
+# def test_base_full_compile(ir):
+#     """
+#     This tests export serde functionality on a base model
+#     which is fully TRT convertible
+#     """
+
+#     class MyModule(torch.nn.Module):
+#         def __init__(self):
+#             super().__init__()
+#             self.conv = torch.nn.Conv2d(3, 16, 3, stride=1, bias=True)
+#             self.relu = torch.nn.ReLU()
+
+#         def forward(self, x):
+#             out = self.conv(x)
+#             out = self.relu(out)
+#             return out
+
+#     model = MyModule().eval().cuda()
+#     input = torch.randn((1, 3, 224, 224)).to("cuda")
+
+#     compile_spec = {
+#         "inputs": [
+#             torchtrt.Input(
+#                 input.shape, dtype=torch.float, format=torch.contiguous_format
+#             )
+#         ],
+#         "ir": ir,
+#         "min_block_size": 1,
+#     }
+
+#     exp_program = torchtrt.dynamo.trace(model, **compile_spec)
+#     trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
+#     trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
+#     serialized_prog = serialize(trt_exp_program)
+#     deserialized_prog = deserialize(*serialized_prog)
+
+#     # Check Pyt and TRT exported program outputs
+#     cos_sim = cosine_similarity(model(input), trt_exp_program(input))
+#     assertions.assertTrue(
+#         cos_sim > COSINE_THRESHOLD,
+#         msg=f"test_base_model_full_compile TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+#     )
+#     # Check Pyt and deserialized TRT exported program outputs
+#     cos_sim = cosine_similarity(model(input), deserialized_prog(input))
+#     assertions.assertTrue(
+#         cos_sim > COSINE_THRESHOLD,
+#         msg=f"test_base_model_full_compile TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+#     )
+
+
+# @pytest.mark.unit
+# def test_base_full_compile_multiple_outputs(ir):
+#     """
+#     This tests export serde functionality on a base model
+#     with multiple outputs which is fully TRT convertible
+#     """
+
+#     class MyModule(torch.nn.Module):
+#         def __init__(self):
+#             super().__init__()
+#             self.conv = torch.nn.Conv2d(3, 16, 3, stride=1, bias=True)
+#             self.relu = torch.nn.ReLU()
+
+#         def forward(self, x):
+#             conv = self.conv(x)
+#             conv = conv * 0.5
+#             relu = self.relu(conv)
+#             return conv, relu
+
+#     model = MyModule().eval().cuda()
+#     input = torch.randn((1, 3, 224, 224)).to("cuda")
+
+#     compile_spec = {
+#         "inputs": [
+#             torchtrt.Input(
+#                 input.shape, dtype=torch.float, format=torch.contiguous_format
+#             )
+#         ],
+#         "ir": ir,
+#         "min_block_size": 1,
+#     }
+
+#     exp_program = torchtrt.dynamo.trace(model, **compile_spec)
+#     trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
+#     trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
+#     serialized_prog = serialize(trt_exp_program)
+#     deserialized_prog = deserialize(*serialized_prog)
+#     # Check Pyt and TRT exported program outputs
+#     outputs_pyt = model(input)
+#     outputs_trt = trt_exp_program(input)
+#     for idx in range(len(outputs_pyt)):
+#         cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt[idx])
+#         assertions.assertTrue(
+#             cos_sim > COSINE_THRESHOLD,
+#             msg=f"test_base_full_compile_multiple_outputs TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+#         )
+
+#     # Check Pyt and deserialized TRT exported program outputs
+#     outputs_trt_deser = deserialized_prog(input)
+#     for idx in range(len(outputs_pyt)):
+#         cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt_deser[idx])
+#         assertions.assertTrue(
+#             cos_sim > COSINE_THRESHOLD,
+#             msg=f"test_base_full_compile_multiple_outputs TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+#         )
+
+
+# @pytest.mark.unit
+# def test_base_full_compile_save_load(ir):
+#     """
+#     This tests export save and load functionality on a base model
+#     with multiple outputs which is fully TRT convertible
+#     """
+
+#     class MyModule(torch.nn.Module):
+#         def __init__(self):
+#             super().__init__()
+#             self.conv = torch.nn.Conv2d(3, 16, 3, stride=1, bias=True)
+#             self.relu = torch.nn.ReLU()
+
+#         def forward(self, x):
+#             conv = self.conv(x)
+#             conv = conv * 0.5
+#             relu = self.relu(conv)
+#             return conv, relu
+
+#     model = MyModule().eval().cuda()
+#     input = torch.randn((1, 3, 224, 224)).to("cuda")
+
+#     compile_spec = {
+#         "inputs": [
+#             torchtrt.Input(
+#                 input.shape, dtype=torch.float, format=torch.contiguous_format
+#             )
+#         ],
+#         "ir": ir,
+#         "min_block_size": 1,
+#     }
+
+#     exp_program = torchtrt.dynamo.trace(model, **compile_spec)
+#     trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
+#     trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
+#     torch._export.save(trt_exp_program, "/tmp/trt.ep")
+#     deser_trt_exp_program = torch._export.load("/tmp/trt.ep")
+
+#     outputs_pyt = model(input)
+#     outputs_trt = trt_exp_program(input)
+#     # Check Pyt and TRT exported program outputs
+#     for idx in range(len(outputs_pyt)):
+#         cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt[idx])
+#         assertions.assertTrue(
+#             cos_sim > COSINE_THRESHOLD,
+#             msg=f"test_base_full_compile_multiple_outputs TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+#         )
+#     # Check Pyt and deserialized TRT exported program outputs
+#     outputs_trt_deser = deser_trt_exp_program(input)
+#     for idx in range(len(outputs_pyt)):
+#         cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt_deser[idx])
+#         assertions.assertTrue(
+#             cos_sim > COSINE_THRESHOLD,
+#             msg=f"test_base_full_compile_save_load TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+#         )
+
+
+# @pytest.mark.unit
+# def test_hybrid_relu_fallback(ir):
 #     """
 #     This tests export save and load functionality on a hybrid
-#     model where a conv (a weighted layer)  has been forced to fallback to Pytorch.
+#     model with Pytorch and TRT segments. Relu (unweighted) layer is forced to
+#     fallback
 #     """
 
 #     class MyModule(torch.nn.Module):
@@ -324,10 +207,12 @@ def test_resnet18_save_load(ir):
 #         ],
 #         "ir": ir,
 #         "min_block_size": 1,
-#         "torch_executed_ops": "torch.ops.aten.convolution.default",
+#         "torch_executed_ops": "torch.ops.aten.relu.default",
 #     }
 
-#     trt_exp_program = torchtrt.compile(model, **compile_spec)
+#     exp_program = torchtrt.dynamo.trace(model, **compile_spec)
+#     trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
+#     trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
 #     torch._export.save(trt_exp_program, "/tmp/trt.ep")
 #     deser_trt_exp_program = torch._export.load("/tmp/trt.ep")
 
@@ -347,3 +232,43 @@ def test_resnet18_save_load(ir):
 #             cos_sim > COSINE_THRESHOLD,
 #             msg=f"test_base_full_compile_save_load TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
 #         )
+
+
+@pytest.mark.unit
+def test_resnet18_save_load(ir):
+    """
+    This tests export save and load functionality on Resnet18 model
+    """
+    model = models.resnet18().eval().cuda()
+    input = torch.randn((1, 3, 224, 224)).to("cuda")
+
+    compile_spec = {
+        "inputs": [
+            torchtrt.Input(
+                input.shape, dtype=torch.float, format=torch.contiguous_format
+            )
+        ],
+        "ir": ir,
+        "min_block_size": 1,
+    }
+
+    exp_program = torchtrt.dynamo.trace(model, **compile_spec)
+    trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
+    trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
+    torch._export.save(trt_exp_program, "/tmp/trt.ep")
+    deser_trt_exp_program = torch._export.load("/tmp/trt.ep")
+
+    outputs_pyt = model(input)
+    outputs_trt = trt_exp_program(input)
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_resnet18_save_load TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+    outputs_trt_deser = deser_trt_exp_program(input)
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt_deser)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_resnet18_save_load TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )

--- a/tests/py/dynamo/models/test_export_serde.py
+++ b/tests/py/dynamo/models/test_export_serde.py
@@ -11,227 +11,227 @@ from torch_tensorrt.dynamo.utils import COSINE_THRESHOLD, cosine_similarity
 assertions = unittest.TestCase()
 
 
-# @pytest.mark.unit
-# def test_base_full_compile(ir):
-#     """
-#     This tests export serde functionality on a base model
-#     which is fully TRT convertible
-#     """
+@pytest.mark.unit
+def test_base_full_compile(ir):
+    """
+    This tests export serde functionality on a base model
+    which is fully TRT convertible
+    """
 
-#     class MyModule(torch.nn.Module):
-#         def __init__(self):
-#             super().__init__()
-#             self.conv = torch.nn.Conv2d(3, 16, 3, stride=1, bias=True)
-#             self.relu = torch.nn.ReLU()
+    class MyModule(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 16, 3, stride=1, bias=True)
+            self.relu = torch.nn.ReLU()
 
-#         def forward(self, x):
-#             out = self.conv(x)
-#             out = self.relu(out)
-#             return out
+        def forward(self, x):
+            out = self.conv(x)
+            out = self.relu(out)
+            return out
 
-#     model = MyModule().eval().cuda()
-#     input = torch.randn((1, 3, 224, 224)).to("cuda")
+    model = MyModule().eval().cuda()
+    input = torch.randn((1, 3, 224, 224)).to("cuda")
 
-#     compile_spec = {
-#         "inputs": [
-#             torchtrt.Input(
-#                 input.shape, dtype=torch.float, format=torch.contiguous_format
-#             )
-#         ],
-#         "ir": ir,
-#         "min_block_size": 1,
-#     }
+    compile_spec = {
+        "inputs": [
+            torchtrt.Input(
+                input.shape, dtype=torch.float, format=torch.contiguous_format
+            )
+        ],
+        "ir": ir,
+        "min_block_size": 1,
+    }
 
-#     exp_program = torchtrt.dynamo.trace(model, **compile_spec)
-#     trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
-#     trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
-#     serialized_prog = serialize(trt_exp_program)
-#     deserialized_prog = deserialize(*serialized_prog)
+    exp_program = torchtrt.dynamo.trace(model, **compile_spec)
+    trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
+    trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
+    serialized_prog = serialize(trt_exp_program)
+    deserialized_prog = deserialize(*serialized_prog)
 
-#     # Check Pyt and TRT exported program outputs
-#     cos_sim = cosine_similarity(model(input), trt_exp_program(input))
-#     assertions.assertTrue(
-#         cos_sim > COSINE_THRESHOLD,
-#         msg=f"test_base_model_full_compile TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-#     )
-#     # Check Pyt and deserialized TRT exported program outputs
-#     cos_sim = cosine_similarity(model(input), deserialized_prog(input))
-#     assertions.assertTrue(
-#         cos_sim > COSINE_THRESHOLD,
-#         msg=f"test_base_model_full_compile TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-#     )
-
-
-# @pytest.mark.unit
-# def test_base_full_compile_multiple_outputs(ir):
-#     """
-#     This tests export serde functionality on a base model
-#     with multiple outputs which is fully TRT convertible
-#     """
-
-#     class MyModule(torch.nn.Module):
-#         def __init__(self):
-#             super().__init__()
-#             self.conv = torch.nn.Conv2d(3, 16, 3, stride=1, bias=True)
-#             self.relu = torch.nn.ReLU()
-
-#         def forward(self, x):
-#             conv = self.conv(x)
-#             conv = conv * 0.5
-#             relu = self.relu(conv)
-#             return conv, relu
-
-#     model = MyModule().eval().cuda()
-#     input = torch.randn((1, 3, 224, 224)).to("cuda")
-
-#     compile_spec = {
-#         "inputs": [
-#             torchtrt.Input(
-#                 input.shape, dtype=torch.float, format=torch.contiguous_format
-#             )
-#         ],
-#         "ir": ir,
-#         "min_block_size": 1,
-#     }
-
-#     exp_program = torchtrt.dynamo.trace(model, **compile_spec)
-#     trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
-#     trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
-#     serialized_prog = serialize(trt_exp_program)
-#     deserialized_prog = deserialize(*serialized_prog)
-#     # Check Pyt and TRT exported program outputs
-#     outputs_pyt = model(input)
-#     outputs_trt = trt_exp_program(input)
-#     for idx in range(len(outputs_pyt)):
-#         cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt[idx])
-#         assertions.assertTrue(
-#             cos_sim > COSINE_THRESHOLD,
-#             msg=f"test_base_full_compile_multiple_outputs TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-#         )
-
-#     # Check Pyt and deserialized TRT exported program outputs
-#     outputs_trt_deser = deserialized_prog(input)
-#     for idx in range(len(outputs_pyt)):
-#         cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt_deser[idx])
-#         assertions.assertTrue(
-#             cos_sim > COSINE_THRESHOLD,
-#             msg=f"test_base_full_compile_multiple_outputs TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-#         )
+    # Check Pyt and TRT exported program outputs
+    cos_sim = cosine_similarity(model(input), trt_exp_program(input))
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_base_model_full_compile TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+    # Check Pyt and deserialized TRT exported program outputs
+    cos_sim = cosine_similarity(model(input), deserialized_prog(input))
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_base_model_full_compile TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
 
 
-# @pytest.mark.unit
-# def test_base_full_compile_save_load(ir):
-#     """
-#     This tests export save and load functionality on a base model
-#     with multiple outputs which is fully TRT convertible
-#     """
+@pytest.mark.unit
+def test_base_full_compile_multiple_outputs(ir):
+    """
+    This tests export serde functionality on a base model
+    with multiple outputs which is fully TRT convertible
+    """
 
-#     class MyModule(torch.nn.Module):
-#         def __init__(self):
-#             super().__init__()
-#             self.conv = torch.nn.Conv2d(3, 16, 3, stride=1, bias=True)
-#             self.relu = torch.nn.ReLU()
+    class MyModule(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 16, 3, stride=1, bias=True)
+            self.relu = torch.nn.ReLU()
 
-#         def forward(self, x):
-#             conv = self.conv(x)
-#             conv = conv * 0.5
-#             relu = self.relu(conv)
-#             return conv, relu
+        def forward(self, x):
+            conv = self.conv(x)
+            conv = conv * 0.5
+            relu = self.relu(conv)
+            return conv, relu
 
-#     model = MyModule().eval().cuda()
-#     input = torch.randn((1, 3, 224, 224)).to("cuda")
+    model = MyModule().eval().cuda()
+    input = torch.randn((1, 3, 224, 224)).to("cuda")
 
-#     compile_spec = {
-#         "inputs": [
-#             torchtrt.Input(
-#                 input.shape, dtype=torch.float, format=torch.contiguous_format
-#             )
-#         ],
-#         "ir": ir,
-#         "min_block_size": 1,
-#     }
+    compile_spec = {
+        "inputs": [
+            torchtrt.Input(
+                input.shape, dtype=torch.float, format=torch.contiguous_format
+            )
+        ],
+        "ir": ir,
+        "min_block_size": 1,
+    }
 
-#     exp_program = torchtrt.dynamo.trace(model, **compile_spec)
-#     trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
-#     trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
-#     torch._export.save(trt_exp_program, "/tmp/trt.ep")
-#     deser_trt_exp_program = torch._export.load("/tmp/trt.ep")
+    exp_program = torchtrt.dynamo.trace(model, **compile_spec)
+    trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
+    trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
+    serialized_prog = serialize(trt_exp_program)
+    deserialized_prog = deserialize(*serialized_prog)
+    # Check Pyt and TRT exported program outputs
+    outputs_pyt = model(input)
+    outputs_trt = trt_exp_program(input)
+    for idx in range(len(outputs_pyt)):
+        cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt[idx])
+        assertions.assertTrue(
+            cos_sim > COSINE_THRESHOLD,
+            msg=f"test_base_full_compile_multiple_outputs TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+        )
 
-#     outputs_pyt = model(input)
-#     outputs_trt = trt_exp_program(input)
-#     # Check Pyt and TRT exported program outputs
-#     for idx in range(len(outputs_pyt)):
-#         cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt[idx])
-#         assertions.assertTrue(
-#             cos_sim > COSINE_THRESHOLD,
-#             msg=f"test_base_full_compile_multiple_outputs TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-#         )
-#     # Check Pyt and deserialized TRT exported program outputs
-#     outputs_trt_deser = deser_trt_exp_program(input)
-#     for idx in range(len(outputs_pyt)):
-#         cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt_deser[idx])
-#         assertions.assertTrue(
-#             cos_sim > COSINE_THRESHOLD,
-#             msg=f"test_base_full_compile_save_load TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-#         )
+    # Check Pyt and deserialized TRT exported program outputs
+    outputs_trt_deser = deserialized_prog(input)
+    for idx in range(len(outputs_pyt)):
+        cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt_deser[idx])
+        assertions.assertTrue(
+            cos_sim > COSINE_THRESHOLD,
+            msg=f"test_base_full_compile_multiple_outputs TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+        )
 
 
-# @pytest.mark.unit
-# def test_hybrid_relu_fallback(ir):
-#     """
-#     This tests export save and load functionality on a hybrid
-#     model with Pytorch and TRT segments. Relu (unweighted) layer is forced to
-#     fallback
-#     """
+@pytest.mark.unit
+def test_base_full_compile_save_load(ir):
+    """
+    This tests export save and load functionality on a base model
+    with multiple outputs which is fully TRT convertible
+    """
 
-#     class MyModule(torch.nn.Module):
-#         def __init__(self):
-#             super().__init__()
-#             self.conv = torch.nn.Conv2d(3, 16, 3, stride=1, bias=True)
-#             self.relu = torch.nn.ReLU()
+    class MyModule(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 16, 3, stride=1, bias=True)
+            self.relu = torch.nn.ReLU()
 
-#         def forward(self, x):
-#             conv = self.conv(x)
-#             relu = self.relu(conv)
-#             mul = relu * 0.5
-#             return mul
+        def forward(self, x):
+            conv = self.conv(x)
+            conv = conv * 0.5
+            relu = self.relu(conv)
+            return conv, relu
 
-#     model = MyModule().eval().cuda()
-#     input = torch.randn((1, 3, 224, 224)).to("cuda")
+    model = MyModule().eval().cuda()
+    input = torch.randn((1, 3, 224, 224)).to("cuda")
 
-#     compile_spec = {
-#         "inputs": [
-#             torchtrt.Input(
-#                 input.shape, dtype=torch.float, format=torch.contiguous_format
-#             )
-#         ],
-#         "ir": ir,
-#         "min_block_size": 1,
-#         "torch_executed_ops": "torch.ops.aten.relu.default",
-#     }
+    compile_spec = {
+        "inputs": [
+            torchtrt.Input(
+                input.shape, dtype=torch.float, format=torch.contiguous_format
+            )
+        ],
+        "ir": ir,
+        "min_block_size": 1,
+    }
 
-#     exp_program = torchtrt.dynamo.trace(model, **compile_spec)
-#     trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
-#     trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
-#     torch._export.save(trt_exp_program, "/tmp/trt.ep")
-#     deser_trt_exp_program = torch._export.load("/tmp/trt.ep")
+    exp_program = torchtrt.dynamo.trace(model, **compile_spec)
+    trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
+    trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
+    torch._export.save(trt_exp_program, "/tmp/trt.ep")
+    deser_trt_exp_program = torch._export.load("/tmp/trt.ep")
 
-#     outputs_pyt = model(input)
-#     outputs_trt = trt_exp_program(input)
-#     for idx in range(len(outputs_pyt)):
-#         cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt[idx])
-#         assertions.assertTrue(
-#             cos_sim > COSINE_THRESHOLD,
-#             msg=f"test_base_full_compile_multiple_outputs TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-#         )
+    outputs_pyt = model(input)
+    outputs_trt = trt_exp_program(input)
+    # Check Pyt and TRT exported program outputs
+    for idx in range(len(outputs_pyt)):
+        cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt[idx])
+        assertions.assertTrue(
+            cos_sim > COSINE_THRESHOLD,
+            msg=f"test_base_full_compile_multiple_outputs TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+        )
+    # Check Pyt and deserialized TRT exported program outputs
+    outputs_trt_deser = deser_trt_exp_program(input)
+    for idx in range(len(outputs_pyt)):
+        cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt_deser[idx])
+        assertions.assertTrue(
+            cos_sim > COSINE_THRESHOLD,
+            msg=f"test_base_full_compile_save_load TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+        )
 
-#     outputs_trt_deser = deser_trt_exp_program(input)
-#     for idx in range(len(outputs_pyt)):
-#         cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt_deser[idx])
-#         assertions.assertTrue(
-#             cos_sim > COSINE_THRESHOLD,
-#             msg=f"test_base_full_compile_save_load TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
-#         )
+
+@pytest.mark.unit
+def test_hybrid_relu_fallback(ir):
+    """
+    This tests export save and load functionality on a hybrid
+    model with Pytorch and TRT segments. Relu (unweighted) layer is forced to
+    fallback
+    """
+
+    class MyModule(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 16, 3, stride=1, bias=True)
+            self.relu = torch.nn.ReLU()
+
+        def forward(self, x):
+            conv = self.conv(x)
+            relu = self.relu(conv)
+            mul = relu * 0.5
+            return mul
+
+    model = MyModule().eval().cuda()
+    input = torch.randn((1, 3, 224, 224)).to("cuda")
+
+    compile_spec = {
+        "inputs": [
+            torchtrt.Input(
+                input.shape, dtype=torch.float, format=torch.contiguous_format
+            )
+        ],
+        "ir": ir,
+        "min_block_size": 1,
+        "torch_executed_ops": "torch.ops.aten.relu.default",
+    }
+
+    exp_program = torchtrt.dynamo.trace(model, **compile_spec)
+    trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
+    trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
+    torch._export.save(trt_exp_program, "/tmp/trt.ep")
+    deser_trt_exp_program = torch._export.load("/tmp/trt.ep")
+
+    outputs_pyt = model(input)
+    outputs_trt = trt_exp_program(input)
+    for idx in range(len(outputs_pyt)):
+        cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt[idx])
+        assertions.assertTrue(
+            cos_sim > COSINE_THRESHOLD,
+            msg=f"test_base_full_compile_multiple_outputs TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+        )
+
+    outputs_trt_deser = deser_trt_exp_program(input)
+    for idx in range(len(outputs_pyt)):
+        cos_sim = cosine_similarity(outputs_pyt[idx], outputs_trt_deser[idx])
+        assertions.assertTrue(
+            cos_sim > COSINE_THRESHOLD,
+            msg=f"test_base_full_compile_save_load TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+        )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
# Description

1) The API to generate an exported program from a TRT graphmodule is as follows:
```
exp_program = torchtrt.dynamo.trace(model, **compile_spec)
trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
trt_exp_program = torchtrt.dynamo.transform(trt_gm, [input], exp_program.call_spec)
```
2) Changed dynamo.compile to allow torch.fx.GraphModules.

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
