### PR TITLE
fix: Converter, inputs, and utils bugfixes for Transformer XL

### DIFF
--- a/py/torch_tensorrt/dynamo/backend/backends.py
+++ b/py/torch_tensorrt/dynamo/backend/backends.py
@@ -89,7 +89,9 @@ def _pretraced_backend(
 
             gm = apply_lowering_passes(gm, sample_inputs)
 
-            torchtrt_inputs = prepare_inputs(sample_inputs)
+            torchtrt_inputs = prepare_inputs(
+                sample_inputs, disable_memory_format_check=True
+            )
             trt_compiled = compile_module(
                 gm,
                 torchtrt_inputs,

--- a/py/torch_tensorrt/dynamo/conversion/impl/reduce.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/reduce.py
@@ -49,10 +49,8 @@ def sum(
     dim: Optional[Union[int, Sequence[int]]],
     keepdim: bool,
 ) -> TRTTensor:
-    if (isinstance(input_val, TRTTensor)) and (
-        input_val.dtype == trt.int8 or input_val.dtype == trt.int32
-    ):
-        input_val = cast_trt_tensor(ctx, input_val, trt.float32, name)
+    if (isinstance(input_val, TRTTensor)) and (input_val.dtype == trt.bool):
+        input_val = cast_trt_tensor(ctx, input_val, trt.int32, name)
 
     if dim is None or (isinstance(dim, (tuple, list)) and len(dim) == 0):
         dim = tuple(range(len(input_val.shape)))

--- a/py/torch_tensorrt/dynamo/utils.py
+++ b/py/torch_tensorrt/dynamo/utils.py
@@ -5,12 +5,12 @@ from dataclasses import fields, replace
 from typing import Any, Callable, Dict, Optional, Sequence, Union
 
 import torch
-import torch_tensorrt
 from torch_tensorrt._Device import Device
 from torch_tensorrt._Input import Input
 from torch_tensorrt.dynamo import CompilationSettings
 from torch_tensorrt.dynamo._defaults import PRECISION
 
+import torch_tensorrt
 from packaging import version
 
 logger = logging.getLogger(__name__)
@@ -104,17 +104,22 @@ def set_log_level(parent_logger: Any, level: Any) -> None:
 
 def prepare_inputs(
     inputs: Input | torch.Tensor | Sequence[Any] | Dict[Any, Any],
+    disable_memory_format_check: bool = False,
 ) -> Any:
     if isinstance(inputs, Input):
         return inputs
 
     elif isinstance(inputs, torch.Tensor):
-        return Input.from_tensor(inputs)
+        return Input.from_tensor(
+            inputs, disable_memory_format_check=disable_memory_format_check
+        )
 
     elif isinstance(inputs, list):
         torchtrt_input_list = []
         for input_obj in inputs:
-            torchtrt_input = prepare_inputs(input_obj)
+            torchtrt_input = prepare_inputs(
+                input_obj, disable_memory_format_check=disable_memory_format_check
+            )
             torchtrt_input_list.append(torchtrt_input)
 
         return torchtrt_input_list
@@ -122,7 +127,9 @@ def prepare_inputs(
     elif isinstance(inputs, tuple):
         torchtrt_inputs_tup = []
         for input_obj in inputs:
-            torchtrt_input = prepare_inputs(input_obj)
+            torchtrt_input = prepare_inputs(
+                input_obj, disable_memory_format_check=disable_memory_format_check
+            )
             torchtrt_inputs_tup.append(torchtrt_input)
 
         return tuple(torchtrt_inputs_tup)
@@ -131,7 +138,9 @@ def prepare_inputs(
         torchtrt_inputs_dict: Dict[Any, Any] = dict()
 
         for key, input_obj in inputs.items():
-            torchtrt_input = prepare_inputs(input_obj)
+            torchtrt_input = prepare_inputs(
+                input_obj, disable_memory_format_check=disable_memory_format_check
+            )
             torchtrt_inputs_dict[key] = torchtrt_input
 
         return torchtrt_inputs_dict

--- a/tests/py/dynamo/conversion/test_slice_aten.py
+++ b/tests/py/dynamo/conversion/test_slice_aten.py
@@ -1,38 +1,20 @@
 import torch
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
+
 from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
 
-class TestSelectConverterImplicitBatch(DispatchTestCase):
+class TestSelectConverter(DispatchTestCase):
     @parameterized.expand(
         [
             ("select_dim_start_stop_step", 0, 0, 7, 2),
-        ]
-    )
-    def test_slice(self, _, dim, start, stop, step):
-        class TestModule(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-
-            def forward(self, input):
-                out = torch.ops.aten.slice.Tensor(input, dim, start, stop, step)
-                return out
-
-        input = [torch.randn(10, 2, 3, 1)]
-        self.run_test(
-            TestModule(),
-            input,
-        )
-
-
-class TestSelectConverterExplicitBatch(DispatchTestCase):
-    @parameterized.expand(
-        [
-            ("select_dim_start_stop_step", 1, 0, 7, 2),
+            ("select_dim_start_stop_step_offset", 1, 0, 7, 2),
             ("select_dim_start_stop_step_exact", 1, 0, 10, 2),
+            ("select_dim_start_stop_step_negatives", -3, -2, -1, 1),
+            ("select_dim_start_stop_step_max_int", 2, 0, 2**63 - 1, 1),
         ]
     )
     def test_slice(self, _, dim, start, stop, step):

--- a/tests/py/dynamo/conversion/test_sum_aten.py
+++ b/tests/py/dynamo/conversion/test_sum_aten.py
@@ -70,8 +70,8 @@ class TestSumConverter(DispatchTestCase):
 
     @parameterized.expand(
         [
-            ((3, 2, 4), 1, True, torch.int, 0, 5),
-            ((2, 3, 4, 5), None, True, torch.int, -10, 10),
+            ((3, 2, 4), 1, True, torch.int32, 0, 5),
+            ((2, 3, 4, 5), None, True, torch.int32, -10, 10),
             ((2, 3, 4, 5), 2, False, torch.int32, -5, 0),
             ((6, 7, 5, 4, 5), 4, False, torch.int32, -5, 5),
         ]
@@ -85,16 +85,18 @@ class TestSumConverter(DispatchTestCase):
         self.run_test(
             Sum(),
             inputs,
-            check_dtype=False,
+            output_dtypes=[torch.int32],
         )
 
     @parameterized.expand(
         [
-            ((1, 2, 4), [], True, torch.int, 0, 5),
-            ((3, 2, 4), [1], True, torch.int, 0, 5),
-            ((2, 1, 4, 5), [0, 3], True, torch.int, -10, 10),
+            ((1, 2, 4), [], True, torch.int32, 0, 5),
+            ((3, 2, 4), [1], True, torch.int32, 0, 5),
+            ((2, 1, 4, 5), [0, 3], True, torch.int32, -10, 10),
             ((2, 3, 4, 5), None, False, torch.int32, -5, 0),
             ((6, 7, 5, 4, 5), [1, 3, 4], False, torch.int32, -5, 5),
+            ((6, 7, 5, 4, 5), [1, 3, 4], False, torch.bool, 0, 2),
+            ((4, 7, 1, 5), None, True, torch.bool, 0, 2),
         ]
     )
     def test_sum_dim_tuple_int(self, input_shape, dim, keep_dims, dtype, low, high):
@@ -106,7 +108,7 @@ class TestSumConverter(DispatchTestCase):
         self.run_test(
             Sum(),
             inputs,
-            check_dtype=False,
+            output_dtypes=[torch.int32],
         )
 
 


### PR DESCRIPTION
# Description

- Fix slice and sum converter bugs
  - `slice` incorrectly parsed negative-indexed start or end indices
  - `sum` needs to cast boolean tensors to int32, and can take the sum of int32 tensors
- Add regression test cases to validate fixes
- Fix issue where outputs can be torch.int64 when a sum of booleans is returned
- Fix issue where inputs in torch compile were being checked for contiguity
- Propagate fix to utility

Fixes #2400 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
