### PR TITLE
fix: Version parsing issue on TRT 10

### DIFF
--- a/py/torch_tensorrt/_enums.py
+++ b/py/torch_tensorrt/_enums.py
@@ -5,10 +5,11 @@ from enum import Enum, auto
 from typing import Any, Optional, Type, Union
 
 import numpy as np
+import tensorrt as trt
 import torch
 from torch_tensorrt._features import ENABLED_FEATURES
 
-import tensorrt as trt
+from packaging import version
 
 
 class dtype(Enum):
@@ -108,7 +109,9 @@ class dtype(Enum):
                 return dtype.f16
             elif t == trt.float32:
                 return dtype.f32
-            elif trt.__version__ >= "7.0" and t == trt.bool:
+            elif (
+                version.parse(trt.__version__) >= version.parse("7.0") and t == trt.bool
+            ):
                 return dtype.b
             else:
                 raise TypeError(

--- a/py/torch_tensorrt/fx/utils.py
+++ b/py/torch_tensorrt/fx/utils.py
@@ -1,18 +1,21 @@
 from enum import Enum
-from typing import Dict, List, Optional, Callable, Union
+from typing import Callable, Dict, List, Optional, Union
+
 import numpy as np
-from packaging import version
 
 # @manual=//deeplearning/trt/python:py_tensorrt
 import tensorrt as trt
 import torch
 from functorch import make_fx
 from functorch.experimental import functionalize
+from torch_tensorrt._utils import sanitized_torch_version
 from torch_tensorrt.fx.passes.lower_basic_pass import (
     replace_op_with_indices,
     run_const_fold,
 )
-from torch_tensorrt._utils import sanitized_torch_version
+
+from packaging import version
+
 from .types import Shape, TRTDataType
 
 
@@ -47,7 +50,7 @@ DataTypeEquivalence: Dict[
     },
 }
 
-if trt.__version__ >= "7.0":
+if version.parse(trt.__version__) >= version.parse("7.0"):
     DataTypeEquivalence[trt.bool] = {
         Frameworks.NUMPY: np.bool_,
         Frameworks.TORCH: torch.bool,


### PR DESCRIPTION
# Description

- In TRT 10, the version string registers as less than `"7.0"`, causing an error for certain test cases

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ - ] I have added tests to verify my fix or my feature
  - Fix to existing test failures
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
