### PR TITLE
fix: Add cmake missing source file ref for core_lowering.passes

### DIFF
--- a/core/lowering/passes/CMakeLists.txt
+++ b/core/lowering/passes/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(${lib_name}
             "${CMAKE_CURRENT_SOURCE_DIR}/unpack_rsqrt.cpp"
             "${CMAKE_CURRENT_SOURCE_DIR}/unpack_std.cpp"
             "${CMAKE_CURRENT_SOURCE_DIR}/unpack_var.cpp"
+	    "${CMAKE_CURRENT_SOURCE_DIR}/unpack_scaled_dot_product_attention.cpp"
             "${CMAKE_CURRENT_SOURCE_DIR}/view_to_reshape.cpp"
             "${CMAKE_CURRENT_SOURCE_DIR}/rewrite_inputs_with_params.cpp"
 )


### PR DESCRIPTION
# Description

Add missing source file `core/lowering/passes/unpack_scaled_dot_product_attention.cpp` to `core/lowering/passes/CMakeLists.txt`. If not do so, when building shared library `torchtrt` will fail due to missing reference to function `UnpackScaledDotProductAttention`.

Fixes # (issue)

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
