### PR TITLE
Bump transformers version from 4.39 to 4.40

### DIFF
--- a/tests/py/requirements.txt
+++ b/tests/py/requirements.txt
@@ -10,7 +10,7 @@ torchvision==0.18.0
 pyyaml
 tensorrt==10.0.1
 timm>=1.0.3
-transformers==4.39.3
+transformers==4.40.2
 parameterized>=0.2.0
 expecttest==0.1.6
 numpy==1.24.1


### PR DESCRIPTION
# Description

Bump transformers version from 4.39 to 4.40

Fixes # (issue)

`FAILED models/test_models_export.py::test_bert_base_uncased - torch._dynamo.exc.InternalTorchDynamoError: 'ascii' codec can't decode byte 0xf0 in position 7043: ordinal not in range(128)`

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
