### PR TITLE
Fix the version compare method

### DIFF
--- a/py/torch_tensorrt/fx/converters/acc_ops_converters.py
+++ b/py/torch_tensorrt/fx/converters/acc_ops_converters.py
@@ -882,8 +882,11 @@ def acc_ops_sign(
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = kwargs["input"]
+    baseline = "8.2"
+    baseline_version = list(map(int, baseline.split('.')))
+    current_version = list(map(int, trt.__version__.split('.')))
 
-    if trt.__version__ >= "8.2" and not network.has_implicit_batch_dimension:
+    if current_version >= baseline_version and not network.has_implicit_batch_dimension:
         input_val = kwargs["input"]
         operation_type = trt.UnaryOperation.SIGN
         return add_unary_layer(network, input_val, operation_type, target, name)


### PR DESCRIPTION
# Description

In the converter of sign, it has two ways:
1 -  when the version is lower than "8.2" add the converted sign.
2 - when the version is greater or equal to "8.2", add the native sign.

But when the version of TRT is upgraded to "10.0.0.0", it is expected that we add a native sign.
But the version string "10.0.0.0" is smaller than "8.2". That is the issue here.

Fixes # (issue)
Change the compare from string type to a list of int values.
## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
