### PR TITLE
cherry pick pull/2879 to release/2.3 branch

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/impl/embedding.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/embedding.py
@@ -94,7 +94,12 @@ def embedding_bag_with_traversable_offsets(
         # however, pytorch doc says if `include_last_offset` is True, the size of offsets
         # is equal to the number of bags + 1. The last element is the size of the input,
         # or the ending index position of the last bag (sequence).
-        offsets.itemset(-1, len_embed)
+        # Notes: here offsets should always be 1d array
+        if len(offsets.shape) != 1:
+            raise TypeError(
+                f"The offsets should be in 1d array, here offset shape is {offsets.shape}."
+            )
+        offsets[-1] = len_embed
     else:
         # add the end index to offsets
         offsets = np.append(offsets, len_embed)


### PR DESCRIPTION
# Description

cherry pick https://github.com/pytorch/TensorRT/pull/2879 to release branch

Fixes # (issue)

Numpy has removed itemset api since 2.0, so need to replace the itemset call

      offsets.itemset(-1, len_embed)
E AttributeError: itemset was removed from the ndarray class in NumPy 2.0. Use arr[index] = value instead.
## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
