### PR TITLE
Doc build pipeline issue fix

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -7,6 +7,7 @@ name: Generate Docs
 on:
   push:
     branches: [ main ]
+  pull_request:
 
 jobs:
   build-docs:

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -7,7 +7,6 @@ name: Generate Docs
 on:
   push:
     branches: [ main ]
-  pull_request:
 
 jobs:
   build-docs:

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -7,12 +7,13 @@ name: Generate Docs
 on:
   push:
     branches: [ main ]
+  pull_request:
 
 jobs:
   build-docs:
     runs-on: linux.g5.4xlarge.nvidia.gpu
     if: ${{ ! contains(github.actor, 'pytorchbot') }}
-    environment: pytorchbot-env
+    #environment: pytorchbot-env
     container:
       image: docker.io/pytorch/manylinux-builder:cuda12.4
       options: --gpus all

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -19,6 +19,8 @@ jobs:
     env:
       CUDA_HOME: /usr/local/cuda-12.4
       VERSION_SUFFIX: cu124
+      CU_VERSION: cu124
+      CHANNEL: nightly
       CI_BUILD: 1
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -7,13 +7,12 @@ name: Generate Docs
 on:
   push:
     branches: [ main ]
-  pull_request:
 
 jobs:
   build-docs:
     runs-on: linux.g5.4xlarge.nvidia.gpu
     if: ${{ ! contains(github.actor, 'pytorchbot') }}
-    #environment: pytorchbot-env
+    environment: pytorchbot-env
     container:
       image: docker.io/pytorch/manylinux-builder:cuda12.4
       options: --gpus all


### PR DESCRIPTION
# Description

We now templaterized the toolchains/ci_workspaces/WORKSPACE.x86_64.release.rhel.tmpl file, it requires the following two envs:
CHANNEL/CU_VERSION

in both linux, windows build pipeline, those two are populated correctly, however in doc gen pipeline, thoese two are not set.
```

http_archive(
    name = "libtorch_pre_cxx11_abi",
    build_file = "@//third_party/libtorch:BUILD",
    strip_prefix = "libtorch",
    urls = ["https://download.pytorch.org/libtorch/${CHANNEL}/${CU_VERSION}/libtorch-shared-with-deps-latest.zip"],
)
```

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
