### PR TITLE
feat: support aten.arange.start_step dynamo converter

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/ops_evaluators.py
+++ b/py/torch_tensorrt/dynamo/conversion/ops_evaluators.py
@@ -3,6 +3,7 @@ import logging
 import operator
 from typing import Dict, Sequence, Tuple, Union
 
+import numpy as np
 import torch
 from torch.fx.node import Argument, Node, Target
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
@@ -26,7 +27,6 @@ def getitem_validator(getitem_node: Node) -> bool:
 @dynamo_tensorrt_converter(operator.getitem, capability_validator=getitem_validator)
 @dynamo_tensorrt_converter(builtins.getattr)
 @dynamo_tensorrt_converter(torch.ops.aten.detach.default)
-@dynamo_tensorrt_converter(torch.ops.aten.arange.start_step)
 def generic_evaluator(
     ctx: ConversionContext,
     target: Target,
@@ -38,3 +38,14 @@ def generic_evaluator(
         f"Evaluating {ConverterRegistry.qualified_name_or_str(target)} on object with name: {name}"
     )
     return target(*args)
+
+
+@dynamo_tensorrt_converter(torch.ops.aten.arange.start_step)
+def aten_ops_arange_start_step(
+    ctx: ConversionContext,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    return np.arange(*args)

--- a/py/torch_tensorrt/dynamo/conversion/ops_evaluators.py
+++ b/py/torch_tensorrt/dynamo/conversion/ops_evaluators.py
@@ -1,3 +1,4 @@
+import builtins
 import logging
 import operator
 from typing import Dict, Sequence, Tuple, Union
@@ -23,7 +24,9 @@ def getitem_validator(getitem_node: Node) -> bool:
 
 # TODO: Subsequent evaluators should be registered here with their own validators
 @dynamo_tensorrt_converter(operator.getitem, capability_validator=getitem_validator)
+@dynamo_tensorrt_converter(builtins.getattr)
 @dynamo_tensorrt_converter(torch.ops.aten.detach.default)
+@dynamo_tensorrt_converter(torch.ops.aten.arange.start_step)
 def generic_evaluator(
     ctx: ConversionContext,
     target: Target,

--- a/py/torch_tensorrt/dynamo/conversion/ops_evaluators.py
+++ b/py/torch_tensorrt/dynamo/conversion/ops_evaluators.py
@@ -1,4 +1,3 @@
-import builtins
 import logging
 import operator
 from typing import Dict, Sequence, Tuple, Union
@@ -25,7 +24,6 @@ def getitem_validator(getitem_node: Node) -> bool:
 
 # TODO: Subsequent evaluators should be registered here with their own validators
 @dynamo_tensorrt_converter(operator.getitem, capability_validator=getitem_validator)
-@dynamo_tensorrt_converter(builtins.getattr)
 @dynamo_tensorrt_converter(torch.ops.aten.detach.default)
 def generic_evaluator(
     ctx: ConversionContext,

--- a/tests/py/dynamo/conversion/test_arange_aten.py
+++ b/tests/py/dynamo/conversion/test_arange_aten.py
@@ -26,6 +26,7 @@ class TestArangeConverter(DispatchTestCase):
         self.run_test(
             Arange(),
             inputs,
+            use_dynamo_tracer=True,
         )
 
 

--- a/tests/py/dynamo/conversion/test_arange_aten.py
+++ b/tests/py/dynamo/conversion/test_arange_aten.py
@@ -1,0 +1,33 @@
+import torch
+import torch.nn as nn
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+
+from .harness import DispatchTestCase
+
+
+class TestArangeConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            (0, 5, 1),
+            (1, 5, 2),
+            (3, 5, 3),
+            (5, 0, -1),
+            (5, 1, -2),
+            (5, 3, -3),
+        ]
+    )
+    def test_arange(self, start, end, step):
+        class Arange(nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.arange.start_step(start, x.shape[0], step)
+
+        inputs = [torch.randn(end, 1)]
+        self.run_test(
+            Arange(),
+            inputs,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
# Description

Support `aten.arange.start_step` dynamo converter.

Fixes #2492 

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
