### PR TITLE
Add dynamic shape support for bitwise_and/or/xor/not, exp/expm1/recip/log/log2/log10

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -1324,7 +1324,7 @@ def aten_ops_mean(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.exp.default)
+@dynamo_tensorrt_converter(torch.ops.aten.exp.default, supports_dynamic_shapes=True)
 def aten_ops_exp(
     ctx: ConversionContext,
     target: Target,
@@ -1341,7 +1341,7 @@ def aten_ops_exp(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.expm1.default)
+@dynamo_tensorrt_converter(torch.ops.aten.expm1.default, supports_dynamic_shapes=True)
 def aten_ops_expm1(
     ctx: ConversionContext,
     target: Target,
@@ -1358,7 +1358,7 @@ def aten_ops_expm1(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.log.default)
+@dynamo_tensorrt_converter(torch.ops.aten.log.default, supports_dynamic_shapes=True)
 def aten_ops_log(
     ctx: ConversionContext,
     target: Target,
@@ -1375,7 +1375,7 @@ def aten_ops_log(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.log2.default)
+@dynamo_tensorrt_converter(torch.ops.aten.log2.default, supports_dynamic_shapes=True)
 def aten_ops_log2(
     ctx: ConversionContext,
     target: Target,
@@ -1392,7 +1392,7 @@ def aten_ops_log2(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.log10.default)
+@dynamo_tensorrt_converter(torch.ops.aten.log10.default, supports_dynamic_shapes=True)
 def aten_ops_log10(
     ctx: ConversionContext,
     target: Target,
@@ -1443,7 +1443,9 @@ def aten_ops_sqrt(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.reciprocal.default)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.reciprocal.default, supports_dynamic_shapes=True
+)
 def aten_ops_recip(
     ctx: ConversionContext,
     target: Target,
@@ -2052,7 +2054,9 @@ def aten_ops_logical_and(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.logical_or.default)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.logical_or.default, supports_dynamic_shapes=True
+)
 def aten_ops_logical_or(
     ctx: ConversionContext,
     target: Target,
@@ -2070,7 +2074,9 @@ def aten_ops_logical_or(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.logical_xor.default)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.logical_xor.default, supports_dynamic_shapes=True
+)
 def aten_ops_logical_xor(
     ctx: ConversionContext,
     target: Target,
@@ -2106,7 +2112,6 @@ def bitwise_type_validator(node: Node) -> bool:
         torch.ops.aten.bitwise_or.Scalar_Tensor,
         torch.ops.aten.bitwise_xor.Scalar_Tensor,
     ]
-
     if node.target in tensor_targets:
         lhs_val = node.args[0]
         rhs_val = node.args[1]
@@ -2137,14 +2142,19 @@ def bitwise_type_validator(node: Node) -> bool:
 
 
 @dynamo_tensorrt_converter(
-    torch.ops.aten.bitwise_and.Tensor, capability_validator=bitwise_type_validator
+    torch.ops.aten.bitwise_and.Tensor,
+    capability_validator=bitwise_type_validator,
+    supports_dynamic_shapes=True,
 )
 @dynamo_tensorrt_converter(
-    torch.ops.aten.bitwise_and.Scalar, capability_validator=bitwise_type_validator
+    torch.ops.aten.bitwise_and.Scalar,
+    capability_validator=bitwise_type_validator,
+    supports_dynamic_shapes=True,
 )
 @dynamo_tensorrt_converter(
     torch.ops.aten.bitwise_and.Scalar_Tensor,
     capability_validator=bitwise_type_validator,
+    supports_dynamic_shapes=True,
 )
 def aten_ops_bitwise_and(
     ctx: ConversionContext,
@@ -2164,13 +2174,19 @@ def aten_ops_bitwise_and(
 
 
 @dynamo_tensorrt_converter(
-    torch.ops.aten.bitwise_or.Tensor, capability_validator=bitwise_type_validator
+    torch.ops.aten.bitwise_or.Tensor,
+    capability_validator=bitwise_type_validator,
+    supports_dynamic_shapes=True,
 )
 @dynamo_tensorrt_converter(
-    torch.ops.aten.bitwise_or.Scalar, capability_validator=bitwise_type_validator
+    torch.ops.aten.bitwise_or.Scalar,
+    capability_validator=bitwise_type_validator,
+    supports_dynamic_shapes=True,
 )
 @dynamo_tensorrt_converter(
-    torch.ops.aten.bitwise_or.Scalar_Tensor, capability_validator=bitwise_type_validator
+    torch.ops.aten.bitwise_or.Scalar_Tensor,
+    capability_validator=bitwise_type_validator,
+    supports_dynamic_shapes=True,
 )
 def aten_ops_bitwise_or(
     ctx: ConversionContext,
@@ -2190,14 +2206,19 @@ def aten_ops_bitwise_or(
 
 
 @dynamo_tensorrt_converter(
-    torch.ops.aten.bitwise_xor.Tensor, capability_validator=bitwise_type_validator
+    torch.ops.aten.bitwise_xor.Tensor,
+    capability_validator=bitwise_type_validator,
+    supports_dynamic_shapes=True,
 )
 @dynamo_tensorrt_converter(
-    torch.ops.aten.bitwise_xor.Scalar, capability_validator=bitwise_type_validator
+    torch.ops.aten.bitwise_xor.Scalar,
+    capability_validator=bitwise_type_validator,
+    supports_dynamic_shapes=True,
 )
 @dynamo_tensorrt_converter(
     torch.ops.aten.bitwise_xor.Scalar_Tensor,
     capability_validator=bitwise_type_validator,
+    supports_dynamic_shapes=True,
 )
 def aten_ops_bitwise_xor(
     ctx: ConversionContext,
@@ -2228,7 +2249,9 @@ def bitwise_not_type_validator(node: Node) -> bool:
 
 
 @dynamo_tensorrt_converter(
-    torch.ops.aten.bitwise_not.default, capability_validator=bitwise_not_type_validator
+    torch.ops.aten.bitwise_not.default,
+    capability_validator=bitwise_not_type_validator,
+    supports_dynamic_shapes=True,
 )
 @enforce_tensor_types(
     {

--- a/tests/py/dynamo/conversion/test_bitwise_and_aten.py
+++ b/tests/py/dynamo/conversion/test_bitwise_and_aten.py
@@ -10,11 +10,11 @@ from .harness import DispatchTestCase
 class TestBitwiseAndConverter(DispatchTestCase):
     @parameterized.expand(
         [
-            # ("2d", (2, 3), (2, 3)),
-            # ("3d", (5, 3, 2), (5, 3, 2)),
+            ("2d", (2, 3), (2, 3)),
+            ("3d", (5, 3, 2), (5, 3, 2)),
             ("3d_broadcast", (2, 3), (2, 1, 3)),
-            # ("4d_broadcast_1", (2, 3), (1, 2, 1, 3)),
-            # ("4d_broadcast_2", (2, 3), (2, 2, 2, 3)),
+            ("4d_broadcast_1", (2, 3), (1, 2, 1, 3)),
+            ("4d_broadcast_2", (2, 3), (2, 2, 2, 3)),
         ]
     )
     def test_bitwise_and_tensor(self, _, lhs_shape, rhs_shape):

--- a/tests/py/dynamo/conversion/test_bitwise_and_aten.py
+++ b/tests/py/dynamo/conversion/test_bitwise_and_aten.py
@@ -37,15 +37,6 @@ class TestBitwiseAndConverter(DispatchTestCase):
         [
             ("2d-2d", (2, 3), (3, 3), (5, 3), (2, 3), (3, 3), (5, 3)),
             ("3d-3d", (2, 2, 2), (2, 3, 2), (2, 4, 2), (1, 2, 2), (1, 3, 2), (1, 4, 2)),
-            # TODO: this should be a valid testcase, figure out why it is failing
-            # # I want to test when the dimension is not the same, it will prepend 1's to make it same rank
-            # ("3d-3d", (2, 2, 2), (2, 3, 2), (2, 4, 2), (2, 2), (3, 2), (4, 2)),
-            # however pytorch throws the folllowing error:
-            # torch._dynamo.exc.UserError: Constraints violated (_0)! For more information, run with TORCH_LOGS="+dynamic".
-            # E  - The values of _0 = L['rhs_val'].size()[0] and _1 = L['lhs_val'].size()[1] must always be equal.
-            # E
-            # E  Suggested fixes:
-            # E  _0 = _1
         ]
     )
     def test_bitwise_and_tensor_dynamic_shape(

--- a/tests/py/dynamo/conversion/test_bitwise_not_aten.py
+++ b/tests/py/dynamo/conversion/test_bitwise_not_aten.py
@@ -49,11 +49,12 @@ class TestBitwiseNotConverter(DispatchTestCase):
                 torch_tensor=torch.randint(0, 2, opt_shape, dtype=bool),
             )
         ]
-        self.run_test(
+        self.run_test_with_dynamic_shape(
             bitwise_not(),
             inputs,
             enable_passes=True,
             use_dynamo_tracer=True,
+            use_example_tensors=False,
         )
 
 

--- a/tests/py/dynamo/conversion/test_bitwise_not_aten.py
+++ b/tests/py/dynamo/conversion/test_bitwise_not_aten.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
@@ -20,6 +21,33 @@ class TestBitwiseNotConverter(DispatchTestCase):
 
         inputs = [
             torch.randint(0, 2, shape, dtype=torch.bool),
+        ]
+        self.run_test(
+            bitwise_not(),
+            inputs,
+            enable_passes=True,
+            use_dynamo_tracer=True,
+        )
+
+    @parameterized.expand(
+        [
+            ("2d", (2, 3), (5, 3), (6, 4)),
+            ("3d", (2, 3, 2), (3, 4, 2), (5, 4, 2)),
+        ]
+    )
+    def test_bitwise_not_tensor_dynamic_shape(self, _, min_shape, opt_shape, max_shape):
+        class bitwise_not(nn.Module):
+            def forward(self, val):
+                return torch.ops.aten.bitwise_not.default(val)
+
+        inputs = [
+            Input(
+                dtype=torch.bool,
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                torch_tensor=torch.randint(0, 2, opt_shape, dtype=bool),
+            )
         ]
         self.run_test(
             bitwise_not(),

--- a/tests/py/dynamo/conversion/test_bitwise_or_aten.py
+++ b/tests/py/dynamo/conversion/test_bitwise_or_aten.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
@@ -30,6 +31,52 @@ class TestBitwiseOrConverter(DispatchTestCase):
             inputs,
             enable_passes=True,
             use_dynamo_tracer=True,
+        )
+
+    @parameterized.expand(
+        [
+            ("2d-2d", (2, 3), (3, 3), (5, 3), (2, 3), (3, 3), (5, 3)),
+            ("3d-3d", (2, 2, 2), (2, 3, 2), (2, 4, 2), (1, 2, 2), (1, 3, 2), (1, 4, 2)),
+            # TODO: figure out why this is failing
+            # ("3d-3d", (2, 2, 2), (2, 3, 2), (2, 4, 2), (2, 2), (3, 2), (4, 2)),
+        ]
+    )
+    def test_bitwise_or_tensor_dynamic_shape(
+        self,
+        _,
+        lhs_min_shape,
+        lhs_opt_shape,
+        lhs_max_shape,
+        rhs_min_shape,
+        rhs_opt_shape,
+        rhs_max_shape,
+    ):
+        class bitwise_or(nn.Module):
+            def forward(self, lhs_val, rhs_val):
+                return torch.ops.aten.bitwise_or.Tensor(lhs_val, rhs_val)
+
+        inputs = [
+            Input(
+                dtype=torch.bool,
+                min_shape=lhs_min_shape,
+                opt_shape=lhs_opt_shape,
+                max_shape=lhs_max_shape,
+                torch_tensor=torch.randint(0, 2, lhs_opt_shape, dtype=bool),
+            ),
+            Input(
+                dtype=torch.bool,
+                min_shape=rhs_min_shape,
+                opt_shape=rhs_opt_shape,
+                max_shape=rhs_max_shape,
+                torch_tensor=torch.randint(0, 2, rhs_opt_shape, dtype=bool),
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            bitwise_or(),
+            inputs,
+            enable_passes=True,
+            use_dynamo_tracer=True,
+            use_example_tensors=False,
         )
 
     @parameterized.expand(

--- a/tests/py/dynamo/conversion/test_bitwise_or_aten.py
+++ b/tests/py/dynamo/conversion/test_bitwise_or_aten.py
@@ -37,8 +37,6 @@ class TestBitwiseOrConverter(DispatchTestCase):
         [
             ("2d-2d", (2, 3), (3, 3), (5, 3), (2, 3), (3, 3), (5, 3)),
             ("3d-3d", (2, 2, 2), (2, 3, 2), (2, 4, 2), (1, 2, 2), (1, 3, 2), (1, 4, 2)),
-            # TODO: figure out why this is failing
-            # ("3d-3d", (2, 2, 2), (2, 3, 2), (2, 4, 2), (2, 2), (3, 2), (4, 2)),
         ]
     )
     def test_bitwise_or_tensor_dynamic_shape(

--- a/tests/py/dynamo/conversion/test_bitwise_xor_aten.py
+++ b/tests/py/dynamo/conversion/test_bitwise_xor_aten.py
@@ -36,16 +36,7 @@ class TestBitwiseXorConverter(DispatchTestCase):
     @parameterized.expand(
         [
             ("2d-2d", (2, 3), (3, 3), (5, 3), (2, 3), (3, 3), (5, 3)),
-            # ("3d-3d", (2, 2, 2), (2, 3, 2), (2, 4, 2), (1, 2, 2), (1, 3, 2), (1, 4, 2)),
-            # TODO: this should be a valid testcase, figure out why it is failing
-            # # I want to test when the dimension is not the same, it will prepend 1's to make it same rank
-            # ("3d-3d", (2, 2, 2), (2, 3, 2), (2, 4, 2), (2, 2), (3, 2), (4, 2)),
-            # however pytorch throws the folllowing error:
-            # torch._dynamo.exc.UserError: Constraints violated (_0)! For more information, run with TORCH_LOGS="+dynamic".
-            # E  - The values of _0 = L['rhs_val'].size()[0] and _1 = L['lhs_val'].size()[1] must always be equal.
-            # E
-            # E  Suggested fixes:
-            # E  _0 = _1
+            ("3d-3d", (2, 2, 2), (2, 3, 2), (2, 4, 2), (1, 2, 2), (1, 3, 2), (1, 4, 2)),
         ]
     )
     def test_bitwise_xor_tensor_dynamic_shape(

--- a/tests/py/dynamo/conversion/test_bitwise_xor_aten.py
+++ b/tests/py/dynamo/conversion/test_bitwise_xor_aten.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
@@ -30,6 +31,59 @@ class TestBitwiseXorConverter(DispatchTestCase):
             inputs,
             enable_passes=True,
             use_dynamo_tracer=True,
+        )
+
+    @parameterized.expand(
+        [
+            ("2d-2d", (2, 3), (3, 3), (5, 3), (2, 3), (3, 3), (5, 3)),
+            # ("3d-3d", (2, 2, 2), (2, 3, 2), (2, 4, 2), (1, 2, 2), (1, 3, 2), (1, 4, 2)),
+            # TODO: this should be a valid testcase, figure out why it is failing
+            # # I want to test when the dimension is not the same, it will prepend 1's to make it same rank
+            # ("3d-3d", (2, 2, 2), (2, 3, 2), (2, 4, 2), (2, 2), (3, 2), (4, 2)),
+            # however pytorch throws the folllowing error:
+            # torch._dynamo.exc.UserError: Constraints violated (_0)! For more information, run with TORCH_LOGS="+dynamic".
+            # E  - The values of _0 = L['rhs_val'].size()[0] and _1 = L['lhs_val'].size()[1] must always be equal.
+            # E
+            # E  Suggested fixes:
+            # E  _0 = _1
+        ]
+    )
+    def test_bitwise_xor_tensor_dynamic_shape(
+        self,
+        _,
+        lhs_min_shape,
+        lhs_opt_shape,
+        lhs_max_shape,
+        rhs_min_shape,
+        rhs_opt_shape,
+        rhs_max_shape,
+    ):
+        class bitwise_xor(nn.Module):
+            def forward(self, lhs_val, rhs_val):
+                return torch.ops.aten.bitwise_xor.Tensor(lhs_val, rhs_val)
+
+        inputs = [
+            Input(
+                dtype=torch.bool,
+                min_shape=lhs_min_shape,
+                opt_shape=lhs_opt_shape,
+                max_shape=lhs_max_shape,
+                torch_tensor=torch.randint(0, 2, lhs_opt_shape, dtype=bool),
+            ),
+            Input(
+                dtype=torch.bool,
+                min_shape=rhs_min_shape,
+                opt_shape=rhs_opt_shape,
+                max_shape=rhs_max_shape,
+                torch_tensor=torch.randint(0, 2, rhs_opt_shape, dtype=bool),
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            bitwise_xor(),
+            inputs,
+            enable_passes=True,
+            use_dynamo_tracer=True,
+            use_example_tensors=False,
         )
 
     @parameterized.expand(

--- a/tests/py/dynamo/conversion/test_exp_aten.py
+++ b/tests/py/dynamo/conversion/test_exp_aten.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
@@ -24,6 +25,32 @@ class TestExpConverter(DispatchTestCase):
         self.run_test(
             exp(),
             inputs,
+        )
+
+    @parameterized.expand(
+        [
+            ((1,), (3,), (5,)),
+            ((1, 20), (2, 20), (3, 20)),
+            ((2, 3, 4), (3, 4, 5), (4, 5, 6)),
+            ((2, 3, 4, 5), (3, 5, 5, 6), (4, 5, 6, 7)),
+        ]
+    )
+    def test_exp_float_dynamic_shape(self, min_shape, opt_shape, max_shape):
+        class exp(nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.exp.default(input)
+
+        input_specs = [
+            Input(
+                dtype=torch.float32,
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            exp(),
+            input_specs,
         )
 
     @parameterized.expand(

--- a/tests/py/dynamo/conversion/test_expm1_aten.py
+++ b/tests/py/dynamo/conversion/test_expm1_aten.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
@@ -26,6 +27,32 @@ class TestExpConverter(DispatchTestCase):
         self.run_test(
             expm1(),
             inputs,
+        )
+
+    @parameterized.expand(
+        [
+            ((1,), (3,), (5,)),
+            ((1, 20), (2, 20), (3, 20)),
+            ((2, 3, 4), (3, 4, 5), (4, 5, 6)),
+            ((2, 3, 4, 5), (3, 5, 5, 6), (4, 5, 6, 7)),
+        ]
+    )
+    def test_expm1_float_dynamic_shape(self, min_shape, opt_shape, max_shape):
+        class expm1(nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.expm1.default(input)
+
+        input_specs = [
+            Input(
+                dtype=torch.float32,
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            expm1(),
+            input_specs,
         )
 
     @parameterized.expand(

--- a/tests/py/dynamo/conversion/test_log10.py
+++ b/tests/py/dynamo/conversion/test_log10.py
@@ -10,6 +10,25 @@ from .harness import DispatchTestCase
 class TestLogConverter(DispatchTestCase):
     @parameterized.expand(
         [
+            ((10,), torch.float),
+            ((1, 20), torch.float),
+            ((2, 3, 4), torch.float),
+            ((2, 3, 4, 5), torch.float),
+        ]
+    )
+    def test_log10_float(self, input_shape, dtype):
+        class log10(nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.log10.default(input)
+
+        inputs = [torch.randn(input_shape, dtype=dtype)]
+        self.run_test(
+            log10(),
+            inputs,
+        )
+
+    @parameterized.expand(
+        [
             ((1,), (3,), (5,)),
             ((1, 20), (2, 20), (3, 20)),
             ((2, 3, 4), (3, 4, 5), (4, 5, 6)),
@@ -32,17 +51,6 @@ class TestLogConverter(DispatchTestCase):
         self.run_test_with_dynamic_shape(
             log10(),
             input_specs,
-        )
-
-    def test_log10_float(self, input_shape, dtype):
-        class log10(nn.Module):
-            def forward(self, input):
-                return torch.ops.aten.log10.default(input)
-
-        inputs = [torch.randn(input_shape, dtype=dtype)]
-        self.run_test(
-            log10(),
-            inputs,
         )
 
     @parameterized.expand(

--- a/tests/py/dynamo/conversion/test_log10.py
+++ b/tests/py/dynamo/conversion/test_log10.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
@@ -9,12 +10,30 @@ from .harness import DispatchTestCase
 class TestLogConverter(DispatchTestCase):
     @parameterized.expand(
         [
-            ((10,), torch.float),
-            ((1, 20), torch.float),
-            ((2, 3, 4), torch.float),
-            ((2, 3, 4, 5), torch.float),
+            ((1,), (3,), (5,)),
+            ((1, 20), (2, 20), (3, 20)),
+            ((2, 3, 4), (3, 4, 5), (4, 5, 6)),
+            ((2, 3, 4, 5), (3, 5, 5, 6), (4, 5, 6, 7)),
         ]
     )
+    def test_log10_float_dynamic_shape(self, min_shape, opt_shape, max_shape):
+        class log10(nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.log10.default(input)
+
+        input_specs = [
+            Input(
+                dtype=torch.float32,
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            log10(),
+            input_specs,
+        )
+
     def test_log10_float(self, input_shape, dtype):
         class log10(nn.Module):
             def forward(self, input):

--- a/tests/py/dynamo/conversion/test_log2.py
+++ b/tests/py/dynamo/conversion/test_log2.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
@@ -24,6 +25,32 @@ class TestLogConverter(DispatchTestCase):
         self.run_test(
             log2(),
             inputs,
+        )
+
+    @parameterized.expand(
+        [
+            ((1,), (3,), (5,)),
+            ((1, 20), (2, 20), (3, 20)),
+            ((2, 3, 4), (3, 4, 5), (4, 5, 6)),
+            ((2, 3, 4, 5), (3, 5, 5, 6), (4, 5, 6, 7)),
+        ]
+    )
+    def test_log_float_dynamic_shape(self, min_shape, opt_shape, max_shape):
+        class log2(nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.log2.default(input)
+
+        input_specs = [
+            Input(
+                dtype=torch.float32,
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            log2(),
+            input_specs,
         )
 
     @parameterized.expand(

--- a/tests/py/dynamo/conversion/test_log_aten.py
+++ b/tests/py/dynamo/conversion/test_log_aten.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
@@ -24,6 +25,32 @@ class TestLogConverter(DispatchTestCase):
         self.run_test(
             log(),
             inputs,
+        )
+
+    @parameterized.expand(
+        [
+            ((1,), (3,), (5,)),
+            ((1, 20), (2, 20), (3, 20)),
+            ((2, 3, 4), (3, 4, 5), (4, 5, 6)),
+            ((2, 3, 4, 5), (3, 5, 5, 6), (4, 5, 6, 7)),
+        ]
+    )
+    def test_log_float_dynamic_shape(self, min_shape, opt_shape, max_shape):
+        class log(nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.log.default(input)
+
+        input_specs = [
+            Input(
+                dtype=torch.float32,
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            log(),
+            input_specs,
         )
 
     @parameterized.expand(

--- a/tests/py/dynamo/conversion/test_recip_aten.py
+++ b/tests/py/dynamo/conversion/test_recip_aten.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
@@ -24,6 +25,32 @@ class TestRecipConverter(DispatchTestCase):
         self.run_test(
             recip(),
             inputs,
+        )
+
+    @parameterized.expand(
+        [
+            ((1,), (3,), (5,)),
+            ((1, 20), (2, 20), (3, 20)),
+            ((2, 3, 4), (3, 4, 5), (4, 5, 6)),
+            ((2, 3, 4, 5), (3, 5, 5, 6), (4, 5, 6, 7)),
+        ]
+    )
+    def test_recip_float_dynamic_shape(self, min_shape, opt_shape, max_shape):
+        class recip(nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.reciprocal.default(input)
+
+        input_specs = [
+            Input(
+                dtype=torch.float32,
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            recip(),
+            input_specs,
         )
 
     @parameterized.expand(


### PR DESCRIPTION
# Description

Add dynamic shape support for bitwise_and/or/xor/not, exp/expm1/recip/log/log2/log10

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
