### PR TITLE
fix: Repair usage of `torch_executed_ops`

### DIFF
--- a/py/torch_tensorrt/dynamo/_settings.py
+++ b/py/torch_tensorrt/dynamo/_settings.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass, field
-from typing import Optional, Set, Union
+from typing import Collection, Optional, Union
 
 import torch
 from tensorrt import EngineCapability
+from torch.fx.node import Target
 from torch_tensorrt._Device import Device
 from torch_tensorrt.dynamo._defaults import (
     DEBUG,
@@ -41,7 +42,7 @@ class CompilationSettings:
         debug (bool): Whether to print out verbose debugging information
         workspace_size (int): Workspace TRT is allowed to use for the module (0 is default)
         min_block_size (int): Minimum number of operators per TRT-Engine Block
-        torch_executed_ops (Sequence[str]): Sequence of operations to run in Torch, regardless of converter coverage
+        torch_executed_ops (Collection[Target]): Collection of operations to run in Torch, regardless of converter coverage
         pass_through_build_failures (bool): Whether to fail on TRT engine build errors (True) or not (False)
         max_aux_streams (Optional[int]): Maximum number of allowed auxiliary TRT streams for each engine
         version_compatible (bool): Provide version forward-compatibility for engine plan files
@@ -75,7 +76,7 @@ class CompilationSettings:
     debug: bool = DEBUG
     workspace_size: int = WORKSPACE_SIZE
     min_block_size: int = MIN_BLOCK_SIZE
-    torch_executed_ops: Set[str] = field(default_factory=set)
+    torch_executed_ops: Collection[Target] = field(default_factory=set)
     pass_through_build_failures: bool = PASS_THROUGH_BUILD_FAILURES
     max_aux_streams: Optional[int] = MAX_AUX_STREAMS
     version_compatible: bool = VERSION_COMPATIBLE

--- a/py/torch_tensorrt/dynamo/partitioning/_adjacency_partitioner.py
+++ b/py/torch_tensorrt/dynamo/partitioning/_adjacency_partitioner.py
@@ -42,8 +42,10 @@ class OpSupportTester(ops.OperatorSupportBase):  # type: ignore
         node_name = ConverterRegistry.qualified_name_or_str(node.target)
 
         if (
-            node in CONVERTERS or node.op == "get_attr"
-        ) and node_name not in self.torch_executed_ops:
+            (node in CONVERTERS or node.op == "get_attr")
+            and node_name not in self.torch_executed_ops
+            and node.target not in self.torch_executed_ops
+        ):
             # If node is a proper, supported computational node, store the operator
             if not node.is_impure() and node.op != "get_attr":
                 if node_name not in self.supported_operators:

--- a/py/torch_tensorrt/dynamo/partitioning/_global_partitioner.py
+++ b/py/torch_tensorrt/dynamo/partitioning/_global_partitioner.py
@@ -1,8 +1,9 @@
 import logging
-from typing import Collection, Dict, List, Mapping, Optional, Sequence, Set, Tuple
+from typing import Collection, Dict, List, Mapping, Optional, Sequence, Tuple
 
 import torch
 from torch.fx.graph_module import GraphModule
