### PR TITLE
feat: dynamic shapes support for neg ops

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -563,7 +563,7 @@ def aten_ops_rsqrt(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.neg.default)
+@dynamo_tensorrt_converter(torch.ops.aten.neg.default, supports_dynamic_shapes=True)
 def aten_ops_neg(
     ctx: ConversionContext,
     target: Target,

--- a/tests/py/dynamo/conversion/test_neg_aten.py
+++ b/tests/py/dynamo/conversion/test_neg_aten.py
@@ -42,6 +42,46 @@ class TestNegConverter(DispatchTestCase):
             check_dtype=False,
         )
 
+    @parameterized.expand(
+        [
+            (
+                "2d_dim_dtype_half",
+                (1, 1),
+                (2, 2),
+                (4, 4),
+                torch.half,
+                torch.half,
+            ),
+            (
+                "3d_dim_dtype_float",
+                (1, 1, 1),
+                (1, 2, 3),
+                (3, 3, 3),
+                torch.float,
+                torch.float,
+            ),
+        ]
+    )
+    def test_dynamic_shape_neg(
+        self, _, min_shape, opt_shape, max_shape, type, output_type
+    ):
+        class neg(nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.neg.default(input)
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(
+            neg(), input_specs, output_dtypes=[output_type]
+        )
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
# Description

Add test case for dynamic shape input of aten.neg ops
Replaced output_dtypes arg in run_test_with_dynamic_shape() with check_dtype to handle
integer type of dynamic shape input test case.

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)
# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
