### PR TITLE
feat: Add dryrun feature to Dynamo paths

### DIFF
--- a/py/torch_tensorrt/dynamo/_DryRunTracker.py
+++ b/py/torch_tensorrt/dynamo/_DryRunTracker.py
@@ -1,0 +1,205 @@
+import logging
+import math
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PerSubgraphData:
+    """Class to track data on a per-subgraph level
+
+    Args:
+        subgraph_name (str): Name of the subgraph in the GraphModule
+        subgraph_op_count (int): Number of operations in the subgraph
+        subgraph_input_shapes (List[Tuple[int, ...]]): Shapes of input Tensors of the subgraph
+        subgraph_input_dtypes (List[torch.device]): Input data types of the subgraph
+        subgraph_output_shapes (List[Tuple[int, ...]]): Shapes of output Tensors of the subgraph
+        subgraph_output_dtypes (List[torch.device]): Output data types of the subgraph
+    """
+
+    subgraph_name: str = ""
+    subgraph_op_count: int = 0
+    subgraph_input_shapes: List[Tuple[int, ...]] = field(default_factory=list)
+    subgraph_input_dtypes: List[torch.device] = field(default_factory=list)
+    subgraph_output_shapes: List[Tuple[int, ...]] = field(default_factory=list)
+    subgraph_output_dtypes: List[torch.device] = field(default_factory=list)
+
+
+@dataclass
+class DryRunTracker:
+    """Class to track data on a graph-wide level
+
+    Args:
+        total_ops_in_graph (int): Total number of operators in graph
+        supported_ops_in_graph (int): Number of supported operators in graph
+        graph_input_shapes (List[Tuple[int, ...]]): Shapes of input Tensors of the graph
+        graph_input_dtypes (List[torch.device]): Input data types of the graph
+        graph_output_shapes (List[Tuple[int, ...]]): Shapes of output Tensors of the graph
+        graph_output_dtypes (List[torch.device]): Output data types of the graph
+        per_subgraph_data (List[PerSubgraphData]): Per-subgraph data, see above class
+        tensorrt_graph_count (int): Number of TensorRT engines to be generated
+        truncated_long_and_double (bool): Whether truncate_long_and_double was enabled
+    """
+
+    total_ops_in_graph: int = 0
+    supported_ops_in_graph: int = 0
+    graph_input_shapes: List[Tuple[int, ...]] = field(default_factory=list)
+    graph_input_dtypes: List[torch.device] = field(default_factory=list)
+    graph_output_shapes: List[Tuple[int, ...]] = field(default_factory=list)
+    graph_output_dtypes: List[torch.device] = field(default_factory=list)
+    per_subgraph_data: List[PerSubgraphData] = field(default_factory=list)
+    tensorrt_graph_count: int = 0
+    truncated_long_and_double: bool = False
+
+
+def dryrun_stats_display(dryrun_tracker: DryRunTracker, dryrun_enabled: bool) -> None:
+    """Displays statistics about the dryrun either to debug logs or info logs"""
+    # If user specified "dryrun=True", print to info logs, else debug
+    if dryrun_enabled:
+        dryrun_logger = logger.info
+    else:
+        dryrun_logger = logger.debug
+
+    formatted_stats = "\n"
+
+    # Print overall stats about the graph, operator counts, etc.
+    formatted_stats += "+" * 50 + " Dry-Run Results for Graph " + "+" * 50 + "\n"
+    formatted_stats += (
+        f"The graph consists of {dryrun_tracker.total_ops_in_graph} Total Operators, "
+        f"of which {dryrun_tracker.supported_ops_in_graph} operators are supported, "
+        f"{round(dryrun_tracker.supported_ops_in_graph*100/dryrun_tracker.total_ops_in_graph, 2)}% coverage\n"
+    )
+    formatted_stats += f"Long and double inputs were {'' if dryrun_tracker.truncated_long_and_double else 'not'} truncated (truncate_long_and_double={dryrun_tracker.truncated_long_and_double})\n"
+    formatted_stats += (
+        f"{dryrun_tracker.tensorrt_graph_count} TRT Engine(s) were generated\n"
+    )
+
+    assert len(dryrun_tracker.per_subgraph_data) == dryrun_tracker.tensorrt_graph_count
+
+    # Print schematic of the graph structure, as in:
+    #
+    #   Inputs: [Tensor: (1, 3, 224, 224)@float32]
+    #    ...
+    #    TRT Engine #1: _run_on_acc_0
+    #     Engine Inputs: [Tensor: (1, 3, 224, 224)@float32]
+    #     Number of Operators in Engine: 1
+    #     Engine Outputs: [Tensor: (1, 64, 112, 112)@float32]
+    #    ...
+    #   Outputs: [Tensor: (1, 1000)@float32]
+    #
+    formatted_stats += " " * 2 + "Graph Structure:\n\n"
+    formatted_stats += (
+        " " * 3
+        + f"Inputs: [{input_formatter(dryrun_tracker.graph_input_shapes, dryrun_tracker.graph_input_dtypes)}]\n"
+    )
+
+    for i, trt_subgraph_data in enumerate(dryrun_tracker.per_subgraph_data):
+        assert len(trt_subgraph_data.subgraph_input_dtypes) == len(
+            trt_subgraph_data.subgraph_input_shapes
+        )
+        assert len(trt_subgraph_data.subgraph_output_dtypes) == len(
+            trt_subgraph_data.subgraph_output_shapes
+        )
+        formatted_stats += " " * 4 + "...\n"
+        formatted_stats += (
+            " " * 4 + f"TRT Engine #{i+1}: {trt_subgraph_data.subgraph_name}\n"
+        )
+        formatted_stats += (
+            " " * 5
+            + f"Engine Inputs: [{input_formatter(trt_subgraph_data.subgraph_input_shapes, trt_subgraph_data.subgraph_input_dtypes)}]\n"
+        )
+        formatted_stats += (
+            " " * 5
+            + f"Number of Operators in Engine: {trt_subgraph_data.subgraph_op_count}\n"
+        )
+        formatted_stats += (
+            " " * 5
+            + f"Engine Outputs: [{input_formatter(trt_subgraph_data.subgraph_output_shapes, trt_subgraph_data.subgraph_output_dtypes)}]\n"
+        )
+
+    formatted_stats += " " * 4 + "...\n"
+    formatted_stats += (
+        " " * 3
+        + f"Outputs: [{input_formatter(dryrun_tracker.graph_output_shapes, dryrun_tracker.graph_output_dtypes)}]\n"
+    )
+
+    # Print aggregate statistics about the graph structure, including recommended "min_block_size" options
+    if dryrun_tracker.tensorrt_graph_count > 0:
+        min_ops_in_an_engine = min(
+            trt_subgraph.subgraph_op_count
+            for trt_subgraph in dryrun_tracker.per_subgraph_data
+        )
+        avg_ops_per_engine = (
+            sum(
+                trt_subgraph.subgraph_op_count
+                for trt_subgraph in dryrun_tracker.per_subgraph_data
+            )
+            / dryrun_tracker.tensorrt_graph_count
+        )
+        avg_ops_per_engine = round(avg_ops_per_engine, 2)
+        most_ops_in_an_engine = max(
+            trt_subgraph.subgraph_op_count
+            for trt_subgraph in dryrun_tracker.per_subgraph_data
+        )
+
+        formatted_stats += "\n" + " " * 2 + "-" * 25 + " Aggregate Stats " + "-" * 25
+        formatted_stats += (
+            "\n\n"
+            + " " * 3
+            + "Average Number of Operators per TRT Engine: "
+            + f"{avg_ops_per_engine}"
+        )
+
+        formatted_stats += (
+            "\n"
+            + " " * 3
+            + "Most Operators in a TRT Engine: "
+            + f"{most_ops_in_an_engine}"
+        )
+
+        formatted_stats += "\n\n" + " " * 2 + "*" * 10 + " Recommendations " + "*" * 10
+        formatted_stats += (
+            "\n\n"
+            + " " * 3
+            + "- For minimal graph segmentation, select min_block_size="
+            + f"{most_ops_in_an_engine} which would generate "
+            + f"{len([1 for trt_subgraph in dryrun_tracker.per_subgraph_data if trt_subgraph.subgraph_op_count >= most_ops_in_an_engine])} TRT engines"
+        )
+        if math.ceil(avg_ops_per_engine) != most_ops_in_an_engine:
+            formatted_stats += (
+                "\n"
+                + " " * 3
+                + "- For moderate graph segmentation, select min_block_size="
+                + f"{math.ceil(avg_ops_per_engine)} which would generate "
+                + f"{len([1 for trt_subgraph in dryrun_tracker.per_subgraph_data if trt_subgraph.subgraph_op_count >= math.ceil(avg_ops_per_engine)])} TRT engines"
+            )
+
+        formatted_stats += (
+            "\n"
+            + " " * 3
+            + "- The current level of graph segmentation is equivalent to selecting min_block_size="
+            + f"{min_ops_in_an_engine} which generates "
+            + f"{len([1 for trt_subgraph in dryrun_tracker.per_subgraph_data if trt_subgraph.subgraph_op_count >= min_ops_in_an_engine])} TRT engines"
+        )
+    else:
+        formatted_stats += (
+            "\n"
+            + " " * 2
+            + "Aggregate stats not available since no TRT Engines were generated."
+        )
+
+    dryrun_logger(formatted_stats)
+
+
+def input_formatter(shapes: List[Tuple[int, ...]], dtypes: List[torch.dtype]) -> str:
+    """Format shapes and dtypes of input Tensors into a readable string"""
+    formatted_str = ", "
+
+    for shape, dtype in zip(shapes, dtypes):
+        formatted_str += f"Tensor: {shape}@{str(dtype)[6:]}, "
+
+    return formatted_str[2:-2]

