### PR TITLE
small fix: Index validator enable int64

### DIFF
--- a/examples/dynamo/torch_compile_advanced_usage.py
+++ b/examples/dynamo/torch_compile_advanced_usage.py
@@ -43,7 +43,7 @@ model = Model().eval().cuda()
 # For the default settings, we can simply call torch.compile
 # with the backend "torch_tensorrt", and run the model on an
 # input to cause compilation, as so:
-optimized_model = torch.compile(model, backend="torch_tensorrt")
+optimized_model = torch.compile(model, backend="torch_tensorrt", dynamic=False)
 optimized_model(*sample_inputs)
 
 # %%
@@ -81,7 +81,10 @@ backend_kwargs = {
 
 # Run the model on an input to cause compilation, as so:
 optimized_model_custom = torch.compile(
-    model_half, backend="torch_tensorrt", options=backend_kwargs
+    model_half,
+    backend="torch_tensorrt",
+    options=backend_kwargs,
+    dynamic=False,
 )
 optimized_model_custom(*sample_inputs_half)
 

--- a/examples/dynamo/torch_compile_transformers_example.py
+++ b/examples/dynamo/torch_compile_transformers_example.py
@@ -61,6 +61,7 @@ compilation_kwargs = {
 optimized_model = torch.compile(
     model,
     backend="torch_tensorrt",
+    dynamic=False,
     options=compilation_kwargs,
 )
 optimized_model(*inputs)

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -397,7 +397,7 @@ def index_dtype_validator(node: Node) -> bool:
     for ind in index:
         if ind is not None:
             val = ind.meta.get("val")
-            if val is not None and val.dtype != torch.int32:
+            if val is not None and val.dtype not in (torch.int32, torch.int64):
                 return False
     return True
 

--- a/tests/py/dynamo/conversion/test_index_aten.py
+++ b/tests/py/dynamo/conversion/test_index_aten.py
@@ -1,10 +1,8 @@
-import operator
-
 import torch
 import torch.nn as nn
-from .harness import DispatchTestCase
 from torch.testing._internal.common_utils import run_tests
-from torch_tensorrt import Input
+
+from .harness import DispatchTestCase
 
 
 class TestIndexConverter(DispatchTestCase):
@@ -15,7 +13,6 @@ class TestIndexConverter(DispatchTestCase):
                 super().__init__()
 
             def forward(self, x):
-                index0 = torch.randint(0, 1, (1, 1))
                 indices = [None, self.index0]
                 out = torch.ops.aten.index.Tensor(x, indices)
                 return out
@@ -158,8 +155,6 @@ class TestIndexConverter(DispatchTestCase):
                 super().__init__()
 
             def forward(self, x):
-                index0 = torch.tensor([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7])
-                index1 = index0.unsqueeze(0).T.long()
                 indices = [None, None, self.index0, self.index1]
                 out = torch.ops.aten.index.Tensor(x, indices)
                 return out


### PR DESCRIPTION
# Description

- Currently, pending the implementation of #2590, constant index Tensors are type `int64` before being frozen. This workaround enables valid usecases while #2590 is being implemented

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
