### PR TITLE
ci: Add release flag for nightly build tag

### DIFF
--- a/packaging/pre_build_script_windows.sh
+++ b/packaging/pre_build_script_windows.sh
@@ -8,3 +8,5 @@ python -m pip install tensorrt==${TRT_VERSION} tensorrt-${CU_VERSION::4}==${TRT_
 choco install bazelisk -y
 
 cat toolchains/ci_workspaces/WORKSPACE.win.release.tmpl | envsubst > WORKSPACE
+
+echo "RELEASE=1" >> ${GITHUB_ENV}


### PR DESCRIPTION
# Description

- As is added in #2806 for C++ builds, enable `--release` flag for builds in `main` to enable correct nightly versioning on PyTorch index

## Type of change

- Address CI Issue

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