--- a/py/torch_tensorrt/dynamo/_DryRunTracker.py
+++ b/py/torch_tensorrt/dynamo/_DryRunTracker.py
@@ -1,9 +1,9 @@
 import logging
 import math
 from dataclasses import dataclass, field
-from typing import List, Tuple
+from typing import Any, Dict, List
 
-import torch
+from torch_tensorrt.dynamo._settings import CompilationSettings
 
 logger = logging.getLogger(__name__)
 
@@ -15,18 +15,18 @@ class PerSubgraphData:
     Args:
         subgraph_name (str): Name of the subgraph in the GraphModule
         subgraph_op_count (int): Number of operations in the subgraph
-        subgraph_input_shapes (List[Tuple[int, ...]]): Shapes of input Tensors of the subgraph
-        subgraph_input_dtypes (List[torch.device]): Input data types of the subgraph
-        subgraph_output_shapes (List[Tuple[int, ...]]): Shapes of output Tensors of the subgraph
-        subgraph_output_dtypes (List[torch.device]): Output data types of the subgraph
+        subgraph_input_shapes (Any): Shapes of input Tensors of the subgraph
+        subgraph_input_dtypes (Any): Input data types of the subgraph
+        subgraph_output_shapes (Any): Shapes of output Tensors of the subgraph
+        subgraph_output_dtypes (Any): Output data types of the subgraph
     """
 
     subgraph_name: str = ""
     subgraph_op_count: int = 0
-    subgraph_input_shapes: List[Tuple[int, ...]] = field(default_factory=list)
-    subgraph_input_dtypes: List[torch.device] = field(default_factory=list)
-    subgraph_output_shapes: List[Tuple[int, ...]] = field(default_factory=list)
-    subgraph_output_dtypes: List[torch.device] = field(default_factory=list)
+    subgraph_input_shapes: Any = field(default_factory=list)
+    subgraph_input_dtypes: Any = field(default_factory=list)
+    subgraph_output_shapes: Any = field(default_factory=list)
+    subgraph_output_dtypes: Any = field(default_factory=list)
 
 
 @dataclass
@@ -36,81 +36,72 @@ class DryRunTracker:
     Args:
         total_ops_in_graph (int): Total number of operators in graph
         supported_ops_in_graph (int): Number of supported operators in graph
-        graph_input_shapes (List[Tuple[int, ...]]): Shapes of input Tensors of the graph
-        graph_input_dtypes (List[torch.device]): Input data types of the graph
-        graph_output_shapes (List[Tuple[int, ...]]): Shapes of output Tensors of the graph
-        graph_output_dtypes (List[torch.device]): Output data types of the graph
+        graph_input_shapes (Any): Shapes of input Tensors of the graph
+        graph_input_dtypes (Any): Input data types of the graph
+        graph_output_shapes (Any): Shapes of output Tensors of the graph
+        graph_output_dtypes (Any): Output data types of the graph
         per_subgraph_data (List[PerSubgraphData]): Per-subgraph data, see above class
         tensorrt_graph_count (int): Number of TensorRT engines to be generated
-        truncated_long_and_double (bool): Whether truncate_long_and_double was enabled
+        compilation_settings (CompilationSettings): User Compilation Settings
+        unsupported_ops (Dict[str, int]): Set of operators not supported in TRT
     """
 
     total_ops_in_graph: int = 0
     supported_ops_in_graph: int = 0
