### PR TITLE
feat: support aten.resize_ converter

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -2695,6 +2695,30 @@ def aten_ops_pixel_unshuffle(
     )
 
 
+@dynamo_tensorrt_converter(torch.ops.aten.resize.default)
+@dynamo_tensorrt_converter(torch.ops.aten.resize_.default)
+@enforce_tensor_types(
+    {
+        0: (TRTTensor,),
+    }
+)
+def aten_ops_resize(
+    ctx: ConversionContext,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    return impl.shuffle.resize_(
+        ctx,
+        target,
+        SourceIR.ATEN,
+        name,
+        input=args[0],
+        sizes=args[1],
+    )
+
+
 @enforce_tensor_types({0: (TRTTensor,)})
 @dynamo_tensorrt_converter(torch.ops.aten.argmax.default)
 def aten_ops_argmax(

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -2695,7 +2695,6 @@ def aten_ops_pixel_unshuffle(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.resize.default)
 @dynamo_tensorrt_converter(torch.ops.aten.resize_.default)
 @enforce_tensor_types(
     {
@@ -2709,7 +2708,7 @@ def aten_ops_resize(
     kwargs: Dict[str, Argument],
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
-    return impl.shuffle.resize_(
+    return impl.shuffle.resize(
         ctx,
         target,
         SourceIR.ATEN,

--- a/py/torch_tensorrt/dynamo/conversion/impl/shuffle.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/shuffle.py
@@ -11,12 +11,9 @@ from torch_tensorrt.dynamo.conversion.converter_utils import (
     cast_trt_tensor,
     flatten_dims,
     get_trt_tensor,
-)
-from torch_tensorrt.fx.converters.converter_utils import (
-    Frameworks,
     set_layer_name,
-    unified_dtype_converter,
 )
+from torch_tensorrt.dynamo.utils import Frameworks, unified_dtype_converter
 from torch_tensorrt.fx.types import TRTTensor
 
 

--- a/py/torch_tensorrt/dynamo/utils.py
+++ b/py/torch_tensorrt/dynamo/utils.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import logging
 from dataclasses import fields, replace
+from enum import Enum
 from typing import Any, Callable, Dict, Optional, Sequence, Union
 
+import numpy as np
+import tensorrt as trt
 import torch
 from torch_tensorrt._Device import Device
 from torch_tensorrt._enums import dtype
@@ -13,10 +16,61 @@ from torch_tensorrt.dynamo._settings import CompilationSettings
 
 from packaging import version
 
+from .types import TRTDataType
+
 logger = logging.getLogger(__name__)
 
 COSINE_THRESHOLD = 0.99
 DYNAMIC_DIM = -1
+
+
+class Frameworks(Enum):
+    NUMPY = "numpy"
+    TORCH = "torch"
+    TRT = "trt"
+
+
+DataTypeEquivalence: Dict[
+    TRTDataType, Dict[Frameworks, Union[TRTDataType, np.dtype, torch.dtype]]
+] = {
+    trt.int8: {
+        Frameworks.NUMPY: np.int8,
+        Frameworks.TORCH: torch.int8,
+        Frameworks.TRT: trt.int8,
+    },
+    trt.int32: {
+        Frameworks.NUMPY: np.int32,
+        Frameworks.TORCH: torch.int32,
+        Frameworks.TRT: trt.int32,
+    },
+    trt.int64: {
+        Frameworks.NUMPY: np.int64,
+        Frameworks.TORCH: torch.int64,
+        Frameworks.TRT: trt.int64,
+    },
+    trt.float16: {
+        Frameworks.NUMPY: np.float16,
+        Frameworks.TORCH: torch.float16,
+        Frameworks.TRT: trt.float16,
+    },
+    trt.float32: {
+        Frameworks.NUMPY: np.float32,
+        Frameworks.TORCH: torch.float32,
+        Frameworks.TRT: trt.float32,
+    },
+    trt.bool: {
+        Frameworks.NUMPY: bool,
+        Frameworks.TORCH: torch.bool,
+        Frameworks.TRT: trt.bool,
+    },
+}
+
+if trt.__version__ >= "7.0":
+    DataTypeEquivalence[trt.bool] = {
+        Frameworks.NUMPY: np.bool_,
+        Frameworks.TORCH: torch.bool,
+        Frameworks.TRT: trt.bool,
+    }
 
 
 def use_python_runtime_parser(use_python_runtime: Optional[bool] = None) -> bool:
@@ -317,3 +371,34 @@ def req_torch_version(min_torch_version: str = "2.dev") -> Callable[..., Any]:
         return function_wrapper
 
     return nested_decorator
+
+
+def unified_dtype_converter(
+    dtype: Union[TRTDataType, torch.dtype, np.dtype], to: Frameworks
+) -> Union[np.dtype, torch.dtype, TRTDataType]:
+    """
+    Convert TensorRT, Numpy, or Torch data types to any other of those data types.
+
+    Args:
+        dtype (TRTDataType, torch.dtype, np.dtype): A TensorRT, Numpy, or Torch data type.
+        to (Frameworks): The framework to convert the data type to.
+
+    Returns:
+        The equivalent data type in the requested framework.
+    """
+    assert to in Frameworks, f"Expected valid Framework for translation, got {to}"
+    trt_major_version = int(trt.__version__.split(".")[0])
+    if dtype in (np.int8, torch.int8, trt.int8):
+        return DataTypeEquivalence[trt.int8][to]
+    elif trt_major_version >= 7 and dtype in (np.bool_, torch.bool, trt.bool):
+        return DataTypeEquivalence[trt.bool][to]
+    elif dtype in (np.int32, torch.int32, trt.int32):
+        return DataTypeEquivalence[trt.int32][to]
+    elif dtype in (np.int64, torch.int64, trt.int64):
+        return DataTypeEquivalence[trt.int64][to]
+    elif dtype in (np.float16, torch.float16, trt.float16):
+        return DataTypeEquivalence[trt.float16][to]
+    elif dtype in (np.float32, torch.float32, trt.float32):
+        return DataTypeEquivalence[trt.float32][to]
+    else:
+        raise TypeError("%s is not a supported dtype" % dtype)

--- a/tests/py/dynamo/conversion/harness.py
+++ b/tests/py/dynamo/conversion/harness.py
@@ -157,12 +157,20 @@ class TRTTestCase(TestCase):
             res_trt = trt_mod(*cuda_inputs).cpu()
             res_cpu = mod(*cuda_inputs).cpu()
             assert len(res_trt) == len(res_cpu)
-            for output_trt, output_cpu, comparator in zip(
-                res_trt, res_cpu, comparators
-            ):
-                comp_func = comparator[0]
-                args = comparator[1]
-                self.assertTrue(comp_func(output_trt, output_cpu, *args))
+            comparator = comparators
+
+            if len(cuda_inputs) == 1:
+                for comparator in comparators:
+                    comp_func = comparator[0]
+                    args = comparator[1]
+                    self.assertTrue(comp_func(res_trt, res_cpu, *args))
+            else:
+                for output_trt, output_cpu, comparator in zip(
+                    res_trt, res_cpu, comparators
+                ):
+                    comp_func = comparator[0]
+                    args = comparator[1]
+                    self.assertTrue(comp_func(output_trt, output_cpu, *args))
 
     def run_test_with_error(self, mod, inputs, interpreter, expect_error):
         with self.assertRaises(expect_error):

--- a/tests/py/dynamo/conversion/test_resize_aten.py
+++ b/tests/py/dynamo/conversion/test_resize_aten.py
@@ -11,11 +11,13 @@ class TestResizeConverter(DispatchTestCase):
             ((3,),),
             ((5,),),
             ((10,),),
+            ((2, 2),),
             ((3, 5),),
             ((8, 3),),
             ((7, 7),),
             ((5, 5, 5),),
-            ((3, 3, 5),),
+            ((3, 3, 10),),
+            ((10, 15, 10),),
         ]
     )
     def test_resize_1d_input_float(self, target_shape):
@@ -23,10 +25,33 @@ class TestResizeConverter(DispatchTestCase):
             def forward(self, x):
                 return torch.ops.aten.resize_.default(x, target_shape)
 
-        inputs = [torch.randn(5)]
-        self.run_test(
+        input_shape = (5,)
+        inputs = [torch.randn(input_shape)]
+
+        def compare_resized_tensors(tensor1, tensor2, input_shape, target_shape):
+            # Check if the sizes match
+            if tensor1.size() != tensor2.size():
+                return False
+
+            # Flatten the tensors to ensure we are comparing the valid elements
+            flat_tensor1 = tensor1.flatten()
+            flat_tensor2 = tensor2.flatten()
+
+            # Calculate the number of valid elements to compare
+            input_numel = torch.Size(input_shape).numel()
+            target_numel = torch.Size(target_shape).numel()
+            min_size = min(input_numel, target_numel)
+
+            # Compare only the valid elements
+            return torch.equal(flat_tensor1[:min_size], flat_tensor2[:min_size])
+
+        comparators = [(compare_resized_tensors, [input_shape, target_shape])]
+
+        self.run_test_compare_tensor_attributes_only(
             Resize(),
             inputs,
+            expected_ops=[],
+            comparators=comparators,
         )
 
     @parameterized.expand(
@@ -39,6 +64,8 @@ class TestResizeConverter(DispatchTestCase):
             ((7, 7),),
             ((5, 5, 5),),
             ((3, 3, 5),),
+            ((15, 10, 3),),
+            ((15, 10, 12),),
         ]
     )
     def test_resize_1d_input_int(self, target_shape):
@@ -46,10 +73,33 @@ class TestResizeConverter(DispatchTestCase):
             def forward(self, x):
                 return torch.ops.aten.resize_.default(x, target_shape)
 
-        inputs = [torch.randint(1, 5, (5,))]
-        self.run_test(
+        input_shape = (5,)
+        inputs = [torch.randint(1, 5, input_shape)]
+
+        def compare_resized_tensors(tensor1, tensor2, input_shape, target_shape):
+            # Check if the sizes match
+            if tensor1.size() != tensor2.size():
+                return False
+
+            # Flatten the tensors to ensure we are comparing the valid elements
+            flat_tensor1 = tensor1.flatten()
+            flat_tensor2 = tensor2.flatten()
+
+            # Calculate the number of valid elements to compare
+            input_numel = torch.Size(input_shape).numel()
+            target_numel = torch.Size(target_shape).numel()
+            min_size = min(input_numel, target_numel)
+
+            # Compare only the valid elements
+            return torch.equal(flat_tensor1[:min_size], flat_tensor2[:min_size])
+
+        comparators = [(compare_resized_tensors, [input_shape, target_shape])]
+
+        self.run_test_compare_tensor_attributes_only(
             Resize(),
             inputs,
+            expected_ops=[],
+            comparators=comparators,
         )
 
     @parameterized.expand(
@@ -61,8 +111,9 @@ class TestResizeConverter(DispatchTestCase):
             ((3, 5),),
             ((8, 3),),
             ((7, 7),),
-            ((5, 5, 5),),
+            ((20, 12, 13),),
             ((3, 3, 5),),
+            ((3, 10, 15),),
         ]
     )
     def test_resize_2d_input_float(self, target_shape):
@@ -70,23 +121,46 @@ class TestResizeConverter(DispatchTestCase):
             def forward(self, x):
                 return torch.ops.aten.resize_.default(x, target_shape)
 
-        inputs = [torch.randn(4, 4)]
-        self.run_test(
+        input_shape = (4, 4)
+        inputs = [torch.randint(1, 10, input_shape)]
+
+        def compare_resized_tensors(tensor1, tensor2, input_shape, target_shape):
+            # Check if the sizes match
+            if tensor1.size() != tensor2.size():
+                return False
+
+            # Flatten the tensors to ensure we are comparing the valid elements
+            flat_tensor1 = tensor1.flatten()
+            flat_tensor2 = tensor2.flatten()
+
+            # Calculate the number of valid elements to compare
+            input_numel = torch.Size(input_shape).numel()
+            target_numel = torch.Size(target_shape).numel()
+            min_size = min(input_numel, target_numel)
+
+            # Compare only the valid elements
+            return torch.equal(flat_tensor1[:min_size], flat_tensor2[:min_size])
+
+        comparators = [(compare_resized_tensors, [input_shape, target_shape])]
+
+        self.run_test_compare_tensor_attributes_only(
             Resize(),
             inputs,
+            expected_ops=[],
+            comparators=comparators,
         )
 
     @parameterized.expand(
         [
             ((3,),),
             ((5,),),
-            ((10,),),
+            ((20,),),
             ((4, 4),),
-            ((3, 5),),
-            ((8, 3),),
-            ((7, 7),),
-            ((5, 5, 5),),
-            ((3, 3, 5),),
+            ((3, 12),),
+            ((12, 3),),
+            ((15, 15),),
+            ((20, 20, 20),),
+            ((3, 3, 10),),
         ]
     )
     def test_resize_2d_input_int(self, target_shape):
@@ -94,10 +168,33 @@ class TestResizeConverter(DispatchTestCase):
             def forward(self, x):
                 return torch.ops.aten.resize_.default(x, target_shape)
 
-        inputs = [torch.randint(1, 10, (4, 4))]
-        self.run_test(
+        input_shape = (4, 4)
+        inputs = [torch.randint(1, 10, input_shape)]
+
+        def compare_resized_tensors(tensor1, tensor2, input_shape, target_shape):
+            # Check if the sizes match
+            if tensor1.size() != tensor2.size():
+                return False
+
+            # Flatten the tensors to ensure we are comparing the valid elements
+            flat_tensor1 = tensor1.flatten()
+            flat_tensor2 = tensor2.flatten()
+
+            # Calculate the number of valid elements to compare
+            input_numel = torch.Size(input_shape).numel()
+            target_numel = torch.Size(target_shape).numel()
+            min_size = min(input_numel, target_numel)
+
+            # Compare only the valid elements
+            return torch.equal(flat_tensor1[:min_size], flat_tensor2[:min_size])
+
+        comparators = [(compare_resized_tensors, [input_shape, target_shape])]
+
+        self.run_test_compare_tensor_attributes_only(
             Resize(),
             inputs,
+            expected_ops=[],
+            comparators=comparators,
         )
 
 

--- a/tests/py/dynamo/conversion/test_resize_aten.py
+++ b/tests/py/dynamo/conversion/test_resize_aten.py
@@ -1,0 +1,117 @@
+import torch
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+
+from .harness import DispatchTestCase
+
+
+class TestResizeConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            ((3,),),
+            ((5,),),
+            ((10,),),
+            ((3, 5),),
+            ((8, 3),),
+            ((7, 7),),
+            ((5, 5, 5),),
+            ((3, 3, 5),),
+        ]
+    )
+    def test_resize_1d_input_float(self, target_shape):
+        class Resize(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.ops.aten.resize_.default(x, target_shape)
+
+        inputs = [torch.randn(5)]
+        self.run_test(
+            Resize(),
+            inputs,
+        )
+
+    @parameterized.expand(
+        [
+            ((3,),),
+            ((5,),),
+            ((10,),),
+            ((3, 5),),
+            ((8, 3),),
+            ((7, 7),),
+            ((5, 5, 5),),
+            ((3, 3, 5),),
+        ]
+    )
+    def test_resize_1d_input_int(self, target_shape):
+        class Resize(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.ops.aten.resize_.default(x, target_shape)
+
+        inputs = [torch.randint(1, 5, (5,))]
+        self.run_test(
+            Resize(),
+            inputs,
+        )
+
+    @parameterized.expand(
+        [
+            ((3,),),
+            ((5,),),
+            ((10,),),
+            ((4, 4),),
+            ((3, 5),),
+            ((8, 3),),
+            ((7, 7),),
+            ((5, 5, 5),),
+            ((3, 3, 5),),
+        ]
+    )
+    def test_resize_2d_input_float(self, target_shape):
+        class Resize(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.ops.aten.resize_.default(x, target_shape)
+
+        inputs = [torch.randn(4, 4)]
+        self.run_test(
+            Resize(),
+            inputs,
+        )
+
+    @parameterized.expand(
+        [
+            ((3,),),
+            ((5,),),
+            ((10,),),
+            ((4, 4),),
+            ((3, 5),),
+            ((8, 3),),
+            ((7, 7),),
+            ((5, 5, 5),),
+            ((3, 3, 5),),
+        ]
+    )
+    def test_resize_2d_input_int(self, target_shape):
+        class Resize(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.ops.aten.resize_.default(x, target_shape)
+
+        inputs = [torch.randint(1, 10, (4, 4))]
+        self.run_test(
+            Resize(),
+            inputs,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/py/dynamo/conversion/test_resize_aten.py
+++ b/tests/py/dynamo/conversion/test_resize_aten.py
@@ -20,9 +20,6 @@ class TestResizeConverter(DispatchTestCase):
     )
     def test_resize_1d_input_float(self, target_shape):
         class Resize(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-
             def forward(self, x):
                 return torch.ops.aten.resize_.default(x, target_shape)
 
@@ -46,9 +43,6 @@ class TestResizeConverter(DispatchTestCase):
     )
     def test_resize_1d_input_int(self, target_shape):
         class Resize(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-
             def forward(self, x):
                 return torch.ops.aten.resize_.default(x, target_shape)
 
@@ -73,9 +67,6 @@ class TestResizeConverter(DispatchTestCase):
     )
     def test_resize_2d_input_float(self, target_shape):
         class Resize(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-
             def forward(self, x):
                 return torch.ops.aten.resize_.default(x, target_shape)
 
@@ -100,9 +91,6 @@ class TestResizeConverter(DispatchTestCase):
     )
     def test_resize_2d_input_int(self, target_shape):
         class Resize(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-
             def forward(self, x):
                 return torch.ops.aten.resize_.default(x, target_shape)
 

--- a/tests/py/dynamo/conversion/test_resize_aten.py
+++ b/tests/py/dynamo/conversion/test_resize_aten.py
@@ -6,6 +6,24 @@ from .harness import DispatchTestCase
 
 
 class TestResizeConverter(DispatchTestCase):
+
+    def compare_resized_tensors(self, tensor1, tensor2, input_shape, target_shape):
+        # Check if the sizes match
+        if tensor1.size() != tensor2.size():
+            return False
+
+        # Flatten the tensors to ensure we are comparing the valid elements
+        flat_tensor1 = tensor1.flatten()
+        flat_tensor2 = tensor2.flatten()
+
+        # Calculate the number of valid elements to compare
+        input_numel = torch.Size(input_shape).numel()
+        target_numel = torch.Size(target_shape).numel()
+        min_size = min(input_numel, target_numel)
+
+        # Compare only the valid elements
+        return torch.equal(flat_tensor1[:min_size], flat_tensor2[:min_size])
+
     @parameterized.expand(
         [
             ((3,),),
@@ -28,24 +46,7 @@ class TestResizeConverter(DispatchTestCase):
         input_shape = (5,)
         inputs = [torch.randn(input_shape)]
 
-        def compare_resized_tensors(tensor1, tensor2, input_shape, target_shape):
-            # Check if the sizes match
-            if tensor1.size() != tensor2.size():
-                return False
-
-            # Flatten the tensors to ensure we are comparing the valid elements
-            flat_tensor1 = tensor1.flatten()
-            flat_tensor2 = tensor2.flatten()
-
-            # Calculate the number of valid elements to compare
-            input_numel = torch.Size(input_shape).numel()
-            target_numel = torch.Size(target_shape).numel()
-            min_size = min(input_numel, target_numel)
-
-            # Compare only the valid elements
-            return torch.equal(flat_tensor1[:min_size], flat_tensor2[:min_size])
-
-        comparators = [(compare_resized_tensors, [input_shape, target_shape])]
+        comparators = [(self.compare_resized_tensors, [input_shape, target_shape])]
 
         self.run_test_compare_tensor_attributes_only(
             Resize(),
@@ -76,24 +77,7 @@ class TestResizeConverter(DispatchTestCase):
         input_shape = (5,)
         inputs = [torch.randint(1, 5, input_shape)]
 
-        def compare_resized_tensors(tensor1, tensor2, input_shape, target_shape):
-            # Check if the sizes match
-            if tensor1.size() != tensor2.size():
-                return False
-
-            # Flatten the tensors to ensure we are comparing the valid elements
-            flat_tensor1 = tensor1.flatten()
-            flat_tensor2 = tensor2.flatten()
-
-            # Calculate the number of valid elements to compare
-            input_numel = torch.Size(input_shape).numel()
-            target_numel = torch.Size(target_shape).numel()
-            min_size = min(input_numel, target_numel)
-
-            # Compare only the valid elements
-            return torch.equal(flat_tensor1[:min_size], flat_tensor2[:min_size])
-
-        comparators = [(compare_resized_tensors, [input_shape, target_shape])]
+        comparators = [(self.compare_resized_tensors, [input_shape, target_shape])]
 
         self.run_test_compare_tensor_attributes_only(
             Resize(),
@@ -124,24 +108,7 @@ class TestResizeConverter(DispatchTestCase):
         input_shape = (4, 4)
         inputs = [torch.randint(1, 10, input_shape)]
 
-        def compare_resized_tensors(tensor1, tensor2, input_shape, target_shape):
-            # Check if the sizes match
-            if tensor1.size() != tensor2.size():
-                return False
-
-            # Flatten the tensors to ensure we are comparing the valid elements
-            flat_tensor1 = tensor1.flatten()
-            flat_tensor2 = tensor2.flatten()
-
-            # Calculate the number of valid elements to compare
-            input_numel = torch.Size(input_shape).numel()
-            target_numel = torch.Size(target_shape).numel()
-            min_size = min(input_numel, target_numel)
-
-            # Compare only the valid elements
-            return torch.equal(flat_tensor1[:min_size], flat_tensor2[:min_size])
-
-        comparators = [(compare_resized_tensors, [input_shape, target_shape])]
+        comparators = [(self.compare_resized_tensors, [input_shape, target_shape])]
 
         self.run_test_compare_tensor_attributes_only(
             Resize(),
@@ -171,24 +138,7 @@ class TestResizeConverter(DispatchTestCase):
         input_shape = (4, 4)
         inputs = [torch.randint(1, 10, input_shape)]
 
-        def compare_resized_tensors(tensor1, tensor2, input_shape, target_shape):
-            # Check if the sizes match
-            if tensor1.size() != tensor2.size():
-                return False
-
-            # Flatten the tensors to ensure we are comparing the valid elements
-            flat_tensor1 = tensor1.flatten()
-            flat_tensor2 = tensor2.flatten()
-
-            # Calculate the number of valid elements to compare
-            input_numel = torch.Size(input_shape).numel()
-            target_numel = torch.Size(target_shape).numel()
-            min_size = min(input_numel, target_numel)
-
-            # Compare only the valid elements
-            return torch.equal(flat_tensor1[:min_size], flat_tensor2[:min_size])
-
-        comparators = [(compare_resized_tensors, [input_shape, target_shape])]
+        comparators = [(self.compare_resized_tensors, [input_shape, target_shape])]
 
         self.run_test_compare_tensor_attributes_only(
             Resize(),


### PR DESCRIPTION
# Description
Support converter for `aten.resize_` operation: https://pytorch.org/docs/stable/generated/torch.Tensor.resize_.html#torch.Tensor.resize_

One critical aspect of this operation is handling cases where the target size (output size) is larger than the input tensor size. When `the target size` is larger than `the input tensor size`, the values of the additional elements are unpredictable. In PyTorch, these additional elements are not initialized, which can result in values that are close to `zero` but are not guaranteed to be `zero`.

![image](https://github.com/pytorch/TensorRT/assets/25674295/43fee82d-c2e3-468a-95ad-015851e4c145)

In the converter developed for this PR, the additional elements are initialized to `zero` using `numpy.zeros`. While this approach ensures a predictable output, it does not exactly replicate the behavior of PyTorch, where the values of the additional elements are not initialized and can be unpredictable.

Fixes # ([issue](https://github.com/pytorch/TensorRT/issues/2872))

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
