### PR TITLE
fix: Add missing select in Bazel BUILD

### DIFF
--- a/tests/core/conversion/converters/BUILD
+++ b/tests/core/conversion/converters/BUILD
@@ -7,6 +7,13 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+)
+
 converter_test(
     name = "test_activation",
 )

--- a/tests/core/conversion/evaluators/BUILD
+++ b/tests/core/conversion/evaluators/BUILD
@@ -7,6 +7,13 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+)
+
 evaluator_test(
     name = "test_prim_evaluators",
 )

--- a/tests/core/runtime/BUILD
+++ b/tests/core/runtime/BUILD
@@ -9,6 +9,13 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+)
+
 runtime_test(
     name = "test_multi_device_safe_mode",
 )


### PR DESCRIPTION
# Description

- Add back missing `select` calls in Bazel `BUILD`s

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x ] My code follows the style guidelines of this project (You can use the linters)
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ x ] I have made corresponding changes to the documentation
- [ x ] I have added tests to verify my fix or my feature
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have added the relevant labels to my PR in so that relevant reviewers are notified