-    graph_input_shapes: List[Tuple[int, ...]] = field(default_factory=list)
-    graph_input_dtypes: List[torch.device] = field(default_factory=list)
-    graph_output_shapes: List[Tuple[int, ...]] = field(default_factory=list)
-    graph_output_dtypes: List[torch.device] = field(default_factory=list)
+    graph_input_shapes: Any = field(default_factory=list)
+    graph_input_dtypes: Any = field(default_factory=list)
+    graph_output_shapes: Any = field(default_factory=list)
+    graph_output_dtypes: Any = field(default_factory=list)
     per_subgraph_data: List[PerSubgraphData] = field(default_factory=list)
     tensorrt_graph_count: int = 0
-    truncated_long_and_double: bool = False
+    compilation_settings: CompilationSettings = field(
+        default_factory=CompilationSettings
+    )
+    unsupported_ops: Dict[str, int] = field(default_factory=dict)
 
 
 def dryrun_stats_display(dryrun_tracker: DryRunTracker, dryrun_enabled: bool) -> None:
-    """Displays statistics about the dryrun either to debug logs or info logs"""
-    # If user specified "dryrun=True", print to info logs, else debug
-    if dryrun_enabled:
-        dryrun_logger = logger.info
-    else:
-        dryrun_logger = logger.debug
-
+    """Displays statistics about the dryrun either to debug logs or stdout"""
     formatted_stats = "\n"
 
     # Print overall stats about the graph, operator counts, etc.
-    formatted_stats += "+" * 50 + " Dry-Run Results for Graph " + "+" * 50 + "\n"
+    formatted_stats += "+" * 50 + " Dry-Run Results for Graph " + "+" * 50 + "\n\n"
     formatted_stats += (
         f"The graph consists of {dryrun_tracker.total_ops_in_graph} Total Operators, "
         f"of which {dryrun_tracker.supported_ops_in_graph} operators are supported, "
-        f"{round(dryrun_tracker.supported_ops_in_graph*100/dryrun_tracker.total_ops_in_graph, 2)}% coverage\n"
+        f"{round(dryrun_tracker.supported_ops_in_graph*100/dryrun_tracker.total_ops_in_graph, 2)}% coverage\n\n"
     )
-    formatted_stats += f"Long and double inputs were {'' if dryrun_tracker.truncated_long_and_double else 'not'} truncated (truncate_long_and_double={dryrun_tracker.truncated_long_and_double})\n"
-    formatted_stats += (
-        f"{dryrun_tracker.tensorrt_graph_count} TRT Engine(s) were generated\n"
-    )
+    formatted_stats += f"The following ops are currently unsupported and set to run in Torch: {dryrun_tracker.unsupported_ops}\n\n"
+    formatted_stats += f"Compiled with: {dryrun_tracker.compilation_settings}\n\n"
 
     assert len(dryrun_tracker.per_subgraph_data) == dryrun_tracker.tensorrt_graph_count
 
     # Print schematic of the graph structure, as in:
     #
-    #   Inputs: [Tensor: (1, 3, 224, 224)@float32]
+    #   Inputs: List[Tensor: (1, 3, 224, 224)@float32]
     #    ...
-    #    TRT Engine #1: _run_on_acc_0
-    #     Engine Inputs: [Tensor: (1, 3, 224, 224)@float32]
-    #     Number of Operators in Engine: 1
-    #     Engine Outputs: [Tensor: (1, 64, 112, 112)@float32]
+    #      TRT Engine #1 - Submodule name: _run_on_acc_0
+    #       Engine Inputs: List[Tensor: (1, 3, 224, 224)@float32]
+    #       Number of Operators in Engine: 1
+    #       Engine Outputs: Tensor: (1, 64, 112, 112)@float32
     #    ...
