### PR TITLE
replace itemset due to numpy version 2.0 removed itemset api

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/impl/embedding.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/embedding.py
@@ -94,7 +94,10 @@ def embedding_bag_with_traversable_offsets(
         # however, pytorch doc says if `include_last_offset` is True, the size of offsets
         # is equal to the number of bags + 1. The last element is the size of the input,
         # or the ending index position of the last bag (sequence).
-        offsets.itemset(-1, len_embed)
+        offsets_shape = offsets.shape
+        offsets = offsets.flatten()
+        offsets[-1] = len_embed
+        offsets.reshape(offsets_shape)
     else:
         # add the end index to offsets
         offsets = np.append(offsets, len_embed)

--- a/py/torch_tensorrt/dynamo/conversion/impl/embedding.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/embedding.py
@@ -99,7 +99,7 @@ def embedding_bag_with_traversable_offsets(
         if len(offsets.shape) != 1:
             raise TypeError(
                 f"The offsets should be in 1d array, here offset shape is {offsets.shape}."
-        )
+            )
         offsets[-1] = len_embed
     else:
         # add the end index to offsets

--- a/py/torch_tensorrt/dynamo/conversion/impl/embedding.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/embedding.py
@@ -94,7 +94,7 @@ def embedding_bag_with_traversable_offsets(
         # however, pytorch doc says if `include_last_offset` is True, the size of offsets
         # is equal to the number of bags + 1. The last element is the size of the input,
         # or the ending index position of the last bag (sequence).
-        
+
         # Notes: here offsets should always be 1d array
         if len(offsets.shape) != 1:
             raise TypeError(

--- a/py/torch_tensorrt/dynamo/conversion/impl/embedding.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/embedding.py
@@ -98,7 +98,7 @@ def embedding_bag_with_traversable_offsets(
         # Notes: here offsets should always be 1d array
         if len(offsets.shape) != 1:
             raise TypeError(
-            f"The offsets should be in 1d array, here offset shape is {offsets.shape}."
+                f"The offsets should be in 1d array, here offset shape is {offsets.shape}."
         )
         offsets[-1] = len_embed
     else:


### PR DESCRIPTION
# Description

Numpy has removed itemset api since 2.0, so need to replace the itemset call

Fixes # (issue)

>           offsets.itemset(-1, len_embed)
E           AttributeError: `itemset` was removed from the ndarray class in NumPy 2.0. Use `arr[index] = value` instead.

Collecting numpy (from torchvision==0.18.0->-r /__w/TensorRT/TensorRT/pytorch/tensorrt/tests/py/requirements.txt (line 8))
398
  Downloading numpy-2.0.0rc2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (19.3 MB)
  
## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
