### PR TITLE
fix: a bug in func run_test_compare_tensor_attributes_only

### DIFF
--- a/tests/py/dynamo/conversion/harness.py
+++ b/tests/py/dynamo/conversion/harness.py
@@ -289,7 +289,7 @@ class DispatchTestCase(TRTTestCase):
         # We replicate this behavior here
         compilation_settings = CompilationSettings(
             enabled_precisions={dtype._from(precision)},
-            truncate_long_and_double=True,
+            truncate_double=True,
             debug=True,
         )
 


### PR DESCRIPTION
# Description

Fix a bug in func `run_test_compare_tensor_attributes_only`

Fixes #2808 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
