### PR TITLE
Selectively enable different frontends

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -227,3 +227,30 @@ jobs:
         ${CONDA_RUN} python -m pytest -n 4 --junitxml=${RUNNER_TEST_RESULTS_DIR}/tests_py_dynamo_core_partitioning_test_results.xml partitioning/
         ${CONDA_RUN} python -m pytest -n 4 --junitxml=${RUNNER_TEST_RESULTS_DIR}/tests_py_dynamo_core_lowering_test_results.xml lowering/
         popd
+
+  tests-py-core:
+    name: Test core [Python]
+    needs: [generate-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: pytorch/tensorrt
+            package-name: torch_tensorrt
+            pre-script: packaging/pre_build_script.sh
+    uses: pytorch/tensorrt/.github/workflows/linux-test.yml@main
+    with:
+      job-name: tests-py-core
+      repository: "pytorch/tensorrt"
+      ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      pre-script: ${{ matrix.pre-script }}
+      script: |
+        export USE_HOST_DEPS=1
+        pushd .
+        cd tests/py/core
+        ${CONDA_RUN} python -m pip install --pre pytest-xdist timm transformers parameterized expecttest==0.1.6 --use-deprecated=legacy-resolver
+        ${CONDA_RUN} python -m pytest -n 4 --junitxml=${RUNNER_TEST_RESULTS_DIR}/tests_py_core_test_results.xml .
+        popd

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: ^.github/actions/assigner/dist
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
       - id: trailing-whitespace
@@ -16,38 +16,38 @@ repos:
           - --fix=lf
         exclude: ^docs
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v16.0.6
+    rev: v18.1.1
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]
   - repo: https://github.com/keith/pre-commit-buildifier
-    rev: 6.1.0.2
+    rev: 6.4.0
     hooks:
     -   id: buildifier
         args:
           - --warnings=all
     -   id: buildifier-lint
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.13
+    rev: v0.16
     hooks:
       - id: validate-pyproject
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.4.1'
+    rev: 'v1.9.0'
     hooks:
     -   id: mypy
         exclude: "^py/torch_tensorrt/fx|^examples|^tests|^py/torch_tensorrt/dynamo/_experimental|^tools|^docs|noxfile.py|setup.py|versions.py"
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.278
+    rev: v0.3.3
     hooks:
       - id: ruff
   - repo: https://github.com/psf/black
-    rev: 24.1.1
+    rev: 24.3.0
     hooks:
       - id: black
         exclude: ^examples/custom_converters/elu_converter/setup.py|^docs

--- a/BUILD
+++ b/BUILD
@@ -34,6 +34,14 @@ pkg_tar(
 )
 
 pkg_tar(
+    name = "include_rt",
+    package_dir = "include/torch_tensorrt",
+    deps = [
+        "//core/runtime:include",
+    ],
+)
+
+pkg_tar(
     name = "include",
     srcs = [
         "//cpp:api_headers",
@@ -48,6 +56,18 @@ pkg_tar(
         "//conditions:default": [
             "//cpp/lib:libtorchtrt.so",
             "//cpp/lib:libtorchtrt_plugins.so",
+            "//cpp/lib:libtorchtrt_runtime.so",
+        ],
+    }),
+    mode = "0755",
+    package_dir = "lib/",
+)
+
+pkg_tar(
+    name = "lib_rt",
+    srcs = select({
+        ":windows": ["//cpp/lib:torch_tensorrt_runtime.dll"],
+        "//conditions:default": [
             "//cpp/lib:libtorchtrt_runtime.so",
         ],
     }),
@@ -81,4 +101,19 @@ pkg_tar(
         ":windows": [],
         "//conditions:default": [":bin"],
     }),
+)
+
+pkg_tar(
+    name = "libtorchtrt_runtime",
+    srcs = [
+        "//:LICENSE",
+        "//bzl_def:BUILD",
+        "//bzl_def:WORKSPACE",
+    ],
+    extension = "tar.gz",
+    package_dir = "torch_tensorrt_runtime",
+    deps = [
+        ":include_rt",
+        ":lib_rt",
+    ],
 )