-    #   Outputs: [Tensor: (1, 1000)@float32]
+    #   Outputs: List[Tensor: (1, 1000)@float32]
     #
     formatted_stats += " " * 2 + "Graph Structure:\n\n"
     formatted_stats += (
         " " * 3
-        + f"Inputs: [{input_formatter(dryrun_tracker.graph_input_shapes, dryrun_tracker.graph_input_dtypes)}]\n"
+        + f"Inputs: {input_formatter(dryrun_tracker.graph_input_shapes, dryrun_tracker.graph_input_dtypes)}\n"
     )
 
     for i, trt_subgraph_data in enumerate(dryrun_tracker.per_subgraph_data):
-        assert len(trt_subgraph_data.subgraph_input_dtypes) == len(
-            trt_subgraph_data.subgraph_input_shapes
-        )
-        assert len(trt_subgraph_data.subgraph_output_dtypes) == len(
-            trt_subgraph_data.subgraph_output_shapes
-        )
         formatted_stats += " " * 4 + "...\n"
         formatted_stats += (
-            " " * 4 + f"TRT Engine #{i+1}: {trt_subgraph_data.subgraph_name}\n"
+            " " * 4
+            + f"TRT Engine #{i+1} - Submodule name: {trt_subgraph_data.subgraph_name}\n"
         )
         formatted_stats += (
             " " * 5
-            + f"Engine Inputs: [{input_formatter(trt_subgraph_data.subgraph_input_shapes, trt_subgraph_data.subgraph_input_dtypes)}]\n"
+            + f"Engine Inputs: {input_formatter(trt_subgraph_data.subgraph_input_shapes, trt_subgraph_data.subgraph_input_dtypes)}\n"
         )
         formatted_stats += (
             " " * 5
@@ -118,13 +109,13 @@ def dryrun_stats_display(dryrun_tracker: DryRunTracker, dryrun_enabled: bool) ->
         )
         formatted_stats += (
             " " * 5
-            + f"Engine Outputs: [{input_formatter(trt_subgraph_data.subgraph_output_shapes, trt_subgraph_data.subgraph_output_dtypes)}]\n"
+            + f"Engine Outputs: {input_formatter(trt_subgraph_data.subgraph_output_shapes, trt_subgraph_data.subgraph_output_dtypes)}\n"
         )
 
     formatted_stats += " " * 4 + "...\n"
     formatted_stats += (
         " " * 3
-        + f"Outputs: [{input_formatter(dryrun_tracker.graph_output_shapes, dryrun_tracker.graph_output_dtypes)}]\n"
+        + f"Outputs: {input_formatter(dryrun_tracker.graph_output_shapes, dryrun_tracker.graph_output_dtypes)}\n"
     )
 
     # Print aggregate statistics about the graph structure, including recommended "min_block_size" options
@@ -167,7 +158,7 @@ def dryrun_stats_display(dryrun_tracker: DryRunTracker, dryrun_enabled: bool) ->
             + " " * 3
             + "- For minimal graph segmentation, select min_block_size="
             + f"{most_ops_in_an_engine} which would generate "
-            + f"{len([1 for trt_subgraph in dryrun_tracker.per_subgraph_data if trt_subgraph.subgraph_op_count >= most_ops_in_an_engine])} TRT engines"
+            + f"{len([1 for trt_subgraph in dryrun_tracker.per_subgraph_data if trt_subgraph.subgraph_op_count >= most_ops_in_an_engine])} TRT engine(s)"
         )
         if math.ceil(avg_ops_per_engine) != most_ops_in_an_engine:
             formatted_stats += (
@@ -175,7 +166,7 @@ def dryrun_stats_display(dryrun_tracker: DryRunTracker, dryrun_enabled: bool) ->
                 + " " * 3
                 + "- For moderate graph segmentation, select min_block_size="
                 + f"{math.ceil(avg_ops_per_engine)} which would generate "
-                + f"{len([1 for trt_subgraph in dryrun_tracker.per_subgraph_data if trt_subgraph.subgraph_op_count >= math.ceil(avg_ops_per_engine)])} TRT engines"
+                + f"{len([1 for trt_subgraph in dryrun_tracker.per_subgraph_data if trt_subgraph.subgraph_op_count >= math.ceil(avg_ops_per_engine)])} TRT engine(s)"
             )
 
         formatted_stats += (
@@ -183,7 +174,7 @@ def dryrun_stats_display(dryrun_tracker: DryRunTracker, dryrun_enabled: bool) ->
             + " " * 3
             + "- The current level of graph segmentation is equivalent to selecting min_block_size="
             + f"{min_ops_in_an_engine} which generates "
-            + f"{len([1 for trt_subgraph in dryrun_tracker.per_subgraph_data if trt_subgraph.subgraph_op_count >= min_ops_in_an_engine])} TRT engines"
+            + f"{len([1 for trt_subgraph in dryrun_tracker.per_subgraph_data if trt_subgraph.subgraph_op_count >= min_ops_in_an_engine])} TRT engine(s)"
         )
     else:
         formatted_stats += (
@@ -192,14 +183,45 @@ def dryrun_stats_display(dryrun_tracker: DryRunTracker, dryrun_enabled: bool) ->
             + "Aggregate stats not available since no TRT Engines were generated."
         )
 
-    dryrun_logger(formatted_stats)
+    # If user specified "dryrun=True", print to stdout, else debug
+    if dryrun_enabled:
+        print(formatted_stats)
+    else:
+        logger.debug(formatted_stats)
 
 
-def input_formatter(shapes: List[Tuple[int, ...]], dtypes: List[torch.dtype]) -> str:
+def input_formatter(shapes: Any, dtypes: Any) -> str:
     """Format shapes and dtypes of input Tensors into a readable string"""
