### PR TITLE
Grant write permission to token

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -16,6 +16,9 @@ on:
 
 jobs:
   assign:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,9 +26,6 @@ jobs:
 
   build:
     needs: generate-matrix
-    permissions:
-      id-token: write
-      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -53,6 +50,9 @@ jobs:
       package-name: ${{ matrix.package-name }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
       trigger-event: ${{ github.event_name }}
+    secrets:
+      AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
+      AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}
 
   tests-py-torchscript-fe:
     name: Test torchscript frontend [Python]

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,6 +26,9 @@ jobs:
 
   build:
     needs: generate-matrix
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -50,9 +53,6 @@ jobs:
       package-name: ${{ matrix.package-name }}
       smoke-test-script: ${{ matrix.smoke-test-script }}
       trigger-event: ${{ github.event_name }}
-    secrets:
-      AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
-      AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}
 
   tests-py-torchscript-fe:
     name: Test torchscript frontend [Python]

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -10,11 +10,12 @@ on: [pull_request_target]
 
 jobs:
   label:
-
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/labeler@v2
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/pr-labels.yml


### PR DESCRIPTION
The default write permission of the token has been revoked org-wide, so we need to set that explicitly here for these workflows that update PRs (write).

(Also update the labeler to v4 cause why not) 