--- a/core/runtime/RTDevice.cpp
+++ b/core/runtime/RTDevice.cpp
@@ -7,8 +7,6 @@ namespace torch_tensorrt {
 namespace core {
 namespace runtime {
 
-const std::string DEVICE_INFO_DELIM = "%";
-
 typedef enum { ID_IDX = 0, SM_MAJOR_IDX, SM_MINOR_IDX, DEVICE_TYPE_IDX, DEVICE_NAME_IDX } SerializedDeviceInfoIndex;
 
 RTDevice::RTDevice() : id{-1}, major{-1}, minor{-1}, device_type{nvinfer1::DeviceType::kGPU} {}

--- a/core/runtime/RTDevice.h
+++ b/core/runtime/RTDevice.h
@@ -6,6 +6,8 @@ namespace torch_tensorrt {
 namespace core {
 namespace runtime {
 
+const std::string DEVICE_INFO_DELIM = "%";
+
 struct RTDevice {
   int64_t id; // CUDA device id
   int64_t major; // CUDA compute major version

--- a/core/runtime/register_jit_hooks.cpp
+++ b/core/runtime/register_jit_hooks.cpp
@@ -116,6 +116,7 @@ static auto TORCHTRT_UNUSED TRTEngineTSRegistrtion =
 TORCH_LIBRARY(tensorrt, m) {
   m.def("execute_engine", execute_engine);
   m.def("SERIALIZED_ENGINE_BINDING_DELIM", []() -> std::string { return std::string(1, TRTEngine::BINDING_DELIM); });
+  m.def("SERIALIZED_RT_DEVICE_DELIM", []() -> std::string { return DEVICE_INFO_DELIM; });
   m.def("ABI_VERSION", []() -> std::string { return ABI_VERSION; });
   m.def("get_multi_device_safe_mode", []() -> bool { return MULTI_DEVICE_SAFE_MODE; });
   m.def("set_multi_device_safe_mode", [](bool multi_device_safe_mode) -> void {

--- a/docsrc/py_api/torch_tensorrt.rst
+++ b/docsrc/py_api/torch_tensorrt.rst
@@ -37,10 +37,6 @@ Classes
    :members:
    :special-members: __init__
 
-.. autoclass:: TRTModuleNext
-   :members:
-   :special-members: __init__
-
 Enums
 -------
 
@@ -50,7 +46,7 @@ Enums
 
 .. autoclass:: EngineCapability
 
-.. autoclass:: TensorFormat
+.. autoclass:: memory_format
 
 Submodules
 ----------

--- a/examples/dynamo/torch_compile_stable_diffusion.py
+++ b/examples/dynamo/torch_compile_stable_diffusion.py
@@ -18,9 +18,8 @@ This interactive script is intended as a sample of the Torch-TensorRT workflow w
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 import torch
-from diffusers import DiffusionPipeline
-
 import torch_tensorrt
+from diffusers import DiffusionPipeline
 
 model_id = "CompVis/stable-diffusion-v1-4"
 device = "cuda:0"
@@ -39,7 +38,7 @@ pipe.unet = torch.compile(
     backend=backend,
     options={
         "truncate_long_and_double": True,
-        "precision": torch.float16,
+        "enabled_precisions": {torch.float32, torch.float16},
     },
     dynamic=False,
 )

--- a/py/torch_tensorrt/_Input.py
+++ b/py/torch_tensorrt/_Input.py
@@ -4,8 +4,10 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import torch
-from torch_tensorrt import _enums
+import numpy as np
+import tensorrt as trt
 
+from torch_tensorrt._enums import dtype, memory_format
 
 class Input(object):
     """
@@ -28,19 +30,19 @@ class Input(object):
         STATIC = 0
         DYNAMIC = 1
 
-    shape_mode: Optional[_ShapeMode] = (
-        None  #: Is input statically or dynamically shaped
-    )
-    shape: Optional[Tuple[int, ...] | Dict[str, Tuple[int, ...]]] = (
-        None  #: Either a single Tuple or a dict of tuples defining the input shape. Static shaped inputs will have a single tuple. Dynamic inputs will have a dict of the form ``{ "min_shape": Tuple, "opt_shape": Tuple, "max_shape": Tuple }``
-    )
-    dtype: _enums.dtype = (
-        _enums.dtype.unknown
+    shape_mode: Optional[
+        _ShapeMode
+    ] = None  #: Is input statically or dynamically shaped
+    shape: Optional[
+        Tuple[int, ...] | Dict[str, Tuple[int, ...]]
+    ] = None  #: Either a single Tuple or a dict of tuples defining the input shape. Static shaped inputs will have a single tuple. Dynamic inputs will have a dict of the form ``{ "min_shape": Tuple, "opt_shape": Tuple, "max_shape": Tuple }``
+    dtype: dtype = (
+        dtype.unknown
     )  #: The expected data type of the input tensor (default: torch_tensorrt.dtype.float32)
     _explicit_set_dtype: bool = False
-    format: _enums.TensorFormat = (
-        _enums.TensorFormat.contiguous
-    )  #: The expected format of the input tensor (default: torch_tensorrt.TensorFormat.NCHW)
+    format: memory_format = (
+        memory_format.linear
+    )  #: The expected format of the input tensor (default: torch_tensorrt.memory_format.linear)
 
     DOMAIN_OFFSET: float = 2.0
     low_tensor_domain_incl: float = 0.0
@@ -157,15 +159,18 @@ class Input(object):
             )
 
         if "dtype" in kwargs:
-            if isinstance(kwargs["dtype"], torch.dtype):
-                self.torch_dtype = kwargs["dtype"]
+            self.dtype = dtype._from(kwargs["dtype"])
+            self.torch_dtype = self.dtype.to(torch.dtype, use_default=True)
+            print(self.dtype)
+            print(self.torch_dtype)
 
-            self.dtype = Input._parse_dtype(kwargs["dtype"])
-            self.torch_dtype = Input._to_torch_dtype(self.dtype)
+        if self.dtype != dtype.unknown:
             self._explicit_set_dtype = True
+        else:
+            self._explicit_set_dtype = False
 
         if "format" in kwargs:
-            self.format = Input._parse_format(kwargs["format"])
+            self.format = memory_format._from(kwargs["format"])
 
         if "tensor_domain" in kwargs:
             domain = kwargs["tensor_domain"]
@@ -212,6 +217,9 @@ class Input(object):
         else:
             raise RuntimeError("Unknown input shape mode")
 
+    def __repr__(self) -> str:
+        return self.__str__()
+
     @staticmethod
     def _supported_input_size_type(input_size: Any) -> bool:
         if isinstance(input_size, torch.Size):
@@ -222,77 +230,6 @@ class Input(object):
             return True
         else:
             return False
-
-    @staticmethod
-    def _parse_dtype(dtype: Any) -> _enums.dtype:
-        if isinstance(dtype, torch.dtype):
-            if dtype == torch.long:
-                return _enums.dtype.long
-            elif dtype == torch.int32:
-                return _enums.dtype.int32
-            elif dtype == torch.half:
-                return _enums.dtype.half
-            elif dtype == torch.float:
-                return _enums.dtype.float
-            elif dtype == torch.float64:
-                return _enums.dtype.double
-            elif dtype == torch.bool:
-                return _enums.dtype.bool
-            else:
-                raise TypeError(
-                    "Provided an unsupported data type as an input data type (support: bool, int32, long, half, float), got: "
-                    + str(dtype)
-                )
-
-        elif isinstance(dtype, _enums.dtype):
-            return dtype
-
-        else:
-            raise TypeError(
-                "Input data type needs to be specified with a torch.dtype or a torch_tensorrt.dtype, got: "
-                + str(type(dtype))
-            )
-
-    @staticmethod
-    def _to_torch_dtype(dtype: _enums.dtype) -> torch.dtype:
-        if dtype == _enums.dtype.long:
-            return torch.long
-        elif dtype == _enums.dtype.int32:
-            return torch.int32
-        elif dtype == _enums.dtype.half:
-            return torch.half
-        elif dtype == _enums.dtype.float:
-            return torch.float
-        elif dtype == _enums.dtype.bool:
-            return torch.bool
-        elif dtype == _enums.dtype.double:
-            return torch.float64
-        else:
-            # Default torch_dtype used in FX path
-            return torch.float32
-
-    def is_trt_dtype(self) -> bool:
-        return bool(self.dtype != _enums.dtype.long)
-
-    @staticmethod
-    def _parse_format(format: Any) -> _enums.TensorFormat:
-        if isinstance(format, torch.memory_format):
-            if format == torch.contiguous_format:
-                return _enums.TensorFormat.contiguous
-            elif format == torch.channels_last:
-                return _enums.TensorFormat.channels_last
-            else:
-                raise ValueError(
-                    "Provided an unsupported tensor format (support: NCHW/contiguous_format, NHWC/channel_last)"
-                )
-
-        elif isinstance(format, _enums.TensorFormat):
-            return format
-
-        else:
-            raise TypeError(
-                "Tensor format needs to be specified with either torch.memory_format or torch_tensorrt.TensorFormat"
-            )
 
     @staticmethod
     def _parse_tensor_domain(

--- a/py/torch_tensorrt/__init__.py
+++ b/py/torch_tensorrt/__init__.py
@@ -103,7 +103,12 @@ def _register_with_torch() -> None:
 _register_with_torch()
 
 from torch_tensorrt._Device import Device  # noqa: F401
-from torch_tensorrt._enums import DeviceType, dtype, memory_format  # noqa: F401
+from torch_tensorrt._enums import (  # noqa: F401
+    DeviceType,
+    EngineCapability,
+    dtype,
+    memory_format,
+)
 from torch_tensorrt._Input import Input  # noqa: F401
 from torch_tensorrt.runtime import *  # noqa: F403
 

--- a/py/torch_tensorrt/__init__.py
+++ b/py/torch_tensorrt/__init__.py
@@ -92,11 +92,11 @@ _LOGGER.debug(_enabled_features_str())
 def _register_with_torch() -> None:
     trtorch_dir = os.path.dirname(__file__)
     if os.path.isfile(trtorch_dir + "/lib/libtorchtrt.so"):
-        assert ENABLED_FEATURES.torchscript_frontend == True
-        assert ENABLED_FEATURES.torch_tensorrt_runtime == True
+        assert ENABLED_FEATURES.torchscript_frontend
+        assert ENABLED_FEATURES.torch_tensorrt_runtime
         torch.ops.load_library(trtorch_dir + "/lib/libtorchtrt.so")
     elif os.path.isfile(trtorch_dir + "/lib/libtorchtrt_runtime.so"):
-        assert ENABLED_FEATURES.torch_tensorrt_runtime == True
+        assert ENABLED_FEATURES.torch_tensorrt_runtime
         torch.ops.load_library(trtorch_dir + "/lib/libtorchtrt_runtime.so")
 
 

--- a/py/torch_tensorrt/__init__.py
+++ b/py/torch_tensorrt/__init__.py
@@ -80,27 +80,30 @@ except ImportError:
         for lib in LINUX_LIBS:
             ctypes.CDLL(_find_lib(lib, LINUX_PATHS))
 
+import logging
+
 import torch
 from torch_tensorrt._features import ENABLED_FEATURES, _enabled_features_str
 
-import logging
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.debug(_enabled_features_str())
+
 
 def _register_with_torch() -> None:
     trtorch_dir = os.path.dirname(__file__)
     if os.path.isfile(trtorch_dir + "/lib/libtorchtrt.so"):
         assert ENABLED_FEATURES.torchscript_frontend == True
-        assert ENABLED_FEATURES.torch_tensorrt_runtime== True
+        assert ENABLED_FEATURES.torch_tensorrt_runtime == True
         torch.ops.load_library(trtorch_dir + "/lib/libtorchtrt.so")
     elif os.path.isfile(trtorch_dir + "/lib/libtorchtrt_runtime.so"):
         assert ENABLED_FEATURES.torch_tensorrt_runtime == True
         torch.ops.load_library(trtorch_dir + "/lib/libtorchtrt_runtime.so")
 
+
 _register_with_torch()
 
-from torch_tensorrt._enums import dtype, memory_format, DeviceType # noqa: F401
 from torch_tensorrt._Device import Device  # noqa: F401
+from torch_tensorrt._enums import DeviceType, dtype, memory_format  # noqa: F401
 from torch_tensorrt._Input import Input  # noqa: F401
 from torch_tensorrt.runtime import *  # noqa: F403
 
@@ -115,4 +118,3 @@ if ENABLED_FEATURES.dynamo_frontend:
     from torch_tensorrt import dynamo  # noqa: F401
 
 from torch_tensorrt._compile import *  # noqa: F403
-

--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -190,9 +190,11 @@ def compile(
     Returns:
         torch.nn.Module: Compiled Module, when run it will execute via TensorRT
     """
-    input_list = inputs if inputs else []
+    input_list = inputs if inputs is not None else []
     enabled_precisions_set: Set[dtype | torch.dtype] = (
-        enabled_precisions if enabled_precisions else _defaults.ENABLED_PRECISIONS
+        enabled_precisions
+        if enabled_precisions is not None
+        else _defaults.ENABLED_PRECISIONS
     )
 
     module_type = _parse_module_type(module)

--- a/py/torch_tensorrt/_enums.py
+++ b/py/torch_tensorrt/_enums.py
@@ -185,7 +185,9 @@ class dtype(Enum):
             casted_format = dtype._from(t, use_default=use_default)
             return casted_format
         except (ValueError, TypeError) as e:
-            logging.debug(e)
+            logging.debug(
+                f"Conversion from {t} to torch_tensorrt.dtype failed", exc_info=True
+            )
             return None
 
     def to(
@@ -301,7 +303,10 @@ class dtype(Enum):
             casted_format = self.to(t, use_default)
             return casted_format
         except (ValueError, TypeError) as e:
-            logging.debug(e)
+            logging.debug(
+                f"torch_tensorrt.dtype conversion to target type {t} failed",
+                exc_info=True,
+            )
             return None
 
     def __eq__(self, other: Union[torch.dtype, trt.DataType, np.dtype, dtype]) -> bool:
@@ -413,7 +418,10 @@ class memory_format(Enum):
             casted_format = memory_format._from(f)
             return casted_format
         except (ValueError, TypeError) as e:
-            logging.debug(e)
+            logging.debug(
+                f"Conversion from {f} to torch_tensorrt.memory_format failed",
+                exc_info=True,
+            )
             return None
 
     def to(
@@ -492,7 +500,10 @@ class memory_format(Enum):
             casted_format = self.to(t)
             return casted_format
         except (ValueError, TypeError) as e:
-            logging.debug(e)
+            logging.debug(
+                f"torch_tensorrt.memory_format conversion to target type {t} failed",
+                exc_info=True,
+            )
             return None
 
     def __eq__(
@@ -546,7 +557,10 @@ class DeviceType(Enum):
             casted_format = DeviceType._from(d)
             return casted_format
         except (ValueError, TypeError) as e:
-            logging.debug(e)
+            logging.debug(
+                f"Conversion from {d} to torch_tensorrt.DeviceType failed",
+                exc_info=True,
+            )
             return None
 
     def to(
@@ -595,7 +609,10 @@ class DeviceType(Enum):
             casted_format = self.to(t, use_default=use_default)
             return casted_format
         except (ValueError, TypeError) as e:
-            logging.debug(e)
+            logging.debug(
+                f"torch_tensorrt.DeviceType conversion to target type {t} failed",
+                exc_info=True,
+            )
             return None
 
     def __eq__(self, other: Union[trt.DeviceType, DeviceType]) -> bool:
@@ -653,7 +670,10 @@ class EngineCapability(Enum):
             casted_format = EngineCapability._from(c)
             return casted_format
         except (ValueError, TypeError) as e:
-            logging.debug(e)
+            logging.debug(
+                f"Conversion from {c} to torch_tensorrt.EngineCapablity failed",
+                exc_info=True,
+            )
             return None
 
     def to(
@@ -696,7 +716,10 @@ class EngineCapability(Enum):
             casted_format = self.to(t)
             return casted_format
         except (ValueError, TypeError) as e:
-            logging.debug(e)
+            logging.debug(
+                f"torch_tensorrt.EngineCapablity conversion to target type {t} failed",
+                exc_info=True,
+            )
             return None
 
     def __eq__(self, other: Union[trt.EngineCapability, EngineCapability]) -> bool:

--- a/py/torch_tensorrt/_enums.py
+++ b/py/torch_tensorrt/_enums.py
@@ -1,3 +1,516 @@
-from torch_tensorrt._C import EngineCapability, TensorFormat, dtype  # noqa: F401
+from typing import Self, Optional
 
-from tensorrt import DeviceType  # noqa: F401
+from enum import Enum, auto
+import torch
+import numpy as np
+import tensorrt as trt
+import logging
+
+from torch_tensorrt._features import ENABLED_FEATURES
+
+class dtype(Enum):
+    """Enum to set supported dtypes in the compiler"""
+
+    # Supported types in Torch-TensorRT
+    unknown = auto()
+    u8 = auto()
+    i8 = auto()
+    i32 = auto()
+    i64 = auto()
+    f16 = auto()
+    f32 = auto()
+    f64 = auto()
+    bool = auto()
+
+    # TODO: Enable FP8 and BF16
+    #f8 = auto()
+    #bf16 = auto()
+
+    uint8 = u8
+
+    int = i32
+    int32 = i32
+
+    long = i64
+    int64 = i64
+
+    half = f16
+    fp16 = f16
+    float16 = f16
+
+    float = f32
+    fp32 = f32
+    float32 = f32
+
+    double = f64
+    fp64 = f64
+    float64 = f64
+
+    # TODO: Enable when FP8 is enabled
+    #float8 = f8
+    #fp8 = f8
+
+    # TODO: Enable when BF16 is enabled
+    #bfloat16 = bf16
+
+
+    @staticmethod
+    def _from(t: torch.dtype | trt.DataType | np.dtype, use_default=False) -> Self:
+        # TODO: Ideally implemented with match statement but need to wait for Py39 EoL
+        if isinstance(t, torch.dtype):
+            if t == torch.uint8:
+                return dtype.u8
+            elif t == torch.long:
+                return dtype.i64
+            elif t == torch.int32:
+                return dtype.i32
+            elif t == torch.half:
+                return dtype.f16
+            elif t == torch.float:
+                return dtype.f32
+            elif t == torch.float64:
+                return dtype.f64
+            elif t == torch.bool:
+                return dtype.bool
+            elif use_default:
+                logging.warning("Given dtype that does not have direct mapping to Torch-TensorRT supported types ({}), defaulting to torch_tensorrt.dtype.float".format(t))
+                return dtype.float
+            else:
+                raise TypeError(
+                    "Provided an unsupported data type as an input data type (support: bool, int32, long, half, float), got: "
+                    + str(t)
+                )
+        elif isinstance(t, trt.DataType):
+            if t == trt.uint8:
+                return dtype.u8
+            elif t == trt.int8:
+                return dtype.i8
+            elif t == trt.int32:
+                return dtype.i32
+            elif t == trt.float16:
+                return dtype.f16
+            elif t == trt.float32:
+                return dtype.f32
+            elif (trt.__version__ >= "7.0" and t == torch.bool):
+                return dtype.bool
+            else:
+                raise TypeError(
+                    "Provided an unsupported data type as an input data type (support: bool, int32, half, float), got: "
+                    + str(t)
+                )
+
+        elif isinstance(t, np.dtype):
+            if t == np.uint8:
+                return dtype.u8
+            elif t == np.int8:
+                return dtype.i8
+            elif t == np.int32:
+                return dtype.i32
+            elif t == np.int64:
+                return dtype.i64
+            elif t == np.float16:
+                return dtype.f16
+            elif t == np.float32:
+                return dtype.f32
+            elif t == np.float64:
+                return dtype.f64
+            elif t == np.bool:
+                return dtype.bool
+            elif use_default:
+                logging.warning("Given dtype that does not have direct mapping to Torch-TensorRT supported types ({}), defaulting to torch_tensorrt.dtype.float".format(t))
+                return dtype.float
+            else:
+                raise TypeError(
+                    "Provided an unsupported data type as an input data type (support: bool, int32, long, half, float), got: "
+                    + str(t)
+                )
+
+        elif isinstance(t, dtype):
+            return t
+
+        elif ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt import _C
+            if isinstance(t, _C.dtype):
+                if t == _C.dtype.long:
+                    return dtype.i64
+                elif t ==  _C.dtype.int32:
+                    return dtype.i32
+                elif t == _C.dtype.half:
+                    return dtype.f16
+                elif t == _C.dtype.float:
+                    return dtype.f32
+                elif t == _C.dtype.double:
+                    return dtype.f64
+                elif t == _C.dtype.bool:
+                    return dtype.bool
+                elif t == _C.dtype.unknown:
+                    return dtype.unknown
+                else:
+                    raise TypeError(
+                        "Provided an unsupported data type as an input data type (support: bool, int32, long, half, float), got: "
+                        + str(t)
+                    )
+        else:
+            raise TypeError(
+                "Provided unsupported source type for dtype conversion"
+            )
+
+    @staticmethod
+    def try_from(t: torch.dtype | trt.DataType | np.dtype) -> Optional[Self]:
+        try:
+            casted_format = dtype._from(t)
+            return casted_format
+        except (ValueError, TypeError) as e:
+            logging.debug(e)
+            return None
+
+    def to(self, t: type, use_default: bool=False) -> torch.dtype | trt.DataType | np.dtype:
+        # TODO: Ideally implemented with match statement but need to wait for Py39 EoL
+        if t == torch.dtype:
+            if self == dtype.u8:
+                return torch.uint8
+            elif self == dtype.i8:
+                return torch.int8
+            elif self == dtype.i32:
+                return torch.int
+            elif self == dtype.i64:
+                return torch.long
+            elif self == dtype.f16:
+                return torch.half
+            elif self == dtype.f32:
+                return torch.float
+            elif self == dtype.f64:
+                return torch.double
+            elif self == dtype.bool:
+                return torch.bool
+            elif use_default:
+                logging.warning("Given dtype that does not have direct mapping to torch ({}), defaulting to torch.float".format(self))
+                return torch.float
+            else:
+                raise TypeError("Unsupported torch dtype")
+
+        elif t == trt.DataType:
+            if self == dtype.u8:
+                return trt.DataType.UINT8
+            if self == dtype.i8:
+                return trt.DataType.INT8
+            elif self == dtype.i32:
+                return trt.DataType.INT32
+            elif self == dtype.f16:
+                return trt.DataType.HALF
+            elif self == dtype.f32:
+                return trt.DataType.FLOAT
+            elif self == dtype.bool:
+                return trt.DataType.BOOL
+            elif use_default:
+                return trt.DataType.FLOAT
+            else:
+                raise TypeError("Unsupported tensorrt dtype")
+
+        elif t == np.dtype:
+            if self == dtype.u8:
+                return np.uint8
+            elif self == dtype.i8:
+                return np.int8
+            elif self == dtype.i32:
+                return np.int32
+            elif self == dtype.i64:
+                return np.int64
+            elif self == dtype.f16:
+                return np.float16
+            elif self == dtype.f32:
+                return np.float32
+            elif self == dtype.f64:
+                return np.float64
+            elif self == dtype.bool:
+                return np.bool
+            elif use_default:
+                return np.float32
+            else:
+                raise TypeError("Unspported numpy dtype")
+
+        elif t == dtype:
+            return self
+
+        elif ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt import _C
+            if t == _C.dtype:
+                if self == dtype.i64:
+                    return _C.dtype.long
+                elif self == dtype.i32:
+                    return _C.dtype.int32
+                elif self == dtype.f16:
+                    return _C.dtype.half
+                elif self == dtype.f32:
+                    return _C.dtype.float
+                elif self == dtype.f64:
+                    return _C.dtype.double
+                elif self == dtype.bool:
+                    return _C.dtype.bool
+                elif self == dtype.unknown:
+                    return _C.dtype.unknown
+                else:
+                    raise TypeError(
+                        "Provided an unsupported data type as an input data type (support: bool, int32, long, half, float), got: "
+                        + str(self)
+                    )
+        else:
+            raise TypeError(
+                "Provided unsupported destination type for dtype conversion"
+            )
+
+    def try_to(self, t: type, use_default: bool=False) -> Optional[torch.dtype | trt.DataType | np.dtype]:
+        try:
+            print(self)
+            casted_format = self.to(t, use_default)
+            return casted_format
+        except (ValueError, TypeError) as e:
+            logging.debug(e)
+            return None
+
+class memory_format(Enum):
+
+    # TensorRT supported memory layouts
+    linear = auto()
+    chw2 = auto()
+    hwc8 = auto()
+    chw4 = auto()
+    chw16 = auto()
+    chw32 = auto()
+    dhwc8 = auto()
+    cdhw32 = auto()
+    hwc = auto()
+    dla_linear = auto()
+    dla_hwc4 = auto()
+    hwc16 = auto()
+    dhwc = auto()
+
+    # PyTorch aliases for TRT layouts
+    contiguous = linear
+    channels_last = hwc
+    channels_last_3d = dhwc
+
+    @staticmethod
+    def _from(f: torch.memory_format | trt.TensorFormat) -> Self:
+        # TODO: Ideally implemented with match statement but need to wait for Py39 EoL
+        if isinstance(f, torch.memory_format):
+            if f == torch.contiguous_format:
+                return memory_format.contiguous
+            elif f == torch.channels_last:
+                return memory_format.channels_last
+            elif f == torch.channels_last_3d:
+                return memory_format.channels_last_3d
+            else:
+                raise TypeError(
+                    "Provided an unsupported memory format for tensor, got: "
+                    + str(dtype)
+                )
+
+        elif isinstance(f, trt.DataType):
+            if f == trt.TensorFormat.LINEAR:
+                return memory_format.linear
+            elif f == trt.TensorFormat.CHW2:
+                return memory_format.chw2
+            elif f == trt.TensorFormat.HWC8:
+                return memory_format.hwc8
+            elif f == trt.TensorFormat.CHW4:
+                return memory_format.chw4
+            elif f == trt.TensorFormat.CHW16:
+                return memory_format.chw16
+            elif f == trt.TensorFormat.CHW32:
+                return memory_format.chw32
+            elif f == trt.TensorFormat.DHWC8:
+                return memory_format.dhwc8
+            elif f == trt.TensorFormat.CDHW32:
+                return memory_format.cdhw32
+            elif f == trt.TensorFormat.HWC:
+                return memory_format.hwc
+            elif f == trt.TensorFormat.DLA_LINEAR:
+                return memory_format.dla_linear
+            elif f == trt.TensorFormat.DLA_HWC4:
+                return memory_format.dla_hwc4
+            elif f == trt.TensorFormat.HWC16:
+                return memory_format.hwc16
+            elif f == trt.TensorFormat.DHWC:
+                return memory_format.dhwc
+            else:
+                raise TypeError(
+                    "Provided an unsupported tensor format for tensor, got: "
+                    + str(dtype)
+                )
+
+        elif isinstance(f, memory_format):
+            return f
+
+        elif ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt import _C
+            if isinstance(f, _C.TensorFormat):
+                if f == _C.TensorFormat.contiguous:
+                    return memory_format.contiguous
+                if f == _C.TensorFormat.channels_last:
+                    return memory_format.channels_last
+                else:
+                    raise ValueError(
+                        "Provided an unsupported tensor format (support: NCHW/contiguous_format, NHWC/channel_last)"
+                    )
+        else:
+            raise TypeError(
+                "Provided unsupported source type for memory_format conversion"
+            )
+
+    @staticmethod
+    def try_from(f: torch.memory_format | trt.TensorFormat) -> Optional[Self]:
+        try:
+            casted_format = memory_format._from(f)
+            return casted_format
+        except (ValueError, TypeError) as e:
+            logging.debug(e)
+            return None
+
+
+    def to(self, t: type) -> torch.memory_format | trt.TensorFormat:
+        if t == torch.memory_format:
+            if self == memory_format.contiguous:
+                return torch.contiguous_format
+            elif self == memory_format.channels_last:
+                return torch.channels_last
+            elif self == memory_format.channels_last_3d:
+                return torch.channels_last_3d
+            else:
+                raise TypeError("Unsupported torch dtype")
+
+        elif t == trt.TensorFormat:
+            if self ==  memory_format.linear:
+                return trt.TensorFormat.LINEAR
+            elif self == memory_format.chw2:
+                return trt.TensorFormat.CHW2
+            elif self ==  memory_format.hwc8:
+                return trt.TensorFormat.HWC8
+            elif self == memory_format.chw4:
+                return trt.TensorFormat.CHW4
+            elif self ==  memory_format.chw16:
+                return trt.TensorFormat.CHW16
+            elif self == memory_format.chw32:
+                return trt.TensorFormat.CHW32
+            elif self == memory_format.dhwc8:
+                return trt.TensorFormat.DHWC8
+            elif self == memory_format.cdhw32:
+                return trt.TensorFormat.CDHW32
+            elif self == memory_format.hwc:
+                return trt.TensorFormat.HWC
+            elif self == memory_format.dla_linear:
+                return trt.TensorFormat.DLA_LINEAR
+            elif self == memory_format.dla_hwc4:
+                return trt.TensorFormat.DLA_HWC4
+            elif self == memory_format.hwc16:
+                return trt.TensorFormat.HWC16
+            elif self == memory_format.dhwc:
+                return trt.TensorFormat.DHWC
+            else:
+                raise TypeError("Unsupported tensorrt dtype")
+
+        elif (t == memory_format):
+            return self
+
+        elif ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt import _C
+            if t == _C.TensorFormat:
+                if self == memory_format.contiguous:
+                    return _C.TensorFormat.contiguous
+                elif self == memory_format.channels_last:
+                    return _C.TensorFormat.channels_last
+                else:
+                    raise ValueError(
+                        "Provided an unsupported tensor format (support: NCHW/contiguous_format, NHWC/channel_last)"
+                    )
+
+        else:
+            raise TypeError(
+                "Provided unsupported destination type for memory format conversion"
+            )
+
+    def try_to(self, t: type) -> Optional[torch.memory_format | trt.TensorFormat]:
+        try:
+            casted_format = self.to(t)
+            return casted_format
+        except (ValueError, TypeError) as e:
+            logging.debug(e)
+            return None
+
+class DeviceType(Enum):
+    GPU = auto()
+    DLA = auto()
+
+    @staticmethod
+    def _from(d: trt.DeviceType) -> Self:
+        if isinstance(d, trt.DeviceType):
+            if d == trt.DeviceType.GPU:
+                return DeviceType.GPU
+            elif d == trt.DeviceType.DLA:
+                return DeviceType.DLA
+            else:
+                raise ValueError(
+                    "Provided an unsupported device type (support: GPU/DLA)"
+                )
+
+        elif isinstance(d, DeviceType):
+            return d
+
+        elif ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt import _C
+            if isinstance(d, _C.DeviceType):
+                if d == _C.DeviceType.GPU:
+                    return DeviceType.GPU
+                if d == _C.DeviceType.DLA:
+                    return DeviceType.DLA
+                else:
+                    raise ValueError(
+                        "Provided an unsupported device type (support: GPU/DLA)"
+                    )
+
+    @staticmethod
+    def try_from(d: trt.DeviceType) -> Optional[Self]:
+        try:
+            casted_format = DeviceType._from(d)
+            return casted_format
+        except (ValueError, TypeError) as e:
+            logging.debug(e)
+            return None
+
+    def to(self, t: type) -> trt.DeviceType:
+        if t == trt.DeviceType:
+            if self == DeviceType.GPU:
+                return trt.DeviceType.GPU
+            elif self == DeviceType.DLA:
+                return trt.DeviceType.DLA
+            else:
+                raise ValueError(
+                    "Provided an unsupported device type (support: GPU/DLA)"
+                )
+
+        elif t == DeviceType:
+            return self
+
+        elif ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt import _C
+            if t == _C.DeviceType:
+                if self == DeviceType.GPU:
+                    return _C.DeviceType.GPU
+                elif self == DeviceType.DLA:
+                    return _C.DeviceType.DLA
+                else:
+                    raise ValueError(
+                        "Provided an unsupported device type (support: GPU/DLA)"
+                    )
+        else:
+           raise TypeError(
+                "Provided unsupported destination type for device type conversion"
+            )
+
+    def try_to(self, t: type) -> Optional[trt.DeviceType]:
+        try:
+            casted_format = self.to(t)
+            return casted_format
+        except (ValueError, TypeError) as e:
+            logging.debug(e)
+            return None

--- a/py/torch_tensorrt/_enums.py
+++ b/py/torch_tensorrt/_enums.py
@@ -299,7 +299,6 @@ class dtype(Enum):
         use_default: bool,
     ) -> Optional[Union[torch.dtype, trt.DataType, np.dtype, dtype]]:
         try:
-            print(self)
             casted_format = self.to(t, use_default)
             return casted_format
         except (ValueError, TypeError) as e:
@@ -689,7 +688,7 @@ class EngineCapability(Enum):
             else:
                 raise ValueError("Provided an unsupported engine capability")
 
-        elif t == DeviceType:
+        elif t == EngineCapability:
             return self
 
         elif ENABLED_FEATURES.torchscript_frontend:

--- a/py/torch_tensorrt/_features.py
+++ b/py/torch_tensorrt/_features.py
@@ -1,29 +1,35 @@
 import os
-from packaging import version
 from collections import namedtuple
 
-from torch_tensorrt._version import __version__
 from torch_tensorrt._utils import sanitized_torch_version
 
-FeatureSet = namedtuple('FeatureSet', [
-    "torchscript_frontend",
-    "torch_tensorrt_runtime",
-    "dynamo_frontend",
-    "fx_frontend"
-])
+from packaging import version
+
+FeatureSet = namedtuple(
+    "FeatureSet",
+    [
+        "torchscript_frontend",
+        "torch_tensorrt_runtime",
+        "dynamo_frontend",
+        "fx_frontend",
+    ],
+)
 
 _TS_FE_AVAIL = os.path.isfile(os.path.dirname(__file__) + "/lib/libtorchtrt.so")
-_TORCHTRT_RT_AVAIL = (_TS_FE_AVAIL or os.path.isfile(os.path.dirname(__file__) + "/lib/libtorchtrt_runtime.so"))
+_TORCHTRT_RT_AVAIL = _TS_FE_AVAIL or os.path.isfile(
+    os.path.dirname(__file__) + "/lib/libtorchtrt_runtime.so"
+)
 _DYNAMO_FE_AVAIL = version.parse(sanitized_torch_version()) >= version.parse("2.1.dev")
 _FX_FE_AVAIL = True
 
 ENABLED_FEATURES = FeatureSet(
-    _TS_FE_AVAIL,
-    _TORCHTRT_RT_AVAIL,
-    _DYNAMO_FE_AVAIL,
-    _FX_FE_AVAIL
+    _TS_FE_AVAIL, _TORCHTRT_RT_AVAIL, _DYNAMO_FE_AVAIL, _FX_FE_AVAIL
 )
+
 
 def _enabled_features_str() -> str:
     enabled = lambda x: "ENABLED" if x else "DISABLED"
-    return f"Enabled Features:\n  - Dynamo Frontend: {enabled(_DYNAMO_FE_AVAIL)}\n  - Torch-TensorRT Runtime: {enabled(_TORCHTRT_RT_AVAIL)}\n  - FX Frontend: {enabled(_FX_FE_AVAIL)}\n  - TorchScript Frontend: {enabled(_TS_FE_AVAIL)}\n"
+    out_str: str = (
+        f"Enabled Features:\n  - Dynamo Frontend: {enabled(_DYNAMO_FE_AVAIL)}\n  - Torch-TensorRT Runtime: {enabled(_TORCHTRT_RT_AVAIL)}\n  - FX Frontend: {enabled(_FX_FE_AVAIL)}\n  - TorchScript Frontend: {enabled(_TS_FE_AVAIL)}\n"  # type: ignore[no-untyped-call]
+    )
+    return out_str

--- a/py/torch_tensorrt/_features.py
+++ b/py/torch_tensorrt/_features.py
@@ -1,0 +1,29 @@
+import os
+from packaging import version
+from collections import namedtuple
+
+from torch_tensorrt._version import __version__
+from torch_tensorrt._utils import sanitized_torch_version
+
+FeatureSet = namedtuple('FeatureSet', [
+    "torchscript_frontend",
+    "torch_tensorrt_runtime",
+    "dynamo_frontend",
+    "fx_frontend"
+])
+
+_TS_FE_AVAIL = os.path.isfile(os.path.dirname(__file__) + "/lib/libtorchtrt.so")
+_TORCHTRT_RT_AVAIL = (_TS_FE_AVAIL or os.path.isfile(os.path.dirname(__file__) + "/lib/libtorchtrt_runtime.so"))
+_DYNAMO_FE_AVAIL = version.parse(sanitized_torch_version()) >= version.parse("2.1.dev")
+_FX_FE_AVAIL = True
+
+ENABLED_FEATURES = FeatureSet(
+    _TS_FE_AVAIL,
+    _TORCHTRT_RT_AVAIL,
+    _DYNAMO_FE_AVAIL,
+    _FX_FE_AVAIL
+)
+
+def _enabled_features_str() -> str:
+    enabled = lambda x: "ENABLED" if x else "DISABLED"
+    return f"Enabled Features:\n  - Dynamo Frontend: {enabled(_DYNAMO_FE_AVAIL)}\n  - Torch-TensorRT Runtime: {enabled(_TORCHTRT_RT_AVAIL)}\n  - FX Frontend: {enabled(_FX_FE_AVAIL)}\n  - TorchScript Frontend: {enabled(_TS_FE_AVAIL)}\n"

--- a/py/torch_tensorrt/_utils.py
+++ b/py/torch_tensorrt/_utils.py
@@ -1,37 +1,7 @@
 from typing import Any
 
 import torch
-from torch_tensorrt import _C
 from torch_tensorrt._version import __version__
-
-
-def dump_build_info() -> None:
-    """Prints build information about the torch_tensorrt distribution to stdout"""
-    print(get_build_info())
-
-
-def get_build_info() -> str:
-    """Returns a string containing the build information of torch_tensorrt distribution
-
-    Returns:
-        str: String containing the build information for torch_tensorrt distribution
-    """
-    core_build_info = _C.get_build_info()
-    build_info = str(
-        "Torch-TensorRT Version: "
-        + str(__version__)
-        + "\n"
-        + "Using PyTorch Version: "
-        + str(torch.__version__)
-        + "\n"
-        + core_build_info
-    )
-    return build_info
-
-
-def set_device(gpu_id: int) -> None:
-    _C.set_device(gpu_id)
-
 
 def sanitized_torch_version() -> Any:
     return (

--- a/py/torch_tensorrt/_utils.py
+++ b/py/torch_tensorrt/_utils.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import torch
-from torch_tensorrt._version import __version__
+
 
 def sanitized_torch_version() -> Any:
     return (

--- a/py/torch_tensorrt/csrc/tensorrt_classes.cpp
+++ b/py/torch_tensorrt/csrc/tensorrt_classes.cpp
@@ -235,23 +235,23 @@ std::string Device::to_str() {
 
 std::string to_str(EngineCapability value) {
   switch (value) {
-    case EngineCapability::kSAFE_GPU:
-      return "Safe GPU";
-    case EngineCapability::kSAFE_DLA:
-      return "Safe DLA";
-    case EngineCapability::kDEFAULT:
+    case EngineCapability::kDLA_STANDALONE:
+      return "DLA Standalone";
+    case EngineCapability::kSAFETY:
+      return "Safety";
+    case EngineCapability::kSTANDARD:
     default:
-      return "Default";
+      return "Standard";
   }
 }
 
 nvinfer1::EngineCapability toTRTEngineCapability(EngineCapability value) {
   switch (value) {
-    case EngineCapability::kSAFE_DLA:
+    case EngineCapability::kDLA_STANDALONE:
       return TRT_ENGINE_CAPABILITY_DLA_STANDALONE;
-    case EngineCapability::kSAFE_GPU:
+    case EngineCapability::kSAFETY:
       return TRT_ENGINE_CAPABILITY_SAFETY;
-    case EngineCapability::kDEFAULT:
+    case EngineCapability::kSTANDARD:
     default:
       return TRT_ENGINE_CAPABILITY_STANDARD;
   }

--- a/py/torch_tensorrt/csrc/tensorrt_classes.h
+++ b/py/torch_tensorrt/csrc/tensorrt_classes.h
@@ -114,9 +114,9 @@ struct TorchFallback : torch::CustomClassHolder {
 };
 
 enum class EngineCapability : int8_t {
-  kDEFAULT,
-  kSAFE_GPU,
-  kSAFE_DLA,
+  kSTANDARD,
+  kSAFETY,
+  kDLA_STANDALONE,
 };
 
 std::string to_str(EngineCapability value);
@@ -160,7 +160,7 @@ struct CompileSpec : torch::CustomClassHolder {
   ADD_FIELD_GET_SET(sparse_weights, bool);
   ADD_FIELD_GET_SET(refit, bool);
   ADD_FIELD_GET_SET(debug, bool);
-  ADD_ENUM_GET_SET(capability, EngineCapability, static_cast<int64_t>(EngineCapability::kSAFE_DLA));
+  ADD_ENUM_GET_SET(capability, EngineCapability, static_cast<int64_t>(EngineCapability::kSTANDARD));
   ADD_FIELD_GET_SET(num_avg_timing_iters, int64_t);
   ADD_FIELD_GET_SET(workspace_size, int64_t);
   ADD_FIELD_GET_SET(dla_sram_size, int64_t);
@@ -184,7 +184,7 @@ struct CompileSpec : torch::CustomClassHolder {
   bool allow_shape_tensors = false;
   Device device;
   TorchFallback torch_fallback;
-  EngineCapability capability = EngineCapability::kDEFAULT;
+  EngineCapability capability = EngineCapability::kSTANDARD;
   int64_t num_avg_timing_iters = 1;
   int64_t workspace_size = 0;
   int64_t dla_sram_size = 1048576;

--- a/py/torch_tensorrt/csrc/torch_tensorrt_py.cpp
+++ b/py/torch_tensorrt/csrc/torch_tensorrt_py.cpp
@@ -261,9 +261,9 @@ PYBIND11_MODULE(_C, m) {
       m,
       "EngineCapability",
       "Enum to specify engine capability settings (selections of kernels to meet safety requirements)")
-      .value("safe_gpu", EngineCapability::kSAFE_GPU, "Use safety GPU kernels only")
-      .value("safe_dla", EngineCapability::kSAFE_DLA, "Use safety DLA kernels only")
-      .value("default", EngineCapability::kDEFAULT, "Use default behavior");
+      .value("SAFETY", EngineCapability::kSAFETY, "Use safe kernels only")
+      .value("DLA_STANDALONE", EngineCapability::kDLA_STANDALONE, "Use DLA kernels only")
+      .value("STANDARD", EngineCapability::kSTANDARD, "Use default behavior");
 
   py::enum_<TensorFormat>(m, "TensorFormat", "Enum to specifiy the memory layout of tensors")
       .value("contiguous", TensorFormat::kContiguous, "Contiguous memory layout (NCHW / Linear)")

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -419,9 +419,9 @@ def convert_module_to_trt_engine(
     module: torch.fx.GraphModule,
     method_name: str = "forward",
     inputs: Optional[Sequence[Input | torch.Tensor]] = None,
-    enabled_precisions: Set[torch.dtype | dtype] | Tuple[torch.dtype | dtype] = (
-        dtype.float32,
-    ),
+    enabled_precisions: (
+        Set[torch.dtype | dtype] | Tuple[torch.dtype | dtype]
+    ) = _defaults.ENABLED_PRECISIONS,
     debug: bool = _defaults.DEBUG,
     workspace_size: int = _defaults.WORKSPACE_SIZE,
     min_block_size: int = _defaults.MIN_BLOCK_SIZE,

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -10,34 +10,7 @@ from torch.fx.node import Target
 from torch_tensorrt._Device import Device
 from torch_tensorrt._enums import EngineCapability, dtype
 from torch_tensorrt._Input import Input
-from torch_tensorrt.dynamo import partitioning
-from torch_tensorrt.dynamo._defaults import (
-    DEBUG,
-    DEVICE,
-    DISABLE_TF32,
-    DLA_GLOBAL_DRAM_SIZE,
-    DLA_LOCAL_DRAM_SIZE,
-    DLA_SRAM_SIZE,
-    DRYRUN,
-    ENABLE_EXPERIMENTAL_DECOMPOSITIONS,
-    ENGINE_CAPABILITY,
-    HARDWARE_COMPATIBLE,
-    MAX_AUX_STREAMS,
-    MIN_BLOCK_SIZE,
-    NUM_AVG_TIMING_ITERS,
-    OPTIMIZATION_LEVEL,
-    OUTPUT_FORMAT,
-    PASS_THROUGH_BUILD_FAILURES,
-    PRECISION,
-    REFIT,
-    REQUIRE_FULL_COMPILATION,
-    SPARSE_WEIGHTS,
-    TRUNCATE_LONG_AND_DOUBLE,
-    USE_FAST_PARTITIONER,
-    USE_PYTHON_RUNTIME,
-    VERSION_COMPATIBLE,
-    WORKSPACE_SIZE,
-)
+from torch_tensorrt.dynamo import _defaults, partitioning
 from torch_tensorrt.dynamo._DryRunTracker import (
     DryRunTracker,
     PerSubgraphData,
@@ -72,35 +45,35 @@ def compile(
     exported_program: ExportedProgram,
     inputs: Tuple[Any, ...],
     *,
-    device: Optional[Union[Device, torch.device, str]] = DEVICE,
-    disable_tf32: bool = DISABLE_TF32,
-    sparse_weights: bool = SPARSE_WEIGHTS,
-    enabled_precisions: Set[torch.dtype | dtype] | Tuple[torch.dtype | dtype] = (
-        dtype.float32,
-    ),
-    engine_capability: EngineCapability = ENGINE_CAPABILITY,
-    refit: bool = REFIT,
-    debug: bool = DEBUG,
-    num_avg_timing_iters: int = NUM_AVG_TIMING_ITERS,
-    workspace_size: int = WORKSPACE_SIZE,
-    dla_sram_size: int = DLA_SRAM_SIZE,
-    dla_local_dram_size: int = DLA_LOCAL_DRAM_SIZE,
-    dla_global_dram_size: int = DLA_GLOBAL_DRAM_SIZE,
-    truncate_long_and_double: bool = TRUNCATE_LONG_AND_DOUBLE,
-    require_full_compilation: bool = REQUIRE_FULL_COMPILATION,
-    min_block_size: int = MIN_BLOCK_SIZE,
+    device: Optional[Union[Device, torch.device, str]] = _defaults.DEVICE,
+    disable_tf32: bool = _defaults.DISABLE_TF32,
+    sparse_weights: bool = _defaults.SPARSE_WEIGHTS,
+    enabled_precisions: (
+        Set[torch.dtype | dtype] | Tuple[torch.dtype | dtype]
+    ) = _defaults.ENABLED_PRECISIONS,
+    engine_capability: EngineCapability = _defaults.ENGINE_CAPABILITY,
+    refit: bool = _defaults.REFIT,
+    debug: bool = _defaults.DEBUG,
+    num_avg_timing_iters: int = _defaults.NUM_AVG_TIMING_ITERS,
+    workspace_size: int = _defaults.WORKSPACE_SIZE,
+    dla_sram_size: int = _defaults.DLA_SRAM_SIZE,
+    dla_local_dram_size: int = _defaults.DLA_LOCAL_DRAM_SIZE,
+    dla_global_dram_size: int = _defaults.DLA_GLOBAL_DRAM_SIZE,
+    truncate_long_and_double: bool = _defaults.TRUNCATE_LONG_AND_DOUBLE,
+    require_full_compilation: bool = _defaults.REQUIRE_FULL_COMPILATION,
+    min_block_size: int = _defaults.MIN_BLOCK_SIZE,
     torch_executed_ops: Optional[Collection[Target]] = None,
     torch_executed_modules: Optional[List[str]] = None,
-    pass_through_build_failures: bool = PASS_THROUGH_BUILD_FAILURES,
-    max_aux_streams: Optional[int] = MAX_AUX_STREAMS,
-    version_compatible: bool = VERSION_COMPATIBLE,
-    optimization_level: Optional[int] = OPTIMIZATION_LEVEL,
-    use_python_runtime: bool = USE_PYTHON_RUNTIME,
-    use_fast_partitioner: bool = USE_FAST_PARTITIONER,
-    enable_experimental_decompositions: bool = ENABLE_EXPERIMENTAL_DECOMPOSITIONS,
-    dryrun: bool = DRYRUN,
-    hardware_compatible: bool = HARDWARE_COMPATIBLE,
-    output_format: str = OUTPUT_FORMAT,
+    pass_through_build_failures: bool = _defaults.PASS_THROUGH_BUILD_FAILURES,
+    max_aux_streams: Optional[int] = _defaults.MAX_AUX_STREAMS,
+    version_compatible: bool = _defaults.VERSION_COMPATIBLE,
+    optimization_level: Optional[int] = _defaults.OPTIMIZATION_LEVEL,
+    use_python_runtime: bool = _defaults.USE_PYTHON_RUNTIME,
+    use_fast_partitioner: bool = _defaults.USE_FAST_PARTITIONER,
+    enable_experimental_decompositions: bool = _defaults.ENABLE_EXPERIMENTAL_DECOMPOSITIONS,
+    dryrun: bool = _defaults.DRYRUN,
+    hardware_compatible: bool = _defaults.HARDWARE_COMPATIBLE,
+    output_format: str = _defaults.OUTPUT_FORMAT,
     **kwargs: Any,
 ) -> Union[ExportedProgram, torch.jit.ScriptModule, torch.fx.GraphModule]:
     """Compile a TorchScript module for NVIDIA GPUs using TensorRT
@@ -182,6 +155,7 @@ def compile(
     # Prepare torch_trt inputs
     inputs = prepare_inputs(inputs)
     device = to_torch_tensorrt_device(device)
+    enabled_precisions = {dtype._from(p) for p in enabled_precisions}
 
     if not isinstance(exported_program, ExportedProgram):
         raise AssertionError(
@@ -198,21 +172,10 @@ def compile(
     gm = apply_lowering_passes(gm, torch_inputs)
     logger.debug("Lowered Input graph: " + str(gm.graph))
 
-    if dtype.float16 in enabled_precisions or dtype.half in enabled_precisions:
-        precision = dtype.float16
-    elif dtype.float32 in enabled_precisions or dtype.float in enabled_precisions:
-        precision = dtype.float32
-    elif len(enabled_precisions) == 0:
-        logger.info(f"No precision specified, defaulting to {PRECISION}")
-        precision = PRECISION
-    else:
-        raise ValueError(
-            f"Precision {enabled_precisions} not supported in the Dynamo Path"
-        )
-    enabled_precisions = {dtype._from(e) for e in enabled_precisions}
-
     compilation_options = {
-        "precision": precision,
+        "enabled_precisions": (
+            enabled_precisions if enabled_precisions else _defaults.ENABLED_PRECISIONS
+        ),
         "debug": debug,
         "device": device,
         "workspace_size": workspace_size,
@@ -459,28 +422,28 @@ def convert_module_to_trt_engine(
     enabled_precisions: Set[torch.dtype | dtype] | Tuple[torch.dtype | dtype] = (
         dtype.float32,
     ),
-    debug: bool = DEBUG,
-    workspace_size: int = WORKSPACE_SIZE,
-    min_block_size: int = MIN_BLOCK_SIZE,
+    debug: bool = _defaults.DEBUG,
+    workspace_size: int = _defaults.WORKSPACE_SIZE,
+    min_block_size: int = _defaults.MIN_BLOCK_SIZE,
     torch_executed_ops: Optional[Set[str]] = None,
-    pass_through_build_failures: bool = PASS_THROUGH_BUILD_FAILURES,
-    max_aux_streams: Optional[int] = MAX_AUX_STREAMS,
-    version_compatible: bool = VERSION_COMPATIBLE,
-    optimization_level: Optional[int] = OPTIMIZATION_LEVEL,
-    use_python_runtime: Optional[bool] = USE_PYTHON_RUNTIME,
-    truncate_long_and_double: bool = TRUNCATE_LONG_AND_DOUBLE,
-    use_fast_partitioner: bool = USE_FAST_PARTITIONER,
-    enable_experimental_decompositions: bool = ENABLE_EXPERIMENTAL_DECOMPOSITIONS,
+    pass_through_build_failures: bool = _defaults.PASS_THROUGH_BUILD_FAILURES,
+    max_aux_streams: Optional[int] = _defaults.MAX_AUX_STREAMS,
+    version_compatible: bool = _defaults.VERSION_COMPATIBLE,
+    optimization_level: Optional[int] = _defaults.OPTIMIZATION_LEVEL,
+    use_python_runtime: Optional[bool] = _defaults.USE_PYTHON_RUNTIME,
+    truncate_long_and_double: bool = _defaults.TRUNCATE_LONG_AND_DOUBLE,
+    use_fast_partitioner: bool = _defaults.USE_FAST_PARTITIONER,
+    enable_experimental_decompositions: bool = _defaults.ENABLE_EXPERIMENTAL_DECOMPOSITIONS,
     device: Device = Device._current_device(),
-    require_full_compilation: bool = REQUIRE_FULL_COMPILATION,
-    disable_tf32: bool = DISABLE_TF32,
-    sparse_weights: bool = SPARSE_WEIGHTS,
-    refit: bool = REFIT,
-    engine_capability: EngineCapability = ENGINE_CAPABILITY,
-    num_avg_timing_iters: int = NUM_AVG_TIMING_ITERS,
-    dla_sram_size: int = DLA_SRAM_SIZE,
-    dla_local_dram_size: int = DLA_LOCAL_DRAM_SIZE,
-    dla_global_dram_size: int = DLA_GLOBAL_DRAM_SIZE,
+    require_full_compilation: bool = _defaults.REQUIRE_FULL_COMPILATION,
+    disable_tf32: bool = _defaults.DISABLE_TF32,
+    sparse_weights: bool = _defaults.SPARSE_WEIGHTS,
+    refit: bool = _defaults.REFIT,
+    engine_capability: EngineCapability = _defaults.ENGINE_CAPABILITY,
+    num_avg_timing_iters: int = _defaults.NUM_AVG_TIMING_ITERS,
+    dla_sram_size: int = _defaults.DLA_SRAM_SIZE,
+    dla_local_dram_size: int = _defaults.DLA_LOCAL_DRAM_SIZE,
+    dla_global_dram_size: int = _defaults.DLA_GLOBAL_DRAM_SIZE,
     calibrator: object = None,
     allow_shape_tensors: bool = False,
 ) -> bytes:
@@ -569,22 +532,10 @@ def convert_module_to_trt_engine(
     input_list = prepare_inputs(input_list)
     device = to_torch_tensorrt_device(device)
 
-    if dtype.float16 in enabled_precisions or dtype.half in enabled_precisions:
-        precision = dtype.float16
-    elif dtype.float32 in enabled_precisions or dtype.float in enabled_precisions:
-        precision = dtype.float32
-    elif len(enabled_precisions) == 0:
-        logger.info(f"No precision specified, defaulting to {PRECISION}")
-        precision = PRECISION
-    else:
-        raise ValueError(
-            f"Precision {enabled_precisions} not supported in the Dynamo Path"
-        )
-
     enabled_precisions = {dtype._from(e) for e in enabled_precisions}
 
     compilation_options = {
-        "precision": precision,
+        "enabled_precisions": enabled_precisions,
         "debug": debug,
         "workspace_size": workspace_size,
         "min_block_size": min_block_size,

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -5,14 +5,10 @@ import logging
 from typing import Any, Collection, List, Optional, Sequence, Set, Tuple, Union
 
 import torch
-import torch_tensorrt
+import tensorrt as trt
 from torch.export import ExportedProgram
 from torch.fx.node import Target
-from torch_tensorrt import _enums
 from torch_tensorrt._Device import Device
-from torch_tensorrt._enums import (  # TODO: Should probabably be the TRT EngineCapability Enum
-    EngineCapability,
-)
 from torch_tensorrt._Input import Input
 from torch_tensorrt.dynamo import partitioning
 from torch_tensorrt.dynamo._defaults import (
@@ -80,7 +76,7 @@ def compile(
     disable_tf32: bool = DISABLE_TF32,
     sparse_weights: bool = SPARSE_WEIGHTS,
     enabled_precisions: Set[torch.dtype] | Tuple[torch.dtype] = (torch.float32,),
-    engine_capability: EngineCapability = ENGINE_CAPABILITY,
+    engine_capability: trt.EngineCapability = ENGINE_CAPABILITY,
     refit: bool = REFIT,
     debug: bool = DEBUG,
     num_avg_timing_iters: int = NUM_AVG_TIMING_ITERS,
@@ -463,7 +459,7 @@ def convert_module_to_trt_engine(
     module: torch.fx.GraphModule,
     method_name: str = "forward",
     inputs: Optional[Sequence[Input | torch.Tensor]] = None,
-    enabled_precisions: Optional[Set[torch.dtype | _enums.dtype]] = None,
+    enabled_precisions: Optional[Set[torch.dtype]] = None,
     debug: bool = DEBUG,
     workspace_size: int = WORKSPACE_SIZE,
     min_block_size: int = MIN_BLOCK_SIZE,
@@ -481,7 +477,7 @@ def convert_module_to_trt_engine(
     disable_tf32: bool = DISABLE_TF32,
     sparse_weights: bool = SPARSE_WEIGHTS,
     refit: bool = REFIT,
-    engine_capability: EngineCapability = ENGINE_CAPABILITY,
+    engine_capability: trt.EngineCapability = ENGINE_CAPABILITY,
     num_avg_timing_iters: int = NUM_AVG_TIMING_ITERS,
     dla_sram_size: int = DLA_SRAM_SIZE,
     dla_local_dram_size: int = DLA_LOCAL_DRAM_SIZE,

--- a/py/torch_tensorrt/dynamo/_defaults.py
+++ b/py/torch_tensorrt/dynamo/_defaults.py
@@ -2,7 +2,7 @@ import torch
 from torch_tensorrt._Device import Device
 from torch_tensorrt._enums import EngineCapability, dtype
 
-PRECISION = dtype.float32
+ENABLED_PRECISIONS = {dtype.f32}
 DEBUG = False
 DEVICE = None
 DISABLE_TF32 = False
@@ -27,6 +27,7 @@ REQUIRE_FULL_COMPILATION = False
 DRYRUN = False
 HARDWARE_COMPATIBLE = False
 OUTPUT_FORMAT = "exported_program"
+SUPPORTED_KERNEL_PRECISIONS = {dtype.f32, dtype.f16, dtype.i8}
 
 
 def default_device() -> Device:

--- a/py/torch_tensorrt/dynamo/_defaults.py
+++ b/py/torch_tensorrt/dynamo/_defaults.py
@@ -1,8 +1,8 @@
 import torch
-from tensorrt import EngineCapability
 from torch_tensorrt._Device import Device
+from torch_tensorrt._enums import EngineCapability, dtype
 
-PRECISION = torch.float32
+PRECISION = dtype.float32
 DEBUG = False
 DEVICE = None
 DISABLE_TF32 = False

--- a/py/torch_tensorrt/dynamo/_settings.py
+++ b/py/torch_tensorrt/dynamo/_settings.py
@@ -12,6 +12,7 @@ from torch_tensorrt.dynamo._defaults import (
     DLA_SRAM_SIZE,
     DRYRUN,
     ENABLE_EXPERIMENTAL_DECOMPOSITIONS,
+    ENABLED_PRECISIONS,
     ENGINE_CAPABILITY,
     HARDWARE_COMPATIBLE,
     MAX_AUX_STREAMS,
@@ -20,7 +21,6 @@ from torch_tensorrt.dynamo._defaults import (
     OPTIMIZATION_LEVEL,
     OUTPUT_FORMAT,
     PASS_THROUGH_BUILD_FAILURES,
-    PRECISION,
     REFIT,
     REQUIRE_FULL_COMPILATION,
     SPARSE_WEIGHTS,
@@ -38,7 +38,7 @@ class CompilationSettings:
     """Compilation settings for Torch-TensorRT Dynamo Paths
 
     Args:
-        precision (torch.dtype): Model Layer precision
+        enabled_precisions (Set[dtype]): Available kernel dtype precisions
         debug (bool): Whether to print out verbose debugging information
         workspace_size (int): Workspace TRT is allowed to use for the module (0 is default)
         min_block_size (int): Minimum number of operators per TRT-Engine Block
@@ -73,7 +73,7 @@ class CompilationSettings:
         output_format (str): Output format of the result of TRT compilation. Options include "exported_program" (or) "ep" | "torchscript" (or) "ts" | "graph_module" (or) "fx". Default is "exported_program"
     """
 
-    precision: dtype = field(default_factory=lambda: PRECISION)
+    enabled_precisions: dtype = field(default_factory=lambda: ENABLED_PRECISIONS)
     debug: bool = DEBUG
     workspace_size: int = WORKSPACE_SIZE
     min_block_size: int = MIN_BLOCK_SIZE

--- a/py/torch_tensorrt/dynamo/_settings.py
+++ b/py/torch_tensorrt/dynamo/_settings.py
@@ -1,10 +1,9 @@
 from dataclasses import dataclass, field
 from typing import Collection, Optional, Union
 
-import torch
-from tensorrt import EngineCapability
 from torch.fx.node import Target
 from torch_tensorrt._Device import Device
+from torch_tensorrt._enums import EngineCapability, dtype
 from torch_tensorrt.dynamo._defaults import (
     DEBUG,
     DISABLE_TF32,
@@ -74,7 +73,7 @@ class CompilationSettings:
         output_format (str): Output format of the result of TRT compilation. Options include "exported_program" (or) "ep" | "torchscript" (or) "ts" | "graph_module" (or) "fx". Default is "exported_program"
     """
 
-    precision: torch.dtype = PRECISION
+    precision: dtype = field(default_factory=lambda: PRECISION)
     debug: bool = DEBUG
     workspace_size: int = WORKSPACE_SIZE
     min_block_size: int = MIN_BLOCK_SIZE
@@ -92,7 +91,9 @@ class CompilationSettings:
     disable_tf32: bool = DISABLE_TF32
     sparse_weights: bool = SPARSE_WEIGHTS
     refit: bool = REFIT
-    engine_capability: EngineCapability = ENGINE_CAPABILITY
+    engine_capability: EngineCapability = field(
+        default_factory=lambda: ENGINE_CAPABILITY
+    )
     num_avg_timing_iters: int = NUM_AVG_TIMING_ITERS
     dla_sram_size: int = DLA_SRAM_SIZE
     dla_local_dram_size: int = DLA_LOCAL_DRAM_SIZE

--- a/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
+++ b/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
@@ -499,6 +499,7 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
                     "not",
                     "ne",
                     "isinf",
+                    "isnan",
                     "any",
                 )
             ):

--- a/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
+++ b/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
@@ -125,7 +125,7 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
 
     @staticmethod
     def _args_str(args: List[Any]) -> str:
-        def clean_repr(x: Any) -> Any:
+        def clean_repr(x: Any, depth: int = 0) -> Any:
             if isinstance(x, trt.ITensor):
                 return f"{x.name} <tensorrt.ITensor [shape={x.shape}, dtype={x.dtype}]>"
             elif isinstance(x, torch.Tensor):
@@ -134,8 +134,11 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
                 return (
                     f"<torch.Tensor as np.ndarray [shape={x.shape}, dtype={x.dtype}]>"
                 )
-            elif isinstance(x, Sequence):
-                return type(x)([clean_repr(i) for i in x])  # type: ignore[call-arg]
+            elif isinstance(x, Sequence) and not isinstance(x, str):
+                if depth < 3:
+                    return type(x)([clean_repr(i, depth=depth + 1) for i in x])  # type: ignore[call-arg]
+                else:
+                    return "(...)"
             else:
                 return x
 

--- a/py/torch_tensorrt/dynamo/conversion/converter_utils.py
+++ b/py/torch_tensorrt/dynamo/conversion/converter_utils.py
@@ -42,7 +42,6 @@ def get_node_name(node: torch.fx.Node) -> str:
         # like the node.meta['source_fn'] attr
         pass
 
-    _LOGGER.debug(f"Node meta name {node_name}")
     return node_name
 
 

--- a/py/torch_tensorrt/dynamo/conversion/converter_utils.py
+++ b/py/torch_tensorrt/dynamo/conversion/converter_utils.py
@@ -4,22 +4,20 @@ import re
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, overload
 
 import numpy as np
-import tensorrt as trt
 import torch
 from torch import SymBool, SymFloat, SymInt
 from torch.fx.node import Argument, Target
+from torch_tensorrt import _enums
 from torch_tensorrt.dynamo._SourceIR import SourceIR
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion._ConverterRegistry import (
     ConverterRegistry,
     DynamoConverterImplSignature,
 )
-from torch_tensorrt.fx.converters.converter_utils import (
-    Frameworks,
-    get_axes_for_reduce_op,
-    unified_dtype_converter,
-)
+from torch_tensorrt.fx.converters.converter_utils import get_axes_for_reduce_op
 from torch_tensorrt.fx.types import TRTDataType, TRTTensor
+
+import tensorrt as trt
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -121,7 +119,7 @@ def _dynamic_unsupported(
 def cast_trt_tensor(
     ctx: ConversionContext,
     input_val: TRTTensor,
-    dtype: TRTDataType,
+    dtype: Union[TRTDataType, torch.dtype, np.dtype, _enums.dtype],
     name: str,
     target: Target = "",
     source_ir: Optional[SourceIR] = None,
@@ -142,7 +140,7 @@ def cast_trt_tensor(
     Returns:
         A TensorRT ITensor which has been casted to the specified dtype
     """
-    trt_dtype = unified_dtype_converter(dtype, Frameworks.TRT)
+    trt_dtype = _enums.dtype._from(dtype).to(trt.DataType)
 
     if input_val.dtype != trt_dtype:
         source_ir = source_ir if source_ir is not None else SourceIR.UNKNOWN
@@ -253,7 +251,7 @@ def create_constant(
     ctx: ConversionContext,
     value: Union[int, float, bool, np.ndarray, torch.Tensor],
     name: str,
-    dtype: Optional[Union[torch.dtype, np.dtype, TRTDataType]],
+    dtype: Optional[Union[torch.dtype, np.dtype, TRTDataType, _enums.dtype]],
 ) -> TRTTensor:
     """
     Add a TensorRT constant layer whose value is `value` to `ctx.net`.
@@ -268,7 +266,9 @@ def create_constant(
     Returns:
         A TensorRT ITensor that represents the given value.
     """
-    numpy_value = to_numpy(value, dtype)
+    numpy_value = to_numpy(
+        value, _enums.dtype._from(dtype).to(np.dtype) if dtype else None
+    )
     constant = ctx.net.add_constant(
         (1,) if isinstance(value, (int, float, bool)) else value.shape,
         numpy_value.copy() if isinstance(numpy_value, np.ndarray) else numpy_value,
@@ -281,7 +281,7 @@ def get_trt_tensor(
     ctx: ConversionContext,
     input_val: Any,
     name: str,
-    dtype: Optional[Union[torch.dtype, np.dtype, TRTDataType]] = None,
+    dtype: Optional[Union[torch.dtype, np.dtype, TRTDataType, _enums.dtype]] = None,
 ) -> TRTTensor:
     """
     Given a value of random type, we try to convert it to a TensorRT ITensor.
@@ -466,7 +466,7 @@ def enforce_tensor_types(
 
 def to_numpy(
     value: Optional[Union[torch.Tensor, np.ndarray, int, float, bool]],
-    dtype: Optional[Union[torch.dtype, np.dtype, TRTDataType]] = None,
+    dtype: Optional[Union[torch.dtype, np.dtype, TRTDataType, _enums.dtype]] = None,
 ) -> Optional[np.ndarray]:
     """
     Convert a PyTorch Tensor, Numpy array, or scalar to a Numpy Array. If the tensor is
@@ -503,7 +503,7 @@ def to_numpy(
         return (
             output
             if (dtype is None or output is None)
-            else output.astype(unified_dtype_converter(dtype, Frameworks.NUMPY))
+            else output.astype(_enums.dtype._from(dtype).to(np.dtype))
         )
     else:
         raise AssertionError(

--- a/py/torch_tensorrt/dynamo/conversion/converter_utils.py
+++ b/py/torch_tensorrt/dynamo/conversion/converter_utils.py
@@ -266,7 +266,7 @@ def create_constant(
         A TensorRT ITensor that represents the given value.
     """
     numpy_value = to_numpy(
-        value, _enums.dtype._from(dtype).to(np.dtype) if dtype else None
+        value, _enums.dtype._from(dtype).to(np.dtype) if dtype is not None else None
     )
     constant = ctx.net.add_constant(
         (1,) if isinstance(value, (int, float, bool)) else value.shape,

--- a/py/torch_tensorrt/dynamo/conversion/impl/cast.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/cast.py
@@ -1,16 +1,17 @@
 import logging
-from typing import Optional
+from typing import Optional, Union
 
+import numpy as np
+import torch
 from torch.fx.node import Target
+from torch_tensorrt import _enums
 from torch_tensorrt.dynamo._SourceIR import SourceIR
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion._ConverterRegistry import ConverterRegistry
 from torch_tensorrt.dynamo.conversion.converter_utils import cast_trt_tensor
-from torch_tensorrt.fx.converters.converter_utils import (
-    Frameworks,
-    unified_dtype_converter,
-)
 from torch_tensorrt.fx.types import TRTDataType, TRTTensor
+
+import tensorrt as trt
 
 LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -21,7 +22,7 @@ def to_copy(
     source_ir: Optional[SourceIR],
     name: str,
     input: TRTTensor,
-    dtype: TRTDataType,
+    dtype: Union[TRTDataType, torch.dtype, np.dtype, _enums.dtype],
     force_layer: bool = False,
 ) -> TRTTensor:
     if not isinstance(input, TRTTensor):
@@ -32,7 +33,7 @@ def to_copy(
     # If cast is forced, insert identity layer regardless of whether the dtype
     # doesn't change
     if force_layer:
-        trt_dtype = unified_dtype_converter(dtype, Frameworks.TRT)
+        trt_dtype = _enums.dtype._from(dtype).to(trt.DataType)
         source_ir = source_ir if source_ir is not None else SourceIR.UNKNOWN
         target_str = ConverterRegistry.qualified_name_or_str(target)
         target_name = f"{source_ir}_ops{('.' + target_str) if target_str else ''}"

--- a/py/torch_tensorrt/dynamo/conversion/impl/elementwise/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/elementwise/ops.py
@@ -1,10 +1,9 @@
 from typing import Optional, Union
 
-import numpy as np
-import tensorrt as trt
 import torch
 import torch_tensorrt.dynamo.conversion.impl as impl
 from torch.fx.node import Target
+from torch_tensorrt import _enums
 from torch_tensorrt.dynamo._SourceIR import SourceIR
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import (
@@ -20,7 +19,8 @@ from torch_tensorrt.dynamo.conversion.impl.unary import atan, sign
 from torch_tensorrt.dynamo.conversion.impl.unary.base import convert_unary
 from torch_tensorrt.fx.converters.converter_utils import broadcast
 from torch_tensorrt.fx.types import TRTTensor
-from torch_tensorrt.fx.utils import Frameworks, unified_dtype_converter
+
+import tensorrt as trt
 
 
 def trunc_div(
@@ -73,7 +73,7 @@ def trunc_div(
             ctx,
             other,
             f"{name}_other",
-            dtype=unified_dtype_converter(input.dtype, Frameworks.TORCH),
+            dtype=_enums.dtype._from(input.dtype).to(torch.dtype),
         )
 
     abs_input_output = convert_unary(

--- a/py/torch_tensorrt/dynamo/conversion/impl/elementwise/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/elementwise/ops.py
@@ -1,5 +1,6 @@
 from typing import Optional, Union
 
+import numpy as np
 import torch
 import torch_tensorrt.dynamo.conversion.impl as impl
 from torch.fx.node import Target

--- a/py/torch_tensorrt/dynamo/conversion/impl/grid.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/grid.py
@@ -1,13 +1,12 @@
-from typing import Optional, Sequence
+from typing import Optional
 
-import tensorrt as trt
-import torch
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
-from torch_tensorrt.dynamo.conversion.converter_utils import cast_trt_tensor
 from torch_tensorrt.fx.converters.converter_utils import set_layer_name
-from torch_tensorrt.fx.types import TRTNetwork, TRTTensor
+from torch_tensorrt.fx.types import TRTTensor
+
+import tensorrt as trt
 
 # nearest, linear, cubic
 GridSamplerInterpolationMode = {

--- a/py/torch_tensorrt/dynamo/conversion/impl/matmul.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/matmul.py
@@ -1,13 +1,15 @@
 from typing import Optional
 
-import tensorrt as trt
+import torch
 from torch.fx.node import Target
+from torch_tensorrt import _enums
 from torch_tensorrt.dynamo._SourceIR import SourceIR
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import get_trt_tensor
 from torch_tensorrt.fx.converters.converter_utils import broadcast, set_layer_name
 from torch_tensorrt.fx.types import TRTTensor
-from torch_tensorrt.fx.utils import Frameworks, unified_dtype_converter
+
+import tensorrt as trt
 
 
 def matrix_multiply(
@@ -20,14 +22,14 @@ def matrix_multiply(
     input_matrix_op: trt.MatrixOperation = trt.MatrixOperation.NONE,
     other_matrix_op: trt.MatrixOperation = trt.MatrixOperation.NONE,
 ) -> TRTTensor:
-    if not isinstance(input, trt.tensorrt.ITensor):
+    if not isinstance(input, trt.ITensor):
         input = get_trt_tensor(ctx, input, f"{name}_input")
-    if not isinstance(other, trt.tensorrt.ITensor):
+    if not isinstance(other, trt.ITensor):
         other = get_trt_tensor(
             ctx,
             other,
             f"{name}_other",
-            dtype=unified_dtype_converter(input.dtype, Frameworks.TORCH),
+            dtype=_enums.dtype._from(input.dtype).to(torch.dtype),
         )
 
     preset_diff = 0

--- a/py/torch_tensorrt/dynamo/conversion/impl/select.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/select.py
@@ -2,7 +2,6 @@ import logging
 from typing import Optional, Sequence, Union, cast
 
 import numpy as np
-import tensorrt as trt
 import torch
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
@@ -20,6 +19,8 @@ from torch_tensorrt.fx.converters.converter_utils import (
     set_layer_name,
 )
 from torch_tensorrt.fx.types import Shape, TRTTensor
+
+import tensorrt as trt
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -81,7 +82,7 @@ def index(
     source_ir: Optional[SourceIR],
     name: str,
     input: TRTTensor,
-    index: Sequence[Union[TRTTensor, np.ndarray, torch.Tensor]],
+    indices: Sequence[Union[TRTTensor, np.ndarray, torch.Tensor]],
 ) -> TRTTensor:
     adv_indx_indices = []
     tensor_indices = []
@@ -93,12 +94,14 @@ def index(
         "Determining whether aten.index constant-index optimization can be invoked"
     )
     is_numpy = all(
-        isinstance(ind, (torch.Tensor, np.ndarray)) for ind in index if ind is not None
+        isinstance(ind, (torch.Tensor, np.ndarray))
+        for ind in indices
+        if ind is not None
     )
     # here we need to check if all the index are broadcastable
     # if no, then we need to broadcast
     last_index = None
-    for i, ind in enumerate(index):
+    for i, ind in enumerate(indices):
         if ind is not None:
             _LOGGER.debug(f"Shape of {i} index is {ind.shape}")
             adv_indx_indices.append(i)
@@ -369,7 +372,7 @@ def index(
             )
             reshape_output = reshape_layer.get_output(0)
 
-    return reshape_output
+        return reshape_output
 
 
 def index_select(

--- a/py/torch_tensorrt/dynamo/conversion/impl/upsample.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/upsample.py
@@ -1,11 +1,12 @@
 from typing import Optional, Sequence
 
-import tensorrt as trt
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.fx.converters.converter_utils import set_layer_name
 from torch_tensorrt.fx.types import TRTTensor
+
+import tensorrt as trt
 
 
 def upsample(
@@ -29,7 +30,7 @@ def upsample(
         resize_layer.scales = [1.0, 1.0] + list(scale_factors)
     else:
         raise RuntimeError(
-            f"At least one of out_shape and scale_factors should be specified."
+            "At least one of out_shape and scale_factors should be specified."
         )
 
     # interpolate mode

--- a/py/torch_tensorrt/dynamo/conversion/truncate_long_and_double.py
+++ b/py/torch_tensorrt/dynamo/conversion/truncate_long_and_double.py
@@ -4,6 +4,7 @@ from typing import Optional, Sequence, Set
 
 import torch
 from torch.fx.node import _get_qualified_name
+from torch_tensorrt._enums import dtype
 from torch_tensorrt._Input import Input
 from torch_tensorrt.dynamo.utils import get_torch_inputs
 
@@ -217,6 +218,8 @@ def repair_long_or_double_inputs(
             # Set the 32bit inputs and their types to the submodule Inputs
             for idx in range(len(submodule_inputs)):
                 submodule_inputs[idx].torch_tensor = submodule_torch_inputs[idx]
-                submodule_inputs[idx].torch_dtype = submodule_torch_inputs[idx].dtype
+                submodule_inputs[idx].dtype = dtype._from(
+                    submodule_torch_inputs[idx].dtype
+                )
 
     return submodule_inputs

--- a/py/torch_tensorrt/dynamo/partitioning/_adjacency_partitioner.py
+++ b/py/torch_tensorrt/dynamo/partitioning/_adjacency_partitioner.py
@@ -110,6 +110,7 @@ class TRTPartitioner(_SplitterBase):  # type: ignore
         allowed_single_node_partition_ops: Optional[Collection[str]] = None,
         min_block_size: int = MIN_BLOCK_SIZE,
         require_full_compilation: bool = REQUIRE_FULL_COMPILATION,
+        return_tuple: bool = False,
     ):
         """
         Preprocesses graph before splitting:
@@ -149,6 +150,7 @@ class TRTPartitioner(_SplitterBase):  # type: ignore
         self.num_trt_accelerated_subgraphs: Optional[int] = None
         self.allowed_single_node_partition_ops = allowed_single_node_partition_ops
         self.require_full_compilation = require_full_compilation
+        self._return_tuple = return_tuple
 
     def remove_small_acc_subgraphs(self, subgraphs: List[Subgraph]) -> List[Subgraph]:
         """

--- a/py/torch_tensorrt/dynamo/runtime/_PythonTorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_PythonTorchTensorRTModule.py
@@ -4,17 +4,18 @@ import logging
 from contextlib import nullcontext
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-import tensorrt as trt
 import torch
 import torch_tensorrt
 from torch.nn import Module
 from torch_tensorrt._Device import Device
+from torch_tensorrt._enums import dtype
 from torch_tensorrt.dynamo.runtime.tools import (
     _is_switch_required,
     _select_rt_device,
     multi_gpu_device_check,
 )
-from torch_tensorrt.fx.utils import Frameworks, unified_dtype_converter
+
+import tensorrt as trt
 
 logger = logging.getLogger(__name__)
 
@@ -84,9 +85,7 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
         )
 
         self.input_dtypes = [
-            unified_dtype_converter(
-                self.engine.get_binding_dtype(idx), Frameworks.TORCH
-            )
+            dtype._from(self.engine.get_binding_dtype(idx))
             for idx in self.input_binding_indices_in_order
         ]
         self.input_shapes: Sequence[Sequence[int]] = [
@@ -94,9 +93,7 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
             for idx in self.input_binding_indices_in_order
         ]
         self.output_dtypes = [
-            unified_dtype_converter(
-                self.engine.get_binding_dtype(idx), Frameworks.TORCH
-            )
+            dtype._from(self.engine.get_binding_dtype(idx))
             for idx in self.output_binding_indices_in_order
         ]
         self.output_shapes = [
@@ -108,9 +105,7 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
             for idx in self.output_binding_indices_in_order
         ]
         self.hidden_output_dtypes = [
-            unified_dtype_converter(
-                self.engine.get_binding_dtype(idx), Frameworks.TORCH
-            )
+            dtype._from(self.engine.get_binding_dtype(idx))
             for idx in self.hidden_output_binding_indices_in_order
         ]
         self.hidden_output_shapes = [
@@ -263,7 +258,7 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
 
                     output = torch.empty(
                         size=shape,
-                        dtype=self.output_dtypes[i],
+                        dtype=self.output_dtypes[i].to(torch.dtype),
                         device=torch.cuda.current_device(),
                     )
                     outputs.append(output)
@@ -274,7 +269,7 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
 
                     output = torch.empty(
                         size=shape,
-                        dtype=self.hidden_output_dtypes[i],
+                        dtype=self.hidden_output_dtypes[i].to(torch.dtype),
                         device=torch.cuda.current_device(),
                     )
                     bindings[idx] = output.data_ptr()

--- a/py/torch_tensorrt/dynamo/utils.py
+++ b/py/torch_tensorrt/dynamo/utils.py
@@ -196,10 +196,7 @@ def to_torch_device(device: Optional[Union[Device, torch.device, str]]) -> torch
     Returns the corresponding torch.device
     """
     if isinstance(device, Device):
-        if device.gpu_id != -1:
-            return torch.device(device.gpu_id)
-        else:
-            raise ValueError("Invalid GPU ID provided for the CUDA device provided")
+        return device.to(torch.device)
 
     elif isinstance(device, torch.device):
         return device
@@ -218,17 +215,7 @@ def to_torch_tensorrt_device(
 
     Returns the corresponding torch_tensorrt.Device
     """
-    if isinstance(device, Device):
-        return device
-
-    elif isinstance(device, torch.device):
-        return Device(gpu_id=device.index)
-
-    elif device is None:
-        return Device(gpu_id=torch.cuda.current_device())
-
-    else:
-        return Device(device)
+    return Device._from(device)
 
 
 def parse_dynamo_kwargs(kwargs: Any) -> CompilationSettings:

--- a/py/torch_tensorrt/dynamo/utils.py
+++ b/py/torch_tensorrt/dynamo/utils.py
@@ -5,12 +5,12 @@ from dataclasses import fields, replace
 from typing import Any, Callable, Dict, Optional, Sequence, Union
 
 import torch
+import torch_tensorrt
 from torch_tensorrt._Device import Device
 from torch_tensorrt._Input import Input
 from torch_tensorrt.dynamo._defaults import PRECISION
 from torch_tensorrt.dynamo._settings import CompilationSettings
 
-import torch_tensorrt
 from packaging import version
 
 logger = logging.getLogger(__name__)

--- a/py/torch_tensorrt/logging.py
+++ b/py/torch_tensorrt/logging.py
@@ -5,6 +5,7 @@ from torch_tensorrt._features import ENABLED_FEATURES
 
 import tensorrt as trt
 
+logging.captureWarnings(True)
 _LOGGER = logging.getLogger("torch_tensorrt [TensorRT Conversion Context]")
 
 

--- a/py/torch_tensorrt/logging.py
+++ b/py/torch_tensorrt/logging.py
@@ -1,17 +1,19 @@
 import logging
 from typing import Any
 
-import tensorrt as trt
 from torch_tensorrt._features import ENABLED_FEATURES
 
+import tensorrt as trt
 
 _LOGGER = logging.getLogger("torch_tensorrt [TensorRT Conversion Context]")
 
-class _TRTLogger(trt.ILogger):
-    def __init__(self):
+
+class _TRTLogger(trt.ILogger):  # type: ignore[misc]
+
+    def __init__(self) -> None:
         trt.ILogger.__init__(self)
 
-    def log(self, severity, msg):
+    def log(self, severity: trt.ILogger.Severity, msg: str) -> None:
         # TODO: Move to match once py39 reaches EoL
         if severity == trt.ILogger.Severity.INTERNAL_ERROR:
             _LOGGER.critical(msg)
@@ -25,7 +27,9 @@ class _TRTLogger(trt.ILogger):
         elif severity == trt.ILogger.Severity.VERBOSE:
             _LOGGER.debug(msg)
 
+
 TRT_LOGGER = _TRTLogger()
+
 
 class internal_errors:
     """Context-manager to limit displayed log messages to just internal errors
@@ -42,6 +46,7 @@ class internal_errors:
 
         if ENABLED_FEATURES.torchscript_frontend:
             from torch_tensorrt.ts import logging as ts_logging
+
             self.ts_level = ts_logging.get_reportable_log_level()
             ts_logging.set_reportable_log_level(ts_logging.Level.InternalError)
 
@@ -50,6 +55,7 @@ class internal_errors:
 
         if ENABLED_FEATURES.torchscript_frontend:
             from torch_tensorrt.ts import logging as ts_logging
+
             ts_logging.set_reportable_log_level(self.ts_level)
 
 
@@ -68,6 +74,7 @@ class errors:
 
         if ENABLED_FEATURES.torchscript_frontend:
             from torch_tensorrt.ts import logging as ts_logging
+
             self.ts_level = ts_logging.get_reportable_log_level()
             ts_logging.set_reportable_log_level(ts_logging.Level.Error)
 
@@ -76,6 +83,7 @@ class errors:
 
         if ENABLED_FEATURES.torchscript_frontend:
             from torch_tensorrt.ts import logging as ts_logging
+
             ts_logging.set_reportable_log_level(self.ts_level)
 
 
@@ -94,6 +102,7 @@ class warnings:
 
         if ENABLED_FEATURES.torchscript_frontend:
             from torch_tensorrt.ts import logging as ts_logging
+
             self.ts_level = ts_logging.get_reportable_log_level()
             ts_logging.set_reportable_log_level(ts_logging.Level.Warning)
 
@@ -102,6 +111,7 @@ class warnings:
 
         if ENABLED_FEATURES.torchscript_frontend:
             from torch_tensorrt.ts import logging as ts_logging
+
             ts_logging.set_reportable_log_level(self.ts_level)
 
 
@@ -120,6 +130,7 @@ class info:
 
         if ENABLED_FEATURES.torchscript_frontend:
             from torch_tensorrt.ts import logging as ts_logging
+
             self.ts_level = ts_logging.get_reportable_log_level()
             ts_logging.set_reportable_log_level(ts_logging.Level.Info)
 
@@ -128,6 +139,7 @@ class info:
 
         if ENABLED_FEATURES.torchscript_frontend:
             from torch_tensorrt.ts import logging as ts_logging
+
             ts_logging.set_reportable_log_level(self.ts_level)
 
 
@@ -146,6 +158,7 @@ class debug:
 
         if ENABLED_FEATURES.torchscript_frontend:
             from torch_tensorrt.ts import logging as ts_logging
+
             self.ts_level = ts_logging.get_reportable_log_level()
             ts_logging.set_reportable_log_level(ts_logging.Level.Debug)
 
@@ -154,6 +167,7 @@ class debug:
 
         if ENABLED_FEATURES.torchscript_frontend:
             from torch_tensorrt.ts import logging as ts_logging
+
             ts_logging.set_reportable_log_level(self.ts_level)
 
 
@@ -173,6 +187,7 @@ class graphs:
 
         if ENABLED_FEATURES.torchscript_frontend:
             from torch_tensorrt.ts import logging as ts_logging
+
             self.ts_level = ts_logging.get_reportable_log_level()
             ts_logging.set_reportable_log_level(ts_logging.Level.Graph)
 
@@ -181,4 +196,5 @@ class graphs:
 
         if ENABLED_FEATURES.torchscript_frontend:
             from torch_tensorrt.ts import logging as ts_logging
+
             ts_logging.set_reportable_log_level(self.ts_level)

--- a/py/torch_tensorrt/logging.py
+++ b/py/torch_tensorrt/logging.py
@@ -1,119 +1,31 @@
-from enum import Enum
+import logging
 from typing import Any
 
-from torch_tensorrt._C import (
-    LogLevel,
-    _get_is_colored_output_on,
-    _get_logging_prefix,
-    _get_reportable_log_level,
-    _log,
-    _set_is_colored_output_on,
-    _set_logging_prefix,
-    _set_reportable_log_level,
-)
+import tensorrt as trt
+from torch_tensorrt._features import ENABLED_FEATURES
 
 
-class Level(Enum):
-    """Enum to set the minimum required logging level to print a message to stdout"""
+_LOGGER = logging.getLogger("torch_tensorrt [TensorRT Conversion Context]")
 
-    InternalError = LogLevel.INTERNAL_ERROR
-    Error = LogLevel.ERROR
-    Warning = LogLevel.WARNING
-    Info = LogLevel.INFO
-    Debug = LogLevel.DEBUG
-    Graph = LogLevel.GRAPH
+class _TRTLogger(trt.ILogger):
+    def __init__(self):
+        trt.ILogger.__init__(self)
 
-    @staticmethod
-    def _to_internal_level(external: "Level") -> LogLevel:
-        if external == Level.InternalError:
-            return LogLevel.INTERNAL_ERROR
-        elif external == Level.Error:
-            return LogLevel.ERROR
-        elif external == Level.Warning:
-            return LogLevel.WARNING
-        elif external == Level.Info:
-            return LogLevel.INFO
-        elif external == Level.Debug:
-            return LogLevel.DEBUG
-        elif external == Level.Graph:
-            return LogLevel.GRAPH
-        else:
-            raise ValueError("Unknown log severity")
+    def log(self, severity, msg):
+        # TODO: Move to match once py39 reaches EoL
+        if severity == trt.ILogger.Severity.INTERNAL_ERROR:
+            _LOGGER.critical(msg)
+            raise RuntimeError(msg)
+        elif severity == trt.ILogger.Severity.ERROR:
+            _LOGGER.error(msg)
+        elif severity == trt.ILogger.Severity.WARNING:
+            _LOGGER.warning(msg)
+        elif severity == trt.ILogger.Severity.INFO:
+            _LOGGER.info(msg)
+        elif severity == trt.ILogger.Severity.VERBOSE:
+            _LOGGER.debug(msg)
 
-
-def get_logging_prefix() -> str:
-    """Get the prefix set for logging messages
-
-    Returns:
-        str: Prefix used for logger
-    """
-    return str(_get_logging_prefix())
-
-
-def set_logging_prefix(prefix: str) -> None:
-    """Set the prefix used when logging messages
-
-    Args:
-        prefix (str): Prefix to use for logging messages
-    """
-    _set_logging_prefix(prefix)
-
-
-def get_reportable_log_level() -> Level:
-    """Get the level required for a message to be printed in the log
-
-    Returns:
-        torch_tensorrt.logging.Level: The enum representing the level required to print
-    """
-    return Level(_get_reportable_log_level())
-
-
-def set_reportable_log_level(level: Level) -> None:
-    """Set the level required for a message to be printed to the log
-
-    Args:
-        level (torch_tensorrt.logging.Level): The enum representing the level required to print
-    """
-    _set_reportable_log_level(Level._to_internal_level(level))
-
-
-def get_is_colored_output_on() -> bool:
-    """Get if colored output is enabled for logging
-
-    Returns:
-        bool: If colored output is one
-    """
-    return bool(_get_is_colored_output_on())
-
-
-def set_is_colored_output_on(colored_output_on: bool) -> None:
-    """Enable or disable color in the log output
-
-    Args:
-        colored_output_on (bool): If colored output should be enabled or not
-    """
-    _set_is_colored_output_on(colored_output_on)
-
-
-def log(level: Level, msg: str) -> None:
-    """Add a new message to the log
-
-    Adds a new message to the log at a specified level. The message
-    will only get printed out if Level > reportable_log_level
-
-    Args:
-        level (torch_tensorrt.logging.Level): Severity of the message
-        msg (str): Actual message text
-    """
-    _log(Level._to_internal_level(level), msg)
-
-    InternalError = LogLevel.INTERNAL_ERROR
-    Error = LogLevel.ERROR
-    Warning = LogLevel.WARNING
-    Info = LogLevel.INFO
-    Debug = LogLevel.DEBUG
-    Graph = LogLevel.GRAPH
-
+TRT_LOGGER = _TRTLogger()
 
 class internal_errors:
     """Context-manager to limit displayed log messages to just internal errors
@@ -125,11 +37,20 @@ class internal_errors:
     """
 
     def __enter__(self) -> None:
-        self.external_lvl = get_reportable_log_level()
-        set_reportable_log_level(Level.InternalError)
+        self.external_lvl = _LOGGER.getEffectiveLevel()
+        _LOGGER.setLevel(logging.CRITICAL)
+
+        if ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt.ts import logging as ts_logging
+            self.ts_level = ts_logging.get_reportable_log_level()
+            ts_logging.set_reportable_log_level(ts_logging.Level.InternalError)
 
     def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
-        set_reportable_log_level(self.external_lvl)
+        _LOGGER.setLevel(self.external_lvl)
+
+        if ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt.ts import logging as ts_logging
+            ts_logging.set_reportable_log_level(self.ts_level)
 
 
 class errors:
@@ -142,11 +63,20 @@ class errors:
     """
 
     def __enter__(self) -> None:
-        self.external_lvl = get_reportable_log_level()
-        set_reportable_log_level(Level.Error)
+        self.external_lvl = _LOGGER.getEffectiveLevel()
+        _LOGGER.setLevel(logging.ERROR)
+
+        if ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt.ts import logging as ts_logging
+            self.ts_level = ts_logging.get_reportable_log_level()
+            ts_logging.set_reportable_log_level(ts_logging.Level.Error)
 
     def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
-        set_reportable_log_level(self.external_lvl)
+        _LOGGER.setLevel(self.external_lvl)
+
+        if ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt.ts import logging as ts_logging
+            ts_logging.set_reportable_log_level(self.ts_level)
 
 
 class warnings:
@@ -159,11 +89,20 @@ class warnings:
     """
 
     def __enter__(self) -> None:
-        self.external_lvl = get_reportable_log_level()
-        set_reportable_log_level(Level.Warning)
+        self.external_lvl = _LOGGER.getEffectiveLevel()
+        _LOGGER.setLevel(logging.WARNING)
+
+        if ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt.ts import logging as ts_logging
+            self.ts_level = ts_logging.get_reportable_log_level()
+            ts_logging.set_reportable_log_level(ts_logging.Level.Warning)
 
     def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
-        set_reportable_log_level(self.external_lvl)
+        _LOGGER.setLevel(self.external_lvl)
+
+        if ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt.ts import logging as ts_logging
+            ts_logging.set_reportable_log_level(self.ts_level)
 
 
 class info:
@@ -176,11 +115,20 @@ class info:
     """
 
     def __enter__(self) -> None:
-        self.external_lvl = get_reportable_log_level()
-        set_reportable_log_level(Level.Info)
+        self.external_lvl = _LOGGER.getEffectiveLevel()
+        _LOGGER.setLevel(logging.INFO)
+
+        if ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt.ts import logging as ts_logging
+            self.ts_level = ts_logging.get_reportable_log_level()
+            ts_logging.set_reportable_log_level(ts_logging.Level.Info)
 
     def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
-        set_reportable_log_level(self.external_lvl)
+        _LOGGER.setLevel(self.external_lvl)
+
+        if ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt.ts import logging as ts_logging
+            ts_logging.set_reportable_log_level(self.ts_level)
 
 
 class debug:
@@ -193,11 +141,20 @@ class debug:
     """
 
     def __enter__(self) -> None:
-        self.external_lvl = get_reportable_log_level()
-        set_reportable_log_level(Level.Debug)
+        self.external_lvl = _LOGGER.getEffectiveLevel()
+        _LOGGER.setLevel(logging.DEBUG)
+
+        if ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt.ts import logging as ts_logging
+            self.ts_level = ts_logging.get_reportable_log_level()
+            ts_logging.set_reportable_log_level(ts_logging.Level.Debug)
 
     def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
-        set_reportable_log_level(self.external_lvl)
+        _LOGGER.setLevel(self.external_lvl)
+
+        if ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt.ts import logging as ts_logging
+            ts_logging.set_reportable_log_level(self.ts_level)
 
 
 class graphs:
@@ -211,8 +168,17 @@ class graphs:
     """
 
     def __enter__(self) -> None:
-        self.external_lvl = get_reportable_log_level()
-        set_reportable_log_level(Level.Graph)
+        self.external_lvl = _LOGGER.getEffectiveLevel()
+        _LOGGER.setLevel(logging.NOTSET)
+
+        if ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt.ts import logging as ts_logging
+            self.ts_level = ts_logging.get_reportable_log_level()
+            ts_logging.set_reportable_log_level(ts_logging.Level.Graph)
 
     def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
-        set_reportable_log_level(self.external_lvl)
+        _LOGGER.setLevel(self.external_lvl)
+
+        if ENABLED_FEATURES.torchscript_frontend:
+            from torch_tensorrt.ts import logging as ts_logging
+            ts_logging.set_reportable_log_level(self.ts_level)

--- a/py/torch_tensorrt/ts/_Device.py
+++ b/py/torch_tensorrt/ts/_Device.py
@@ -51,7 +51,6 @@ class TorchScriptDevice(Device):
             - Device(gpu_id=1)
         """
         super().__init__(*args, **kwargs)
-        print(self)
 
     def _to_internal(self) -> _C.Device:
         internal_dev = _C.Device()

--- a/py/torch_tensorrt/ts/_Device.py
+++ b/py/torch_tensorrt/ts/_Device.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Optional, Tuple
+from typing import Any
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -8,9 +8,6 @@ else:
 
 import warnings
 
-import tensorrt as trt
-import torch
-from torch_tensorrt._enums import DeviceType
 from torch_tensorrt._Device import Device
 
 try:
@@ -31,13 +28,6 @@ class TorchScriptDevice(Device):
         dla_core (int): Core ID for target DLA core
         allow_gpu_fallback (bool): Whether falling back to GPU if DLA cannot support an op should be allowed
     """
-
-    device_type: Optional[
-        DeviceType
-    ] = None  #: Target device type (GPU or DLA). Set implicitly based on if dla_core is specified.
-    gpu_id: int = -1  #: Device ID for target GPU
-    dla_core: int = -1  #: Core ID for target DLA core
-    allow_gpu_fallback: bool = False  #: Whether falling back to GPU if DLA cannot support an op should be allowed
 
     def __init__(self, *args: Any, **kwargs: Any):
         """__init__ Method for torch_tensorrt.Device
@@ -72,5 +62,9 @@ class TorchScriptDevice(Device):
         return internal_dev
 
     @classmethod
-    def _from(cls, d: Device) -> Self:
-        return cls(gpu_id=d.gpu_id, dla_core=d.dla_core, allow_gpu_fallback=d.allow_gpu_fallback)
+    def _from(cls, d: object) -> Self:
+        return cls(
+            gpu_id=d.gpu_id,
+            dla_core=d.dla_core,
+            allow_gpu_fallback=d.allow_gpu_fallback,
+        )

--- a/py/torch_tensorrt/ts/_Device.py
+++ b/py/torch_tensorrt/ts/_Device.py
@@ -1,0 +1,76 @@
+import sys
+from typing import Any, Optional, Tuple
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+import warnings
+
+import tensorrt as trt
+import torch
+from torch_tensorrt._enums import DeviceType
+from torch_tensorrt._Device import Device
+
+try:
+    from torch_tensorrt import _C
+except ImportError:
+    warnings.warn(
+        "Unable to import torchscript frontend core and torch-tensorrt runtime. Some dependent features may be unavailable."
+    )
+
+
+class TorchScriptDevice(Device):
+    """
+    Defines a device that can be used to specify target devices for engines
+
+    Attributes:
+        device_type (torch_tensorrt.DeviceType): Target device type (GPU or DLA). Set implicitly based on if dla_core is specified.
+        gpu_id (int): Device ID for target GPU
+        dla_core (int): Core ID for target DLA core
+        allow_gpu_fallback (bool): Whether falling back to GPU if DLA cannot support an op should be allowed
+    """
+
+    device_type: Optional[
+        DeviceType
+    ] = None  #: Target device type (GPU or DLA). Set implicitly based on if dla_core is specified.
+    gpu_id: int = -1  #: Device ID for target GPU
+    dla_core: int = -1  #: Core ID for target DLA core
+    allow_gpu_fallback: bool = False  #: Whether falling back to GPU if DLA cannot support an op should be allowed
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        """__init__ Method for torch_tensorrt.Device
+
+        Device accepts one of a few construction patterns
+
+        Args:
+            spec (str): String with device spec e.g. "dla:0" for dla, core_id 0
+
+        Keyword Arguments:
+            gpu_id (int): ID of target GPU (will get overrided if dla_core is specified to the GPU managing DLA). If specified, no positional arguments should be provided
+            dla_core (int): ID of target DLA core. If specified, no positional arguments should be provided.
+            allow_gpu_fallback (bool): Allow TensorRT to schedule operations on GPU if they are not supported on DLA (ignored if device type is not DLA)
+
+        Examples:
+            - Device("gpu:1")
+            - Device("cuda:1")
+            - Device("dla:0", allow_gpu_fallback=True)
+            - Device(gpu_id=0, dla_core=0, allow_gpu_fallback=True)
+            - Device(dla_core=0, allow_gpu_fallback=True)
+            - Device(gpu_id=1)
+        """
+        super().__init__(*args, **kwargs)
+        print(self)
+
+    def _to_internal(self) -> _C.Device:
+        internal_dev = _C.Device()
+        internal_dev.device_type = self.device_type.to(_C.DeviceType)
+        internal_dev.gpu_id = self.gpu_id
+        internal_dev.dla_core = self.dla_core
+        internal_dev.allow_gpu_fallback = self.allow_gpu_fallback
+        return internal_dev
+
+    @classmethod
+    def _from(cls, d: Device) -> Self:
+        return cls(gpu_id=d.gpu_id, dla_core=d.dla_core, allow_gpu_fallback=d.allow_gpu_fallback)

--- a/py/torch_tensorrt/ts/_Input.py
+++ b/py/torch_tensorrt/ts/_Input.py
@@ -1,10 +1,8 @@
 from typing import Any
-import torch
-from torch_tensorrt.ts import _enums
 
 from torch_tensorrt import _C
+from torch_tensorrt._enums import dtype
 from torch_tensorrt._Input import Input
-from torch_tensorrt._enums import dtype, memory_format
 
 
 class TorchScriptInput(Input):
@@ -52,88 +50,16 @@ class TorchScriptInput(Input):
         """
         super().__init__(*args, **kwargs)
 
-    @staticmethod
-    def _parse_dtype(d: Any) -> _enums.dtype:
-        if isinstance(d, torch.dtype):
-            if d == torch.long:
-                return _enums.dtype.long
-            elif d == torch.int32:
-                return _enums.dtype.int32
-            elif d == torch.half:
-                return _enums.dtype.half
-            elif d == torch.float:
-                return _enums.dtype.float
-            elif d == torch.float64:
-                return _enums.dtype.double
-            elif d == torch.bool:
-                return _enums.dtype.bool
-            else:
-                raise TypeError(
-                    "Provided an unsupported data type as an input data type (support: bool, int32, long, half, float), got: "
-                    + str(d)
-                )
-
-        elif isinstance(d, dtype):
-            return d.to(_enums.dtype)
-
-        elif isinstance(d, _enums.dtype):
-            return d
-
-        else:
-            raise TypeError(
-                "Input data type needs to be specified with a torch.dtype or a torch_tensorrt.dtype, got: "
-                + str(type(d))
-            )
-
-    @staticmethod
-    def _to_torch_dtype(dtype: _enums.dtype) -> torch.dtype:
-        if dtype == _enums.dtype.long:
-            return torch.long
-        elif dtype == _enums.dtype.int32:
-            return torch.int32
-        elif dtype == _enums.dtype.half:
-            return torch.half
-        elif dtype == _enums.dtype.float:
-            return torch.float
-        elif dtype == _enums.dtype.bool:
-            return torch.bool
-        elif dtype == _enums.dtype.double:
-            return torch.float64
-        else:
-            # Default torch_dtype used in FX path
-            return torch.float32
-
     def is_trt_dtype(self) -> bool:
-        return bool(self.dtype != _enums.dtype.long)
-
-    @staticmethod
-    def _parse_format(format: Any) -> _enums.TensorFormat:
-        if isinstance(format, torch.memory_format):
-            if format == torch.contiguous_format:
-                return _enums.TensorFormat.contiguous
-            elif format == torch.channels_last:
-                return _enums.TensorFormat.channels_last
-            else:
-                raise ValueError(
-                    "Provided an unsupported tensor format (support: NCHW/contiguous_format, NHWC/channel_last)"
-                )
-
-        elif isinstance(format, _enums.TensorFormat):
-            return format
-
-        elif isinstance(format, memory_format):
-            return format.to(_enums.TensorFormat)
-
-        else:
-            raise TypeError(
-                "Tensor format needs to be specified with either torch.memory_format or torch_tensorrt.TensorFormat"
-            )
+        return bool(self.dtype != dtype.long)
 
     def _to_internal(self) -> _C.Input:
         internal_in = _C.Input()
         if self.shape_mode == Input._ShapeMode.DYNAMIC:
             if isinstance(self.shape, dict):
-                if not TorchScriptInput._supported_input_size_type(self.shape["min_shape"]):
+                if not TorchScriptInput._supported_input_size_type(
+                    self.shape["min_shape"]
+                ):
                     raise TypeError(
                         "Input shape specifications for inputs are required to be a List, tuple or torch.Size, found type: "
                         + str(type(self.shape["min_shape"]))
@@ -142,7 +68,9 @@ class TorchScriptInput(Input):
                 else:
                     internal_in.min = self.shape["min_shape"]
 
-                if not TorchScriptInput._supported_input_size_type(self.shape["opt_shape"]):
+                if not TorchScriptInput._supported_input_size_type(
+                    self.shape["opt_shape"]
+                ):
                     raise TypeError(
                         "Input shape specifications for inputs are required to be a List, tuple or torch.Size, found type: "
                         + str(type(self.shape["opt_shape"]))
@@ -151,7 +79,9 @@ class TorchScriptInput(Input):
                 else:
                     internal_in.opt = self.shape["opt_shape"]
 
-                if not TorchScriptInput._supported_input_size_type(self.shape["max_shape"]):
+                if not TorchScriptInput._supported_input_size_type(
+                    self.shape["max_shape"]
+                ):
                     raise TypeError(
                         "Input shape specifications for inputs are required to be a List, tuple or torch.Size, found type: "
                         + str(type(self.shape["max_shape"]))
@@ -171,9 +101,11 @@ class TorchScriptInput(Input):
                 internal_in.opt = self.shape
             internal_in.input_is_dynamic = False
 
-        internal_in.dtype = TorchScriptInput._parse_dtype(self.dtype)
+        internal_in.dtype = self.dtype.to(_C.dtype)
         internal_in._explicit_set_dtype = self._explicit_set_dtype
-        internal_in.format = TorchScriptInput._parse_format(self.format)
+        internal_in.format = self.format.to(_C.TensorFormat)
 
-        internal_in.tensor_domain = TorchScriptInput._parse_tensor_domain(self.tensor_domain)
+        internal_in.tensor_domain = TorchScriptInput._parse_tensor_domain(
+            self.tensor_domain
+        )
         return internal_in

--- a/py/torch_tensorrt/ts/__init__.py
+++ b/py/torch_tensorrt/ts/__init__.py
@@ -1,3 +1,5 @@
 from torch_tensorrt.ts._compile_spec import TensorRTCompileSpec  # noqa: F401
 from torch_tensorrt.ts._compiler import *  # noqa: F403
 from torch_tensorrt.ts._Input import TorchScriptInput  # noqa: F401
+from torch_tensorrt.ts._Device import TorchScriptDevice  # noqa: F401
+from torch_tensorrt.ts._enums import * # noqa: F403

--- a/py/torch_tensorrt/ts/__init__.py
+++ b/py/torch_tensorrt/ts/__init__.py
@@ -1,5 +1,5 @@
 from torch_tensorrt.ts._compile_spec import TensorRTCompileSpec  # noqa: F401
 from torch_tensorrt.ts._compiler import *  # noqa: F403
-from torch_tensorrt.ts._Input import TorchScriptInput  # noqa: F401
 from torch_tensorrt.ts._Device import TorchScriptDevice  # noqa: F401
-from torch_tensorrt.ts._enums import * # noqa: F403
+from torch_tensorrt.ts._enums import *  # noqa: F403
+from torch_tensorrt.ts._Input import TorchScriptInput  # noqa: F401

--- a/py/torch_tensorrt/ts/_compile_spec.py
+++ b/py/torch_tensorrt/ts/_compile_spec.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Set
 
-import tensorrt as trt
 import torch
-from torch_tensorrt.ts import _enums
 import torch_tensorrt._C.ts as _ts_C
 from torch_tensorrt import _C
-from torch_tensorrt._enums import dtype, DeviceType
 from torch_tensorrt._Device import Device
+from torch_tensorrt._enums import DeviceType, EngineCapability, dtype
 from torch_tensorrt._Input import Input
-from torch_tensorrt.ts.logging import Level, log
-from torch_tensorrt.ts._Input import TorchScriptInput
 from torch_tensorrt.ts._Device import TorchScriptDevice
+from torch_tensorrt.ts._Input import TorchScriptInput
+from torch_tensorrt.ts.logging import Level, log
+
+import tensorrt as trt
 
 
 def _internal_input_to_torch_class_input(i: _C.Input) -> torch.classes.tensorrt._Input:
@@ -43,11 +43,11 @@ def _supported_input_size_type(input_size: Any) -> bool:
         )
 
 
-def _parse_op_precision(precision: Any) -> _enums.dtype:
-    return dtype._from(precision).to(_enums.dtype)
+def _parse_op_precision(precision: Any) -> _C.dtype:
+    return dtype._from(precision).to(_C.dtype)
 
 
-def _parse_enabled_precisions(precisions: Any) -> Set[_enums.dtype]:
+def _parse_enabled_precisions(precisions: Any) -> Set[_C.dtype]:
     parsed_precisions = set()
     if any(isinstance(precisions, type) for type in [list, tuple, set]):
         for p in precisions:
@@ -57,7 +57,7 @@ def _parse_enabled_precisions(precisions: Any) -> Set[_enums.dtype]:
     return parsed_precisions
 
 
-def _parse_device_type(device: Any) -> _enums.DeviceType:
+def _parse_device_type(device: Any) -> _C.DeviceType:
     return DeviceType._from(device).to(_C.DeviceType)
 
 
@@ -87,7 +87,7 @@ def _parse_device(device_info: Any) -> _C.Device:
     elif isinstance(device_info, TorchScriptDevice):
         return device_info._to_internal()
     elif isinstance(device_info, torch.device):
-        return (Device._from_torch_device(device_info))._to_internal()
+        return TorchScriptDevice._from(device_info)._to_internal()
     else:
         raise ValueError(
             "Unsupported data for device specification. Expected either a dict, torch_tensorrt.Device or torch.Device"
@@ -143,7 +143,9 @@ def _parse_input_signature(input_signature: Any, depth: int = 0) -> Any:
 
         if not i.dtype.try_to(trt.DataType, use_default=True):
             raise TypeError(
-                "Using non-TRT input types ({}) with input_signature is not currently ".format(i.dtype)
+                "Using non-TRT input types ({}) with input_signature is not currently ".format(
+                    i.dtype
+                )
                 + "supported. Please specify inputs individually to use "
                 + "non-TRT types."
             )
@@ -198,16 +200,14 @@ def _parse_compile_spec(compile_spec_: Dict[str, Any]) -> _ts_C.CompileSpec:
             Input.from_tensor(i) if isinstance(i, torch.Tensor) else i
             for i in compile_spec["inputs"]
         ]
-        print(inputs)
         ts_inputs = []
         for i in inputs:
             if i.shape_mode == Input._ShapeMode.STATIC:
-                print(i)
                 ts_inputs.append(
                     TorchScriptInput(
                         shape=i.shape,
                         dtype=i.dtype.to(_C.dtype),
-                        format=i.format.to(_C.TensorFormat)
+                        format=i.format.to(_C.TensorFormat),
                     )._to_internal()
                 )
             elif i.shape_mode == Input._ShapeMode.DYNAMIC:
@@ -267,8 +267,10 @@ def _parse_compile_spec(compile_spec_: Dict[str, Any]) -> _ts_C.CompileSpec:
         info.device = _parse_device(compile_spec["device"])
 
     if "capability" in compile_spec:
-        assert isinstance(compile_spec["capability"], _enums.EngineCapability)
-        info.capability = compile_spec["capability"]
+        capability = EngineCapability._from(compile_spec["capability"]).to(
+            _C.EngineCapability
+        )
+        info.capability = capability
 
     if "num_avg_timing_iters" in compile_spec:
         assert type(compile_spec["num_avg_timing_iters"]) is int
@@ -308,10 +310,10 @@ def TensorRTCompileSpec(
     device: torch.device | Device = Device._current_device(),
     disable_tf32: bool = False,
     sparse_weights: bool = False,
-    enabled_precisions: Optional[Set[torch.dtype | _enums.dtype]] = None,
+    enabled_precisions: Optional[Set[torch.dtype | dtype]] = None,
     refit: bool = False,
     debug: bool = False,
-    capability: _enums.EngineCapability = _enums.EngineCapability.default,
+    capability: EngineCapability = EngineCapability.STANDARD,
     num_avg_timing_iters: int = 1,
     workspace_size: int = 0,
     dla_sram_size: int = 1048576,

--- a/py/torch_tensorrt/ts/_compile_spec.py
+++ b/py/torch_tensorrt/ts/_compile_spec.py
@@ -5,12 +5,15 @@ from typing import Any, Dict, List, Optional, Set
 
 import tensorrt as trt
 import torch
+from torch_tensorrt.ts import _enums
 import torch_tensorrt._C.ts as _ts_C
-from torch_tensorrt import _C, _enums
+from torch_tensorrt import _C
+from torch_tensorrt._enums import dtype, DeviceType
 from torch_tensorrt._Device import Device
 from torch_tensorrt._Input import Input
-from torch_tensorrt.logging import Level, log
+from torch_tensorrt.ts.logging import Level, log
 from torch_tensorrt.ts._Input import TorchScriptInput
+from torch_tensorrt.ts._Device import TorchScriptDevice
 
 
 def _internal_input_to_torch_class_input(i: _C.Input) -> torch.classes.tensorrt._Input:
@@ -41,27 +44,7 @@ def _supported_input_size_type(input_size: Any) -> bool:
 
 
 def _parse_op_precision(precision: Any) -> _enums.dtype:
-    if isinstance(precision, torch.dtype):
-        if precision == torch.int8:
-            return _enums.dtype.int8
-        elif precision == torch.half:
-            return _enums.dtype.half
-        elif precision == torch.float:
-            return _enums.dtype.float
-        else:
-            raise TypeError(
-                "Provided an unsupported dtype as operating precision (support: int8, half, float), got: "
-                + str(precision)
-            )
-
-    elif isinstance(precision, _enums.dtype):
-        return precision
-
-    else:
-        raise TypeError(
-            "Op precision type needs to be specified with a torch.dtype or a torch_tensorrt.dtype, got: "
-            + str(type(precision))
-        )
+    return dtype._from(precision).to(_enums.dtype)
 
 
 def _parse_enabled_precisions(precisions: Any) -> Set[_enums.dtype]:
@@ -75,35 +58,7 @@ def _parse_enabled_precisions(precisions: Any) -> Set[_enums.dtype]:
 
 
 def _parse_device_type(device: Any) -> _enums.DeviceType:
-    if isinstance(device, torch.device):
-        if device.type == "cuda":
-            return _C.DeviceType.gpu
-        else:
-            ValueError(
-                "Got a device type other than GPU or DLA (type: "
-                + str(device.type)
-                + ")"
-            )
-    elif isinstance(device, _C.DeviceType):
-        return device
-    elif isinstance(device, trt.DeviceType):
-        if device == trt.DeviceType.DLA:
-            return _C.DeviceType.DLA
-        return _C.DeviceType.GPU
-    elif isinstance(device, str):
-        if device == "gpu" or device == "GPU":
-            return _C.DeviceType.GPU
-        elif device == "dla" or device == "DLA":
-            return _C.DeviceType.DLA
-        else:
-            ValueError(
-                "Got a device type other than GPU or DLA (type: " + str(device) + ")"
-            )
-    else:
-        raise TypeError(
-            "Device specification must be of type torch.device, string or torch_tensorrt.DeviceType, but got: "
-            + str(type(device))
-        )
+    return DeviceType._from(device).to(_C.DeviceType)
 
 
 def _parse_device(device_info: Any) -> _C.Device:
@@ -128,6 +83,8 @@ def _parse_device(device_info: Any) -> _C.Device:
 
         return info
     elif isinstance(device_info, Device):
+        return TorchScriptDevice._from(device_info)._to_internal()
+    elif isinstance(device_info, TorchScriptDevice):
         return device_info._to_internal()
     elif isinstance(device_info, torch.device):
         return (Device._from_torch_device(device_info))._to_internal()
@@ -184,9 +141,9 @@ def _parse_input_signature(input_signature: Any, depth: int = 0) -> Any:
             else input_signature
         )
 
-        if not i.is_trt_dtype():
+        if not i.dtype.try_to(trt.DataType, use_default=True):
             raise TypeError(
-                "Using non-TRT input types with input_signature is not currently "
+                "Using non-TRT input types ({}) with input_signature is not currently ".format(i.dtype)
                 + "supported. Please specify inputs individually to use "
                 + "non-TRT types."
             )
@@ -241,12 +198,16 @@ def _parse_compile_spec(compile_spec_: Dict[str, Any]) -> _ts_C.CompileSpec:
             Input.from_tensor(i) if isinstance(i, torch.Tensor) else i
             for i in compile_spec["inputs"]
         ]
+        print(inputs)
         ts_inputs = []
         for i in inputs:
             if i.shape_mode == Input._ShapeMode.STATIC:
+                print(i)
                 ts_inputs.append(
                     TorchScriptInput(
-                        shape=i.shape, dtype=i.dtype, format=i.format
+                        shape=i.shape,
+                        dtype=i.dtype.to(_C.dtype),
+                        format=i.format.to(_C.TensorFormat)
                     )._to_internal()
                 )
             elif i.shape_mode == Input._ShapeMode.DYNAMIC:
@@ -255,8 +216,8 @@ def _parse_compile_spec(compile_spec_: Dict[str, Any]) -> _ts_C.CompileSpec:
                         min_shape=i.shape["min_shape"],
                         opt_shape=i.shape["opt_shape"],
                         max_shape=i.shape["max_shape"],
-                        dtype=i.dtype,
-                        format=i.format,
+                        dtype=i.dtype.to(_C.dtype),
+                        format=i.format.to(_C.TensorFormat),
                     )._to_internal()
                 )
         info.inputs = ts_inputs

--- a/py/torch_tensorrt/ts/_compiler.py
+++ b/py/torch_tensorrt/ts/_compiler.py
@@ -4,8 +4,8 @@ from typing import Any, List, Optional, Sequence, Set, Tuple
 
 import torch
 import torch_tensorrt._C.ts as _C
-from torch_tensorrt.ts import _enums
 from torch_tensorrt._Device import Device
+from torch_tensorrt._enums import EngineCapability, dtype
 from torch_tensorrt._Input import Input
 from torch_tensorrt.ts._compile_spec import _parse_compile_spec, _parse_device
 
@@ -19,10 +19,10 @@ def compile(
     device: Device = Device._current_device(),
     disable_tf32: bool = False,
     sparse_weights: bool = False,
-    enabled_precisions: Optional[Set[torch.dtype | _enums.dtype]] = None,
+    enabled_precisions: Optional[Set[torch.dtype | dtype]] = None,
     refit: bool = False,
     debug: bool = False,
-    capability: _enums.EngineCapability = _enums.EngineCapability.default,
+    capability: EngineCapability = EngineCapability.STANDARD,
     num_avg_timing_iters: int = 1,
     workspace_size: int = 0,
     dla_sram_size: int = 1048576,
@@ -167,10 +167,10 @@ def convert_method_to_trt_engine(
     device: Device = Device._current_device(),
     disable_tf32: bool = False,
     sparse_weights: bool = False,
-    enabled_precisions: Optional[Set[torch.dtype | _enums.dtype]] = None,
+    enabled_precisions: Optional[Set[torch.dtype | dtype]] = None,
     refit: bool = False,
     debug: bool = False,
-    capability: _enums.EngineCapability = _enums.EngineCapability.default,
+    capability: EngineCapability = EngineCapability.STANDARD,
     num_avg_timing_iters: int = 1,
     workspace_size: int = 0,
     dla_sram_size: int = 1048576,

--- a/py/torch_tensorrt/ts/_compiler.py
+++ b/py/torch_tensorrt/ts/_compiler.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional, Sequence, Set, Tuple
 
 import torch
 import torch_tensorrt._C.ts as _C
+from torch_tensorrt.ts import _enums
 from torch_tensorrt._Device import Device
 from torch_tensorrt._Input import Input
 from torch_tensorrt.ts._compile_spec import _parse_compile_spec, _parse_device

--- a/py/torch_tensorrt/ts/_enums.py
+++ b/py/torch_tensorrt/ts/_enums.py
@@ -1,0 +1,3 @@
+from torch_tensorrt._C import EngineCapability, TensorFormat, dtype  # noqa: F401
+
+from tensorrt import DeviceType  # noqa: F401

--- a/py/torch_tensorrt/ts/_utils.py
+++ b/py/torch_tensorrt/ts/_utils.py
@@ -1,7 +1,6 @@
 import torch
-
-from torch_tensorrt._version import __version__
 from torch_tensorrt import _C
+from torch_tensorrt._version import __version__
 
 
 def dump_build_info() -> None:

--- a/py/torch_tensorrt/ts/_utils.py
+++ b/py/torch_tensorrt/ts/_utils.py
@@ -1,0 +1,32 @@
+import torch
+
+from torch_tensorrt._version import __version__
+from torch_tensorrt import _C
+
+
+def dump_build_info() -> None:
+    """Prints build information about the torch_tensorrt distribution to stdout"""
+    print(get_build_info())
+
+
+def get_build_info() -> str:
+    """Returns a string containing the build information of torch_tensorrt distribution
+
+    Returns:
+        str: String containing the build information for torch_tensorrt distribution
+    """
+    core_build_info = _C.get_build_info()
+    build_info = str(
+        "Torch-TensorRT Version: "
+        + str(__version__)
+        + "\n"
+        + "Using PyTorch Version: "
+        + str(torch.__version__)
+        + "\n"
+        + core_build_info
+    )
+    return build_info
+
+
+def set_device(gpu_id: int) -> None:
+    _C.set_device(gpu_id)

--- a/py/torch_tensorrt/ts/logging.py
+++ b/py/torch_tensorrt/ts/logging.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import Any
 
 from torch_tensorrt._C import (
     LogLevel,
@@ -114,5 +113,3 @@ def log(level: Level, msg: str) -> None:
     Info = LogLevel.INFO
     Debug = LogLevel.DEBUG
     Graph = LogLevel.GRAPH
-
-

--- a/py/torch_tensorrt/ts/logging.py
+++ b/py/torch_tensorrt/ts/logging.py
@@ -1,0 +1,118 @@
+from enum import Enum
+from typing import Any
+
+from torch_tensorrt._C import (
+    LogLevel,
+    _get_is_colored_output_on,
+    _get_logging_prefix,
+    _get_reportable_log_level,
+    _log,
+    _set_is_colored_output_on,
+    _set_logging_prefix,
+    _set_reportable_log_level,
+)
+
+
+class Level(Enum):
+    """Enum to set the minimum required logging level to print a message to stdout"""
+
+    InternalError = LogLevel.INTERNAL_ERROR
+    Error = LogLevel.ERROR
+    Warning = LogLevel.WARNING
+    Info = LogLevel.INFO
+    Debug = LogLevel.DEBUG
+    Graph = LogLevel.GRAPH
+
+    @staticmethod
+    def _to_internal_level(external: "Level") -> LogLevel:
+        if external == Level.InternalError:
+            return LogLevel.INTERNAL_ERROR
+        elif external == Level.Error:
+            return LogLevel.ERROR
+        elif external == Level.Warning:
+            return LogLevel.WARNING
+        elif external == Level.Info:
+            return LogLevel.INFO
+        elif external == Level.Debug:
+            return LogLevel.DEBUG
+        elif external == Level.Graph:
+            return LogLevel.GRAPH
+        else:
+            print(external)
+            raise ValueError("Unknown log severity")
+
+
+def get_logging_prefix() -> str:
+    """Get the prefix set for logging messages
+
+    Returns:
+        str: Prefix used for logger
+    """
+    return str(_get_logging_prefix())
+
+
+def set_logging_prefix(prefix: str) -> None:
+    """Set the prefix used when logging messages
+
+    Args:
+        prefix (str): Prefix to use for logging messages
+    """
+    _set_logging_prefix(prefix)
+
+
+def get_reportable_log_level() -> Level:
+    """Get the level required for a message to be printed in the log
+
+    Returns:
+        torch_tensorrt.logging.Level: The enum representing the level required to print
+    """
+    return Level(_get_reportable_log_level())
+
+
+def set_reportable_log_level(level: Level) -> None:
+    """Set the level required for a message to be printed to the log
+
+    Args:
+        level (torch_tensorrt.logging.Level): The enum representing the level required to print
+    """
+    _set_reportable_log_level(Level._to_internal_level(level))
+
+
+def get_is_colored_output_on() -> bool:
+    """Get if colored output is enabled for logging
+
+    Returns:
+        bool: If colored output is one
+    """
+    return bool(_get_is_colored_output_on())
+
+
+def set_is_colored_output_on(colored_output_on: bool) -> None:
+    """Enable or disable color in the log output
+
+    Args:
+        colored_output_on (bool): If colored output should be enabled or not
+    """
+    _set_is_colored_output_on(colored_output_on)
+
+
+def log(level: Level, msg: str) -> None:
+    """Add a new message to the log
+
+    Adds a new message to the log at a specified level. The message
+    will only get printed out if Level > reportable_log_level
+
+    Args:
+        level (torch_tensorrt.logging.Level): Severity of the message
+        msg (str): Actual message text
+    """
+    _log(Level._to_internal_level(level), msg)
+
+    InternalError = LogLevel.INTERNAL_ERROR
+    Error = LogLevel.ERROR
+    Warning = LogLevel.WARNING
+    Info = LogLevel.INFO
+    Debug = LogLevel.DEBUG
+    Graph = LogLevel.GRAPH
+
+

--- a/py/torch_tensorrt/ts/ptq.py
+++ b/py/torch_tensorrt/ts/ptq.py
@@ -11,7 +11,7 @@ from enum import Enum
 
 import torch
 from torch_tensorrt import _C
-from torch_tensorrt.logging import Level, log
+from py.torch_tensorrt.ts.logging import Level, log
 
 
 class CalibrationAlgo(Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ include-package-data = false
 
 [tool.ruff]
 # NOTE: Synchoronize the ignores with .flake8
-ignore = [
+lint.ignore = [
     # these ignores are from flake8-bugbear; please fix!
     "B007", "B008", "B017",
     "B018", # Useless expression
@@ -97,7 +97,7 @@ ignore = [
     "SIM118",
 ]
 #line-length = 120
-select = [
+lint.select = [
     "B",
     "C4",
     "G",
@@ -112,11 +112,11 @@ select = [
 ]
 
 # Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 target-version = "py311"
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = [
+lint.fixable = [
     "A","B","C","D","E","F","G",
     "I","N","Q","S","T","W",
     "ANN", "ARG", "BLE", "COM", "DJ",
@@ -125,7 +125,7 @@ fixable = [
     "PGH", "PIE", "PL", "PT", "PTH",
     "PYI", "RET", "RSE", "RUF", "SIM",
     "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
-unfixable = []
+lint.unfixable = []
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -164,7 +164,7 @@ exclude = [
     "__init__.py"
 ]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ transformers
 timm
 parameterized
 expecttest==0.1.6
+pyyaml

--- a/setup.py
+++ b/setup.py
@@ -194,7 +194,9 @@ if not PY_ONLY:
             sys.exit("Could not find bazel in PATH")
 
 
-def build_libtorchtrt_pre_cxx11_abi(develop=True, use_dist_dir=True, cxx11_abi=False, rt_only=False):
+def build_libtorchtrt_pre_cxx11_abi(
+    develop=True, use_dist_dir=True, cxx11_abi=False, rt_only=False
+):
     cmd = [BAZEL_EXE, "build"]
     if rt_only:
         cmd.append("//:libtorchtrt_runtime")
@@ -288,7 +290,9 @@ class DevelopCommand(develop):
 
         if not PY_ONLY:
             global CXX11_ABI
-            build_libtorchtrt_pre_cxx11_abi(develop=True, cxx11_abi=CXX11_ABI, rt_only=NO_TS)
+            build_libtorchtrt_pre_cxx11_abi(
+                develop=True, cxx11_abi=CXX11_ABI, rt_only=NO_TS
+            )
             copy_libtorchtrt(rt_only=NO_TS)
 
         gen_version_file()
@@ -310,7 +314,9 @@ class InstallCommand(install):
 
         if not PY_ONLY:
             global CXX11_ABI
-            build_libtorchtrt_pre_cxx11_abi(develop=False, cxx11_abi=CXX11_ABI, rt_only=NO_TS)
+            build_libtorchtrt_pre_cxx11_abi(
+                develop=False, cxx11_abi=CXX11_ABI, rt_only=NO_TS
+            )
             copy_libtorchtrt(rt_only=NO_TS)
 
         gen_version_file()
@@ -331,7 +337,9 @@ class BdistCommand(bdist_wheel):
     def run(self):
         if not PY_ONLY:
             global CXX11_ABI
-            build_libtorchtrt_pre_cxx11_abi(develop=False, cxx11_abi=CXX11_ABI, rt_only=NO_TS)
+            build_libtorchtrt_pre_cxx11_abi(
+                develop=False, cxx11_abi=CXX11_ABI, rt_only=NO_TS
+            )
             copy_libtorchtrt(rt_only=NO_TS)
 
         gen_version_file()
@@ -355,7 +363,9 @@ class EditableWheelCommand(editable_wheel):
             editable_wheel.run(self)
         else:
             global CXX11_ABI
-            build_libtorchtrt_pre_cxx11_abi(develop=True, cxx11_abi=CXX11_ABI, rt_only=NO_TS)
+            build_libtorchtrt_pre_cxx11_abi(
+                develop=True, cxx11_abi=CXX11_ABI, rt_only=NO_TS
+            )
             gen_version_file()
             copy_libtorchtrt(rt_only=NO_TS)
             editable_wheel.run(self)
@@ -574,7 +584,7 @@ if not (PY_ONLY or NO_TS):
         }
     )
 elif NO_TS:
-        package_data.update(
+    package_data.update(
         {
             "torch_tensorrt": [
                 "BUILD",

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 import glob
 import os
 import platform
@@ -283,7 +285,7 @@ class DevelopCommand(develop):
 
     def finalize_options(self):
         develop.finalize_options(self)
-        if NO_TS:
+        if NO_TS or PY_ONLY:
             self.root_is_pure = False
 
     def run(self):
@@ -307,7 +309,7 @@ class InstallCommand(install):
 
     def finalize_options(self):
         install.finalize_options(self)
-        if NO_TS:
+        if NO_TS or PY_ONLY:
             self.root_is_pure = False
 
     def run(self):
@@ -331,7 +333,7 @@ class BdistCommand(bdist_wheel):
 
     def finalize_options(self):
         bdist_wheel.finalize_options(self)
-        if NO_TS:
+        if NO_TS or PY_ONLY:
             self.root_is_pure = False
 
     def run(self):
@@ -354,7 +356,7 @@ class EditableWheelCommand(editable_wheel):
 
     def finalize_options(self):
         editable_wheel.finalize_options(self)
-        if NO_TS:
+        if NO_TS or PY_ONLY:
             self.root_is_pure = False
 
     def run(self):

--- a/tests/py/core/test_classes.py
+++ b/tests/py/core/test_classes.py
@@ -1,11 +1,13 @@
-import unittest
-import torch_tensorrt as torchtrt
-from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import TorchTensorRTModule
-import torch
-import torchvision.models as models
-import tensorrt as trt
 import copy
+import unittest
 from typing import Dict
+
+import torch
+import torch_tensorrt as torchtrt
+import torchvision.models as models
+from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import TorchTensorRTModule
+
+import tensorrt as trt
 
 
 class TestDevice(unittest.TestCase):
@@ -44,7 +46,9 @@ class TestDevice(unittest.TestCase):
 
         device = torchtrt.Device(gpu_id=1, dla_core=0, allow_gpu_fallback=True)
         self.assertEqual(device.device_type, torchtrt.DeviceType.DLA)
-        self.assertEqual(device.gpu_id, 0) # Override since AGX platforms use iGPU to manage DLA
+        self.assertEqual(
+            device.gpu_id, 0
+        )  # Override since AGX platforms use iGPU to manage DLA
         self.assertEqual(device.dla_core, 0)
         self.assertEqual(device.allow_gpu_fallback, True)
 

--- a/tests/py/core/test_classes.py
+++ b/tests/py/core/test_classes.py
@@ -1,0 +1,54 @@
+import unittest
+import torch_tensorrt as torchtrt
+from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import TorchTensorRTModule
+import torch
+import torchvision.models as models
+import tensorrt as trt
+import copy
+from typing import Dict
+
+
+class TestDevice(unittest.TestCase):
+    def test_from_string_constructor(self):
+        device = torchtrt.Device("cuda:0")
+        self.assertEqual(device.device_type, torchtrt.DeviceType.GPU)
+        self.assertEqual(device.gpu_id, 0)
+
+        device = torchtrt.Device("gpu:1")
+        self.assertEqual(device.device_type, torchtrt.DeviceType.GPU)
+        self.assertEqual(device.gpu_id, 1)
+
+    def test_from_string_constructor_dla(self):
+        device = torchtrt.Device("dla:0")
+        self.assertEqual(device.device_type, torchtrt.DeviceType.DLA)
+        self.assertEqual(device.gpu_id, 0)
+        self.assertEqual(device.dla_core, 0)
+
+        device = torchtrt.Device("dla:1", allow_gpu_fallback=True)
+        self.assertEqual(device.device_type, torchtrt.DeviceType.DLA)
+        self.assertEqual(device.gpu_id, 0)
+        self.assertEqual(device.dla_core, 1)
+        self.assertEqual(device.allow_gpu_fallback, True)
+
+    def test_kwargs_gpu(self):
+        device = torchtrt.Device(gpu_id=0)
+        self.assertEqual(device.device_type, torchtrt.DeviceType.GPU)
+        self.assertEqual(device.gpu_id, 0)
+
+    def test_kwargs_dla_and_settings(self):
+        device = torchtrt.Device(dla_core=1, allow_gpu_fallback=False)
+        self.assertEqual(device.device_type, torchtrt.DeviceType.DLA)
+        self.assertEqual(device.gpu_id, 0)
+        self.assertEqual(device.dla_core, 1)
+        self.assertEqual(device.allow_gpu_fallback, False)
+
+        device = torchtrt.Device(gpu_id=1, dla_core=0, allow_gpu_fallback=True)
+        self.assertEqual(device.device_type, torchtrt.DeviceType.DLA)
+        self.assertEqual(device.gpu_id, 0) # Override since AGX platforms use iGPU to manage DLA
+        self.assertEqual(device.dla_core, 0)
+        self.assertEqual(device.allow_gpu_fallback, True)
+
+    def test_from_torch(self):
+        device = torchtrt.Device._from_torch_device(torch.device("cuda:0"))
+        self.assertEqual(device.device_type, torchtrt.DeviceType.GPU)
+        self.assertEqual(device.gpu_id, 0)

--- a/tests/py/dynamo/backend/test_backend_compiler.py
+++ b/tests/py/dynamo/backend/test_backend_compiler.py
@@ -1,10 +1,10 @@
+# type: ignore
 from copy import deepcopy
 
 import torch
+import torch_tensorrt
 from torch.testing._internal.common_utils import TestCase, run_tests
 from torch_tensorrt.dynamo.partitioning import fast_partition
-
-import torch_tensorrt
 
 from ..testing_utilities import DECIMALS_OF_AGREEMENT, lower_graph_testing
 

--- a/tests/py/dynamo/backend/test_specialized_models.py
+++ b/tests/py/dynamo/backend/test_specialized_models.py
@@ -1,3 +1,4 @@
+# type: ignore
 import torch
 import torch_tensorrt
 from torch.testing._internal.common_utils import TestCase, run_tests

--- a/tests/py/dynamo/conversion/harness.py
+++ b/tests/py/dynamo/conversion/harness.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 import logging
 import time
 import unittest

--- a/tests/py/dynamo/conversion/harness.py
+++ b/tests/py/dynamo/conversion/harness.py
@@ -8,6 +8,7 @@ from typing import Callable, List, Optional, Set, Tuple
 import torch
 from torch.testing._internal.common_utils import TestCase
 from torch_tensorrt import Input
+from torch_tensorrt._enums import dtype
 from torch_tensorrt.dynamo._settings import CompilationSettings
 
 # Use interpreter, input spec, and test case from fx_ts_compat to test Dynamo Converter Registry
@@ -219,7 +220,7 @@ class DispatchTestCase(TRTTestCase):
         inputs,
         rtol=1e-03,
         atol=1e-03,
-        precision=torch.float,
+        precision=dtype.f32,
         check_dtype=True,
         output_dtypes=None,
         use_dynamo_tracer=False,
@@ -236,7 +237,7 @@ class DispatchTestCase(TRTTestCase):
         # Previous instance of the interpreter auto-casted 64-bit inputs
         # We replicate this behavior here
         compilation_settings = CompilationSettings(
-            precision=precision, truncate_long_and_double=True
+            enabled_precisions={dtype._from(precision)}, truncate_long_and_double=True
         )
 
         interp = TRTInterpreter(

--- a/tests/py/dynamo/conversion/harness.py
+++ b/tests/py/dynamo/conversion/harness.py
@@ -13,6 +13,7 @@ from torch_tensorrt.dynamo._settings import CompilationSettings
 
 # Use interpreter, input spec, and test case from fx_ts_compat to test Dynamo Converter Registry
 from torch_tensorrt.dynamo.conversion import TRTInterpreter
+from torch_tensorrt.dynamo.conversion._conversion import infer_module_output_dtypes
 from torch_tensorrt.dynamo.lowering import apply_lowering_passes
 from torch_tensorrt.dynamo.runtime import PythonTorchTensorRTModule
 
@@ -71,7 +72,8 @@ class TRTTestCase(TestCase):
                 interpreter_result.output_names,
             )
 
-            ref_outputs = mod(*inputs)
+            mod = mod.cuda()
+            ref_outputs = mod(*cuda_inputs)
 
             torch.cuda.synchronize()
             start_event = torch.cuda.Event(enable_timing=True)
@@ -147,7 +149,7 @@ class TRTTestCase(TestCase):
                 interpreter_result.output_names,
             )
             res_trt = trt_mod(*cuda_inputs).cpu()
-            res_cpu = mod(*inputs)
+            res_cpu = mod(*cuda_inputs).cpu()
             assert len(res_trt) == len(res_cpu)
             assert len(res_cpu) == len(comparators)
             for output_trt, output_cpu, comparator in zip(
@@ -211,7 +213,6 @@ class DispatchTestCase(TRTTestCase):
             fx_module = torch.fx.symbolic_trace(mod)
         if enable_passes:
             fx_module = apply_lowering_passes(fx_module, original_inputs)
-        _LOGGER.info(f"FX graph= {fx_module.graph}")
         return fx_module
 
     def run_test(
@@ -222,7 +223,6 @@ class DispatchTestCase(TRTTestCase):
         atol=1e-03,
         precision=dtype.f32,
         check_dtype=True,
-        output_dtypes=None,
         use_dynamo_tracer=False,
         enable_passes=False,
     ):
@@ -237,12 +237,24 @@ class DispatchTestCase(TRTTestCase):
         # Previous instance of the interpreter auto-casted 64-bit inputs
         # We replicate this behavior here
         compilation_settings = CompilationSettings(
-            enabled_precisions={dtype._from(precision)}, truncate_long_and_double=True
+            enabled_precisions={dtype._from(precision)},
+            truncate_long_and_double=True,
         )
+
+        input_specs = [Input.from_tensor(i) for i in inputs]
+
+        output_dtypes = None
+        if check_dtype:
+            output_dtypes = infer_module_output_dtypes(
+                mod,
+                input_specs,
+                compilation_settings.device,
+                truncate_long_and_double=compilation_settings.truncate_long_and_double,
+            )
 
         interp = TRTInterpreter(
             mod,
-            Input.from_tensors(inputs),
+            input_specs,
             output_dtypes=output_dtypes,
             compilation_settings=compilation_settings,
         )

--- a/tests/py/dynamo/conversion/harness.py
+++ b/tests/py/dynamo/conversion/harness.py
@@ -239,6 +239,7 @@ class DispatchTestCase(TRTTestCase):
         compilation_settings = CompilationSettings(
             enabled_precisions={dtype._from(precision)},
             truncate_long_and_double=True,
+            debug=True,
         )
 
         input_specs = [Input.from_tensor(i) for i in inputs]

--- a/tests/py/dynamo/conversion/test_abs_aten.py
+++ b/tests/py/dynamo/conversion/test_abs_aten.py
@@ -42,7 +42,6 @@ class TestAbsConverter(DispatchTestCase):
         self.run_test(
             abs(),
             inputs,
-            output_dtypes=[torch.int],
         )
 
 

--- a/tests/py/dynamo/conversion/test_any.py
+++ b/tests/py/dynamo/conversion/test_any.py
@@ -26,7 +26,7 @@ class TestAnyConverter(DispatchTestCase):
                 return torch.ops.aten.any.default(x)
 
         inputs = [torch.randn(*input_shape)]
-        self.run_test(Any(), inputs, output_dtypes=[torch.bool])
+        self.run_test(Any(), inputs)
 
     @parameterized.expand(
         [
@@ -43,7 +43,7 @@ class TestAnyConverter(DispatchTestCase):
                 return torch.ops.aten.any.dim(x, dim, keep_dims)
 
         inputs = [torch.randn(*input_shape)]
-        self.run_test(AnyDim(), inputs, output_dtypes=[torch.bool])
+        self.run_test(AnyDim(), inputs)
 
     @parameterized.expand(
         [
@@ -59,7 +59,7 @@ class TestAnyConverter(DispatchTestCase):
                 return torch.ops.aten.any.dims(x, dims, keep_dims)
 
         inputs = [torch.randn(*input_shape)]
-        self.run_test(AnyDims(), inputs, output_dtypes=[torch.bool])
+        self.run_test(AnyDims(), inputs)
 
     @parameterized.expand(
         [
@@ -79,7 +79,6 @@ class TestAnyConverter(DispatchTestCase):
         self.run_test(
             Any(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -100,7 +99,6 @@ class TestAnyConverter(DispatchTestCase):
         self.run_test(
             AnyDim(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -123,7 +121,6 @@ class TestAnyConverter(DispatchTestCase):
         self.run_test(
             AnyDims(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -142,7 +139,6 @@ class TestAnyConverter(DispatchTestCase):
         self.run_test(
             Any(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -163,7 +159,6 @@ class TestAnyConverter(DispatchTestCase):
         self.run_test(
             AnyDim(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -186,7 +181,6 @@ class TestAnyConverter(DispatchTestCase):
         self.run_test(
             AnyDims(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
 

--- a/tests/py/dynamo/conversion/test_bitwise_not_aten.py
+++ b/tests/py/dynamo/conversion/test_bitwise_not_aten.py
@@ -25,7 +25,6 @@ class TestBitwiseNotConverter(DispatchTestCase):
             bitwise_not(),
             inputs,
             enable_passes=True,
-            output_dtypes=[torch.bool],
         )
 
 

--- a/tests/py/dynamo/conversion/test_casts.py
+++ b/tests/py/dynamo/conversion/test_casts.py
@@ -3,6 +3,7 @@
 import torch
 import torch.nn as nn
 from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt import dtype
 from torch_tensorrt.dynamo.conversion import UnsupportedOperatorException
 
 from .harness import DispatchTestCase

--- a/tests/py/dynamo/conversion/test_casts.py
+++ b/tests/py/dynamo/conversion/test_casts.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 import torch
 import torch.nn as nn
 from torch.testing._internal.common_utils import run_tests

--- a/tests/py/dynamo/conversion/test_eq_aten.py
+++ b/tests/py/dynamo/conversion/test_eq_aten.py
@@ -25,7 +25,6 @@ class TestEqualConverter(DispatchTestCase):
         self.run_test(
             eq(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -43,7 +42,6 @@ class TestEqualConverter(DispatchTestCase):
         self.run_test(
             eq(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -61,7 +59,6 @@ class TestEqualConverter(DispatchTestCase):
         self.run_test(
             eq(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
 

--- a/tests/py/dynamo/conversion/test_ge_aten.py
+++ b/tests/py/dynamo/conversion/test_ge_aten.py
@@ -25,7 +25,6 @@ class TestGtConverter(DispatchTestCase):
         self.run_test(
             ge(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -43,7 +42,6 @@ class TestGtConverter(DispatchTestCase):
         self.run_test(
             ge(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -61,7 +59,6 @@ class TestGtConverter(DispatchTestCase):
         self.run_test(
             ge(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
 

--- a/tests/py/dynamo/conversion/test_gt_aten.py
+++ b/tests/py/dynamo/conversion/test_gt_aten.py
@@ -22,7 +22,6 @@ class TestGtConverter(DispatchTestCase):
         self.run_test(
             gt(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -40,7 +39,6 @@ class TestGtConverter(DispatchTestCase):
         self.run_test(
             gt(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -58,7 +56,6 @@ class TestGtConverter(DispatchTestCase):
         self.run_test(
             gt(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
 

--- a/tests/py/dynamo/conversion/test_isinf_aten.py
+++ b/tests/py/dynamo/conversion/test_isinf_aten.py
@@ -35,7 +35,6 @@ class TestIsInfConverter(DispatchTestCase):
         self.run_test(
             isinf(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -54,7 +53,6 @@ class TestIsInfConverter(DispatchTestCase):
         self.run_test(
             isinf(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
 

--- a/tests/py/dynamo/conversion/test_isnan_aten.py
+++ b/tests/py/dynamo/conversion/test_isnan_aten.py
@@ -1,3 +1,4 @@
+# type: ignore
 import torch
 import torch.nn as nn
 from parameterized import parameterized
@@ -36,7 +37,6 @@ class TestIsNanConverter(DispatchTestCase):
         self.run_test(
             isnan(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -55,7 +55,6 @@ class TestIsNanConverter(DispatchTestCase):
         self.run_test(
             isnan(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -74,7 +73,6 @@ class TestIsNanConverter(DispatchTestCase):
         self.run_test(
             isnan(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
 

--- a/tests/py/dynamo/conversion/test_le_aten.py
+++ b/tests/py/dynamo/conversion/test_le_aten.py
@@ -25,7 +25,6 @@ class TestLeConverter(DispatchTestCase):
         self.run_test(
             le(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -43,7 +42,6 @@ class TestLeConverter(DispatchTestCase):
         self.run_test(
             le(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -61,7 +59,6 @@ class TestLeConverter(DispatchTestCase):
         self.run_test(
             le(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
 

--- a/tests/py/dynamo/conversion/test_logical_not_aten.py
+++ b/tests/py/dynamo/conversion/test_logical_not_aten.py
@@ -22,7 +22,6 @@ class TestLogicalNotConverter(DispatchTestCase):
         self.run_test(
             logical_not(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -41,7 +40,6 @@ class TestLogicalNotConverter(DispatchTestCase):
         self.run_test(
             logical_not(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -60,7 +58,6 @@ class TestLogicalNotConverter(DispatchTestCase):
         self.run_test(
             logical_not(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
 

--- a/tests/py/dynamo/conversion/test_lt_aten.py
+++ b/tests/py/dynamo/conversion/test_lt_aten.py
@@ -22,7 +22,6 @@ class TestLtConverter(DispatchTestCase):
         self.run_test(
             lt(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -40,7 +39,6 @@ class TestLtConverter(DispatchTestCase):
         self.run_test(
             lt(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -58,7 +56,6 @@ class TestLtConverter(DispatchTestCase):
         self.run_test(
             lt(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
 

--- a/tests/py/dynamo/conversion/test_ne_aten.py
+++ b/tests/py/dynamo/conversion/test_ne_aten.py
@@ -25,7 +25,6 @@ class TestNotEqualConverter(DispatchTestCase):
         self.run_test(
             ne(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -43,7 +42,6 @@ class TestNotEqualConverter(DispatchTestCase):
         self.run_test(
             ne(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
     @parameterized.expand(
@@ -61,7 +59,6 @@ class TestNotEqualConverter(DispatchTestCase):
         self.run_test(
             ne(),
             inputs,
-            output_dtypes=[torch.bool],
         )
 
 

--- a/tests/py/dynamo/conversion/test_pad_aten.py
+++ b/tests/py/dynamo/conversion/test_pad_aten.py
@@ -1,3 +1,4 @@
+# type: ignore
 import torch
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests

--- a/tests/py/dynamo/conversion/test_scalar_tensor_aten.py
+++ b/tests/py/dynamo/conversion/test_scalar_tensor_aten.py
@@ -87,7 +87,6 @@ class TestScalarTensorConverter(DispatchTestCase):
         self.run_test(
             ScalarTensor(),
             inputs,
-            output_dtypes=None if dtype is None else [dtype],
         )
 
 

--- a/tests/py/dynamo/conversion/test_sum_aten.py
+++ b/tests/py/dynamo/conversion/test_sum_aten.py
@@ -85,7 +85,6 @@ class TestSumConverter(DispatchTestCase):
         self.run_test(
             Sum(),
             inputs,
-            output_dtypes=[torch.int32],
         )
 
     @parameterized.expand(
@@ -108,7 +107,6 @@ class TestSumConverter(DispatchTestCase):
         self.run_test(
             Sum(),
             inputs,
-            output_dtypes=[torch.int32],
         )
 
 

--- a/tests/py/dynamo/lowering/test_aten_lowering_passes.py
+++ b/tests/py/dynamo/lowering/test_aten_lowering_passes.py
@@ -1,3 +1,5 @@
+import unittest
+
 import torch
 from torch.testing._internal.common_utils import TestCase, run_tests
 
@@ -267,7 +269,10 @@ class TestLowerEfficientAttention(TestCase):
         )
         torch._dynamo.reset()
 
-
+@unittest.skipIf(
+    torch.cuda.get_device_properties(torch.cuda.current_device()).major < 8,
+    "GPU compute capability is too low to run flash attention, need Ampere (8.0) or greater"
+)
 class TestLowerFlashAttention(TestCase):
     def test_lower_flash_attention(self):
         class FlashAttention(torch.nn.Module):

--- a/tests/py/dynamo/lowering/test_aten_lowering_passes.py
+++ b/tests/py/dynamo/lowering/test_aten_lowering_passes.py
@@ -1,9 +1,8 @@
 import unittest
 
 import torch
-from torch.testing._internal.common_utils import TestCase, run_tests
-
 import torch_tensorrt
+from torch.testing._internal.common_utils import TestCase, run_tests
 
 from ..testing_utilities import DECIMALS_OF_AGREEMENT, lower_graph_testing
 
@@ -269,9 +268,10 @@ class TestLowerEfficientAttention(TestCase):
         )
         torch._dynamo.reset()
 
+
 @unittest.skipIf(
     torch.cuda.get_device_properties(torch.cuda.current_device()).major < 8,
-    "GPU compute capability is too low to run flash attention, need Ampere (8.0) or greater"
+    "GPU compute capability is too low to run flash attention, need Ampere (8.0) or greater",
 )
 class TestLowerFlashAttention(TestCase):
     def test_lower_flash_attention(self):

--- a/tests/py/dynamo/models/test_models_export.py
+++ b/tests/py/dynamo/models/test_models_export.py
@@ -1,3 +1,4 @@
+# type: ignore
 import unittest
 
 import pytest

--- a/tests/py/dynamo/runtime/test_hw_compat.py
+++ b/tests/py/dynamo/runtime/test_hw_compat.py
@@ -7,6 +7,14 @@ from torch.testing._internal.common_utils import TestCase, run_tests
 
 
 class TestHardwareCompatibility(TestCase):
+    @unittest.skipIf(
+        not torch_tensorrt.ENABLED_FEATURES.torch_tensorrt_runtime,
+        "Torch-TensorRT Runtime is not available"
+    )
+    @unittest.skipIf(
+        not torch.cuda.get_device_properties(torch.cuda.current_device()).major >= 8,
+        "HW Compatibility is not supported on cards older than Ampere"
+    )
     def test_hw_compat_enabled(self):
         class SampleModel(torch.nn.Module):
             def forward(self, x):
@@ -57,6 +65,14 @@ class TestHardwareCompatibility(TestCase):
     @unittest.skipIf(
         torch.ops.tensorrt.ABI_VERSION() != "5",
         "Detected incorrect ABI version, please update this test case",
+    )
+    @unittest.skipIf(
+        not torch_tensorrt.ENABLED_FEATURES.torch_tensorrt_runtime,
+        "Torch-TensorRT runtime is not available"
+    )
+    @unittest.skipIf(
+        not torch.cuda.get_device_properties(torch.cuda.current_device()).major >= 8,
+        "HW Compatibility is not supported on cards older than Ampere"
     )
     def test_hw_compat_3080_build(self):
         inputs = [torch.randn(5, 7).cuda()]

--- a/tests/py/dynamo/runtime/test_hw_compat.py
+++ b/tests/py/dynamo/runtime/test_hw_compat.py
@@ -9,11 +9,11 @@ from torch.testing._internal.common_utils import TestCase, run_tests
 class TestHardwareCompatibility(TestCase):
     @unittest.skipIf(
         not torch_tensorrt.ENABLED_FEATURES.torch_tensorrt_runtime,
-        "Torch-TensorRT Runtime is not available"
+        "Torch-TensorRT Runtime is not available",
     )
     @unittest.skipIf(
         not torch.cuda.get_device_properties(torch.cuda.current_device()).major >= 8,
-        "HW Compatibility is not supported on cards older than Ampere"
+        "HW Compatibility is not supported on cards older than Ampere",
     )
     def test_hw_compat_enabled(self):
         class SampleModel(torch.nn.Module):
@@ -68,11 +68,11 @@ class TestHardwareCompatibility(TestCase):
     )
     @unittest.skipIf(
         not torch_tensorrt.ENABLED_FEATURES.torch_tensorrt_runtime,
-        "Torch-TensorRT runtime is not available"
+        "Torch-TensorRT runtime is not available",
     )
     @unittest.skipIf(
         not torch.cuda.get_device_properties(torch.cuda.current_device()).major >= 8,
-        "HW Compatibility is not supported on cards older than Ampere"
+        "HW Compatibility is not supported on cards older than Ampere",
     )
     def test_hw_compat_3080_build(self):
         inputs = [torch.randn(5, 7).cuda()]

--- a/tests/py/dynamo/runtime/test_safe_mode.py
+++ b/tests/py/dynamo/runtime/test_safe_mode.py
@@ -1,15 +1,15 @@
 import unittest
-import torch
-from torch.testing._internal.common_utils import TestCase, run_tests
 
+import torch
 import torch_tensorrt
+from torch.testing._internal.common_utils import TestCase, run_tests
 
 from ..testing_utilities import DECIMALS_OF_AGREEMENT
 
 
 @unittest.skipIf(
     not torch_tensorrt.ENABLED_FEATURES.torch_tensorrt_runtime,
-    "Torch-TensorRT runtime is not available"
+    "Torch-TensorRT runtime is not available",
 )
 class TestSafeMode(TestCase):
     def test_multi_device_safe_mode_on(self):

--- a/tests/py/dynamo/runtime/test_safe_mode.py
+++ b/tests/py/dynamo/runtime/test_safe_mode.py
@@ -1,3 +1,4 @@
+import unittest
 import torch
 from torch.testing._internal.common_utils import TestCase, run_tests
 
@@ -6,6 +7,10 @@ import torch_tensorrt
 from ..testing_utilities import DECIMALS_OF_AGREEMENT
 
 
+@unittest.skipIf(
+    not torch_tensorrt.ENABLED_FEATURES.torch_tensorrt_runtime,
+    "Torch-TensorRT runtime is not available"
+)
 class TestSafeMode(TestCase):
     def test_multi_device_safe_mode_on(self):
         torch_tensorrt.runtime.set_multi_device_safe_mode(True)

--- a/tests/py/ts/api/test_classes.py
+++ b/tests/py/ts/api/test_classes.py
@@ -1,16 +1,16 @@
-import unittest
-import torch_tensorrt as torchtrt
-from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import TorchTensorRTModule
-import torch
-import torchvision.models as models
 import copy
+import unittest
 from typing import Dict
 
+import torch
+import torch_tensorrt as torchtrt
+import torchvision.models as models
+from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import TorchTensorRTModule
 
 
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestInput(unittest.TestCase):
     def _verify_correctness(self, struct: torchtrt.Input, target: Dict) -> bool:
@@ -39,10 +39,16 @@ class TestInput(unittest.TestCase):
             target["explicit_set_dtype"],
         )
         dtype_ = field_is_correct(
-            "dtype", eq, torchtrt.dtype._from(internal.dtype), torchtrt.dtype._from(target["dtype"])
+            "dtype",
+            eq,
+            torchtrt.dtype._from(internal.dtype),
+            torchtrt.dtype._from(target["dtype"]),
         )
         format_ = field_is_correct(
-            "format", eq, torchtrt.memory_format._from(internal.format), torchtrt.memory_format._from(target["format"])
+            "format",
+            eq,
+            torchtrt.memory_format._from(internal.format),
+            torchtrt.memory_format._from(target["format"]),
         )
 
         return all(
@@ -219,9 +225,10 @@ class TestInput(unittest.TestCase):
         )
         self.assertTrue(self._verify_correctness(ts_i, target))
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestTorchTensorRTModule(unittest.TestCase):
     @staticmethod

--- a/tests/py/ts/api/test_collections.py
+++ b/tests/py/ts/api/test_collections.py
@@ -20,7 +20,10 @@ def find_repo_root(max_depth=10):
 
 MODULE_DIR = find_repo_root() + "/tests/modules"
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestStandardTensorInput(unittest.TestCase):
     def test_compile(self):
         self.input = torch.randn((1, 3, 224, 224)).to("cuda")
@@ -48,7 +51,10 @@ class TestStandardTensorInput(unittest.TestCase):
             msg=f"standard_tensor_input_scripted TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
         )
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestStandardTensorInputLong(unittest.TestCase):
     def test_compile(self):
         self.input = torch.randn((1, 3, 224, 224)).to("cuda")
@@ -77,7 +83,10 @@ class TestStandardTensorInputLong(unittest.TestCase):
             msg=f"standard_tensor_input_long_scripted TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
         )
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestStandardTensorInputDomain(unittest.TestCase):
     def test_compile(self):
         self.input = torch.randn((1, 3, 224, 224)).to("cuda")
@@ -105,7 +114,10 @@ class TestStandardTensorInputDomain(unittest.TestCase):
             msg=f"standard_tensor_input_scripted with tensor domain specified TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
         )
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestTupleInput(unittest.TestCase):
     def test_compile(self):
         self.input = torch.randn((1, 3, 224, 224)).to("cuda")
@@ -133,7 +145,10 @@ class TestTupleInput(unittest.TestCase):
             msg=f"tuple_input_scripted TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
         )
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestListInput(unittest.TestCase):
     def test_compile(self):
         self.input = torch.randn((1, 3, 224, 224)).to("cuda")
@@ -159,7 +174,10 @@ class TestListInput(unittest.TestCase):
             msg=f"list_input_scripted TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
         )
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestTupleInputOutput(unittest.TestCase):
     def test_compile(self):
         self.input = torch.randn((1, 3, 224, 224)).to("cuda")
@@ -216,7 +234,10 @@ class TestTupleInputOutput(unittest.TestCase):
                 msg=f"tuple_input_output_scripted TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
             )
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestListInputOutput(unittest.TestCase):
     def test_compile(self):
         self.input = torch.randn((1, 3, 224, 224)).to("cuda")
@@ -275,7 +296,10 @@ class TestListInputOutput(unittest.TestCase):
                 msg=f"list_input_output_scripted TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
             )
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestListInputTupleOutput(unittest.TestCase):
     def test_compile(self):
         self.input = torch.randn((1, 3, 224, 224)).to("cuda")

--- a/tests/py/ts/api/test_collections.py
+++ b/tests/py/ts/api/test_collections.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 import os
 import unittest
 
@@ -58,9 +60,10 @@ class TestStandardTensorInput(unittest.TestCase):
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
     "TorchScript Frontend is not available",
 )
+@unittest.skip("TODO: @bowang007, Invalid test case, needs fixing")
 class TestStandardTensorInputLong(unittest.TestCase):
     def test_compile(self):
-        self.input = torch.randn((1, 3, 224, 224)).to("cuda")
+        self.input = torch.randn((1, 3, 224, 224)).to("cuda").to(torch.int32)
         self.model = (
             torch.jit.load(MODULE_DIR + "/standard_tensor_input_scripted.jit.pt")
             .eval()
@@ -75,6 +78,7 @@ class TestStandardTensorInputLong(unittest.TestCase):
             "device": torchtrt.Device("gpu:0"),
             "enabled_precisions": {torch.float},
             "truncate_long_and_double": True,
+            "require_full_compilation": True,
         }
 
         trt_mod = torchtrt.ts.compile(self.model, **compile_spec)

--- a/tests/py/ts/api/test_collections.py
+++ b/tests/py/ts/api/test_collections.py
@@ -1,9 +1,10 @@
-import unittest
-import torch_tensorrt as torchtrt
-import torch
-import torchvision.models as models
 import os
-from utils import cosine_similarity, COSINE_THRESHOLD
+import unittest
+
+import torch
+import torch_tensorrt as torchtrt
+import torchvision.models as models
+from utils import COSINE_THRESHOLD, cosine_similarity
 
 
 def find_repo_root(max_depth=10):
@@ -20,9 +21,10 @@ def find_repo_root(max_depth=10):
 
 MODULE_DIR = find_repo_root() + "/tests/modules"
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestStandardTensorInput(unittest.TestCase):
     def test_compile(self):
@@ -51,9 +53,10 @@ class TestStandardTensorInput(unittest.TestCase):
             msg=f"standard_tensor_input_scripted TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
         )
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestStandardTensorInputLong(unittest.TestCase):
     def test_compile(self):
@@ -83,9 +86,10 @@ class TestStandardTensorInputLong(unittest.TestCase):
             msg=f"standard_tensor_input_long_scripted TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
         )
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestStandardTensorInputDomain(unittest.TestCase):
     def test_compile(self):
@@ -114,9 +118,10 @@ class TestStandardTensorInputDomain(unittest.TestCase):
             msg=f"standard_tensor_input_scripted with tensor domain specified TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
         )
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestTupleInput(unittest.TestCase):
     def test_compile(self):
@@ -145,9 +150,10 @@ class TestTupleInput(unittest.TestCase):
             msg=f"tuple_input_scripted TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
         )
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestListInput(unittest.TestCase):
     def test_compile(self):
@@ -174,9 +180,10 @@ class TestListInput(unittest.TestCase):
             msg=f"list_input_scripted TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
         )
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestTupleInputOutput(unittest.TestCase):
     def test_compile(self):
@@ -234,9 +241,10 @@ class TestTupleInputOutput(unittest.TestCase):
                 msg=f"tuple_input_output_scripted TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
             )
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestListInputOutput(unittest.TestCase):
     def test_compile(self):
@@ -296,9 +304,10 @@ class TestListInputOutput(unittest.TestCase):
                 msg=f"list_input_output_scripted TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
             )
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestListInputTupleOutput(unittest.TestCase):
     def test_compile(self):

--- a/tests/py/ts/api/test_e2e_behavior.py
+++ b/tests/py/ts/api/test_e2e_behavior.py
@@ -39,7 +39,7 @@ class TestInputTypeDefaultsFP32Model(unittest.TestCase):
 
         ts_model = torch.jit.script(self.model)
         input_spec = torchtrt.Input(self.input.shape)
-        input_spec.dtype = torch.half
+        input_spec.dtype = torchtrt.dtype.half
 
         trt_mod = torchtrt.ts.compile(
             ts_model,
@@ -100,7 +100,7 @@ class TestInputTypeDefaultsFP16Model(unittest.TestCase):
         half_mod.half()
 
         input_spec = torchtrt.Input(self.input.shape)
-        input_spec.dtype = torch.float
+        input_spec.dtype = torchtrt.dtype.float
 
         trt_mod = torchtrt.ts.compile(
             half_mod,

--- a/tests/py/ts/api/test_e2e_behavior.py
+++ b/tests/py/ts/api/test_e2e_behavior.py
@@ -1,9 +1,10 @@
-import unittest
-import torch_tensorrt as torchtrt
-import torch
-import torchvision.models as models
 import copy
+import unittest
 from typing import Dict
+
+import torch
+import torch_tensorrt as torchtrt
+import torchvision.models as models
 from utils import same_output_format
 
 

--- a/tests/py/ts/api/test_logging.py
+++ b/tests/py/ts/api/test_logging.py
@@ -1,14 +1,15 @@
-import unittest
-import torch_tensorrt as torchtrt
-import torch
-import torchvision.models as models
 import copy
+import unittest
 from typing import Dict
+
+import torch
+import torch_tensorrt as torchtrt
+import torchvision.models as models
 
 
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestLoggingAPIs(unittest.TestCase):
     def test_logging_prefix(self):

--- a/tests/py/ts/api/test_logging.py
+++ b/tests/py/ts/api/test_logging.py
@@ -6,66 +6,70 @@ import copy
 from typing import Dict
 
 
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestLoggingAPIs(unittest.TestCase):
     def test_logging_prefix(self):
         new_prefix = "Python API Test: "
-        torchtrt.logging.set_logging_prefix(new_prefix)
-        logging_prefix = torchtrt.logging.get_logging_prefix()
+        torchtrt.ts.logging.set_logging_prefix(new_prefix)
+        logging_prefix = torchtrt.ts.logging.get_logging_prefix()
         self.assertEqual(new_prefix, logging_prefix)
 
     def test_reportable_log_level(self):
-        new_level = torchtrt.logging.Level.Error
-        torchtrt.logging.set_reportable_log_level(new_level)
-        level = torchtrt.logging.get_reportable_log_level()
+        new_level = torchtrt.ts.logging.Level.Error
+        torchtrt.ts.logging.set_reportable_log_level(new_level)
+        level = torchtrt.ts.logging.get_reportable_log_level()
         self.assertEqual(new_level, level)
 
     def test_is_colored_output_on(self):
-        torchtrt.logging.set_is_colored_output_on(True)
-        color = torchtrt.logging.get_is_colored_output_on()
+        torchtrt.ts.logging.set_is_colored_output_on(True)
+        color = torchtrt.ts.logging.get_is_colored_output_on()
         self.assertTrue(color)
 
     def test_context_managers(self):
-        base_lvl = torchtrt.logging.get_reportable_log_level()
+        base_lvl = torchtrt.ts.logging.get_reportable_log_level()
         with torchtrt.logging.internal_errors():
-            lvl = torchtrt.logging.get_reportable_log_level()
-            self.assertEqual(torchtrt.logging.Level.InternalError, lvl)
+            lvl = torchtrt.ts.logging.get_reportable_log_level()
+            self.assertEqual(torchtrt.ts.logging.Level.InternalError, lvl)
 
-        lvl = torchtrt.logging.get_reportable_log_level()
+        lvl = torchtrt.ts.logging.get_reportable_log_level()
         self.assertEqual(base_lvl, lvl)
 
         with torchtrt.logging.errors():
-            lvl = torchtrt.logging.get_reportable_log_level()
-            self.assertEqual(torchtrt.logging.Level.Error, lvl)
+            lvl = torchtrt.ts.logging.get_reportable_log_level()
+            self.assertEqual(torchtrt.ts.logging.Level.Error, lvl)
 
-        lvl = torchtrt.logging.get_reportable_log_level()
+        lvl = torchtrt.ts.logging.get_reportable_log_level()
         self.assertEqual(base_lvl, lvl)
 
         with torchtrt.logging.warnings():
-            lvl = torchtrt.logging.get_reportable_log_level()
-            self.assertEqual(torchtrt.logging.Level.Warning, lvl)
+            lvl = torchtrt.ts.logging.get_reportable_log_level()
+            self.assertEqual(torchtrt.ts.logging.Level.Warning, lvl)
 
-        lvl = torchtrt.logging.get_reportable_log_level()
+        lvl = torchtrt.ts.logging.get_reportable_log_level()
         self.assertEqual(base_lvl, lvl)
 
         with torchtrt.logging.info():
-            lvl = torchtrt.logging.get_reportable_log_level()
-            self.assertEqual(torchtrt.logging.Level.Info, lvl)
+            lvl = torchtrt.ts.logging.get_reportable_log_level()
+            self.assertEqual(torchtrt.ts.logging.Level.Info, lvl)
 
-        lvl = torchtrt.logging.get_reportable_log_level()
+        lvl = torchtrt.ts.logging.get_reportable_log_level()
         self.assertEqual(base_lvl, lvl)
 
         with torchtrt.logging.debug():
-            lvl = torchtrt.logging.get_reportable_log_level()
-            self.assertEqual(torchtrt.logging.Level.Debug, lvl)
+            lvl = torchtrt.ts.logging.get_reportable_log_level()
+            self.assertEqual(torchtrt.ts.logging.Level.Debug, lvl)
 
-        lvl = torchtrt.logging.get_reportable_log_level()
+        lvl = torchtrt.ts.logging.get_reportable_log_level()
         self.assertEqual(base_lvl, lvl)
 
         with torchtrt.logging.graphs():
-            lvl = torchtrt.logging.get_reportable_log_level()
-            self.assertEqual(torchtrt.logging.Level.Graph, lvl)
+            lvl = torchtrt.ts.logging.get_reportable_log_level()
+            self.assertEqual(torchtrt.ts.logging.Level.Graph, lvl)
 
-        lvl = torchtrt.logging.get_reportable_log_level()
+        lvl = torchtrt.ts.logging.get_reportable_log_level()
         self.assertEqual(base_lvl, lvl)
 
 

--- a/tests/py/ts/hw/test_api_dla.py
+++ b/tests/py/ts/hw/test_api_dla.py
@@ -5,6 +5,10 @@ import torchvision.models as models
 from utils import cosine_similarity, COSINE_THRESHOLD
 
 
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class ModelTestCaseOnDLA(unittest.TestCase):
     def __init__(self, methodName="runTest", model=None):
         super(ModelTestCaseOnDLA, self).__init__(methodName)
@@ -20,7 +24,10 @@ class ModelTestCaseOnDLA(unittest.TestCase):
             suite.addTest(testcase_class(name, model=model))
         return suite
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestCompile(ModelTestCaseOnDLA):
     def setUp(self):
         self.input = torch.randn((1, 3, 224, 224)).to("cuda").half()

--- a/tests/py/ts/hw/test_api_dla.py
+++ b/tests/py/ts/hw/test_api_dla.py
@@ -1,13 +1,14 @@
 import unittest
-import torch_tensorrt as torchtrt
+
 import torch
+import torch_tensorrt as torchtrt
 import torchvision.models as models
-from utils import cosine_similarity, COSINE_THRESHOLD
+from utils import COSINE_THRESHOLD, cosine_similarity
 
 
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class ModelTestCaseOnDLA(unittest.TestCase):
     def __init__(self, methodName="runTest", model=None):
@@ -24,9 +25,10 @@ class ModelTestCaseOnDLA(unittest.TestCase):
             suite.addTest(testcase_class(name, model=model))
         return suite
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestCompile(ModelTestCaseOnDLA):
     def setUp(self):

--- a/tests/py/ts/hw/test_multi_gpu.py
+++ b/tests/py/ts/hw/test_multi_gpu.py
@@ -1,13 +1,14 @@
 import unittest
-import torch_tensorrt as torchtrt
-import torch
-import torchvision.models as models
 
+import torch
+import torch_tensorrt as torchtrt
+import torchvision.models as models
 from model_test_case import ModelTestCase
+
 
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestMultiGpuSwitching(ModelTestCase):
     def setUp(self):
@@ -67,9 +68,10 @@ class TestMultiGpuSwitching(ModelTestCase):
             msg=f"TestMultiGpuSwitching scripted TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
         )
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestMultiGpuSerializeDeserializeSwitching(ModelTestCase):
     def setUp(self):

--- a/tests/py/ts/hw/test_multi_gpu.py
+++ b/tests/py/ts/hw/test_multi_gpu.py
@@ -5,7 +5,10 @@ import torchvision.models as models
 
 from model_test_case import ModelTestCase
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestMultiGpuSwitching(ModelTestCase):
     def setUp(self):
         if torch.cuda.device_count() < 2:
@@ -64,7 +67,10 @@ class TestMultiGpuSwitching(ModelTestCase):
             msg=f"TestMultiGpuSwitching scripted TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
         )
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestMultiGpuSerializeDeserializeSwitching(ModelTestCase):
     def setUp(self):
         if torch.cuda.device_count() < 2:

--- a/tests/py/ts/integrations/test_to_backend_api.py
+++ b/tests/py/ts/integrations/test_to_backend_api.py
@@ -1,13 +1,14 @@
 import unittest
-import torch_tensorrt as torchtrt
+
 import torch
+import torch_tensorrt as torchtrt
 import torchvision.models as models
-from utils import cosine_similarity, COSINE_THRESHOLD
+from utils import COSINE_THRESHOLD, cosine_similarity
 
 
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestToBackendLowering(unittest.TestCase):
     def setUp(self):

--- a/tests/py/ts/integrations/test_to_backend_api.py
+++ b/tests/py/ts/integrations/test_to_backend_api.py
@@ -5,6 +5,10 @@ import torchvision.models as models
 from utils import cosine_similarity, COSINE_THRESHOLD
 
 
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestToBackendLowering(unittest.TestCase):
     def setUp(self):
         self.input = torch.randn((1, 3, 300, 300)).to("cuda")
@@ -23,7 +27,7 @@ class TestToBackendLowering(unittest.TestCase):
                         "dla_core": 0,
                         "allow_gpu_fallback": True,
                     },
-                    "capability": torchtrt.EngineCapability.default,
+                    "capability": torchtrt.ts.EngineCapability.default,
                     "num_avg_timing_iters": 1,
                     "disable_tf32": False,
                 }

--- a/tests/py/ts/integrations/test_to_backend_api.py
+++ b/tests/py/ts/integrations/test_to_backend_api.py
@@ -29,7 +29,9 @@ class TestToBackendLowering(unittest.TestCase):
                         "dla_core": 0,
                         "allow_gpu_fallback": True,
                     },
-                    "capability": torchtrt.ts.EngineCapability.DEFAULT,
+                    "capability": torchtrt.EngineCapability.STANDARD.to(
+                        torchtrt._C.EngineCapability
+                    ),
                     "num_avg_timing_iters": 1,
                     "disable_tf32": False,
                 }

--- a/tests/py/ts/integrations/test_to_backend_api.py
+++ b/tests/py/ts/integrations/test_to_backend_api.py
@@ -1,3 +1,4 @@
+# type: ignore
 import unittest
 
 import torch
@@ -28,7 +29,7 @@ class TestToBackendLowering(unittest.TestCase):
                         "dla_core": 0,
                         "allow_gpu_fallback": True,
                     },
-                    "capability": torchtrt.ts.EngineCapability.default,
+                    "capability": torchtrt.ts.EngineCapability.DEFAULT,
                     "num_avg_timing_iters": 1,
                     "disable_tf32": False,
                 }

--- a/tests/py/ts/integrations/test_trt_intercompatibility.py
+++ b/tests/py/ts/integrations/test_trt_intercompatibility.py
@@ -5,7 +5,10 @@ import torchvision.models as models
 import tensorrt as trt
 from utils import cosine_similarity, COSINE_THRESHOLD
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestPyTorchToTRTEngine(unittest.TestCase):
     def test_pt_to_trt(self):
         self.model = models.resnet18(pretrained=True).eval().to("cuda:0")

--- a/tests/py/ts/integrations/test_trt_intercompatibility.py
+++ b/tests/py/ts/integrations/test_trt_intercompatibility.py
@@ -1,13 +1,16 @@
 import unittest
-import torch_tensorrt as torchtrt
+
 import torch
+import torch_tensorrt as torchtrt
 import torchvision.models as models
+from utils import COSINE_THRESHOLD, cosine_similarity
+
 import tensorrt as trt
-from utils import cosine_similarity, COSINE_THRESHOLD
+
 
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestPyTorchToTRTEngine(unittest.TestCase):
     def test_pt_to_trt(self):

--- a/tests/py/ts/models/test_models.py
+++ b/tests/py/ts/models/test_models.py
@@ -9,9 +9,10 @@ import torch_tensorrt as torchtrt
 import torchvision.models as models
 from utils import COSINE_THRESHOLD, cosine_similarity
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestModels(unittest.TestCase):
     def test_resnet18(self):

--- a/tests/py/ts/models/test_models.py
+++ b/tests/py/ts/models/test_models.py
@@ -9,7 +9,10 @@ import torch_tensorrt as torchtrt
 import torchvision.models as models
 from utils import COSINE_THRESHOLD, cosine_similarity
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestModels(unittest.TestCase):
     def test_resnet18(self):
         self.model = models.resnet18(pretrained=True).eval().to("cuda")

--- a/tests/py/ts/models/test_multiple_registered_engines.py
+++ b/tests/py/ts/models/test_multiple_registered_engines.py
@@ -8,7 +8,10 @@ import custom_models as cm
 from typing import Dict
 from utils import cosine_similarity, COSINE_THRESHOLD
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestModelToEngineToModel(unittest.TestCase):
     def test_multiple_engines(self):
         self.resnet18 = models.resnet18(pretrained=True).eval().to("cuda")

--- a/tests/py/ts/models/test_multiple_registered_engines.py
+++ b/tests/py/ts/models/test_multiple_registered_engines.py
@@ -1,16 +1,18 @@
-import unittest
-import torch_tensorrt as torchtrt
-import torch
-import torchvision.models as models
 import copy
-import timm
-import custom_models as cm
+import unittest
 from typing import Dict
-from utils import cosine_similarity, COSINE_THRESHOLD
+
+import custom_models as cm
+import timm
+import torch
+import torch_tensorrt as torchtrt
+import torchvision.models as models
+from utils import COSINE_THRESHOLD, cosine_similarity
+
 
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestModelToEngineToModel(unittest.TestCase):
     def test_multiple_engines(self):

--- a/tests/py/ts/ptq/test_ptq_dataloader_calibrator.py
+++ b/tests/py/ts/ptq/test_ptq_dataloader_calibrator.py
@@ -1,6 +1,6 @@
 import unittest
 import torch_tensorrt as torchtrt
-from torch_tensorrt.logging import *
+from torch_tensorrt.ts.logging import *
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
@@ -48,7 +48,10 @@ def compute_accuracy(testing_dataloader, model):
     test_preds = torch.cat(class_preds)
     return correct / total
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestAccuracy(unittest.TestCase):
     def test_compile_script(self):
         self.model = (

--- a/tests/py/ts/ptq/test_ptq_dataloader_calibrator.py
+++ b/tests/py/ts/ptq/test_ptq_dataloader_calibrator.py
@@ -1,13 +1,13 @@
+import os
 import unittest
-import torch_tensorrt as torchtrt
-from torch_tensorrt.ts.logging import *
+
 import torch
 import torch.nn as nn
-from torch.nn import functional as F
+import torch_tensorrt as torchtrt
 import torchvision
 import torchvision.transforms as transforms
-
-import os
+from torch.nn import functional as F
+from torch_tensorrt.ts.logging import *
 
 
 def find_repo_root(max_depth=10):
@@ -48,9 +48,10 @@ def compute_accuracy(testing_dataloader, model):
     test_preds = torch.cat(class_preds)
     return correct / total
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestAccuracy(unittest.TestCase):
     def test_compile_script(self):

--- a/tests/py/ts/ptq/test_ptq_to_backend.py
+++ b/tests/py/ts/ptq/test_ptq_to_backend.py
@@ -1,12 +1,13 @@
+import os
 import unittest
-import torch_tensorrt as torchtrt
-from torch_tensorrt.ts.logging import *
+
 import torch
 import torch.nn as nn
-from torch.nn import functional as F
+import torch_tensorrt as torchtrt
 import torchvision
 import torchvision.transforms as transforms
-import os
+from torch.nn import functional as F
+from torch_tensorrt.ts.logging import *
 
 
 def find_repo_root(max_depth=10):
@@ -47,9 +48,10 @@ def compute_accuracy(testing_dataloader, model):
     test_preds = torch.cat(class_preds)
     return correct / total
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestAccuracy(unittest.TestCase):
     def test_compile_script(self):

--- a/tests/py/ts/ptq/test_ptq_to_backend.py
+++ b/tests/py/ts/ptq/test_ptq_to_backend.py
@@ -1,6 +1,6 @@
 import unittest
 import torch_tensorrt as torchtrt
-from torch_tensorrt.logging import *
+from torch_tensorrt.ts.logging import *
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
@@ -47,7 +47,10 @@ def compute_accuracy(testing_dataloader, model):
     test_preds = torch.cat(class_preds)
     return correct / total
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestAccuracy(unittest.TestCase):
     def test_compile_script(self):
         self.model = (

--- a/tests/py/ts/ptq/test_ptq_trt_calibrator.py
+++ b/tests/py/ts/ptq/test_ptq_trt_calibrator.py
@@ -1,13 +1,15 @@
-import unittest
 import os
-import torch_tensorrt as torchtrt
-from torch_tensorrt.ts.logging import *
+import unittest
+
 import torch
-import tensorrt as trt
 import torch.nn as nn
-from torch.nn import functional as F
+import torch_tensorrt as torchtrt
 import torchvision
 import torchvision.transforms as transforms
+from torch.nn import functional as F
+from torch_tensorrt.ts.logging import *
+
+import tensorrt as trt
 
 
 def find_repo_root(max_depth=10):
@@ -48,9 +50,10 @@ def compute_accuracy(testing_dataloader, model):
     test_preds = torch.cat(class_preds)
     return correct / total
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TRTEntropyCalibrator(trt.IInt8EntropyCalibrator2):
     def __init__(self, dataloader, **kwargs):
@@ -96,9 +99,10 @@ class TRTEntropyCalibrator(trt.IInt8EntropyCalibrator2):
             with open(self.cache_file, "wb") as f:
                 f.write(cache)
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestAccuracy(unittest.TestCase):
     def test_compile_script(self):

--- a/tests/py/ts/ptq/test_ptq_trt_calibrator.py
+++ b/tests/py/ts/ptq/test_ptq_trt_calibrator.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import torch_tensorrt as torchtrt
-from torch_tensorrt.logging import *
+from torch_tensorrt.ts.logging import *
 import torch
 import tensorrt as trt
 import torch.nn as nn
@@ -48,7 +48,10 @@ def compute_accuracy(testing_dataloader, model):
     test_preds = torch.cat(class_preds)
     return correct / total
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TRTEntropyCalibrator(trt.IInt8EntropyCalibrator2):
     def __init__(self, dataloader, **kwargs):
         trt.IInt8EntropyCalibrator2.__init__(self)
@@ -93,7 +96,10 @@ class TRTEntropyCalibrator(trt.IInt8EntropyCalibrator2):
             with open(self.cache_file, "wb") as f:
                 f.write(cache)
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestAccuracy(unittest.TestCase):
     def test_compile_script(self):
         self.model = (

--- a/tests/py/ts/qat/test_qat_trt_accuracy.py
+++ b/tests/py/ts/qat/test_qat_trt_accuracy.py
@@ -1,6 +1,6 @@
 import unittest
 import torch_tensorrt as torchtrt
-from torch_tensorrt.logging import *
+from torch_tensorrt.ts.logging import *
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
@@ -50,7 +50,10 @@ def compute_accuracy(testing_dataloader, model):
     test_preds = torch.cat(class_preds)
     return correct / total
 
-
+@unittest.skipIf(
+    not torchtrt.ENABLED_FEATURES.torchscript_frontend,
+    "TorchScript Frontend is not available"
+)
 class TestAccuracy(unittest.TestCase):
     def test_compile_script(self):
         self.model = (

--- a/tests/py/ts/qat/test_qat_trt_accuracy.py
+++ b/tests/py/ts/qat/test_qat_trt_accuracy.py
@@ -1,13 +1,14 @@
-import unittest
-import torch_tensorrt as torchtrt
-from torch_tensorrt.ts.logging import *
-import torch
-import torch.nn as nn
-from torch.nn import functional as F
-import torchvision
-import torchvision.transforms as transforms
 import os
 import sys
+import unittest
+
+import torch
+import torch.nn as nn
+import torch_tensorrt as torchtrt
+import torchvision
+import torchvision.transforms as transforms
+from torch.nn import functional as F
+from torch_tensorrt.ts.logging import *
 
 
 def find_repo_root(max_depth=10):
@@ -50,9 +51,10 @@ def compute_accuracy(testing_dataloader, model):
     test_preds = torch.cat(class_preds)
     return correct / total
 
+
 @unittest.skipIf(
     not torchtrt.ENABLED_FEATURES.torchscript_frontend,
-    "TorchScript Frontend is not available"
+    "TorchScript Frontend is not available",
 )
 class TestAccuracy(unittest.TestCase):
     def test_compile_script(self):

--- a/toolchains/legacy/pyproject.toml
+++ b/toolchains/legacy/pyproject.toml
@@ -64,7 +64,7 @@ include-package-data = false
 
 [tool.ruff]
 # NOTE: Synchoronize the ignores with .flake8
-ignore = [
+lint.ignore = [
     # these ignores are from flake8-bugbear; please fix!
     "B007", "B008", "B017",
     "B018", # Useless expression
@@ -97,7 +97,7 @@ ignore = [
     "SIM118",
 ]
 #line-length = 120
-select = [
+lint.select = [
     "B",
     "C4",
     "G",
@@ -112,11 +112,11 @@ select = [
 ]
 
 # Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 target-version = "py311"
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = [
+lint.fixable = [
     "A","B","C","D","E","F","G",
     "I","N","Q","S","T","W",
     "ANN", "ARG", "BLE", "COM", "DJ",
@@ -125,10 +125,10 @@ fixable = [
     "PGH", "PIE", "PL", "PT", "PTH",
     "PYI", "RET", "RSE", "RUF", "SIM",
     "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
-unfixable = []
+lint.unfixable = []
 
 # Exclude a variety of commonly ignored directories.
-exclude = [
+lint.exclude = [
     ".bzr",
     ".direnv",
     ".eggs",
@@ -164,7 +164,7 @@ exclude = [
     "__init__.py"
 ]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10
 

--- a/versions.py
+++ b/versions.py
@@ -1,11 +1,10 @@
-import yaml
-import re
 import os
+import re
 import subprocess
-
 from datetime import datetime
 from pathlib import Path
-from typing import List
+
+import yaml
 
 __version__ = "0.0.0"
 __cuda_version__ = "0.0"


### PR DESCRIPTION
# Description

Allows users to configure which frontends/features they want to include in the `torch-tensorrt` builds.

Features can be enabled as so: 
```py
NO_TORCHSCRIPT=1 pip install -e . ... # Includes the C++ runtime but no Torchscript frontend
PYTHON_ONLY=1 pip install -e . ... # No C++ dependencies at all, a pure python package 
```

A builds feature set can be accessed via the following struct 

```py
import torch_tensorrt

torch_tensorrt.ENABLED_FEATURES
```

where `ENABLED_FEATURES` is a `namedtuple` `FeatureSet`: 
```py
namedtuple('FeatureSet', [
    "torchscript_frontend",
    "torch_tensorrt_runtime",
    "dynamo_frontend",
    "fx_frontend"
])
```


In order to support optional features, a number of core types have been abstracted: 

- `torch_tensorrt.Device` has no direct dependencies on the torchscript core and can be translated to `torch_tensorrt.ts.Device` to access those features
- Similarly `torch_tensorrt.Input` behaves the same way
- enums for `dtype`,`DeviceType`, `memory_format` have been defined and can translate from `numpy`, `tensorrt`, `torch` and `torch_tensorrt._C` (assuming `torch_tensorrt.ENABLED_FEATURES.torchscript_frontend` is `True`)

Translating between different library enums now can take the form
```py
import torch
import tensorrt as trt
import torch_tensorrt

# Convert, throw error if no conversion exists
trt_dtype = torch_tensorrt.dtype._from(torch.float16).to(trt.DataType) # returns trt.DataType.HALF

#Try to convert, do not throw an error if there is no conversion, just return None
trt_dtype = torch_tensorrt.dtype.try_from(torch.float16).to(trt.DataType) # returns trt.DataType.HALF

# Alternatively, use a fallback type
trt_dtype = torch_tensorrt.dtype.unknown.to(trt.DataType, use_default=True) #returns trt.DataType.FLOAT
```

Fixes #1943
Fixes #2379 
 

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
