### PR TITLE
fix: param bug in `test_binary_ops_aten`

### DIFF
--- a/tests/py/dynamo/conversion/test_binary_ops_aten.py
+++ b/tests/py/dynamo/conversion/test_binary_ops_aten.py
@@ -116,7 +116,7 @@ class TestBinaryOpConverters(DispatchTestCase):
         inputs = [torch.randn(2, 2)]
         self.run_test(m, inputs)
 
-    @parameterized.expand([((lambda x, y: torch.ops.aten.div.Tensor(x, y)))])
+    @parameterized.expand([(lambda x, y: torch.ops.aten.div.Tensor(x, y),)])
     def test_elementwise_op_div_with_two_ints(self, orig_op: Callable):
         class TestModule(nn.Module):
             def __init__(self, orig_op):
@@ -130,7 +130,7 @@ class TestBinaryOpConverters(DispatchTestCase):
         inputs = [torch.randint(1, 10, (5,), dtype=torch.int32)]
         self.run_test(m, inputs)
 
-    @parameterized.expand([(lambda x, y: torch.ops.aten.div.Tensor(x, y))])
+    @parameterized.expand([(lambda x, y: torch.ops.aten.div.Tensor(x, y),)])
     def test_elementwise_op_div_with_one_int_one_constant(self, orig_op: Callable):
         class TestModule(nn.Module):
             def __init__(self, orig_op):


### PR DESCRIPTION
# Description

Fixed a param bug in `test_binary_ops_aten`. The param is required to be a tuple instead of a single value.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
