### PR TITLE
feat: introduce type propagation infrastructure

### DIFF
--- a/core/compiler.cpp
+++ b/core/compiler.cpp
@@ -167,6 +167,7 @@ partitioning::GraphAndMapping BuildHybridGraph(
         auto inputs = seg_block.construct_inputs_spec();
         // update the input ranges for each segments
         convert_info.inputs = ir::associate_specs_with_inputs(seg_block.g(), inputs, static_params);
+        convert_info.out_types = seg_block.out_types();
 
         // TODO mapping Inputs Ivalue to flatten one here
         auto engine = conversion::ConvertBlockToEngine(seg_block.block(), convert_info, static_params);

--- a/core/conversion/conversion.h
+++ b/core/conversion/conversion.h
@@ -14,6 +14,7 @@ namespace conversion {
 struct ConversionInfo {
   ir::InputSpecMap inputs;
   ir::CollectionInputSpecMap collection_input_spec_map;
+  std::vector<at::ScalarType> out_types;
   BuilderSettings engine_settings;
 };
 

--- a/core/partitioning/partitioning.h
+++ b/core/partitioning/partitioning.h
@@ -37,6 +37,12 @@ ExampleIValues generateRandomInputs(
     const ir::ShapeMode& shape_mode = ir::ShapeMode::kOPT,
     int64_t gpu_id = 0);
 
+void getSegmentsOutputByRunning(
+    SegmentedBlock& seg_block,
+    std::unordered_map<const torch::jit::Value*, torch::jit::IValue>& ivalues_maps,
+    const PartitioningInfo& partitioning_info,
+    const ir::ShapeMode& shape_mode);
+
 void populateInputIValues(PartitioningCtx* ctx);
 
 void runShapeAnalysis(

--- a/core/partitioning/segmentedblock/SegmentedBlock.cpp
+++ b/core/partitioning/segmentedblock/SegmentedBlock.cpp
@@ -21,6 +21,15 @@ SegmentedBlock::SegmentedBlock(SegmentedBlockTarget blk_target, const std::vecto
   }
 }
 
+SegmentedBlock::SegmentedBlock(SegmentedBlockTarget blk_target, std::shared_ptr<torch::jit::Graph> g)
+    : target_(blk_target), g_(g) {
+  for (auto input : g_->inputs())
+    inputs_.push_back(input);
+
+  for (auto output : g_->outputs())
+    outputs_.push_back(output);
+}
+
 void SegmentedBlock::registerOutput(torch::jit::Value* raw_output) {
   outputs_.push_back(raw_output);
   g_->registerOutput(old_to_new_[raw_output]);

--- a/core/partitioning/segmentedblock/SegmentedBlock.h
+++ b/core/partitioning/segmentedblock/SegmentedBlock.h
@@ -94,8 +94,15 @@ struct SegmentedBlock {
   void register_intypes(std::vector<at::ScalarType>& in_types) {
     in_types_ = in_types;
   }
+  void register_outtypes(std::vector<at::ScalarType>& out_types) {
+    out_types_ = out_types;
+  }
+
   const std::vector<at::ScalarType>& in_types() const {
     return in_types_;
+  }
+  std::vector<at::ScalarType> out_types() const {
+    return out_types_;
   }
 
   BlockID get_id() {
@@ -128,6 +135,7 @@ struct SegmentedBlock {
   std::vector<std::vector<int64_t>> opt_shapes_;
   std::vector<std::vector<int64_t>> max_shapes_;
   std::vector<at::ScalarType> in_types_;
+  std::vector<at::ScalarType> out_types_;
   std::vector<torch::jit::Value*> inputs_;
   std::vector<torch::jit::Value*> outputs_;
   std::vector<torch::jit::Node*> nodes_;

--- a/core/partitioning/segmentedblock/SegmentedBlock.h
+++ b/core/partitioning/segmentedblock/SegmentedBlock.h
@@ -31,7 +31,7 @@ struct SegmentedBlock {
   SegmentedBlock() = default;
   SegmentedBlock(SegmentedBlockTarget blk_target) : target_(blk_target), g_(std::make_shared<torch::jit::Graph>()) {}
   SegmentedBlock(SegmentedBlockTarget blk_target, const std::vector<torch::jit::Node*>& nodes);
-  SegmentedBlock(SegmentedBlockTarget blk_target, std::shared_ptr<torch::jit::Graph> g) : target_(blk_target), g_(g) {}
+  SegmentedBlock(SegmentedBlockTarget blk_target, std::shared_ptr<torch::jit::Graph> g);
   SegmentedBlock(BlockID id, SegmentedBlockTarget blk_target, const std::vector<torch::jit::Node*>& nodes);
 
   torch::jit::Value* getOrAddInputForValue(torch::jit::Value* v);

--- a/core/partitioning/shape_analysis.cpp
+++ b/core/partitioning/shape_analysis.cpp
@@ -340,6 +340,19 @@ void getSegmentsOutputByRunning(
 
   seg_block.register_inshapes(input_shapes, shape_mode);
   seg_block.register_intypes(input_types);
+
+  // get output type for each segmented block so this can be used in conversion process
+  std::vector<at::ScalarType> output_types;
+  for (size_t i = 0; i < seg_block.outputs().size(); ++i) {
+    auto current_output = seg_block.raw_outputs()[i];
+
+    if (ivalues_maps[current_output].isTensor()) {
+      auto cur_ivalue = ivalues_maps[current_output];
+
+      output_types.push_back(cur_ivalue.toTensor().scalar_type());
+    }
+  }
+  seg_block.register_outtypes(output_types);
 }
 
 void runShapeAnalysis(


### PR DESCRIPTION
# Description

This PR introduces type propagation infrastructure through pytorch inference.
Inferred output types are used to set the TensorRT engines output types.

Related PR: #1853 

Previous solution has several limitations. 

- Bug fix 
- New feature 

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
