### PR TITLE
fix: Add continuation on failure code to GHA

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -56,6 +56,7 @@ jobs:
 
   tests-py-torchscript-fe:
     name: Test torchscript frontend [Python]
+    if:  success() || failure()
     needs: [generate-matrix, build]
     strategy:
       fail-fast: false
@@ -91,6 +92,7 @@ jobs:
 
   tests-py-dynamo-converters:
     name: Test dynamo converters [Python]
+    if:  success() || failure()
     needs: [generate-matrix, build]
     strategy:
       fail-fast: false
@@ -118,6 +120,7 @@ jobs:
 
   tests-py-dynamo-fe:
     name: Test dynamo frontend [Python]
+    if:  success() || failure()
     needs: [generate-matrix, build]
     strategy:
       fail-fast: false
@@ -146,6 +149,7 @@ jobs:
 
   tests-py-dynamo-serde:
     name: Test dynamo export serde [Python]
+    if:  success() || failure()
     needs: [generate-matrix, build]
     strategy:
       fail-fast: false
@@ -173,6 +177,7 @@ jobs:
 
   tests-py-torch-compile-be:
     name: Test torch compile backend [Python]
+    if:  success() || failure()
     needs: [generate-matrix, build]
     strategy:
       fail-fast: false
@@ -201,6 +206,7 @@ jobs:
 
   tests-py-dynamo-core:
     name: Test dynamo core [Python]
+    if:  success() || failure()
     needs: [generate-matrix, build]
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Description

- Addresses failure to run testing when a particular Python version build fails, as here: https://github.com/pytorch/TensorRT/actions/runs/7135610502/job/19432697880

## Type of change

- CI Fix

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ - ] I have added tests to verify my fix or my feature
  - Validated through CI
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
