### PR TITLE
feat: support more elementwise and unary dynamo converters

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -1703,6 +1703,11 @@ def aten_ops_logical_xor(
 
 @dynamo_tensorrt_converter(torch.ops.aten.eq.Tensor)  # type: ignore[misc]
 @dynamo_tensorrt_converter(torch.ops.aten.eq.Scalar)  # type: ignore[misc]
+@enforce_tensor_types(
+    {
+        0: (TRTTensor,),
+    }
+)  # type: ignore[misc]
 def aten_ops_eq(
     ctx: ConversionContext,
     target: Target,
@@ -1722,6 +1727,11 @@ def aten_ops_eq(
 
 @dynamo_tensorrt_converter(torch.ops.aten.ne.Tensor)  # type: ignore[misc]
 @dynamo_tensorrt_converter(torch.ops.aten.ne.Scalar)  # type: ignore[misc]
+@enforce_tensor_types(
+    {
+        0: (TRTTensor,),
+    }
+)  # type: ignore[misc]
 def aten_ops_ne(
     ctx: ConversionContext,
     target: Target,
@@ -1741,6 +1751,11 @@ def aten_ops_ne(
 
 @dynamo_tensorrt_converter(torch.ops.aten.gt.Tensor)  # type: ignore[misc]
 @dynamo_tensorrt_converter(torch.ops.aten.gt.Scalar)  # type: ignore[misc]
+@enforce_tensor_types(
+    {
+        0: (TRTTensor,),
+    }
+)  # type: ignore[misc]
 def aten_ops_gt(
     ctx: ConversionContext,
     target: Target,
@@ -1760,6 +1775,11 @@ def aten_ops_gt(
 
 @dynamo_tensorrt_converter(torch.ops.aten.ge.Tensor)  # type: ignore[misc]
 @dynamo_tensorrt_converter(torch.ops.aten.ge.Scalar)  # type: ignore[misc]
+@enforce_tensor_types(
+    {
+        0: (TRTTensor,),
+    }
+)  # type: ignore[misc]
 def aten_ops_ge(
     ctx: ConversionContext,
     target: Target,
@@ -1779,6 +1799,11 @@ def aten_ops_ge(
 
 @dynamo_tensorrt_converter(torch.ops.aten.lt.Tensor)  # type: ignore[misc]
 @dynamo_tensorrt_converter(torch.ops.aten.lt.Scalar)  # type: ignore[misc]
+@enforce_tensor_types(
+    {
+        0: (TRTTensor,),
+    }
+)  # type: ignore[misc]
 def aten_ops_lt(
     ctx: ConversionContext,
     target: Target,
@@ -1798,6 +1823,11 @@ def aten_ops_lt(
 
 @dynamo_tensorrt_converter(torch.ops.aten.le.Tensor)  # type: ignore[misc]
 @dynamo_tensorrt_converter(torch.ops.aten.le.Scalar)  # type: ignore[misc]
+@enforce_tensor_types(
+    {
+        0: (TRTTensor,),
+    }
+)  # type: ignore[misc]
 def aten_ops_le(
     ctx: ConversionContext,
     target: Target,

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -1701,9 +1701,9 @@ def aten_ops_logical_xor(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.eq.Tensor)
-@dynamo_tensorrt_converter(torch.ops.aten.eq.Scalar)
-def aten_ops_equal(
+@dynamo_tensorrt_converter(torch.ops.aten.eq.Tensor)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.eq.Scalar)  # type: ignore[misc]
+def aten_ops_eq(
     ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
@@ -1720,9 +1720,28 @@ def aten_ops_equal(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.gt.Tensor)
-@dynamo_tensorrt_converter(torch.ops.aten.gt.Scalar)
-def aten_ops_greater(
+@dynamo_tensorrt_converter(torch.ops.aten.ne.Tensor)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.ne.Scalar)  # type: ignore[misc]
+def aten_ops_ne(
+    ctx: ConversionContext,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    return impl.elementwise.ne(
+        ctx,
+        target,
+        SourceIR.ATEN,
+        name,
+        args[0],
+        args[1],
+    )
+
+
+@dynamo_tensorrt_converter(torch.ops.aten.gt.Tensor)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.gt.Scalar)  # type: ignore[misc]
+def aten_ops_gt(
     ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
@@ -1739,9 +1758,28 @@ def aten_ops_greater(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.lt.Tensor)
-@dynamo_tensorrt_converter(torch.ops.aten.lt.Scalar)
-def aten_ops_less(
+@dynamo_tensorrt_converter(torch.ops.aten.ge.Tensor)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.ge.Scalar)  # type: ignore[misc]
+def aten_ops_ge(
+    ctx: ConversionContext,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    return impl.elementwise.ge(
+        ctx,
+        target,
+        SourceIR.ATEN,
+        name,
+        args[0],
+        args[1],
+    )
+
+
+@dynamo_tensorrt_converter(torch.ops.aten.lt.Tensor)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.lt.Scalar)  # type: ignore[misc]
+def aten_ops_lt(
     ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
@@ -1749,6 +1787,25 @@ def aten_ops_less(
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     return impl.elementwise.lt(
+        ctx,
+        target,
+        SourceIR.ATEN,
+        name,
+        args[0],
+        args[1],
+    )
+
+
+@dynamo_tensorrt_converter(torch.ops.aten.le.Tensor)  # type: ignore[misc]
+@dynamo_tensorrt_converter(torch.ops.aten.le.Scalar)  # type: ignore[misc]
+def aten_ops_le(
+    ctx: ConversionContext,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    return impl.elementwise.le(
         ctx,
         target,
         SourceIR.ATEN,

--- a/py/torch_tensorrt/dynamo/conversion/impl/elementwise/base.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/elementwise/base.py
@@ -120,11 +120,11 @@ def convert_binary_elementwise(
     # Note that the dtype here is supposed to be the same as the scalar
     # dtype but we don't have a way to detect whether it makes sense for the
     # scalar to be float or half. Hence we go with the lhs dtype.
-    if is_lhs_trt_tensor and isinstance(rhs_val, (float, int)):
+    if is_lhs_trt_tensor and isinstance(rhs_val, (float, int, bool)):
         rhs_val = np.array(
             [rhs_val], dtype=unified_dtype_converter(lhs_dtype, Frameworks.NUMPY)
         )
-    if is_rhs_trt_tensor and isinstance(lhs_val, (float, int)):
+    if is_rhs_trt_tensor and isinstance(lhs_val, (float, int, bool)):
         lhs_val = np.array(
             [lhs_val], dtype=unified_dtype_converter(rhs_dtype, Frameworks.NUMPY)
         )

--- a/py/torch_tensorrt/dynamo/conversion/impl/elementwise/base.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/elementwise/base.py
@@ -58,8 +58,8 @@ def convert_binary_elementwise(
     source_ir: Optional[SourceIR],
     name: str,
     op_type: trt.ElementWiseOperation,
-    lhs_val: Union[int, float, TRTTensor, torch.Tensor],
-    rhs_val: Union[int, float, TRTTensor, torch.Tensor],
+    lhs_val: Union[int, float, bool, TRTTensor, torch.Tensor],
+    rhs_val: Union[int, float, bool, TRTTensor, torch.Tensor],
 ) -> TRTTensor:
     """
     This function adds a TensorRT elementwise layer. We allow both operands to be

--- a/py/torch_tensorrt/dynamo/conversion/impl/elementwise/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/elementwise/ops.py
@@ -2,6 +2,7 @@ from typing import Optional, Union
 
 import numpy as np
 import tensorrt as trt
+import torch_tensorrt.dynamo.conversion.impl as impl
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
@@ -441,6 +442,23 @@ def eq(
     )
 
 
+def ne(
+    ctx: ConversionContext,
+    target: Target,
+    source_ir: Optional[SourceIR],
+    name: str,
+    lhs_val: Union[TRTTensor, int, float],
+    rhs_val: Union[TRTTensor, int, float],
+) -> TRTTensor:
+    return impl.unary.logical_not(
+        ctx,
+        target,
+        source_ir,
+        f"{name}_logical_not",
+        eq(ctx, target, source_ir, f"{name}_eq", lhs_val, rhs_val),
+    )
+
+
 def gt(
     ctx: ConversionContext,
     target: Target,
@@ -460,6 +478,24 @@ def gt(
     )
 
 
+def ge(
+    ctx: ConversionContext,
+    target: Target,
+    source_ir: Optional[SourceIR],
+    name: str,
+    lhs_val: Union[TRTTensor, int, float],
+    rhs_val: Union[TRTTensor, int, float],
+) -> TRTTensor:
+    return logical_or(
+        ctx,
+        target,
+        source_ir,
+        name,
+        gt(ctx, target, source_ir, f"{name}_gt", lhs_val, rhs_val),
+        eq(ctx, target, source_ir, f"{name}_eq", lhs_val, rhs_val),
+    )
+
+
 def lt(
     ctx: ConversionContext,
     target: Target,
@@ -476,4 +512,22 @@ def lt(
         trt.ElementWiseOperation.LESS,
         lhs_val,
         rhs_val,
+    )
+
+
+def le(
+    ctx: ConversionContext,
+    target: Target,
+    source_ir: Optional[SourceIR],
+    name: str,
+    lhs_val: Union[TRTTensor, int, float],
+    rhs_val: Union[TRTTensor, int, float],
+) -> TRTTensor:
+    return logical_or(
+        ctx,
+        target,
+        source_ir,
+        name,
+        lt(ctx, target, source_ir, f"{name}_lt", lhs_val, rhs_val),
+        eq(ctx, target, source_ir, f"{name}_eq", lhs_val, rhs_val),
     )

--- a/py/torch_tensorrt/dynamo/conversion/impl/elementwise/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/elementwise/ops.py
@@ -423,6 +423,39 @@ def logical_xor(
     )
 
 
+def bitwise_and(
+    ctx: ConversionContext,
+    target: Target,
+    source_ir: Optional[SourceIR],
+    name: str,
+    lhs_val: Union[TRTTensor, int, bool, Sequence[Union[int, bool]]],
+    rhs_val: Union[TRTTensor, int, bool, Sequence[Union[int, bool]]],
+) -> TRTTensor:
+    return logical_and(ctx, target, source_ir, f"{name}_logical_and", lhs_val, rhs_val)
+
+
+def bitwise_or(
+    ctx: ConversionContext,
+    target: Target,
+    source_ir: Optional[SourceIR],
+    name: str,
+    lhs_val: Union[TRTTensor, int, bool, Sequence[Union[int, bool]]],
+    rhs_val: Union[TRTTensor, int, bool, Sequence[Union[int, bool]]],
+) -> TRTTensor:
+    return logical_or(ctx, target, source_ir, f"{name}_logical_or", lhs_val, rhs_val)
+
+
+def bitwise_xor(
+    ctx: ConversionContext,
+    target: Target,
+    source_ir: Optional[SourceIR],
+    name: str,
+    lhs_val: Union[TRTTensor, int, bool, Sequence[Union[int, bool]]],
+    rhs_val: Union[TRTTensor, int, bool, Sequence[Union[int, bool]]],
+) -> TRTTensor:
+    return logical_xor(ctx, target, source_ir, f"{name}_logical_xor", lhs_val, rhs_val)
+
+
 def eq(
     ctx: ConversionContext,
     target: Target,

--- a/py/torch_tensorrt/dynamo/conversion/impl/elementwise/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/elementwise/ops.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Sequence, Union
 
 import numpy as np
 import tensorrt as trt
@@ -428,8 +428,8 @@ def eq(
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
-    lhs_val: Union[TRTTensor, int, float],
-    rhs_val: Union[TRTTensor, int, float],
+    lhs_val: TRTTensor,
+    rhs_val: Union[TRTTensor, int, float, bool, Sequence[Union[int, float, bool]]],
 ) -> TRTTensor:
     return convert_binary_elementwise(
         ctx,
@@ -447,8 +447,8 @@ def ne(
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
-    lhs_val: Union[TRTTensor, int, float],
-    rhs_val: Union[TRTTensor, int, float],
+    lhs_val: TRTTensor,
+    rhs_val: Union[TRTTensor, int, float, bool, Sequence[Union[int, float, bool]]],
 ) -> TRTTensor:
     return impl.unary.logical_not(
         ctx,
@@ -464,8 +464,8 @@ def gt(
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
-    lhs_val: Union[TRTTensor, int, float],
-    rhs_val: Union[TRTTensor, int, float],
+    lhs_val: TRTTensor,
+    rhs_val: Union[TRTTensor, int, float, Sequence[Union[int, float]]],
 ) -> TRTTensor:
     return convert_binary_elementwise(
         ctx,
@@ -483,8 +483,8 @@ def ge(
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
-    lhs_val: Union[TRTTensor, int, float],
-    rhs_val: Union[TRTTensor, int, float],
+    lhs_val: TRTTensor,
+    rhs_val: Union[TRTTensor, int, float, Sequence[Union[int, float]]],
 ) -> TRTTensor:
     return logical_or(
         ctx,
@@ -501,8 +501,8 @@ def lt(
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
-    lhs_val: Union[TRTTensor, int, float],
-    rhs_val: Union[TRTTensor, int, float],
+    lhs_val: TRTTensor,
+    rhs_val: Union[TRTTensor, int, float, Sequence[Union[int, float]]],
 ) -> TRTTensor:
     return convert_binary_elementwise(
         ctx,
@@ -520,8 +520,8 @@ def le(
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
-    lhs_val: Union[TRTTensor, int, float],
-    rhs_val: Union[TRTTensor, int, float],
+    lhs_val: TRTTensor,
+    rhs_val: Union[TRTTensor, int, float, Sequence[Union[int, float]]],
 ) -> TRTTensor:
     return logical_or(
         ctx,

--- a/py/torch_tensorrt/dynamo/conversion/impl/elementwise/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/elementwise/ops.py
@@ -1,7 +1,8 @@
-from typing import Optional, Sequence, Union
+from typing import Optional, Union
 
 import numpy as np
 import tensorrt as trt
+import torch
 import torch_tensorrt.dynamo.conversion.impl as impl
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
@@ -371,8 +372,8 @@ def logical_and(
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
-    lhs_val: Union[TRTTensor, int, float],
-    rhs_val: Union[TRTTensor, int, float],
+    lhs_val: Union[TRTTensor, int, float, bool],
+    rhs_val: Union[TRTTensor, int, float, bool],
 ) -> TRTTensor:
     if isinstance(lhs_val, TRTTensor):
         lhs_val = cast_int_or_float_to_bool(ctx, name, lhs_val)
@@ -390,8 +391,8 @@ def logical_or(
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
-    lhs_val: Union[TRTTensor, int, float],
-    rhs_val: Union[TRTTensor, int, float],
+    lhs_val: Union[TRTTensor, int, float, bool],
+    rhs_val: Union[TRTTensor, int, float, bool],
 ) -> TRTTensor:
     if isinstance(lhs_val, TRTTensor):
         lhs_val = cast_int_or_float_to_bool(ctx, name, lhs_val)
@@ -409,8 +410,8 @@ def logical_xor(
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
-    lhs_val: Union[TRTTensor, int, float],
-    rhs_val: Union[TRTTensor, int, float],
+    lhs_val: Union[TRTTensor, int, float, bool],
+    rhs_val: Union[TRTTensor, int, float, bool],
 ) -> TRTTensor:
     if isinstance(lhs_val, TRTTensor):
         lhs_val = cast_int_or_float_to_bool(ctx, name, lhs_val)
@@ -428,8 +429,8 @@ def bitwise_and(
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
-    lhs_val: Union[TRTTensor, int, bool, Sequence[Union[int, bool]]],
-    rhs_val: Union[TRTTensor, int, bool, Sequence[Union[int, bool]]],
+    lhs_val: Union[TRTTensor, int, float, torch.Tensor, bool],
+    rhs_val: Union[TRTTensor, int, float, torch.Tensor, bool],
 ) -> TRTTensor:
     return logical_and(ctx, target, source_ir, f"{name}_logical_and", lhs_val, rhs_val)
 
@@ -439,8 +440,8 @@ def bitwise_or(
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
-    lhs_val: Union[TRTTensor, int, bool, Sequence[Union[int, bool]]],
-    rhs_val: Union[TRTTensor, int, bool, Sequence[Union[int, bool]]],
+    lhs_val: Union[TRTTensor, int, float, torch.Tensor, bool],
+    rhs_val: Union[TRTTensor, int, float, torch.Tensor, bool],
 ) -> TRTTensor:
     return logical_or(ctx, target, source_ir, f"{name}_logical_or", lhs_val, rhs_val)
 
@@ -450,8 +451,8 @@ def bitwise_xor(
     target: Target,
     source_ir: Optional[SourceIR],
     name: str,
-    lhs_val: Union[TRTTensor, int, bool, Sequence[Union[int, bool]]],
-    rhs_val: Union[TRTTensor, int, bool, Sequence[Union[int, bool]]],
+    lhs_val: Union[TRTTensor, int, float, torch.Tensor, bool],
+    rhs_val: Union[TRTTensor, int, float, torch.Tensor, bool],
 ) -> TRTTensor:
     return logical_xor(ctx, target, source_ir, f"{name}_logical_xor", lhs_val, rhs_val)
 
@@ -462,7 +463,7 @@ def eq(
     source_ir: Optional[SourceIR],
     name: str,
     lhs_val: TRTTensor,
-    rhs_val: Union[TRTTensor, int, float, bool, Sequence[Union[int, float, bool]]],
+    rhs_val: Union[TRTTensor, int, float, torch.Tensor],
 ) -> TRTTensor:
     return convert_binary_elementwise(
         ctx,
@@ -481,7 +482,7 @@ def ne(
     source_ir: Optional[SourceIR],
     name: str,
     lhs_val: TRTTensor,
-    rhs_val: Union[TRTTensor, int, float, bool, Sequence[Union[int, float, bool]]],
+    rhs_val: Union[TRTTensor, int, float, torch.Tensor],
 ) -> TRTTensor:
     return impl.unary.logical_not(
         ctx,
@@ -498,7 +499,7 @@ def gt(
     source_ir: Optional[SourceIR],
     name: str,
     lhs_val: TRTTensor,
-    rhs_val: Union[TRTTensor, int, float, Sequence[Union[int, float]]],
+    rhs_val: Union[TRTTensor, int, float, torch.Tensor],
 ) -> TRTTensor:
     return convert_binary_elementwise(
         ctx,
@@ -517,7 +518,7 @@ def ge(
     source_ir: Optional[SourceIR],
     name: str,
     lhs_val: TRTTensor,
-    rhs_val: Union[TRTTensor, int, float, Sequence[Union[int, float]]],
+    rhs_val: Union[TRTTensor, int, float, torch.Tensor],
 ) -> TRTTensor:
     return logical_or(
         ctx,
@@ -535,7 +536,7 @@ def lt(
     source_ir: Optional[SourceIR],
     name: str,
     lhs_val: TRTTensor,
-    rhs_val: Union[TRTTensor, int, float, Sequence[Union[int, float]]],
+    rhs_val: Union[TRTTensor, int, float, torch.Tensor],
 ) -> TRTTensor:
     return convert_binary_elementwise(
         ctx,
@@ -554,7 +555,7 @@ def le(
     source_ir: Optional[SourceIR],
     name: str,
     lhs_val: TRTTensor,
-    rhs_val: Union[TRTTensor, int, float, Sequence[Union[int, float]]],
+    rhs_val: Union[TRTTensor, int, float, torch.Tensor],
 ) -> TRTTensor:
     return logical_or(
         ctx,

--- a/py/torch_tensorrt/dynamo/conversion/impl/unary/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/unary/ops.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import tensorrt as trt
+import torch_tensorrt.dynamo.conversion.impl as impl
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
@@ -333,6 +334,18 @@ def logical_not(
 
     return convert_unary(
         ctx, target, source_ir, name, trt.UnaryOperation.NOT, input_val
+    )
+
+
+def bitwise_not(
+    ctx: ConversionContext,
+    target: Target,
+    source_ir: Optional[SourceIR],
+    name: str,
+    input_val: TRTTensor,
+) -> TRTTensor:
+    return impl.unary.logical_not(
+        ctx, target, source_ir, f"{name}_logical_not", input_val
     )
 
 

--- a/tests/py/dynamo/conversion/test_bitwise_and_aten.py
+++ b/tests/py/dynamo/conversion/test_bitwise_and_aten.py
@@ -28,6 +28,46 @@ class TestBitwiseAndConverter(DispatchTestCase):
             enable_passes=True,
         )
 
+    @parameterized.expand(
+        [
+            ("2d", (5, 3), True),
+            ("3d", (5, 3, 2), False),
+        ]
+    )
+    def test_bitwise_and_scalar(self, _, shape, scalar):
+        class bitwise_and(nn.Module):
+            def forward(self, tensor):
+                return torch.ops.aten.bitwise_and.Scalar(tensor, scalar)
+
+        inputs = [
+            torch.randint(0, 2, shape, dtype=bool),
+        ]
+        self.run_test(
+            bitwise_and(),
+            inputs,
+            enable_passes=True,
+        )
+
+    @parameterized.expand(
+        [
+            ("2d", (5, 3), True),
+            ("3d", (5, 3, 2), False),
+        ]
+    )
+    def test_bitwise_and_scalar_tensor(self, _, shape, scalar):
+        class bitwise_and(nn.Module):
+            def forward(self, tensor):
+                return torch.ops.aten.bitwise_and.Scalar_Tensor(scalar, tensor)
+
+        inputs = [
+            torch.randint(0, 2, shape, dtype=bool),
+        ]
+        self.run_test(
+            bitwise_and(),
+            inputs,
+            enable_passes=True,
+        )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/tests/py/dynamo/conversion/test_bitwise_and_aten.py
+++ b/tests/py/dynamo/conversion/test_bitwise_and_aten.py
@@ -1,0 +1,33 @@
+import torch
+import torch.nn as nn
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+
+from .harness import DispatchTestCase
+
+
+class TestBitwiseAndConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            ("2d", (5, 3)),
+            ("3d", (5, 3, 2)),
+        ]
+    )
+    def test_bitwise_and_tensor(self, _, shape):
+        class bitwise_and(nn.Module):
+            def forward(self, lhs_val, rhs_val):
+                return torch.ops.aten.bitwise_and.Tensor(lhs_val, rhs_val)
+
+        inputs = [
+            torch.randint(0, 2, shape, dtype=bool),
+            torch.randint(0, 2, shape, dtype=bool),
+        ]
+        self.run_test(
+            bitwise_and(),
+            inputs,
+            enable_passes=True,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/py/dynamo/conversion/test_bitwise_not_aten.py
+++ b/tests/py/dynamo/conversion/test_bitwise_not_aten.py
@@ -1,0 +1,33 @@
+import torch
+import torch.nn as nn
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+
+from .harness import DispatchTestCase
+
+
+class TestBitwiseNotConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            ("2d", (5, 3)),
+            ("3d", (5, 3, 2)),
+        ]
+    )
+    def test_bitwise_not_tensor(self, _, shape):
+        class bitwise_not(nn.Module):
+            def forward(self, val):
+                return torch.ops.aten.bitwise_not.default(val)
+
+        inputs = [
+            torch.randint(0, 2, shape, dtype=torch.bool),
+        ]
+        self.run_test(
+            bitwise_not(),
+            inputs,
+            enable_passes=True,
+            output_dtypes=[torch.bool],
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/py/dynamo/conversion/test_bitwise_or_aten.py
+++ b/tests/py/dynamo/conversion/test_bitwise_or_aten.py
@@ -28,6 +28,46 @@ class TestBitwiseOrConverter(DispatchTestCase):
             enable_passes=True,
         )
 
+    @parameterized.expand(
+        [
+            ("2d", (5, 3), True),
+            ("3d", (5, 3, 2), False),
+        ]
+    )
+    def test_bitwise_or_scalar(self, _, shape, scalar):
+        class bitwise_or(nn.Module):
+            def forward(self, tensor):
+                return torch.ops.aten.bitwise_or.Scalar(tensor, scalar)
+
+        inputs = [
+            torch.randint(0, 2, shape, dtype=bool),
+        ]
+        self.run_test(
+            bitwise_or(),
+            inputs,
+            enable_passes=True,
+        )
+
+    @parameterized.expand(
+        [
+            ("2d", (5, 3), True),
+            ("3d", (5, 3, 2), False),
+        ]
+    )
+    def test_bitwise_or_scalar_tensor(self, _, shape, scalar):
+        class bitwise_or(nn.Module):
+            def forward(self, tensor):
+                return torch.ops.aten.bitwise_or.Scalar_Tensor(scalar, tensor)
+
+        inputs = [
+            torch.randint(0, 2, shape, dtype=bool),
+        ]
+        self.run_test(
+            bitwise_or(),
+            inputs,
+            enable_passes=True,
+        )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/tests/py/dynamo/conversion/test_bitwise_or_aten.py
+++ b/tests/py/dynamo/conversion/test_bitwise_or_aten.py
@@ -1,0 +1,33 @@
+import torch
+import torch.nn as nn
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+
+from .harness import DispatchTestCase
+
+
+class TestBitwiseOrConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            ("2d", (5, 3)),
+            ("3d", (5, 3, 2)),
+        ]
+    )
+    def test_bitwise_or_tensor(self, _, shape):
+        class bitwise_or(nn.Module):
+            def forward(self, lhs_val, rhs_val):
+                return torch.ops.aten.bitwise_or.Tensor(lhs_val, rhs_val)
+
+        inputs = [
+            torch.randint(0, 2, shape, dtype=bool),
+            torch.randint(0, 2, shape, dtype=bool),
+        ]
+        self.run_test(
+            bitwise_or(),
+            inputs,
+            enable_passes=True,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/py/dynamo/conversion/test_bitwise_xor_aten.py
+++ b/tests/py/dynamo/conversion/test_bitwise_xor_aten.py
@@ -28,6 +28,46 @@ class TestBitwiseXorConverter(DispatchTestCase):
             enable_passes=True,
         )
 
+    @parameterized.expand(
+        [
+            ("2d", (5, 3), True),
+            ("3d", (5, 3, 2), False),
+        ]
+    )
+    def test_bitwise_xor_scalar(self, _, shape, scalar):
+        class bitwise_xor(nn.Module):
+            def forward(self, tensor):
+                return torch.ops.aten.bitwise_xor.Scalar(tensor, scalar)
+
+        inputs = [
+            torch.randint(0, 2, shape, dtype=bool),
+        ]
+        self.run_test(
+            bitwise_xor(),
+            inputs,
+            enable_passes=True,
+        )
+
+    @parameterized.expand(
+        [
+            ("2d", (5, 3), True),
+            ("3d", (5, 3, 2), False),
+        ]
+    )
+    def test_bitwise_xor_scalar_tensor(self, _, shape, scalar):
+        class bitwise_xor(nn.Module):
+            def forward(self, tensor):
+                return torch.ops.aten.bitwise_xor.Scalar_Tensor(scalar, tensor)
+
+        inputs = [
+            torch.randint(0, 2, shape, dtype=bool),
+        ]
+        self.run_test(
+            bitwise_xor(),
+            inputs,
+            enable_passes=True,
+        )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/tests/py/dynamo/conversion/test_bitwise_xor_aten.py
+++ b/tests/py/dynamo/conversion/test_bitwise_xor_aten.py
@@ -1,0 +1,33 @@
+import torch
+import torch.nn as nn
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+
+from .harness import DispatchTestCase
+
+
+class TestBitwiseXorConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            ("2d", (5, 3)),
+            ("3d", (5, 3, 2)),
+        ]
+    )
+    def test_bitwise_xor_tensor(self, _, shape):
+        class bitwise_xor(nn.Module):
+            def forward(self, lhs_val, rhs_val):
+                return torch.ops.aten.bitwise_xor.Tensor(lhs_val, rhs_val)
+
+        inputs = [
+            torch.randint(0, 2, shape, dtype=bool),
+            torch.randint(0, 2, shape, dtype=bool),
+        ]
+        self.run_test(
+            bitwise_xor(),
+            inputs,
+            enable_passes=True,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/py/dynamo/conversion/test_eq_aten.py
+++ b/tests/py/dynamo/conversion/test_eq_aten.py
@@ -2,7 +2,6 @@ import torch
 import torch.nn as nn
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
-from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
@@ -10,56 +9,58 @@ from .harness import DispatchTestCase
 class TestEqualConverter(DispatchTestCase):
     @parameterized.expand(
         [
-            ("2d", (2, 1)),
-            ("3d", (2, 1, 2)),
+            ("2d", (5, 3)),
+            ("3d", (5, 3, 2)),
         ]
     )
-    def test_equal_tensor(self, _, shape):
-        class equal(nn.Module):
+    def test_eq_tensor(self, _, shape):
+        class eq(nn.Module):
             def forward(self, lhs_val, rhs_val):
                 return torch.ops.aten.eq.Tensor(lhs_val, rhs_val)
 
-        inputs = [torch.randn(shape), torch.randn(shape)]
+        inputs = [
+            torch.randint(0, 3, shape, dtype=torch.int32),
+            torch.randint(0, 3, shape, dtype=torch.int32),
+        ]
         self.run_test(
-            equal(),
+            eq(),
             inputs,
             output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
         [
-            ("2d", (2, 1), 1),
-            ("3d", (2, 1, 2), 2.0),
+            ("2d", (5, 3), 1),
+            ("3d", (5, 3, 2), 2.0),
         ]
     )
-    def test_equal_tensor_scalar(self, _, shape, scalar):
-        class equal(nn.Module):
+    def test_eq_tensor_scalar(self, _, shape, scalar):
+        class eq(nn.Module):
             def forward(self, lhs_val):
                 return torch.ops.aten.eq.Tensor(lhs_val, torch.tensor(scalar))
 
-        inputs = [torch.randn(shape)]
+        inputs = [torch.randint(0, 3, shape, dtype=torch.int32)]
         self.run_test(
-            equal(),
+            eq(),
             inputs,
             output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
         [
-            ("2d", (2, 1), 1),
-            ("3d", (2, 1, 2), 2.0),
+            ("2d", (5, 3), 1),
+            ("3d", (5, 3, 2), 2.0),
         ]
     )
-    def test_equal_scalar(self, _, shape, scalar):
-        class equal(nn.Module):
+    def test_eq_scalar(self, _, shape, scalar):
+        class eq(nn.Module):
             def forward(self, lhs_val):
                 return torch.ops.aten.eq.Scalar(lhs_val, scalar)
 
-        inputs = [torch.randn(shape)]
+        inputs = [torch.randint(0, 3, shape, dtype=torch.int32)]
         self.run_test(
-            equal(),
+            eq(),
             inputs,
-            # expected_ops={torch.ops.aten.eq.Scalar},
             output_dtypes=[torch.bool],
         )
 

--- a/tests/py/dynamo/conversion/test_ge_aten.py
+++ b/tests/py/dynamo/conversion/test_ge_aten.py
@@ -1,0 +1,69 @@
+import torch
+import torch.nn as nn
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+
+from .harness import DispatchTestCase
+
+
+class TestGtConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            ("2d", (5, 3)),
+            ("3d", (5, 3, 2)),
+        ]
+    )
+    def test_ge_tensor(self, _, shape):
+        class ge(nn.Module):
+            def forward(self, lhs_val, rhs_val):
+                return torch.ops.aten.ge.Tensor(lhs_val, rhs_val)
+
+        inputs = [
+            torch.randint(0, 3, shape, dtype=torch.int32),
+            torch.randint(0, 3, shape, dtype=torch.int32),
+        ]
+        self.run_test(
+            ge(),
+            inputs,
+            output_dtypes=[torch.bool],
+        )
+
+    @parameterized.expand(
+        [
+            ("2d", (5, 3), 1),
+            ("3d", (5, 3, 2), 2.0),
+        ]
+    )
+    def test_ge_tensor_scalar(self, _, shape, scalar):
+        class ge(nn.Module):
+            def forward(self, lhs_val):
+                return torch.ops.aten.ge.Tensor(lhs_val, torch.tensor(scalar))
+
+        inputs = [torch.randint(0, 3, shape, dtype=torch.int32)]
+        self.run_test(
+            ge(),
+            inputs,
+            output_dtypes=[torch.bool],
+        )
+
+    @parameterized.expand(
+        [
+            ("2d", (5, 3), 1),
+            ("3d", (5, 3, 2), 2.0),
+        ]
+    )
+    def test_ge_scalar(self, _, shape, scalar):
+        class ge(nn.Module):
+            def forward(self, lhs_val):
+                return torch.ops.aten.ge.Scalar(lhs_val, scalar)
+
+        inputs = [torch.randint(0, 3, shape, dtype=torch.int32)]
+        self.run_test(
+            ge(),
+            inputs,
+            output_dtypes=[torch.bool],
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/py/dynamo/conversion/test_gt_aten.py
+++ b/tests/py/dynamo/conversion/test_gt_aten.py
@@ -1,0 +1,66 @@
+import torch
+import torch.nn as nn
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+
+from .harness import DispatchTestCase
+
+
+class TestGtConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            ("2d", (5, 3)),
+            ("3d", (5, 3, 2)),
+        ]
+    )
+    def test_gt_tensor(self, _, shape):
+        class gt(nn.Module):
+            def forward(self, lhs_val, rhs_val):
+                return torch.ops.aten.gt.Tensor(lhs_val, rhs_val)
+
+        inputs = [torch.randn(shape), torch.randn(shape)]
+        self.run_test(
+            gt(),
+            inputs,
+            output_dtypes=[torch.bool],
+        )
+
+    @parameterized.expand(
+        [
+            ("2d", (5, 3), 1),
+            ("3d", (5, 3, 2), 2.0),
+        ]
+    )
+    def test_gt_tensor_scalar(self, _, shape, scalar):
+        class gt(nn.Module):
+            def forward(self, lhs_val):
+                return torch.ops.aten.gt.Tensor(lhs_val, torch.tensor(scalar))
+
+        inputs = [torch.randn(shape)]
+        self.run_test(
+            gt(),
+            inputs,
+            output_dtypes=[torch.bool],
+        )
+
+    @parameterized.expand(
+        [
+            ("2d", (5, 3), 1),
+            ("3d", (5, 3, 2), 2.0),
+        ]
+    )
+    def test_gt_scalar(self, _, shape, scalar):
+        class gt(nn.Module):
+            def forward(self, lhs_val):
+                return torch.ops.aten.gt.Scalar(lhs_val, scalar)
+
+        inputs = [torch.randn(shape)]
+        self.run_test(
+            gt(),
+            inputs,
+            output_dtypes=[torch.bool],
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/py/dynamo/conversion/test_le_aten.py
+++ b/tests/py/dynamo/conversion/test_le_aten.py
@@ -2,62 +2,64 @@ import torch
 import torch.nn as nn
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
-from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
 
-class TestLessConverter(DispatchTestCase):
+class TestLeConverter(DispatchTestCase):
     @parameterized.expand(
         [
-            ("2d", (2, 1)),
-            ("3d", (2, 1, 2)),
+            ("2d", (5, 3)),
+            ("3d", (5, 3, 2)),
         ]
     )
-    def test_less_tensor(self, _, shape):
-        class less(nn.Module):
+    def test_le_tensor(self, _, shape):
+        class le(nn.Module):
             def forward(self, lhs_val, rhs_val):
                 return torch.ops.aten.lt.Tensor(lhs_val, rhs_val)
 
-        inputs = [torch.randn(shape), torch.randn(shape)]
+        inputs = [
+            torch.randint(0, 3, shape, dtype=torch.int32),
+            torch.randint(0, 3, shape, dtype=torch.int32),
+        ]
         self.run_test(
-            less(),
+            le(),
             inputs,
             output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
         [
-            ("2d", (2, 1), 1),
-            ("3d", (2, 1, 2), 2.0),
+            ("2d", (5, 3), 1),
+            ("3d", (5, 3, 2), 2.0),
         ]
     )
-    def test_less_tensor_scalar(self, _, shape, scalar):
-        class less(nn.Module):
+    def test_le_tensor_scalar(self, _, shape, scalar):
+        class le(nn.Module):
             def forward(self, lhs_val):
                 return torch.ops.aten.lt.Tensor(lhs_val, torch.tensor(scalar))
 
-        inputs = [torch.randn(shape)]
+        inputs = [torch.randint(0, 3, shape, dtype=torch.int32)]
         self.run_test(
-            less(),
+            le(),
             inputs,
             output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
         [
-            ("2d", (2, 1), 1),
-            ("3d", (2, 1, 2), 2.0),
+            ("2d", (5, 3), 1),
+            ("3d", (5, 3, 2), 2.0),
         ]
     )
-    def test_less_scalar(self, _, shape, scalar):
-        class less(nn.Module):
+    def test_le_scalar(self, _, shape, scalar):
+        class le(nn.Module):
             def forward(self, lhs_val):
                 return torch.ops.aten.lt.Scalar(lhs_val, scalar)
 
-        inputs = [torch.randn(shape)]
+        inputs = [torch.randint(0, 3, shape, dtype=torch.int32)]
         self.run_test(
-            less(),
+            le(),
             inputs,
             output_dtypes=[torch.bool],
         )

--- a/tests/py/dynamo/conversion/test_lt_aten.py
+++ b/tests/py/dynamo/conversion/test_lt_aten.py
@@ -2,26 +2,25 @@ import torch
 import torch.nn as nn
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
-from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
 
-class TestGreaterConverter(DispatchTestCase):
+class TestLtConverter(DispatchTestCase):
     @parameterized.expand(
         [
             ("2d", (2, 1)),
             ("3d", (2, 1, 2)),
         ]
     )
-    def test_greater_tensor(self, _, shape):
-        class greater(nn.Module):
+    def test_lt_tensor(self, _, shape):
+        class lt(nn.Module):
             def forward(self, lhs_val, rhs_val):
-                return torch.ops.aten.gt.Tensor(lhs_val, rhs_val)
+                return torch.ops.aten.lt.Tensor(lhs_val, rhs_val)
 
         inputs = [torch.randn(shape), torch.randn(shape)]
         self.run_test(
-            greater(),
+            lt(),
             inputs,
             output_dtypes=[torch.bool],
         )
@@ -32,14 +31,14 @@ class TestGreaterConverter(DispatchTestCase):
             ("3d", (2, 1, 2), 2.0),
         ]
     )
-    def test_greater_tensor_scalar(self, _, shape, scalar):
-        class greater(nn.Module):
+    def test_lt_tensor_scalar(self, _, shape, scalar):
+        class lt(nn.Module):
             def forward(self, lhs_val):
-                return torch.ops.aten.gt.Tensor(lhs_val, torch.tensor(scalar))
+                return torch.ops.aten.lt.Tensor(lhs_val, torch.tensor(scalar))
 
         inputs = [torch.randn(shape)]
         self.run_test(
-            greater(),
+            lt(),
             inputs,
             output_dtypes=[torch.bool],
         )
@@ -50,14 +49,14 @@ class TestGreaterConverter(DispatchTestCase):
             ("3d", (2, 1, 2), 2.0),
         ]
     )
-    def test_greater_scalar(self, _, shape, scalar):
-        class greater(nn.Module):
+    def test_lt_scalar(self, _, shape, scalar):
+        class lt(nn.Module):
             def forward(self, lhs_val):
-                return torch.ops.aten.gt.Scalar(lhs_val, scalar)
+                return torch.ops.aten.lt.Scalar(lhs_val, scalar)
 
         inputs = [torch.randn(shape)]
         self.run_test(
-            greater(),
+            lt(),
             inputs,
             output_dtypes=[torch.bool],
         )

--- a/tests/py/dynamo/conversion/test_ne_aten.py
+++ b/tests/py/dynamo/conversion/test_ne_aten.py
@@ -1,0 +1,69 @@
+import torch
+import torch.nn as nn
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+
+from .harness import DispatchTestCase
+
+
+class TestNotEqualConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            ("2d", (5, 3)),
+            ("3d", (5, 3, 2)),
+        ]
+    )
+    def test_ne_tensor(self, _, shape):
+        class ne(nn.Module):
+            def forward(self, lhs_val, rhs_val):
+                return torch.ops.aten.ne.Tensor(lhs_val, rhs_val)
+
+        inputs = [
+            torch.randint(0, 3, shape, dtype=torch.int32),
+            torch.randint(0, 3, shape, dtype=torch.int32),
+        ]
+        self.run_test(
+            ne(),
+            inputs,
+            output_dtypes=[torch.bool],
+        )
+
+    @parameterized.expand(
+        [
+            ("2d", (5, 3), 1),
+            ("3d", (5, 3, 2), 2.0),
+        ]
+    )
+    def test_ne_tensor_scalar(self, _, shape, scalar):
+        class ne(nn.Module):
+            def forward(self, lhs_val):
+                return torch.ops.aten.ne.Tensor(lhs_val, torch.tensor(scalar))
+
+        inputs = [torch.randint(0, 3, shape, dtype=torch.int32)]
+        self.run_test(
+            ne(),
+            inputs,
+            output_dtypes=[torch.bool],
+        )
+
+    @parameterized.expand(
+        [
+            ("2d", (5, 3), 1),
+            ("3d", (5, 3, 2), 2.0),
+        ]
+    )
+    def test_ne_scalar(self, _, shape, scalar):
+        class ne(nn.Module):
+            def forward(self, lhs_val):
+                return torch.ops.aten.ne.Scalar(lhs_val, scalar)
+
+        inputs = [torch.randint(0, 3, shape, dtype=torch.int32)]
+        self.run_test(
+            ne(),
+            inputs,
+            output_dtypes=[torch.bool],
+        )
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
# Description

Support more elementwise and unary dynamo converters.

For `bitwise_op` converters, TensorRT doesn't support bitwise ops. Thus, if inputs are `int` values, they will fall back to pytorch. If inputs are `bool`, they will be converted with the help of `logical_op`.

Fixes #2208 #2199 

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
