### PR TITLE
feat: support `native_dropout` dynamo converter

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -3247,7 +3247,13 @@ def aten_ops_index_select(
 
 def dropout_inference_validator(node: Node) -> bool:
     train_mode = args_bounds_check(node.args, 2, None)
-    return train_mode is False
+    if train_mode is False:
+        return True
+    else:  # train_mode is True or None
+        _LOGGER.debug(
+            "Currently only inference mode is supported for dropout operation."
+        )
+        return False
 
 
 @dynamo_tensorrt_converter(

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -3243,3 +3243,30 @@ def aten_ops_index_select(
         args[1],
         args[2],
     )
+
+
+def dropout_inference_validator(node: Node) -> bool:
+    train_mode = args_bounds_check(node.args, 2, None)
+    return train_mode is False
+
+
+@dynamo_tensorrt_converter(
+    torch.ops.aten.native_dropout.default,
+    capability_validator=dropout_inference_validator,
+)
+def aten_ops_native_dropout(
+    ctx: ConversionContext,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    return impl.unary.native_dropout(
+        ctx,
+        target,
+        SourceIR.ATEN,
+        name,
+        args[0],
+        args[1],
+        args_bounds_check(args, 2, None),
+    )

--- a/py/torch_tensorrt/dynamo/conversion/impl/unary/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/unary/ops.py
@@ -571,3 +571,20 @@ def isnan(
     )
 
     return nan_values_mask
+
+
+def native_dropout(
+    ctx: ConversionContext,
+    target: Target,
+    source_ir: Optional[SourceIR],
+    name: str,
+    input_val: Union[TRTTensor, torch.Tensor, np.ndarray],
+    p: float,
+    train: Optional[bool] = False,
+) -> TRTTensor:
+    if train is False:
+        identity_layer = ctx.net.add_identity(input_val)
+        set_layer_name(identity_layer, target, f"{name}_input", source_ir)
+        mask = np.ones(input_val.shape, dtype=np.bool)
+        mask = get_trt_tensor(ctx, mask, f"{name}_mask")
+        return identity_layer.get_output(0), mask

--- a/py/torch_tensorrt/dynamo/conversion/impl/unary/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/unary/ops.py
@@ -585,6 +585,6 @@ def native_dropout(
     if train is False:
         identity_layer = ctx.net.add_identity(input_val)
         set_layer_name(identity_layer, target, f"{name}_input", source_ir)
-        mask = np.ones(input_val.shape, dtype=np.bool)
+        mask = np.ones(input_val.shape, dtype=bool)
         mask = get_trt_tensor(ctx, mask, f"{name}_mask")
         return identity_layer.get_output(0), mask

--- a/tests/py/dynamo/conversion/test_dropout_aten.py
+++ b/tests/py/dynamo/conversion/test_dropout_aten.py
@@ -1,0 +1,56 @@
+import torch
+import torch.nn as nn
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+
+from .harness import DispatchTestCase
+
+
+class TestDropOutConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            ((10,), 0, False),
+            ((1, 3), 0.3, False),
+            ((2, 2, 2), 0.5),
+            ((2, 2, 2, 2), 1),
+        ]
+    )
+    def test_native_dropout(self, input_shape, p, train=False):
+        class NativeDropout(nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.native_dropout.default(input, p, train)
+
+        inputs = [torch.randn(input_shape)]
+        self.run_test(
+            NativeDropout(),
+            inputs,
+        )
+
+    @parameterized.expand(
+        [
+            (
+                torch.randn(
+                    10,
+                ),
+                0,
+                False,
+            ),
+            (torch.randn(1, 3), 0.3, False),
+            (torch.randn(2, 2, 2), 0.5),
+            (torch.randn(2, 2, 2, 2), 1),
+        ]
+    )
+    def test_native_dropout_pytorch(self, input, p, train=False):
+        class NativeDropout(nn.Module):
+            def forward(self):
+                return torch.ops.aten.native_dropout.default(input, p, train)
+
+        inputs = []
+        self.run_test(
+            NativeDropout(),
+            inputs,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
# Description

Support `native_dropout` dynamo converter.

Per [the schema](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/native_functions.yaml#L283), this function returns two tensors. The first is `output` and the other is `mask`. For inference, i.e., `train` is not `True` or `None`, whatever the `p` is, it always returns `input` and all `True`s.

Fixes #2494 

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