-    formatted_str = ", "
 
-    for shape, dtype in zip(shapes, dtypes):
-        formatted_str += f"Tensor: {shape}@{str(dtype)[6:]}, "
+    def input_formatter_helper(shapes: Any, dtypes: Any) -> str:
+        """Helper for input formatter"""
+        # Base case - single shape, single dtype
+        if isinstance(shapes, tuple) and all(isinstance(elt, int) for elt in shapes):
+            return f"Tensor: {shapes}@{str(dtypes)[6:]}, "
 
-    return formatted_str[2:-2]
+        # Shapes is a sequence
+        elif isinstance(shapes, (list, tuple)):
+            formatted_str = "List[" if isinstance(shapes, list) else "Tuple("
+            for shape, dtype in zip(shapes, dtypes):
+                formatted_str += input_formatter_helper(shape, dtype)
+            formatted_str = formatted_str[:-2] + (
+                "], " if isinstance(shapes, list) else "), "
+            )
+            return formatted_str
+
+        # Shapes is a dictionary
+        elif isinstance(shapes, dict):
+            formatted_str = "Dict{"
+
+            for key, shape in shapes.items():
+                formatted_str += input_formatter_helper(shape, dtypes[key])
+
+            formatted_str = formatted_str[:-2] + "}, "
+            return formatted_str
+
+        else:
+            raise ValueError(
+                f"Invalid input type {type(shapes)} encountered in parse_complex_tensor_structs parsing."
+            )
+
+    return input_formatter_helper(shapes, dtypes)[:-2]

--- a/py/torch_tensorrt/dynamo/_DryRunTracker.py
+++ b/py/torch_tensorrt/dynamo/_DryRunTracker.py
@@ -229,6 +229,21 @@ def input_formatter(shapes: Any, dtypes: Any) -> str:
         if isinstance(shapes, tuple) and all(isinstance(elt, int) for elt in shapes):
             return f"Tensor: {shapes}@{str(dtypes)[6:]}, "
 
