### PR TITLE
feat: support aten index_put converter for accumulate=False

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -834,7 +834,7 @@ def index_put_validator(node: Node) -> bool:
 
 
 @dynamo_tensorrt_converter(
-    torch.ops.aten.index_put_.default,
+    torch.ops.aten.index_put.default,
     capability_validator=index_put_validator,
 )
 @enforce_tensor_types(

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -802,12 +802,12 @@ def aten_ops_select(
 
 
 def index_put_validator(node: Node) -> bool:
-    if args_bounds_check(node.args, 3, False): # Check if accumulate is valid
+    if args_bounds_check(node.args, 3, False):  # Check if accumulate is valid
         _LOGGER.debug("We do not support accumulate=True for aten.index_put operation")
         accumulate_valid = False
     else:
         accumulate_valid = True
-    
+
     # Retrieve input tensor's meta information
     input_meta = node.args[0].meta.get("tensor_meta")
     if not input_meta:
@@ -815,7 +815,7 @@ def index_put_validator(node: Node) -> bool:
             "Meta information of input is missing. Unable to validate if broadcasting is needed, falling back to PyTorch operation."
         )
         return False
-    
+
     input_shape = input_meta.shape
     input_num_dims = len(input_shape)
 
@@ -824,9 +824,11 @@ def index_put_validator(node: Node) -> bool:
     if indices_num_dims == input_num_dims:
         broadcast_valid = True
     else:
-        _LOGGER.debug("We do not support broadcasting when the number of index dimensions does not match the number of input tensor dimensions.")
+        _LOGGER.debug(
+            "We do not support broadcasting when the number of index dimensions does not match the number of input tensor dimensions."
+        )
         broadcast_valid = False
-    
+
     # Return validation result
     return accumulate_valid and broadcast_valid
 

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -801,6 +801,33 @@ def aten_ops_select(
     )
 
 
+@dynamo_tensorrt_converter(torch.ops.aten.index_put.default)
+@dynamo_tensorrt_converter(torch.ops.aten.index_put_.default)
+@enforce_tensor_types(
+    {
+        0: (TRTTensor,),
+        2: (TRTTensor,),
+    }
+)
+def aten_ops_index_put_(
+    ctx: ConversionContext,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    return impl.select.index_put_converter(
+        ctx,
+        target,
+        SourceIR.ATEN,
+        name,
+        args[0],
+        args[1],
+        args[2],
+        args_bounds_check(args, 3, []),
+    )
+
+
 @dynamo_tensorrt_converter(torch.ops.aten.slice.Tensor, supports_dynamic_shapes=True)
 @enforce_tensor_types(
     {
@@ -3210,6 +3237,27 @@ def aten_ops_roll(
         args[0],
         args[1],
         args_bounds_check(args, 2, []),
+    )
+
+
+@enforce_tensor_types(
+    {
+        0: (TRTTensor,),
+    }
+)
+@dynamo_tensorrt_converter(torch.ops.aten.scatter.src)
+# @dynamo_tensorrt_converter(torch.ops.aten.scatter.src.default)
+@dynamo_tensorrt_converter(torch.ops.aten.scatter.value)
+# @dynamo_tensorrt_converter(torch.ops.aten.scatter.value.default)
+def aten_ops_scatter(
+    ctx: ConversionContext,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    return impl.select.scatter(
+        ctx, target, SourceIR.ATEN, name, args[0], args[1], args[2], args[3]
     )
 
 

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -801,24 +801,40 @@ def aten_ops_select(
     )
 
 
-def index_put_accumulate_validator(node: Node) -> bool:
-    if args_bounds_check(node.args, 3, False):
+def index_put_validator(node: Node) -> bool:
+    if args_bounds_check(node.args, 3, False): # Check if accumulate is valid
         _LOGGER.debug("We do not support accumulate=True for aten.index_put operation")
-        return False
+        accumulate_valid = False
     else:
-        return True
+        accumulate_valid = True
+    
+    # Retrieve input tensor's meta information
+    input_meta = node.args[0].meta.get("tensor_meta")
+    if not input_meta:
+        _LOGGER.warning(
+            "Meta information of input is missing. Unable to validate if broadcasting is needed, falling back to PyTorch operation."
+        )
+        return False
+    
+    input_shape = input_meta.shape
+    input_num_dims = len(input_shape)
+
+    # Check if broadcasting is valid
+    indices_num_dims = len(node.args[1])
+    if indices_num_dims == input_num_dims:
+        broadcast_valid = True
+    else:
+        _LOGGER.debug("We do not support broadcasting when the number of index dimensions does not match the number of input tensor dimensions.")
+        broadcast_valid = False
+    
+    # Return validation result
+    return accumulate_valid and broadcast_valid
 
 
 @dynamo_tensorrt_converter(
     torch.ops.aten.index_put_.default,
-    capability_validator=index_put_accumulate_validator,
+    capability_validator=index_put_validator,
 )
-@dynamo_tensorrt_converter(
-    torch.ops.aten.index_put.default,
-    capability_validator=index_put_accumulate_validator,
-)
-@dynamo_tensorrt_converter(torch.ops.aten.index_put.default)
-@dynamo_tensorrt_converter(torch.ops.aten.index_put_.default)
 @enforce_tensor_types(
     {
         0: (TRTTensor,),

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -801,6 +801,22 @@ def aten_ops_select(
     )
 
 
+def index_put_accumulate_validator(node: Node) -> bool:
+    if args_bounds_check(node.args, 3, False):
+        _LOGGER.debug("We do not support accumulate=True for aten.index_put operation")
+        return False
+    else:
+        return True
+
+
+@dynamo_tensorrt_converter(
+    torch.ops.aten.index_put_.default,
+    capability_validator=index_put_accumulate_validator,
+)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.index_put.default,
+    capability_validator=index_put_accumulate_validator,
+)
 @dynamo_tensorrt_converter(torch.ops.aten.index_put.default)
 @dynamo_tensorrt_converter(torch.ops.aten.index_put_.default)
 @enforce_tensor_types(
@@ -809,7 +825,7 @@ def aten_ops_select(
         2: (TRTTensor,),
     }
 )
-def aten_ops_index_put_(
+def aten_ops_index_put(
     ctx: ConversionContext,
     target: Target,
     args: Tuple[Argument, ...],
@@ -824,7 +840,7 @@ def aten_ops_index_put_(
         args[0],
         args[1],
         args[2],
-        args_bounds_check(args, 3, []),
+        args_bounds_check(args, 3, False),
     )
 
 
@@ -3237,27 +3253,6 @@ def aten_ops_roll(
         args[0],
         args[1],
         args_bounds_check(args, 2, []),
-    )
-
-
-@enforce_tensor_types(
-    {
-        0: (TRTTensor,),
-    }
-)
-@dynamo_tensorrt_converter(torch.ops.aten.scatter.src)
-# @dynamo_tensorrt_converter(torch.ops.aten.scatter.src.default)
-@dynamo_tensorrt_converter(torch.ops.aten.scatter.value)
-# @dynamo_tensorrt_converter(torch.ops.aten.scatter.value.default)
-def aten_ops_scatter(
-    ctx: ConversionContext,
-    target: Target,
-    args: Tuple[Argument, ...],
-    kwargs: Dict[str, Argument],
-    name: str,
-) -> Union[TRTTensor, Sequence[TRTTensor]]:
-    return impl.select.scatter(
-        ctx, target, SourceIR.ATEN, name, args[0], args[1], args[2], args[3]
     )
 
 

--- a/py/torch_tensorrt/dynamo/conversion/impl/select.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/select.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Sequence, Tuple, Union, cast
+from typing import Optional, Sequence, Union, cast
 
 import numpy as np
 import tensorrt as trt
@@ -455,7 +455,7 @@ def index_put_converter(
     source_ir: Optional[SourceIR],
     name: str,
     input_tensor: TRTTensor,
-    indices: Union[TRTTensor, Tuple[TRTTensor, ...]],
+    indices: Sequence[Union[TRTTensor, np.ndarray, torch.Tensor]],
     values: TRTTensor,
     accumulate: bool = False,
 ) -> TRTTensor:

--- a/tests/py/dynamo/conversion/test_index_put_aten.py
+++ b/tests/py/dynamo/conversion/test_index_put_aten.py
@@ -1,0 +1,49 @@
+import torch
+import torch.nn as nn
+from parameterized import param, parameterized
+from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt import Input
+
+from .harness import DispatchTestCase
+
+
+class TestIndexPutConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            param(
+                test_name="1d_indices_single",
+                source_tensor=torch.zeros([5], dtype=torch.int32),
+                indices_tensor=(torch.tensor([0], dtype=torch.int32),),
+                value_tensor=torch.tensor([1], dtype=torch.int32),
+            ),
+            param(
+                test_name="1d_indices_multiple",
+                source_tensor=torch.zeros([5], dtype=torch.int32),
+                indices_tensor=(torch.tensor([0, 3], dtype=torch.int32),),
+                value_tensor=torch.tensor([1, 3], dtype=torch.int32),
+            ),
+            # param(
+            #     test_name="2d_indices",
+            #     source_tensor=torch.zeros([5,5], dtype=torch.int32),
+            #     indices_tensor=(torch.tensor([0,2], dtype=torch.int32),torch.tensor([2,0], dtype=torch.int32),),
+            #     value_tensor=torch.tensor([1,3], dtype=torch.int32),
+            # ),
+        ]
+    )
+    def test_index_put(
+        self, test_name, source_tensor, indices_tensor, value_tensor, accumulate=True
+    ):
+        class TestIndexPut(torch.nn.Module):
+            def forward(self, source_tensor, value_tensor):
+                return torch.ops.aten.index_put_.default(
+                    source_tensor, indices_tensor, value_tensor
+                )
+
+        self.run_test(
+            TestIndexPut(),
+            inputs=[source_tensor, value_tensor],
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/py/dynamo/conversion/test_index_put_aten.py
+++ b/tests/py/dynamo/conversion/test_index_put_aten.py
@@ -137,6 +137,15 @@ class TestIndexPutConverter(DispatchTestCase):
                 value_tensor=torch.tensor([5.5, 7.5], dtype=torch.float32),
             ),
             # param(
+            #     test_name="3d_indices_float_broadcase_index",
+            #     source_tensor=torch.zeros([3, 3, 3], dtype = torch.int32),
+            #     indices_tensor=(
+            #         torch.tensor([0,1], dtype=torch.int32), 
+            #         torch.tensor([0,1], dtype=torch.int32),
+            #     ),
+            #     value_tensor=torch.tensor([10],  dtype = torch.int32),
+            # ),
+            # param(
             #     test_name="2d_indices_accumulate_True",
             #     source_tensor=torch.zeros([5, 5], dtype=torch.int32),
             #     indices_tensor=(torch.tensor([0, 0], dtype=torch.int32), torch.tensor([1, 1], dtype=torch.int32)),
@@ -160,7 +169,7 @@ class TestIndexPutConverter(DispatchTestCase):
         ]
     )
     def test_index_put(
-        self, test_name, source_tensor, indices_tensor, value_tensor, accumulate=True
+        self, test_name, source_tensor, indices_tensor, value_tensor, accumulate=False
     ):
         class TestIndexPut(torch.nn.Module):
             def forward(self, source_tensor, value_tensor):
@@ -171,6 +180,8 @@ class TestIndexPutConverter(DispatchTestCase):
         self.run_test(
             TestIndexPut(),
             inputs=[source_tensor, value_tensor],
+            # enable_passes=True,
+            # use_dynamo_tracer=True,
         )
 
 

--- a/tests/py/dynamo/conversion/test_index_put_aten.py
+++ b/tests/py/dynamo/conversion/test_index_put_aten.py
@@ -190,5 +190,6 @@ class TestIndexPutConverter(DispatchTestCase):
             use_dynamo_tracer=True,
         )
 
+
 if __name__ == "__main__":
     run_tests()

--- a/tests/py/dynamo/conversion/test_index_put_aten.py
+++ b/tests/py/dynamo/conversion/test_index_put_aten.py
@@ -140,7 +140,7 @@ class TestIndexPutConverter(DispatchTestCase):
             #     test_name="3d_indices_float_broadcase_index",
             #     source_tensor=torch.zeros([3, 3, 3], dtype = torch.int32),
             #     indices_tensor=(
-            #         torch.tensor([0,1], dtype=torch.int32), 
+            #         torch.tensor([0,1], dtype=torch.int32),
             #         torch.tensor([0,1], dtype=torch.int32),
             #     ),
             #     value_tensor=torch.tensor([10],  dtype = torch.int32),

--- a/tests/py/dynamo/conversion/test_index_put_aten.py
+++ b/tests/py/dynamo/conversion/test_index_put_aten.py
@@ -22,11 +22,140 @@ class TestIndexPutConverter(DispatchTestCase):
                 indices_tensor=(torch.tensor([0, 3], dtype=torch.int32),),
                 value_tensor=torch.tensor([1, 3], dtype=torch.int32),
             ),
+            param(
+                test_name="2d_indices_single",
+                source_tensor=torch.zeros([5, 5], dtype=torch.int32),
+                indices_tensor=(
+                    torch.tensor([2], dtype=torch.int32),
+                    torch.tensor([0], dtype=torch.int32),
+                ),
+                value_tensor=torch.tensor([3], dtype=torch.int32),
+            ),
+            param(
+                test_name="2d_indices_multiple",
+                source_tensor=torch.zeros([5, 5], dtype=torch.int32),
+                indices_tensor=(
+                    torch.tensor([0, 2, 2], dtype=torch.int32),
+                    torch.tensor([2, 0, 2], dtype=torch.int32),
+                ),
+                value_tensor=torch.tensor([1, 3, 4], dtype=torch.int32),
+            ),
+            param(
+                test_name="3d_indices_single",
+                source_tensor=torch.zeros([3, 3, 3], dtype=torch.int32),
+                indices_tensor=(
+                    torch.tensor([1], dtype=torch.int32),
+                    torch.tensor([2], dtype=torch.int32),
+                    torch.tensor([2], dtype=torch.int32),
+                ),
+                value_tensor=torch.tensor([7], dtype=torch.int32),
+            ),
+            param(
+                test_name="3d_indices_multiple",
+                source_tensor=torch.zeros([3, 3, 3], dtype=torch.int32),
+                indices_tensor=(
+                    torch.tensor([0, 1, 1], dtype=torch.int32),
+                    torch.tensor([1, 2, 1], dtype=torch.int32),
+                    torch.tensor([2, 0, 2], dtype=torch.int32),
+                ),
+                value_tensor=torch.tensor([5, 7, 2], dtype=torch.int32),
+            ),
+            param(
+                test_name="4d_indices_single",
+                source_tensor=torch.zeros([2, 2, 2, 2], dtype=torch.int32),
+                indices_tensor=(
+                    torch.tensor([1], dtype=torch.int32),
+                    torch.tensor([1], dtype=torch.int32),
+                    torch.tensor([0], dtype=torch.int32),
+                    torch.tensor([1], dtype=torch.int32),
+                ),
+                value_tensor=torch.tensor([5], dtype=torch.int32),
+            ),
+            param(
+                test_name="4d_indices_multiple",
+                source_tensor=torch.zeros([2, 2, 2, 2], dtype=torch.int32),
+                indices_tensor=(
+                    torch.tensor([0, 1], dtype=torch.int32),
+                    torch.tensor([1, 1], dtype=torch.int32),
+                    torch.tensor([1, 0], dtype=torch.int32),
+                    torch.tensor([1, 0], dtype=torch.int32),
+                ),
+                value_tensor=torch.tensor([5, 7], dtype=torch.int32),
+            ),
+            param(
+                test_name="negative_indices",
+                source_tensor=torch.zeros([5, 5], dtype=torch.int32),
+                indices_tensor=(
+                    torch.tensor([-1, -2], dtype=torch.int32),
+                    torch.tensor([2, 0], dtype=torch.int32),
+                ),
+                value_tensor=torch.tensor([1, 3], dtype=torch.int32),
+            ),
+            param(
+                test_name="mixed_indices",
+                source_tensor=torch.zeros([4, 4], dtype=torch.int32),
+                indices_tensor=(
+                    torch.tensor([0, 1, -1, -2], dtype=torch.int32),
+                    torch.tensor([0, -1, 2, 1], dtype=torch.int32),
+                ),
+                value_tensor=torch.tensor([2, 4, 6, 8], dtype=torch.int32),
+            ),
+            param(
+                test_name="1d_indices_float",
+                source_tensor=torch.zeros([5], dtype=torch.float32),
+                indices_tensor=(torch.tensor([0, 3], dtype=torch.int32),),
+                value_tensor=torch.tensor([1.5, 3.5], dtype=torch.float32),
+            ),
+            param(
+                test_name="2d_indices_float",
+                source_tensor=torch.zeros([5, 5], dtype=torch.float32),
+                indices_tensor=(
+                    torch.tensor([0, 2], dtype=torch.int32),
+                    torch.tensor([2, 0], dtype=torch.int32),
+                ),
+                value_tensor=torch.tensor([1.5, 3.5], dtype=torch.float32),
+            ),
+            param(
+                test_name="3d_indices_float",
+                source_tensor=torch.zeros([3, 3, 3], dtype=torch.float32),
+                indices_tensor=(
+                    torch.tensor([0, 1], dtype=torch.int32),
+                    torch.tensor([1, 2], dtype=torch.int32),
+                    torch.tensor([2, 0], dtype=torch.int32),
+                ),
+                value_tensor=torch.tensor([5.5, 7.5], dtype=torch.float32),
+            ),
+            param(
+                test_name="4d_indices_float",
+                source_tensor=torch.zeros([2, 2, 2, 2], dtype=torch.float32),
+                indices_tensor=(
+                    torch.tensor([0, 1], dtype=torch.int32),
+                    torch.tensor([1, 0], dtype=torch.int32),
+                    torch.tensor([0, 1], dtype=torch.int32),
+                    torch.tensor([1, 0], dtype=torch.int32),
+                ),
+                value_tensor=torch.tensor([5.5, 7.5], dtype=torch.float32),
+            ),
             # param(
-            #     test_name="2d_indices",
-            #     source_tensor=torch.zeros([5,5], dtype=torch.int32),
-            #     indices_tensor=(torch.tensor([0,2], dtype=torch.int32),torch.tensor([2,0], dtype=torch.int32),),
-            #     value_tensor=torch.tensor([1,3], dtype=torch.int32),
+            #     test_name="2d_indices_accumulate_True",
+            #     source_tensor=torch.zeros([5, 5], dtype=torch.int32),
+            #     indices_tensor=(torch.tensor([0, 0], dtype=torch.int32), torch.tensor([1, 1], dtype=torch.int32)),
+            #     value_tensor=torch.tensor([1, 2], dtype=torch.int32),
+            #     accumulate=True,
+            # ),
+            # param(
+            #     test_name="3d_indices_accumulate_True",
+            #     source_tensor=torch.zeros([3, 3, 3], dtype=torch.int32),
+            #     indices_tensor=(torch.tensor([0, 0], dtype=torch.int32), torch.tensor([1, 1], dtype=torch.int32), torch.tensor([2, 2], dtype=torch.int32)),
+            #     value_tensor=torch.tensor([1, 2], dtype=torch.int32),
+            #     accumulate=True,
+            # ),
+            # param(
+            #     test_name="4d_indices_accumulate_True",
+            #     source_tensor=torch.zeros([2, 2, 2, 2], dtype=torch.int32),
+            #     indices_tensor=(torch.tensor([0, 0], dtype=torch.int32), torch.tensor([1, 1], dtype=torch.int32), torch.tensor([0, 0], dtype=torch.int32), torch.tensor([1, 1], dtype=torch.int32)),
+            #     value_tensor=torch.tensor([1, 2], dtype=torch.int32),
+            #     accumulate=True,
             # ),
         ]
     )
