### PR TITLE
feat: add a pre-AOT lowering pass to remove detach ops

### DIFF
--- a/py/torch_tensorrt/dynamo/backend/backends.py
+++ b/py/torch_tensorrt/dynamo/backend/backends.py
@@ -13,6 +13,7 @@ from torch_tensorrt.dynamo._compiler import compile_module
 from torch_tensorrt.dynamo.lowering import (
     apply_lowering_passes,
     get_decompositions,
+    remove_detach,
     repair_input_aliasing,
 )
 from torch_tensorrt.dynamo.utils import (
@@ -74,6 +75,7 @@ def _pretraced_backend(
             fake_mode, "allow_non_fake_inputs", True
         ), fake_mode:
             repair_input_aliasing(gm)
+            remove_detach(gm)
 
             # Invoke AOTAutograd to translate operators to aten
             gm = aot_export_joint_simple(

--- a/py/torch_tensorrt/dynamo/lowering/__init__.py
+++ b/py/torch_tensorrt/dynamo/lowering/__init__.py
@@ -4,5 +4,6 @@ from ._decomposition_groups import (
 )
 from ._decompositions import get_decompositions  # noqa: F401
 from ._fusers import *  # noqa: F401
+from ._remove_detach import remove_detach
 from ._repair_input_aliasing import repair_input_aliasing
 from .passes import apply_lowering_passes

--- a/py/torch_tensorrt/dynamo/lowering/_remove_detach.py
+++ b/py/torch_tensorrt/dynamo/lowering/_remove_detach.py
@@ -1,0 +1,32 @@
+import logging
+
+import torch
+from torch_tensorrt.dynamo.lowering.passes.pass_utils import (
+    clean_up_graph_after_modifications,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def remove_detach(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    """
+    Remove detach ops from the graph
+    """
+    modified_graph = False
+
+    for node in gm.graph.nodes:
+        # If the node is a detach node
+        if len(node.users) == 1 and list(node.users)[0].target == "detach":
+            modified_graph = True
+            detach_node = list(node.users)[0]
+            logger.debug(
+                f"Removing node {detach_node} from the graph. It is a detach node with a single user."
+            )
+            detach_node.replace_all_uses_with(node)
+            gm.graph.erase_node(detach_node)
+
+    if modified_graph:
+        gm = clean_up_graph_after_modifications(gm)
+        logger.debug(f"Removed detach nodes:\n{gm.graph}")
+
+    return gm


### PR DESCRIPTION
# Description

Added a pre-AOT lowering pass to remove `detach` ops

Fixes #2657 

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
