### PR TITLE
fix: Bug in slice operator with default inputs

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -687,6 +687,11 @@ def aten_ops_select(
 
 
 @dynamo_tensorrt_converter(torch.ops.aten.slice.Tensor)
+@enforce_tensor_types(
+    {
+        0: (TRTTensor,),
+    }
+)
 def aten_ops_slice(
     ctx: ConversionContext,
     target: Target,
@@ -900,6 +905,11 @@ def aten_ops_clone_copy_placeholder(
 
 
 @dynamo_tensorrt_converter(torch.ops.aten.expand.default)
+@enforce_tensor_types(
+    {
+        0: (TRTTensor,),
+    }
+)
 def aten_ops_expand(
     ctx: ConversionContext,
     target: Target,

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -700,9 +700,9 @@ def aten_ops_slice(
         SourceIR.ATEN,
         name,
         args[0],
-        args[1],
-        args[2],
-        args[3],
+        args_bounds_check(args, 1, replacement=0),
+        args_bounds_check(args, 2, replacement=None),
+        args_bounds_check(args, 3, replacement=None),
         args_bounds_check(args, 4, replacement=1),
     )
 

--- a/py/torch_tensorrt/dynamo/conversion/converter_utils.py
+++ b/py/torch_tensorrt/dynamo/conversion/converter_utils.py
@@ -4,6 +4,7 @@ import re
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, overload
 
 import numpy as np
+import tensorrt as trt
 import torch
 from torch import SymBool, SymFloat, SymInt
 from torch.fx.node import Argument, Target
@@ -19,8 +20,6 @@ from torch_tensorrt.fx.converters.converter_utils import (
     unified_dtype_converter,
 )
 from torch_tensorrt.fx.types import TRTDataType, TRTTensor
-
-import tensorrt as trt
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -339,8 +338,8 @@ def get_positive_dim(
 ) -> Union[int, Tuple[int, ...]]:
     """
     Given an integer number or tuple that represents dimension(s) in the array,
-    transform it to a positive integer dim if it's negative. Otherwise, do
-    nothing.
+    transform it to a positive integer dim if it's negative.
+    Otherwise, truncate it to the dimension size
 
     Args:
         dim (Union[int, Sequence[int]]): A integer or Sequence of integers that represent dimension(s) in an array.
@@ -353,7 +352,8 @@ def get_positive_dim(
     def positive_dim(d: int) -> int:
         if d < 0:
             return d % dim_size
-        return d
+        else:
+            return min(d, dim_size)
 
     return (
         positive_dim(dim)

--- a/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
@@ -31,12 +31,6 @@ def slice_op(  # TODO: This should be slice not whatever is in base
     stop: Optional[int],
     step: int,
 ) -> TRTTensor:
-    if not isinstance(input, TRTTensor):
-        raise RuntimeError(
-            f"slice_tensor received input {input} that is not part "
-            "of the TensorRT region!"
-        )
-
     # Special case for start being None
     if start is None:
         start = 0
@@ -73,11 +67,6 @@ def expand(
     input_t: TRTTensor,
     shape: Shape,
 ) -> TRTTensor:
-    if not isinstance(input_t, TRTTensor):
-        raise RuntimeError(
-            f"expand received input {input_t} that is not a TensorRT ITensor"
-        )
-
     shape_rank = len(shape)
     initial_tensor_rank = len(input_t.shape)
 

--- a/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
@@ -27,8 +27,8 @@ def slice_op(  # TODO: This should be slice not whatever is in base
     name: str,
     input: TRTTensor,
     dim: int,
-    start: int,
-    stop: int,
+    start: Optional[int],
+    stop: Optional[int],
     step: int,
 ) -> TRTTensor:
     if not isinstance(input, TRTTensor):
@@ -37,6 +37,14 @@ def slice_op(  # TODO: This should be slice not whatever is in base
             "of the TensorRT region!"
         )
 
+    # Special case for start being None
+    if start is None:
+        start = 0
+
+    # Special case for stop being None
+    if stop is None:
+        stop = input.shape[dim]
+
     dim = get_positive_dim(dim, len(input.shape))
     start = get_positive_dim(start, input.shape[dim])
     stop = get_positive_dim(stop, input.shape[dim])
@@ -44,9 +52,6 @@ def slice_op(  # TODO: This should be slice not whatever is in base
     if has_dynamic_shape(input.shape):
         # Check whether slice target dim is dynamic shape dim
         assert input.shape[dim] != -1, "Can't slice on dynamic shape dimension!"
-
-    if stop == 2**63 - 1:
-        stop = input.shape[dim]
 
     start_slice = [0] * len(input.shape)
     start_slice[dim] = start

--- a/tests/py/dynamo/conversion/test_slice_aten.py
+++ b/tests/py/dynamo/conversion/test_slice_aten.py
@@ -7,7 +7,7 @@ from torch_tensorrt import Input
 from .harness import DispatchTestCase
 
 
-class TestSelectConverter(DispatchTestCase):
+class TestSliceConverter(DispatchTestCase):
     @parameterized.expand(
         [
             ("slice_dim_start_stop_step", 0, 0, 7, 2),
@@ -50,11 +50,11 @@ class TestSelectConverter(DispatchTestCase):
         )
 
 
-class TestSelectConverterDynamicShape(DispatchTestCase):
+class TestSliceConverterDynamicShape(DispatchTestCase):
     @parameterized.expand(
         [
-            ("select_dim_start_stop_step", 1, 0, 7, 2),
-            ("select_dim_start_stop_step", 1, 0, 10, 2),
+            ("slice_dim_start_stop_step", 1, 0, 7, 2),
+            ("slice_dim_start_stop_step", 1, 0, 10, 2),
         ]
     )
     def test_slice(self, _, dim, start, stop, step):

--- a/tests/py/dynamo/conversion/test_slice_aten.py
+++ b/tests/py/dynamo/conversion/test_slice_aten.py
@@ -10,11 +10,13 @@ from .harness import DispatchTestCase
 class TestSelectConverter(DispatchTestCase):
     @parameterized.expand(
         [
-            ("select_dim_start_stop_step", 0, 0, 7, 2),
-            ("select_dim_start_stop_step_offset", 1, 0, 7, 2),
-            ("select_dim_start_stop_step_exact", 1, 0, 10, 2),
-            ("select_dim_start_stop_step_negatives", -3, -2, -1, 1),
-            ("select_dim_start_stop_step_max_int", 2, 0, 2**63 - 1, 1),
+            ("slice_dim_start_stop_step", 0, 0, 7, 2),
+            ("slice_dim_start_stop_step_offset", 1, 0, 7, 2),
+            ("slice_dim_start_stop_step_exact", 1, 0, 10, 2),
+            ("slice_dim_start_stop_step_negatives", -3, -2, -1, 1),
+            ("slice_dim_start_stop_step_max_int", 2, 0, 2**63 - 1, 1),
+            ("slice_dim_start_stop_step_past_end", 2, 0, 2048, 1),
+            ("slice_dim_start_stop_step_none", 2, None, None, 1),
         ]
     )
     def test_slice(self, _, dim, start, stop, step):
@@ -24,6 +26,21 @@ class TestSelectConverter(DispatchTestCase):
 
             def forward(self, input):
                 out = torch.ops.aten.slice.Tensor(input, dim, start, stop, step)
+                return out
+
+        input = [torch.randn(10, 10, 3, 1)]
+        self.run_test(
+            TestModule(),
+            input,
+        )
+
+    def test_slice_empty(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, input):
+                out = torch.ops.aten.slice.Tensor(input)
                 return out
 
         input = [torch.randn(10, 10, 3, 1)]


### PR DESCRIPTION
# Description

- Slice operator schema allows optional inputs for specified dimensions and allows not specifying certain inputs at all
- Fix issue where the converter did not reflect these Torch behaviors
- Fix issue where bounds past the end of the array were not allowed (as they are in Python, ONNX, Torch)
- Add regression tests to catch such errors

[Slice Schema](https://github.com/pytorch/pytorch/blob/68278cf7a805d2307859bbc364f2e163ae6dba67/aten/src/ATen/native/native_functions.yaml#L5340)
## Type of change

- Bug fix (non-breaking change which fixes an issue)
# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