+        # Base case - dynamic shape, single dtype
+        elif (
+            isinstance(shapes, dict)
+            and len(shapes) == 3
+            and all(
+                (
+                    isinstance(shape, tuple)
+                    and all(isinstance(elt, int) for elt in shape)
+                    and k in ("min_shape", "opt_shape", "max_shape")
+                )
+                for k, shape in shapes.items()
+            )
+        ):
+            return f"Tensor: {shapes}@{str(dtypes)[6:]}, "
+
         # Shapes is a sequence
         elif isinstance(shapes, (list, tuple)):
             formatted_str = "List[" if isinstance(shapes, list) else "Tuple("

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -260,7 +260,7 @@ def compile_module(
     dryrun_tracker.total_ops_in_graph = total_ops
     dryrun_tracker.supported_ops_in_graph = num_supported_ops
     dryrun_tracker.graph_input_shapes = parse_complex_tensor_structs(
-        sample_inputs, "shape", tuple
+        sample_inputs, "shape", lambda x: dict(x) if isinstance(x, dict) else tuple(x)
     )
     dryrun_tracker.graph_input_dtypes = parse_complex_tensor_structs(
         sample_inputs, "torch_dtype"
@@ -372,7 +372,9 @@ def compile_module(
             )
 
         subgraph_data.subgraph_input_shapes = parse_complex_tensor_structs(
-            submodule_inputs, "shape", tuple
+            submodule_inputs,
+            "shape",
+            lambda x: dict(x) if isinstance(x, dict) else tuple(x),
         )
         subgraph_data.subgraph_input_dtypes = parse_complex_tensor_structs(
             submodule_inputs, "torch_dtype"
@@ -383,7 +385,9 @@ def compile_module(
         )
 
         subgraph_data.subgraph_output_shapes = parse_complex_tensor_structs(
-            submodule_outputs, "shape", tuple
+            submodule_outputs,
+            "shape",
+            lambda x: dict(x) if isinstance(x, dict) else tuple(x),
         )
         subgraph_data.subgraph_output_dtypes = parse_complex_tensor_structs(
             submodule_outputs, "dtype"
@@ -411,7 +415,7 @@ def compile_module(
         sample_outputs = [sample_outputs]
 
     dryrun_tracker.graph_output_shapes = parse_complex_tensor_structs(
-        sample_outputs, "shape", tuple
+        sample_outputs, "shape", lambda x: dict(x) if isinstance(x, dict) else tuple(x)
     )
     dryrun_tracker.graph_output_dtypes = parse_complex_tensor_structs(
         sample_outputs, "dtype"

--- a/py/torch_tensorrt/dynamo/_defaults.py
+++ b/py/torch_tensorrt/dynamo/_defaults.py
@@ -24,6 +24,7 @@ USE_FAST_PARTITIONER = True
 ENABLE_EXPERIMENTAL_DECOMPOSITIONS = False
 REFIT = False
 REQUIRE_FULL_COMPILATION = False
+DRYRUN = False
 
 
 def default_device() -> Device:

--- a/py/torch_tensorrt/dynamo/_settings.py
+++ b/py/torch_tensorrt/dynamo/_settings.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Optional, Set
+from typing import Optional, Set, Union
 
 import torch
 from tensorrt import EngineCapability
@@ -64,8 +64,9 @@ class CompilationSettings:
         dla_sram_size (int): Fast software managed RAM used by DLA to communicate within a layer.
         dla_local_dram_size (int): Host RAM used by DLA to share intermediate tensor data across operations
         dla_global_dram_size (int): Host RAM used by DLA to store weights and metadata for execution
-        dryrun (bool): Toggle "Dryrun" mode, which runs everything through partitioning, short of conversion to
-            TRT Engines. Prints detailed logs of the graph structure and nature of partitioning
+        dryrun (Union[bool, str]): Toggle "Dryrun" mode, which runs everything through partitioning, short of conversion to
+            TRT Engines. Prints detailed logs of the graph structure and nature of partitioning. Optionally saves the
+            ouptut to a file if a string path is specified
     """
 
     precision: torch.dtype = PRECISION
@@ -91,4 +92,4 @@ class CompilationSettings:
     dla_sram_size: int = DLA_SRAM_SIZE
     dla_local_dram_size: int = DLA_LOCAL_DRAM_SIZE
     dla_global_dram_size: int = DLA_GLOBAL_DRAM_SIZE
-    dryrun: bool = DRYRUN
+    dryrun: Union[bool, str] = DRYRUN

--- a/py/torch_tensorrt/dynamo/_settings.py
+++ b/py/torch_tensorrt/dynamo/_settings.py
@@ -10,6 +10,7 @@ from torch_tensorrt.dynamo._defaults import (
     DLA_GLOBAL_DRAM_SIZE,
     DLA_LOCAL_DRAM_SIZE,
     DLA_SRAM_SIZE,
+    DRYRUN,
     ENABLE_EXPERIMENTAL_DECOMPOSITIONS,
     ENGINE_CAPABILITY,
     MAX_AUX_STREAMS,
@@ -63,6 +64,8 @@ class CompilationSettings:
         dla_sram_size (int): Fast software managed RAM used by DLA to communicate within a layer.
         dla_local_dram_size (int): Host RAM used by DLA to share intermediate tensor data across operations
         dla_global_dram_size (int): Host RAM used by DLA to store weights and metadata for execution
+        dryrun (bool): Toggle "Dryrun" mode, which runs everything through partitioning, short of conversion to
+            TRT Engines. Prints detailed logs of the graph structure and nature of partitioning
     """
 
     precision: torch.dtype = PRECISION
@@ -88,3 +91,4 @@ class CompilationSettings:
     dla_sram_size: int = DLA_SRAM_SIZE
     dla_local_dram_size: int = DLA_LOCAL_DRAM_SIZE
     dla_global_dram_size: int = DLA_GLOBAL_DRAM_SIZE
+    dryrun: bool = DRYRUN

--- a/py/torch_tensorrt/dynamo/partitioning/_adjacency_partitioner.py
+++ b/py/torch_tensorrt/dynamo/partitioning/_adjacency_partitioner.py
@@ -248,7 +248,7 @@ def partition(
     min_block_size: int = MIN_BLOCK_SIZE,
     torch_executed_ops: Collection[Target] = set(),
     require_full_compilation: bool = REQUIRE_FULL_COMPILATION,
-) -> torch.fx.GraphModule:
+) -> Tuple[torch.fx.GraphModule, OpSupportTester]:
     """Partition an FX GraphModule with aten ops into TRT engines
     Partitioning is based on converter operator support
 
@@ -259,7 +259,7 @@ def partition(
         torch_executed_ops: Collection of operations to run in Torch, regardless of converter coverage
         require_full_compilation: Require that all computational operators be run in TRT
     Returns:
-        torch.fx.GraphModule
+        torch.fx.GraphModule, OpSupportTester
     """
     # Ensure graph is clean prior to partitioning
     gm.graph.eliminate_dead_code()
@@ -280,4 +280,4 @@ def partition(
     if verbose:
         supported_ops.print_support_overview(partitioner.num_trt_accelerated_subgraphs)
 
-    return partitioned_graph
+    return partitioned_graph, supported_ops

--- a/py/torch_tensorrt/dynamo/partitioning/_global_partitioner.py
+++ b/py/torch_tensorrt/dynamo/partitioning/_global_partitioner.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Collection, Dict, List, Mapping, Optional, Sequence, Set
+from typing import Collection, Dict, List, Mapping, Optional, Sequence, Set, Tuple
 
 import torch
 from torch.fx.graph_module import GraphModule
@@ -203,7 +203,7 @@ def partition(
     min_block_size: int = MIN_BLOCK_SIZE,
     torch_executed_ops: Optional[Set[str]] = None,
     require_full_compilation: bool = REQUIRE_FULL_COMPILATION,
-) -> torch.fx.GraphModule:
+) -> Tuple[torch.fx.GraphModule, TorchTensorRTOperatorSupport]:
     """Partition an FX GraphModule with aten ops into TRT engines
     Partitioning is based on converter operator support
 
@@ -214,7 +214,7 @@ def partition(
         torch_executed_ops: Sequence of operations to run in Torch, regardless of converter coverage
         require_full_compilation: Whether to require that all operators be run in TRT
     Returns:
-        torch.fx.GraphModule
+        torch.fx.GraphModule, TorchTensorRTOperatorSupport
     """
     supported_ops = TorchTensorRTOperatorSupport(
         torch_executed_ops=torch_executed_ops
@@ -236,4 +236,4 @@ def partition(
     if verbose:
         supported_ops.print_support_overview(len(partitions))
 
-    return fused_graph
+    return fused_graph, supported_ops

--- a/tests/py/dynamo/backend/test_backend_compiler.py
+++ b/tests/py/dynamo/backend/test_backend_compiler.py
@@ -1,9 +1,10 @@
 from copy import deepcopy
 
 import torch
-import torch_tensorrt
 from torch.testing._internal.common_utils import TestCase, run_tests
 from torch_tensorrt.dynamo.partitioning import fast_partition
+
+import torch_tensorrt
 
 from ..testing_utilities import DECIMALS_OF_AGREEMENT, lower_graph_testing
 
@@ -19,7 +20,7 @@ class TestTRTModuleNextCompilation(TestCase):
                 return torch.mean(out, dim=1)
 
         fx_graph = torch.fx.symbolic_trace(FullySupportedMultiOp())
-        partitioned_graph = fast_partition(deepcopy(fx_graph), min_block_size=3)
+        partitioned_graph, _ = fast_partition(deepcopy(fx_graph), min_block_size=3)
 
         self.assertEquals(
             len(
@@ -198,7 +199,7 @@ class Test64BitInput(TestCase):
                 )
 
         fx_graph = torch.fx.symbolic_trace(FullySupportedMultiOp())
-        partitioned_graph = fast_partition(deepcopy(fx_graph), min_block_size=3)
+        partitioned_graph, _ = fast_partition(deepcopy(fx_graph), min_block_size=3)
 
         self.assertEquals(
             len(list(partitioned_graph.named_children())),

--- a/tests/py/dynamo/partitioning/test_fast_partitioning.py
+++ b/tests/py/dynamo/partitioning/test_fast_partitioning.py
@@ -18,7 +18,7 @@ class TestFastPartitioning(TestCase):
                 return torch.ops.aten.add.Tensor(x, y)
 
         fx_graph = torch.fx.symbolic_trace(FullySupportedOneOp())
-        partitioned_graph = partitioning.fast_partition(deepcopy(fx_graph))
+        partitioned_graph, _ = partitioning.fast_partition(deepcopy(fx_graph))
         self.assertEquals(
             len(
                 [
@@ -40,7 +40,7 @@ class TestFastPartitioning(TestCase):
                 return torch.ops.aten.add.Tensor(x, y)
 
         fx_graph = torch.fx.symbolic_trace(FullySupportedOneOp())
-        partitioned_graph = partitioning.fast_partition(
+        partitioned_graph, _ = partitioning.fast_partition(
             deepcopy(fx_graph), require_full_compilation=True
         )
         self.assertEquals(
@@ -68,7 +68,7 @@ class TestFastPartitioning(TestCase):
                 return pow_
 
         fx_graph = torch.fx.symbolic_trace(FullySupportedMultiOp())
-        partitioned_graph = partitioning.fast_partition(
+        partitioned_graph, _ = partitioning.fast_partition(
             deepcopy(fx_graph), min_block_size=2
         )
         self.assertEquals(
@@ -97,7 +97,7 @@ class TestFastPartitioning(TestCase):
                 return pow_
 
         fx_graph = torch.fx.symbolic_trace(PartiallySupportedMultiOp())
-        partitioned_graph = partitioning.fast_partition(
+        partitioned_graph, _ = partitioning.fast_partition(
             deepcopy(fx_graph), min_block_size=2
         )
         self.assertEquals(

--- a/tests/py/dynamo/partitioning/test_global_partitioning.py
+++ b/tests/py/dynamo/partitioning/test_global_partitioning.py
@@ -18,7 +18,7 @@ class TestGlobalPartitioning(TestCase):
                 return torch.ops.aten.add.Tensor(x, y)
 
         fx_graph = torch.fx.symbolic_trace(FullySupportedOneOp())
-        partitioned_graph = partitioning.global_partition(deepcopy(fx_graph))
+        partitioned_graph, _ = partitioning.global_partition(deepcopy(fx_graph))
         self.assertEquals(
             len(list(partitioned_graph.named_children())),
             0,
@@ -34,7 +34,7 @@ class TestGlobalPartitioning(TestCase):
                 return torch.ops.aten.add.Tensor(x, y)
 
         fx_graph = torch.fx.symbolic_trace(FullySupportedOneOp())
-        partitioned_graph = partitioning.global_partition(
+        partitioned_graph, _ = partitioning.global_partition(
             deepcopy(fx_graph), require_full_compilation=True
         )
         self.assertEquals(
@@ -56,7 +56,7 @@ class TestGlobalPartitioning(TestCase):
                 return pow_
 
         fx_graph = torch.fx.symbolic_trace(FullySupportedMultiOp())
-        partitioned_graph = partitioning.global_partition(
+        partitioned_graph, _ = partitioning.global_partition(
             deepcopy(fx_graph), min_block_size=2
         )
         self.assertEquals(
@@ -79,7 +79,7 @@ class TestGlobalPartitioning(TestCase):
                 return pow_
 
         fx_graph = torch.fx.symbolic_trace(PartiallySupportedMultiOp())
-        partitioned_graph = partitioning.global_partition(
+        partitioned_graph, _ = partitioning.global_partition(
             deepcopy(fx_graph), min_block_size=2
         )
         self.assertEquals(

--- a/tests/py/dynamo/testing_utilities.py
+++ b/tests/py/dynamo/testing_utilities.py
@@ -70,13 +70,13 @@ def compile_module_testing(
 ) -> torch.fx.GraphModule:
     """Helper compiler exclusively for testing"""
     if use_fast_partitioner:
-        partitioned_module = partitioning.fast_partition(
+        partitioned_module, _ = partitioning.fast_partition(
             gm,
             min_block_size=min_block_size,
             torch_executed_ops=torch_executed_ops,
         )
     else:
-        partitioned_module = partitioning.global_partition(
+        partitioned_module, _ = partitioning.global_partition(
             gm,
             min_block_size=min_block_size,
             torch_executed_ops=torch_executed_ops,


### PR DESCRIPTION
# Description
- Enables building of TRT engines with "dryrun" capabilities, meaning all of the phases except conversion are run and verbose logs of the graph structure and composition are printed for the user
- Improves general-purpose debug logging by printing dryrun stats to the debug logs regardless of option specification
- Provides intuitive schematic of the graph engines, inputs, and code path through the course of the graph

<details>
<summary>
<b>Sample Schematic</b>
</summary>

```python
++++++++++++++++++++++++++++++++++++++++++++++++++ Dry-Run Results for Graph ++++++++++++++++++++++++++++++++++++++++++++++++++

The graph consists of 89 Total Operators, of which 81 operators are supported, 91.01% coverage

The following ops are currently unsupported or excluded from conversion, and are listed with their op-count in the graph:
 torch.ops.aten.add.Tensor: 8

The following nodes are currently set to run in Torch:
Node: torch.ops.aten.add.Tensor, with layer location: /layer1/0/add
Node: torch.ops.aten.add.Tensor, with layer location: /layer1/1/add_1
Node: torch.ops.aten.add.Tensor, with layer location: /layer2/0/add_2
Node: torch.ops.aten.add.Tensor, with layer location: /layer2/1/add_3
Node: torch.ops.aten.add.Tensor, with layer location: /layer3/0/add_4
Node: torch.ops.aten.add.Tensor, with layer location: /layer3/1/add_5
Node: torch.ops.aten.add.Tensor, with layer location: /layer4/0/add_6
Node: torch.ops.aten.add.Tensor, with layer location: /layer4/1/add_7
Note: Some of the above nodes may be supported, but were not included in a TRT graph by the partitioner

Compiled with: CompilationSettings(precision=torch.float32, debug=True, workspace_size=0, min_block_size=1, torch_executed_ops={'torch.ops.aten.add.Tensor'}, pass_through_build_failures=False, max_aux_streams=None, version_compatible=False, optimization_level=None, use_python_runtime=False, truncate_long_and_double=False, use_fast_partitioner=False, enable_experimental_decompositions=False, device=Device(type=DeviceType.GPU, gpu_id=0), require_full_compilation=False, dryrun=True)

  Graph Structure:

   Inputs: List[Tensor: (1, 3, 224, 224)@float32]
    ...
    TRT Engine #1 - Submodule name: fused_0
     Engine Inputs: List[Tensor: (1, 512, 7, 7)@float32]
     Number of Operators in Engine: 4
     Engine Outputs: Tensor: (1, 1000)@float32
    ...
    TRT Engine #2 - Submodule name: fused_1
     Engine Inputs: List[Tensor: (1, 512, 7, 7)@float32]
     Number of Operators in Engine: 8
     Engine Outputs: Tuple(Tensor: (1, 512, 7, 7)@float32, Tensor: (1, 512, 7, 7)@float32)
    ...
    TRT Engine #3 - Submodule name: fused_2
     Engine Inputs: List[Tensor: (1, 256, 14, 14)@float32]
     Number of Operators in Engine: 11
     Engine Outputs: Tuple(Tensor: (1, 512, 7, 7)@float32, Tensor: (1, 512, 7, 7)@float32)
    ...
    TRT Engine #4 - Submodule name: fused_3
     Engine Inputs: List[Tensor: (1, 256, 14, 14)@float32]
     Number of Operators in Engine: 8
     Engine Outputs: Tuple(Tensor: (1, 256, 14, 14)@float32, Tensor: (1, 256, 14, 14)@float32)
    ...
    TRT Engine #5 - Submodule name: fused_4
     Engine Inputs: List[Tensor: (1, 128, 28, 28)@float32]
     Number of Operators in Engine: 11
     Engine Outputs: Tuple(Tensor: (1, 256, 14, 14)@float32, Tensor: (1, 256, 14, 14)@float32)
    ...
    TRT Engine #6 - Submodule name: fused_5
     Engine Inputs: List[Tensor: (1, 128, 28, 28)@float32]
     Number of Operators in Engine: 8
     Engine Outputs: Tuple(Tensor: (1, 128, 28, 28)@float32, Tensor: (1, 128, 28, 28)@float32)
    ...
    TRT Engine #7 - Submodule name: fused_6
     Engine Inputs: List[Tensor: (1, 64, 56, 56)@float32]
     Number of Operators in Engine: 11
     Engine Outputs: Tuple(Tensor: (1, 128, 28, 28)@float32, Tensor: (1, 128, 28, 28)@float32)
    ...
    TRT Engine #8 - Submodule name: fused_7
     Engine Inputs: List[Tensor: (1, 64, 56, 56)@float32]
     Number of Operators in Engine: 8
     Engine Outputs: Tuple(Tensor: (1, 64, 56, 56)@float32, Tensor: (1, 64, 56, 56)@float32)
    ...
    TRT Engine #9 - Submodule name: fused_8
     Engine Inputs: List[Tensor: (1, 3, 224, 224)@float32]
     Number of Operators in Engine: 12
     Engine Outputs: Tuple(Tensor: (1, 64, 56, 56)@float32, Tensor: (1, 64, 56, 56)@float32)
    ...
   Outputs: List[Tensor: (1, 1000)@float32]

  ------------------------- Aggregate Stats -------------------------

   Average Number of Operators per TRT Engine: 9.0
   Most Operators in a TRT Engine: 12

  ********** Recommendations **********

   - For minimal graph segmentation, select min_block_size=12 which would generate 1 TRT engine(s)
   - For moderate graph segmentation, select min_block_size=9 which would generate 4 TRT engine(s)
   - The current level of graph segmentation is equivalent to selecting min_block_size=4 which generates 9 TRT engine(s)
```
</details>

Fixes #2081
Fixes #2413

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ - ] I have added tests to verify my fix or my feature
  - Validated via CI
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
