### PR TITLE
feat: dynamic shape support for aten.select.int

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -794,7 +794,7 @@ def aten_ops_scatter(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.select.int)
+@dynamo_tensorrt_converter(torch.ops.aten.select.int, supports_dynamic_shapes=True)
 def aten_ops_select(
     ctx: ConversionContext,
     target: Target,

--- a/py/torch_tensorrt/dynamo/conversion/impl/select.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/select.py
@@ -47,26 +47,16 @@ def select(
     if dynamic_shape:
         # Check whether slice target dim is dynamic shape dim
         assert input.shape[dim] != -1, "Can't select on negative shape dimension!"
-    index = index
 
     if index >= input.shape[dim]:
         raise RuntimeError(
             f"cannot have index greater than the dimension length! {input.shape[dim]}"
         )
-    output_shape = list(input.shape)
-    output_shape[dim] = 1
-    if dynamic_shape > 0:
-        output_shape = get_shape_with_dynamic_shape(
-            ctx, target, source_ir, name, output_shape, input
-        )
+
     index_value = np.array(index, dtype=np.int32)
-    indices_tensor = ctx.net.add_constant(
-        index_value.shape, to_numpy(index_value)
-    ).get_output(0)
+    indices_tensor = ctx.net.add_constant(index_value.shape, index_value).get_output(0)
     layer = ctx.net.add_gather(input, indices_tensor, dim)
-    out = layer.get_output(0)
-    if len(out.shape) != 1:
-        layer = ctx.net.add_shuffle(out)
+
     return layer.get_output(0)
 
 

--- a/tests/py/dynamo/conversion/test_select_aten.py
+++ b/tests/py/dynamo/conversion/test_select_aten.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn as nn
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
 from torch_tensorrt import Input
@@ -13,7 +14,7 @@ class TestSelectConverterOne(DispatchTestCase):
         ]
     )
     def test_select(self, _, dim, index):
-        class TestModule(torch.nn.Module):
+        class select(nn.Module):
             def __init__(self):
                 super().__init__()
 
@@ -22,7 +23,7 @@ class TestSelectConverterOne(DispatchTestCase):
 
         input = [torch.randn(1, 2)]
         self.run_test(
-            TestModule(),
+            select(),
             input,
         )
 
@@ -34,7 +35,7 @@ class TestSelectConverterTwo(DispatchTestCase):
         ]
     )
     def test_select(self, _, dim, index):
-        class TestModule(torch.nn.Module):
+        class select(nn.Module):
             def __init__(self):
                 super().__init__()
 
@@ -43,33 +44,63 @@ class TestSelectConverterTwo(DispatchTestCase):
 
         input = [torch.randn(4, 4, 4, 4)]
         self.run_test(
-            TestModule(),
+            select(),
             input,
         )
 
 
-class TestSelectConverterWithDynamicShape(DispatchTestCase):
+class TestSelectConverterDynamicShape(DispatchTestCase):
     @parameterized.expand(
         [
-            ("select_dim_index", 1, 0),
+            (
+                "select_dim_index",
+                (1, 3, 3),
+                (2, 3, 3),
+                (3, 3, 3),
+                torch.int32,
+                1,
+                0,
+            ),
+            (
+                "select_dim_index",
+                (1, 1, 3),
+                (2, 2, 3),
+                (3, 3, 3),
+                torch.float,
+                2,
+                0,
+            ),
+            (
+                "select_dim_index",
+                (3, 1, 1),
+                (3, 2, 2),
+                (3, 3, 3),
+                torch.float,
+                0,
+                2,
+            ),
         ]
     )
-    def test_select_with_dynamic_shape(self, _, dim, index):
-        class TestModule(torch.nn.Module):
+    def test_dynamic_shape_select(
+        self, _, min_shape, opt_shape, max_shape, type, dim, index
+    ):
+        class select(nn.Module):
             def __init__(self):
                 super().__init__()
 
             def forward(self, input):
                 return torch.ops.aten.select.int(input, dim, index)
 
-        input_spec = [
+        input_specs = [
             Input(
-                shape=(-1, 3, 3),
-                dtype=torch.float32,
-                shape_ranges=[((1, 3, 3), (3, 3, 3), (3, 3, 3))],
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
             ),
         ]
-        self.run_test_with_dynamic_shape(TestModule(), input_spec)
+
+        self.run_test_with_dynamic_shape(select(), input_specs)
 
 
 if __name__ == "__main__":

--- a/tests/py/dynamo/conversion/test_select_aten.py
+++ b/tests/py/dynamo/conversion/test_select_aten.py
@@ -10,10 +10,10 @@ from .harness import DispatchTestCase
 class TestSelectConverterOne(DispatchTestCase):
     @parameterized.expand(
         [
-            ("select_dim_index", 1, 0),
+            ("dim_index", 1, 0),
         ]
     )
-    def test_select(self, _, dim, index):
+    def test_select_2d(self, _, dim, index):
         class select(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -27,14 +27,12 @@ class TestSelectConverterOne(DispatchTestCase):
             input,
         )
 
-
-class TestSelectConverterTwo(DispatchTestCase):
     @parameterized.expand(
         [
-            ("select_dim_index", 1, 0),
+            ("dim_index", 1, 0),
         ]
     )
-    def test_select(self, _, dim, index):
+    def test_select_4d(self, _, dim, index):
         class select(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -48,21 +46,10 @@ class TestSelectConverterTwo(DispatchTestCase):
             input,
         )
 
-
-class TestSelectConverterDynamicShape(DispatchTestCase):
     @parameterized.expand(
         [
             (
-                "select_dim_index",
-                (1, 3, 3),
-                (2, 3, 3),
-                (3, 3, 3),
-                torch.int32,
-                1,
-                0,
-            ),
-            (
-                "select_dim_index",
+                "partial_dynamic_static_dim",
                 (1, 1, 3),
                 (2, 2, 3),
                 (3, 3, 3),
@@ -71,13 +58,31 @@ class TestSelectConverterDynamicShape(DispatchTestCase):
                 0,
             ),
             (
-                "select_dim_index",
-                (3, 1, 1),
-                (3, 2, 2),
+                "partial_dynamic_dynamic_dim",
+                (1, 1, 3),
+                (2, 2, 3),
                 (3, 3, 3),
                 torch.float,
-                0,
-                2,
+                1,
+                1,
+            ),
+            (
+                "fully_dynamic",
+                (1, 1, 1),
+                (2, 2, 2),
+                (3, 3, 3),
+                torch.float,
+                1,
+                1,
+            ),
+            (
+                "fully_dynamic_neg_dim",
+                (1, 1, 1),
+                (2, 2, 2),
+                (3, 3, 3),
+                torch.float,
+                -1,
+                1,
             ),
         ]
     )


### PR DESCRIPTION
# Description

Support dynamic shapes for aten.select.int. As shown below, since the arguments dim and index for select.int are int and not list, no reshaping is required.

```
- func: select.int(Tensor(a) self, int dim, SymInt index) -> Tensor(a)
  variants: function, method
  device_check: NoCheck
  device_guard: False
  dispatch:
    CompositeExplicitAutograd: select_symint
    SparseCsrCPU, SparseCsrCUDA: select_sparse_csr
    NestedTensorCPU, NestedTensorCUDA: select_nested
  tags: core
```

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
