### PR TITLE
fix: Fix deconv kernel channel num_output_maps where wts are ITensor

### DIFF
--- a/core/conversion/converters/impl/conv_deconv.cpp
+++ b/core/conversion/converters/impl/conv_deconv.cpp
@@ -139,7 +139,12 @@ bool add_conv_deconv(ConversionCtx* ctx, const torch::jit::Node* n, args& args) 
     filter_dim.nbDims = nbSpatialDims;
     filter_dim.d[0] = kernel_dims.d[2];
     filter_dim.d[1] = kernel_dims.d[3];
+    // For Conv2d layer, weights are in the shape of (out_channels, in_channels/groups,...)
     int32_t num_output_maps = kernel_dims.d[0];
+    if (transposed) {
+      // For ConvTranspose layer, weights are in the shape of (in_channels, out_channel/groups,...)
+      num_output_maps = kernel_dims.d[1];
+    }
     bool expand_dims = nbSpatialDims == 1;
     if (expand_dims) {
       // In case of Conv1D -> map it to 2D version
@@ -150,9 +155,6 @@ bool add_conv_deconv(ConversionCtx* ctx, const torch::jit::Node* n, args& args) 
       LOG_DEBUG("Reshaping input dimensions to: " << in->getDimensions());
       kernel = addPadding(ctx, n, kernel, 4);
       LOG_DEBUG("Reshaping kernel dimensions to: " << kernel->getDimensions());
-      if (transposed) {
-        num_output_maps = kernel_dims.d[1];
-      }
     }
 
     // Initialize a dummy constant kernel to pass it to INetwork->addConvolutionNd/addDeconvolutionNd API.


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
In current implementation deconv layer picks up the in_channel for kernel incorrectly when weight is also an ITensor.
This PR fixes that issue.

[Conv2d](https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html)
[ConvTranspose2d](https://pytorch.org/docs/stable/generated/torch.nn.ConvTranspose2d.html)

For conv2d the kernel dimensions are: [out_channels, in_channels / group, ... ]
For convTranspose2d the kernel dimension should be: [in_channel, out_channels / group, ... ]

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
