### PR TITLE
[doc] Update options documentation for torch.compile

### DIFF
--- a/docsrc/dynamo/torch_compile.rst
+++ b/docsrc/dynamo/torch_compile.rst
@@ -32,13 +32,14 @@ Customizeable Settings
 
 Custom Setting Usage
 ^^^^^^^^^^^^^^^^^
+
 .. code-block:: python
 
     import torch_tensorrt
     ...
     optimized_model = torch.compile(model, backend="torch_tensorrt", dynamic=False,
                                     options={"truncate_long_and_double": True,
-                                             "enabled_precisions": [torch.half],
+                                             "enabled_precisions": {torch.float, torch.half},
                                              "debug": True,
                                              "min_block_size": 2,
                                              "torch_executed_ops": {"torch.ops.aten.sub.Tensor"},

--- a/docsrc/dynamo/torch_compile.rst
+++ b/docsrc/dynamo/torch_compile.rst
@@ -38,7 +38,7 @@ Custom Setting Usage
     ...
     optimized_model = torch.compile(model, backend="torch_tensorrt", dynamic=False,
                                     options={"truncate_long_and_double": True,
-                                             "precision": torch.half,
+                                             "enabled_precisions": [torch.half],
                                              "debug": True,
                                              "min_block_size": 2,
                                              "torch_executed_ops": {"torch.ops.aten.sub.Tensor"},


### PR DESCRIPTION
# Description

TensorRT backend for torch.compile documentation, In the snippet it sets the precision using options={"precision": torch.half} which isn’t documented and dosen’t seem to have effect and it should be replaced by options={"enabled_precisions": [torch.half]}

Fixes # (issue)

## Type of change

- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