@@ -36,7 +165,7 @@ class TestIndexPutConverter(DispatchTestCase):
         class TestIndexPut(torch.nn.Module):
             def forward(self, source_tensor, value_tensor):
                 return torch.ops.aten.index_put_.default(
-                    source_tensor, indices_tensor, value_tensor
+                    source_tensor, indices_tensor, value_tensor, accumulate
                 )
 
         self.run_test(

--- a/tests/py/dynamo/conversion/test_index_put_aten.py
+++ b/tests/py/dynamo/conversion/test_index_put_aten.py
@@ -1,8 +1,6 @@
 import torch
-import torch.nn as nn
 from parameterized import param, parameterized
 from torch.testing._internal.common_utils import run_tests
-from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
@@ -174,7 +172,6 @@ class TestIndexPutConverter(DispatchTestCase):
         @torch._dynamo.assume_constant_result
         def get_indices_tensor():
             return indices_tensor
-            # return (torch.tensor([0], dtype=torch.int32),)
 
         class TestIndexPut(torch.nn.Module):
             def forward(self, source_tensor, value_tensor):


### PR DESCRIPTION
# Description

I have implemented the `aten::index_put` operation using the `add_scatter` layer with `trt.ScatterMode.ND`. However, I was unable to implement the `accumulate=True` case, which is currently handled by the validator.

Fixes # ([issue](https://github.com/pytorch/TensorRT/issues/2544))

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
