### PR TITLE
fix: Switch all copies to force cast

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -911,7 +911,7 @@ def aten_ops_clone_copy_dtype(
         name,
         args[0],
         kwargs.get("dtype", args[0].dtype),
-        force_layer=False,
+        force_layer=True,
     )
 
 
@@ -1043,7 +1043,7 @@ def aten_ops_sum(
             name,
             sum_,
             kwargs["output_dtype"],
-            force_layer=False,
+            force_layer=True,
         )
     else:
         return sum_

--- a/tests/py/dynamo/conversion/test_casts.py
+++ b/tests/py/dynamo/conversion/test_casts.py
@@ -75,6 +75,21 @@ class TestToCopyConverter(DispatchTestCase):
                 inputs,
             )
 
+    def test_to_copy_multiple_returns(self):
+        class ToCopyReturns(nn.Module):
+            def forward(self, x):
+                x_1 = x + 1
+                y = torch.ops.aten._to_copy.default(x_1, dtype=torch.float)
+                z = torch.ops.aten._to_copy.default(x_1, dtype=torch.float)
+                return y, z
+
+        inputs = [torch.rand((1, 3, 10))]
+        self.run_test(
+            ToCopyReturns(),
+            inputs,
+            precision=torch.float,
+        )
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
# Description
- Fixes the case where engines return multiple copies of the same tensor with inserted casts. This behavior is disallowed in TRT
- Added regression test case
- This fix should be removed once #2561 is merged

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