+from torch.fx.node import Target
 from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner, Partition
 from torch.fx.passes.operator_support import OperatorSupport, SupportDict
 from torch_tensorrt.dynamo._defaults import (
@@ -133,16 +134,14 @@ class TorchTensorRTOperatorSupport(OperatorSupport):  # type: ignore[misc]
     def __init__(
         self,
         support_dict: Optional[SupportDict] = None,
-        torch_executed_ops: Optional[Set[str]] = None,
+        torch_executed_ops: Collection[Target] = set(),
     ):
         super().__init__(support_dict)
 
         # Initialize sets of supported/unsupported operators
         self.supported_operators: Dict[str, int] = {}
         self.unsupported_operators: Dict[str, int] = {}
-        self.torch_executed_ops: Set[str] = (
-            torch_executed_ops if torch_executed_ops is not None else set()
-        )
+        self.torch_executed_ops: Collection[Target] = torch_executed_ops
 
     def is_node_supported(
         self, submodules: Mapping[str, torch.nn.Module], node: torch.fx.Node
@@ -150,8 +149,10 @@ class TorchTensorRTOperatorSupport(OperatorSupport):  # type: ignore[misc]
         node_name = ConverterRegistry.qualified_name_or_str(node.target)
 
         if (
-            node in CONVERTERS or node.op == "get_attr"
-        ) and node_name not in self.torch_executed_ops:
+            (node in CONVERTERS or node.op == "get_attr")
+            and node_name not in self.torch_executed_ops
+            and node.target not in self.torch_executed_ops
+        ):
             # If node is a proper, supported computational node, store the operator
             if not node.is_impure() and node.op != "get_attr":
                 if node_name not in self.supported_operators:
@@ -201,7 +202,7 @@ def partition(
     gm: torch.fx.GraphModule,
     verbose: bool = DEBUG,
     min_block_size: int = MIN_BLOCK_SIZE,
-    torch_executed_ops: Optional[Set[str]] = None,
+    torch_executed_ops: Collection[Target] = set(),
     require_full_compilation: bool = REQUIRE_FULL_COMPILATION,
 ) -> Tuple[torch.fx.GraphModule, TorchTensorRTOperatorSupport]:
     """Partition an FX GraphModule with aten ops into TRT engines
@@ -211,16 +212,12 @@ def partition(
         gm: FX GraphModule to partition
         verbose: Bool representing whether to print operator support
         min_block_size: Minimum number of operators per TRT-Engine Block
-        torch_executed_ops: Sequence of operations to run in Torch, regardless of converter coverage
+        torch_executed_ops: Collection of operations to run in Torch, regardless of converter coverage
         require_full_compilation: Whether to require that all operators be run in TRT
     Returns:
         torch.fx.GraphModule, TorchTensorRTOperatorSupport
     """
-    supported_ops = TorchTensorRTOperatorSupport(
-        torch_executed_ops=torch_executed_ops
-        if torch_executed_ops is not None
-        else set()
-    )
+    supported_ops = TorchTensorRTOperatorSupport(torch_executed_ops=torch_executed_ops)
     partitioner = TRTPartitioner(
         gm,
         supported_ops,

--- a/tests/py/dynamo/models/test_dyn_models.py
+++ b/tests/py/dynamo/models/test_dyn_models.py
@@ -3,8 +3,9 @@ import unittest
 import pytest
 import timm
 import torch
-import torch_tensorrt as torchtrt
 from torch_tensorrt.dynamo.utils import COSINE_THRESHOLD, cosine_similarity
+
+import torch_tensorrt as torchtrt
 
 assertions = unittest.TestCase()
 
@@ -97,7 +98,7 @@ def test_base_dynamic_fallback(ir):
         "ir": ir,
         "pass_through_build_failures": True,
         "optimization_level": 1,
-        "torch_executed_ops": "torch.ops.aten.abs.default",
+        "torch_executed_ops": {"torch.ops.aten.abs.default"},
         "min_block_size": 1,
     }
 

--- a/tests/py/dynamo/models/test_export_serde.py
+++ b/tests/py/dynamo/models/test_export_serde.py
@@ -3,9 +3,10 @@ import unittest
 import pytest
 import timm
 import torch
-import torch_tensorrt as torchtrt
 import torchvision.models as models
 from torch_tensorrt.dynamo.utils import COSINE_THRESHOLD, cosine_similarity
+
+import torch_tensorrt as torchtrt
 
 assertions = unittest.TestCase()
 
@@ -206,7 +207,7 @@ def test_hybrid_relu_fallback(ir):
         ],
         "ir": ir,
         "min_block_size": 1,
-        "torch_executed_ops": "torch.ops.aten.relu.default",
+        "torch_executed_ops": {"torch.ops.aten.relu.default"},
     }
 
     exp_program = torchtrt.dynamo.trace(model, **compile_spec)


### PR DESCRIPTION
# Description
- Previously, `torch_executed_ops` were excluded at partitioning time, but not conversion time, causing a bug with obscure usages of `getitem`
- Now, `torch_executed_ops` are excluded at partitioning time and their converters are explicitly disabled

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
