### PR TITLE
fix: Missing nvinfer.dll in CI for Windows [`release/2.3`]

### DIFF
--- a/.github/scripts/install-torch-tensorrt-windows.sh
+++ b/.github/scripts/install-torch-tensorrt-windows.sh
@@ -5,7 +5,6 @@ source ${BUILD_ENV_FILE}
 export EXTRA_INDEX_URL="https://download.pytorch.org/whl/test/${CU_VERSION}"
 # Install all the dependencies required for Torch-TensorRT
 ${CONDA_RUN} pip install --pre -r ${PWD}/tests/py/requirements.txt --use-deprecated=legacy-resolver --extra-index-url=${EXTRA_INDEX_URL}
-${CONDA_RUN} pip install --pre -r ${PWD}/tests/py/requirements.txt --use-deprecated legacy-resolver
 
 # Install Torch-TensorRT via pre-built wheels. On windows, the location of wheels is not fixed.
 ${CONDA_RUN} pip install ${RUNNER_ARTIFACT_DIR}/torch_tensorrt*.whl

--- a/.github/scripts/install-torch-tensorrt-windows.sh
+++ b/.github/scripts/install-torch-tensorrt-windows.sh
@@ -5,6 +5,7 @@ source ${BUILD_ENV_FILE}
 export EXTRA_INDEX_URL="https://download.pytorch.org/whl/test/${CU_VERSION}"
 # Install all the dependencies required for Torch-TensorRT
 ${CONDA_RUN} pip install --pre -r ${PWD}/tests/py/requirements.txt --use-deprecated=legacy-resolver --extra-index-url=${EXTRA_INDEX_URL}
+${CONDA_RUN} pip install --pre -r ${PWD}/tests/py/requirements.txt --use-deprecated legacy-resolver
 
 # Install Torch-TensorRT via pre-built wheels. On windows, the location of wheels is not fixed.
 ${CONDA_RUN} pip install ${RUNNER_ARTIFACT_DIR}/torch_tensorrt*.whl

--- a/packaging/pre_build_script_windows.sh
+++ b/packaging/pre_build_script_windows.sh
@@ -1,7 +1,8 @@
 python -m pip install -U numpy packaging pyyaml setuptools wheel
 
 # Install TRT 10 from PyPi
-python -m pip install tensorrt==10.0.1 --extra-index-url https://pypi.nvidia.com
+TRT_VERSION=$(python -c "import yaml; print(yaml.safe_load(open('dev_dep_versions.yml', 'r'))['__tensorrt_version__'])")
+pip install tensorrt==${TRT_VERSION} tensorrt-cu12-bindings==${TRT_VERSION} tensorrt-cu12-libs==${TRT_VERSION} --extra-index-url https://pypi.nvidia.com
 
 choco install bazelisk -y
 

--- a/tests/py/requirements.txt
+++ b/tests/py/requirements.txt
@@ -6,9 +6,11 @@ pytest-xdist>=3.6.1
 networkx==2.8.8
 torch==2.3.0
 torchvision==0.18.0
---extra-index-url https://pypi.ngc.nvidia.com
+--extra-index-url https://pypi.nvidia.com
 pyyaml
 tensorrt==10.0.1
+tensorrt-cu12-bindings==10.0.1
+tensorrt-cu12-libs==10.0.1
 timm>=1.0.3
 transformers==4.39.3
 parameterized>=0.2.0


### PR DESCRIPTION
# Description

- Addresses CI error for missing `nvinfer.dll` on release branch

## Type of change

- CI fix

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
