### PR TITLE
feat: support aten._local_scalar_dense converter

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -1714,6 +1714,23 @@ def aten_ops_isnan(
     )
 
 
+@dynamo_tensorrt_converter(torch.ops.aten._local_scalar_dense.default)
+def aten_ops_local_scalar_dense(
+    ctx: ConversionContext,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    return impl.unary.local_scalar_dense(
+        ctx,
+        target,
+        SourceIR.ATEN,
+        name,
+        args[0],
+    )
+
+
 @dynamo_tensorrt_converter(operator.add, supports_dynamic_shapes=True)
 @dynamo_tensorrt_converter(torch.ops.aten.add.Tensor, supports_dynamic_shapes=True)
 @dynamo_tensorrt_converter(torch.ops.aten.add.Scalar, supports_dynamic_shapes=True)

--- a/tests/py/dynamo/conversion/test_local_scalar_dense_aten.py
+++ b/tests/py/dynamo/conversion/test_local_scalar_dense_aten.py
@@ -8,24 +8,12 @@ from torch.testing._internal.common_utils import run_tests
 class TestLocalScalarDenseConverter(DispatchTestCase):
     @parameterized.expand(
         [
-            (
-                torch.randn((5, 10, 5), dtype=torch.float32),
-            ),
-            (
-                torch.randint(-10, 10, (5, 1, 15), dtype=torch.int32),
-            ),
-            (
-                torch.randn((1), dtype=torch.float32),
-            ),
-            (
-                (torch.tensor([-2.4])),
-            ),
-            (
-                (torch.tensor([5.5, 3.5, 3.6])),
-            ),
-            (
-                (torch.tensor([True])),
-            ),
+            (torch.randn((5, 10, 5), dtype=torch.float32),),
+            (torch.randint(-10, 10, (5, 1, 15), dtype=torch.int32),),
+            (torch.randn((1), dtype=torch.float32),),
+            ((torch.tensor([-2.4])),),
+            ((torch.tensor([5.5, 3.5, 3.6])),),
+            ((torch.tensor([True])),),
             (
                 torch.tensor(
                     [
@@ -44,9 +32,7 @@ class TestLocalScalarDenseConverter(DispatchTestCase):
                     ]
                 ),
             ),
-            (
-                (torch.tensor([float("inf")])),
-            ),
+            ((torch.tensor([float("inf")])),),
         ]
     )
     def test_local_scalar_dense(self, data):

--- a/tests/py/dynamo/conversion/test_local_scalar_dense_aten.py
+++ b/tests/py/dynamo/conversion/test_local_scalar_dense_aten.py
@@ -1,0 +1,65 @@
+import torch
+import torch.nn as nn
+from harness import DispatchTestCase
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+
+
+class TestLocalScalarDenseConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            (
+                torch.randn((5, 10, 5), dtype=torch.float32),
+            ),
+            (
+                torch.randint(-10, 10, (5, 1, 15), dtype=torch.int32),
+            ),
+            (
+                torch.randn((1), dtype=torch.float32),
+            ),
+            (
+                (torch.tensor([-2.4])),
+            ),
+            (
+                (torch.tensor([5.5, 3.5, 3.6])),
+            ),
+            (
+                (torch.tensor([True])),
+            ),
+            (
+                torch.tensor(
+                    [
+                        float("nan"),
+                        1.23,
+                        float("inf"),
+                    ]
+                ),
+            ),
+            (
+                torch.tensor(
+                    [
+                        float("-inf"),
+                        1.23,
+                        float("nan"),
+                    ]
+                ),
+            ),
+            (
+                (torch.tensor([float("inf")])),
+            ),
+        ]
+    )
+    def test_local_scalar_dense(self, data):
+        class local_scalar_dense(nn.Module):
+            def forward(self, input):
+                return torch.ops.aten._local_scalar_dense.default(input)
+
+        inputs = [data]
+        self.run_test(
+            local_scalar_dense(),
+            inputs,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/py/dynamo/conversion/test_local_scalar_dense_aten.py
+++ b/tests/py/dynamo/conversion/test_local_scalar_dense_aten.py
@@ -1,8 +1,9 @@
 import torch
 import torch.nn as nn
-from harness import DispatchTestCase
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
+
+from .harness import DispatchTestCase
 
 
 class TestLocalScalarDenseConverter(DispatchTestCase):


### PR DESCRIPTION
# Description

A converter for the torch.ops.aten._local_scalar_dense operation, a low-level operation in PyTorch used internally to extract a scalar value from a tensor containing a single element.

To reviewer, I did not incorporate type-specific considerations in the implementation of the converter and test code. However, all test cases have successfully passed. I would greatly appreciate any feedback or suggestions regarding this aspect—especially if there are potential implications or improvements I might have overlooked. 

![image](https://github.com/pytorch/TensorRT/assets/25674295/01e32f3e-93c7-4bd6-964a-6f66bf4bdd8d)


Fixes # ([issue](https://github.com/pytorch/TensorRT/issues/2743))

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
