### PR TITLE
feat: Lazy engine initialization

### DIFF
--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -27,7 +27,7 @@ if ENABLED_FEATURES.dynamo_frontend:
     from torch.export import ExportedProgram
     from torch_tensorrt.dynamo._compiler import compile as dynamo_compile
     from torch_tensorrt.dynamo._compiler import (
-        convert_module_to_trt_engine as dynamo_convert_module_to_trt_engine,
+        convert_exported_program_to_serialized_trt_engine as dynamo_convert_exported_program_to_serialized_trt_engine,
     )
     from torch_tensorrt.dynamo._tracer import trace as dynamo_trace
 
@@ -351,7 +351,7 @@ def convert_method_to_trt_engine(
         torchtrt_inputs = prepare_inputs(inputs)
         exp_program = torch_tensorrt.dynamo.trace(module, torchtrt_inputs, **kwargs)
 
-        return dynamo_convert_module_to_trt_engine(
+        return dynamo_convert_exported_program_to_serialized_trt_engine(
             exp_program,
             inputs=tuple(inputs),
             enabled_precisions=enabled_precisions_set,

--- a/py/torch_tensorrt/dynamo/__init__.py
+++ b/py/torch_tensorrt/dynamo/__init__.py
@@ -7,7 +7,7 @@ from packaging import version
 logger = logging.getLogger(__name__)
 
 if version.parse(sanitized_torch_version()) >= version.parse("2.1.dev"):
-    from ._compiler import compile, convert_module_to_trt_engine
+    from ._compiler import compile, convert_exported_program_to_serialized_trt_engine
     from ._exporter import export
     from ._refit import refit_module_weights
     from ._settings import CompilationSettings

--- a/py/torch_tensorrt/dynamo/_defaults.py
+++ b/py/torch_tensorrt/dynamo/_defaults.py
@@ -32,6 +32,7 @@ DRYRUN = False
 HARDWARE_COMPATIBLE = False
 SUPPORTED_KERNEL_PRECISIONS = {dtype.f32, dtype.f16, dtype.bf16, dtype.i8, dtype.f8}
 TIMING_CACHE_PATH = os.path.join(tempfile.gettempdir(), "timing_cache.bin")
+LAZY_ENGINE_INIT = False
 
 
 def default_device() -> Device:

--- a/py/torch_tensorrt/dynamo/_settings.py
+++ b/py/torch_tensorrt/dynamo/_settings.py
@@ -16,6 +16,7 @@ from torch_tensorrt.dynamo._defaults import (
     ENABLED_PRECISIONS,
     ENGINE_CAPABILITY,
     HARDWARE_COMPATIBLE,
+    LAZY_ENGINE_INIT,
     MAKE_REFITABLE,
     MAX_AUX_STREAMS,
     MIN_BLOCK_SIZE,
@@ -104,3 +105,4 @@ class CompilationSettings:
     dryrun: Union[bool, str] = DRYRUN
     hardware_compatible: bool = HARDWARE_COMPATIBLE
     timing_cache_path: str = TIMING_CACHE_PATH
+    lazy_engine_init: bool = LAZY_ENGINE_INIT

--- a/py/torch_tensorrt/dynamo/runtime/_PythonTorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_PythonTorchTensorRTModule.py
@@ -4,8 +4,8 @@ import logging
 from contextlib import nullcontext
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-import tensorrt as trt
 import torch
+import torch_tensorrt
 from torch.nn import Module
 from torch_tensorrt._Device import Device
 from torch_tensorrt._enums import dtype
@@ -18,7 +18,7 @@ from torch_tensorrt.dynamo.runtime.tools import (
 from torch_tensorrt.dynamo.utils import DYNAMIC_DIM
 from torch_tensorrt.logging import TRT_LOGGER
 
-import torch_tensorrt
+import tensorrt as trt
 
 logger = logging.getLogger(__name__)
 
@@ -32,17 +32,45 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
 
     def __init__(
         self,
-        engine: bytes,
-        input_names: Optional[List[str]] = None,
-        output_names: Optional[List[str]] = None,
+        serialized_engine: Optional[bytes] = None,
+        input_binding_names: Optional[List[str]] = None,
+        output_binding_names: Optional[List[str]] = None,
+        *,
+        name: str = "",
         settings: CompilationSettings = CompilationSettings(),
     ):
+        """Takes a name, target device, serialized TensorRT engine, and binding names / order and constructs
+        a PyTorch ``torch.nn.Module`` around it. Uses TensorRT Python APIs to run the engine
+
+        Arguments:
+            serialized_engine (bytes): Serialized TensorRT engine in the form of a bytearray
+            input_binding_names (List[str]): List of input TensorRT engine binding names in the order they would be passed to the TRT modules
+            output_binding_names (List[str]): List of output TensorRT engine binding names in the order they should be returned
+
+        Keyword Arguments:
+            name (str): Name for module
+            settings (torch_tensorrt.dynamo.CompilationSettings): Settings used to compile engine, assumes engine was built with default compilation settings if object not passed
+
+        Example:
+
+            .. code-block:: py
+
+                trt_module = PythonTorchTensorRTModule(
+                    engine_str,
+                    input_binding_names=["x"],
+                    output_binding_names=["output"],
+                    name="my_module",
+                    settings=CompilationSettings(device=torch.cuda.current_device)
+                )
+
+        """
         super(PythonTorchTensorRTModule, self).__init__()
         self._register_state_dict_hook(PythonTorchTensorRTModule._on_state_dict)
 
         # Run multi-gpu device check to validate engine instantiation
         multi_gpu_device_check()
 
+        self.name = name
         self.input_buffers: List[torch.Tensor] = []
         self.output_buffers: List[torch.Tensor] = []
         self.cudagraph: Optional[torch.cuda.CUDAGraph] = None
@@ -55,9 +83,13 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
         # Unused currently - to be used by Dynamic Shape support implementation
         self.memory_pool = None
 
-        self.engine = engine
-        self.input_names = input_names if input_names is not None else []
-        self.output_names = output_names if output_names is not None else []
+        self.serialized_engine = serialized_engine
+        self.input_names = (
+            input_binding_names if input_binding_names is not None else []
+        )
+        self.output_names = (
+            output_binding_names if output_binding_names is not None else []
+        )
         self.initialized = False
         self.target_device_id = (
             settings.device.gpu_id
@@ -69,12 +101,15 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
         )
         self.profiling_enabled = settings.debug if settings.debug is not None else False
         self.settings = settings
-        self._initialize()
+        self.engine = None
 
-    def _initialize(self) -> None:
+        if self.serialized_engine is not None and not self.settings.lazy_engine_init:
+            self.setup_engine()
+
+    def setup_engine(self) -> None:
         self.initialized = True
         runtime = trt.Runtime(TRT_LOGGER)
-        self.engine = runtime.deserialize_cuda_engine(self.engine)
+        self.engine = runtime.deserialize_cuda_engine(self.serialized_engine)
         self.context = self.engine.create_execution_context()
 
         assert self.engine.num_io_tensors == (
@@ -114,8 +149,7 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
             raise RuntimeError("PythonTorchTensorRTModule is not initialized.")
 
     def _on_state_dict(self, state_dict: Dict[str, Any], prefix: str, _: Any) -> None:
-        self._check_initialized()
-        state_dict[prefix + "engine"] = bytearray(self.engine.serialize())
+        state_dict[prefix + "engine"] = self.serialized_engine
         state_dict[prefix + "input_names"] = self.input_names
         state_dict[prefix + "output_names"] = self.output_names
 
@@ -129,17 +163,13 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
         unexpected_keys: Any,
         error_msgs: Any,
     ) -> None:
-        engine_bytes = state_dict[prefix + "engine"]
+        self.serialized_engine = state_dict[prefix + "engine"]
+        self.input_names = state_dict[prefix + "input_names"]
+        self.output_names = state_dict[prefix + "output_names"]
 
         # Run multi-gpu device check to validate engine instantiation
         multi_gpu_device_check()
-
-        runtime = trt.Runtime(TRT_LOGGER)
-        self.engine = runtime.deserialize_cuda_engine(engine_bytes)
-
-        self.input_names = state_dict[prefix + "input_names"]
-        self.output_names = state_dict[prefix + "output_names"]
-        self._initialize()
+        self.setup_engine()
 
     def __getstate__(self) -> Dict[str, Any]:
         state = self.__dict__.copy()

--- a/tests/py/dynamo/models/test_dtype_support.py
+++ b/tests/py/dynamo/models/test_dtype_support.py
@@ -178,6 +178,14 @@ class Test64BitSupport(TestCase):
         )
 
 
+@unittest.skipIf(
+    torch.cuda.get_device_properties(torch.cuda.current_device()).major < 8
+    or (
+        torch.cuda.get_device_properties(torch.cuda.current_device()).major == 8
+        and torch.cuda.get_device_properties(torch.cuda.current_device()).major == 7
+    ),
+    "Platform does not have BF16 support",
+)
 class TestBF16Support(TestCase):
     @unittest.skipIf(
         not torch_tensorrt.ENABLED_FEATURES.torch_tensorrt_runtime,

--- a/tests/py/dynamo/models/test_models_export.py
+++ b/tests/py/dynamo/models/test_models_export.py
@@ -30,7 +30,6 @@ def test_resnet18(ir):
         "pass_through_build_failures": True,
         "optimization_level": 1,
         "min_block_size": 8,
-        "ir": "dynamo",
     }
 
     trt_mod = torchtrt.compile(model, **compile_spec)
@@ -61,7 +60,6 @@ def test_mobilenet_v2(ir):
         "pass_through_build_failures": True,
         "optimization_level": 1,
         "min_block_size": 8,
-        "ir": "dynamo",
     }
 
     trt_mod = torchtrt.compile(model, **compile_spec)
@@ -92,7 +90,6 @@ def test_efficientnet_b0(ir):
         "pass_through_build_failures": True,
         "optimization_level": 1,
         "min_block_size": 8,
-        "ir": "dynamo",
     }
 
     trt_mod = torchtrt.compile(model, **compile_spec)
@@ -170,7 +167,6 @@ def test_resnet18_half(ir):
         "pass_through_build_failures": True,
         "optimization_level": 1,
         "min_block_size": 8,
-        "ir": "dynamo",
     }
 
     trt_mod = torchtrt.compile(model, **compile_spec)

--- a/tests/py/dynamo/runtime/conftest.py
+++ b/tests/py/dynamo/runtime/conftest.py
@@ -1,0 +1,21 @@
+# type: ignore
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--ir",
+        metavar="Internal Representation",
+        nargs=1,
+        type=str,
+        required=False,
+        help="IR to compile with",
+        choices=["dynamo", "torch_compile"],
+    )
+
+
+@pytest.fixture
+def ir(request):
+    ir_opt = request.config.getoption("--ir")
+    return ir_opt[0] if ir_opt else "dynamo"

--- a/tests/py/dynamo/runtime/test_convert_module_to_trt_engine.py
+++ b/tests/py/dynamo/runtime/test_convert_module_to_trt_engine.py
@@ -1,10 +1,11 @@
 import unittest
 
-import tensorrt as trt
 import torch
 import torch_tensorrt
 from torch_tensorrt.dynamo.runtime import PythonTorchTensorRTModule
 from torch_tensorrt.dynamo.utils import COSINE_THRESHOLD, cosine_similarity
+
+import tensorrt as trt
 
 
 class TestConvertModuleToTrtEngine(unittest.TestCase):
@@ -21,8 +22,10 @@ class TestConvertModuleToTrtEngine(unittest.TestCase):
         exp_program = torch.export.export(model, (input_data_0, input_data_1))
 
         # Convert to TensorRT engine
-        trt_engine_str = torch_tensorrt.dynamo.convert_module_to_trt_engine(
-            exp_program, inputs=(input_data_0, input_data_1)
+        trt_engine_str = (
+            torch_tensorrt.dynamo.convert_exported_program_to_serialized_trt_engine(
+                exp_program, inputs=(input_data_0, input_data_1)
+            )
         )
 
         # Inference on TRT Engine

--- a/tests/py/dynamo/runtime/test_lazy_engine_init.py
+++ b/tests/py/dynamo/runtime/test_lazy_engine_init.py
@@ -1,0 +1,329 @@
+# type: ignore
+import os
+import tempfile
+import unittest
+
+import torch
+import torch_tensorrt
+import torch_tensorrt as torchtrt
+import torchvision.models as models
+from torch.testing._internal.common_utils import TestCase
+from torch_tensorrt.dynamo import CompilationSettings
+from torch_tensorrt.dynamo.utils import COSINE_THRESHOLD, cosine_similarity
+from torch_tensorrt.runtime import PythonTorchTensorRTModule, TorchTensorRTModule
+
+assertions = unittest.TestCase()
+
+
+def assert_close(outputs, ref_outputs):
+    if type(outputs) not in (list, tuple):
+        outputs = [outputs]
+
+    if type(ref_outputs) not in (
+        list,
+        tuple,
+        torch.return_types.max,
+        torch.return_types.min,
+    ):
+        ref_outputs = [ref_outputs]
+
+    for out, ref in zip(outputs, ref_outputs):
+        if not isinstance(ref, torch.Tensor):
+            if len(out.shape) == 0:
+                ref = torch.tensor(ref)
+            else:
+                ref = torch.tensor([ref])
+        ref = ref.cpu()  # to_dtype test has cases with gpu output
+        torch.testing.assert_close(
+            out.cpu(),
+            ref.cpu(),
+            rtol=1e-03,
+            atol=1e-03,
+            equal_nan=True,
+            check_dtype=True,
+        )
+
+
+class TestLazyEngineInit(TestCase):
+
+    def test_lazy_engine_init_py(self):
+        class Test(torch.nn.Module):
+            def forward(self, a, b):
+                return torch.add(a, b)
+
+        # Prepare the input data
+        input_data_0, input_data_1 = torch.randn((2, 4)), torch.randn((2, 4))
+
+        # Create a model
+        model = Test()
+        exp_program = torch.export.export(model, (input_data_0, input_data_1))
+
+        # Convert to TensorRT engine
+        trt_engine_str = (
+            torch_tensorrt.dynamo.convert_exported_program_to_serialized_trt_engine(
+                exp_program, inputs=(input_data_0, input_data_1)
+            )
+        )
+
+        # Inference on TRT Engine
+        trt_module = PythonTorchTensorRTModule(
+            trt_engine_str,
+            ["a", "b"],
+            ["output0"],
+            settings=CompilationSettings(lazy_engine_init=True),
+        )
+
+        assertions.assertTrue(
+            trt_module.engine is None,
+            msg="Engine was proactively instantiated even though lazy engine loading was enabled",
+        )
+
+        with assertions.assertRaises(Exception):
+            trt_output = trt_module(input_data_0, input_data_1).cpu()
+
+        trt_module.setup_engine()
+        assertions.assertTrue(trt_module.engine, msg="Engine was not setup")
+
+        trt_output = trt_module(input_data_0, input_data_1).cpu()
+
+        # Inference on PyTorch model
+        model_output = model(input_data_0, input_data_1)
+
+        assert_close(trt_output, model_output)
+
+    @unittest.skipIf(
+        not torch_tensorrt.ENABLED_FEATURES.torch_tensorrt_runtime,
+        "Torch-TensorRT Runtime is not available",
+    )
+    def test_lazy_engine_init_cpp(self):
+        class Test(torch.nn.Module):
+            def forward(self, a, b):
+                return torch.add(a, b)
+
+        # Prepare the input data
+        input_data_0, input_data_1 = torch.randn((2, 4)), torch.randn((2, 4))
+
+        # Create a model
+        model = Test()
+        exp_program = torch.export.export(model, (input_data_0, input_data_1))
+
+        # Convert to TensorRT engine
+        trt_engine_str = (
+            torch_tensorrt.dynamo.convert_exported_program_to_serialized_trt_engine(
+                exp_program, inputs=(input_data_0, input_data_1)
+            )
+        )
+
+        # Inference on TRT Engine
+        trt_module = TorchTensorRTModule(
+            trt_engine_str,
+            ["a", "b"],
+            ["output0"],
+            settings=CompilationSettings(lazy_engine_init=True),
+        )
+
+        assertions.assertTrue(
+            trt_module.engine is None,
+            msg="Engine was proactively instantiated even though lazy engine loading was enabled",
+        )
+
+        with assertions.assertRaises(Exception):
+            trt_output = trt_module(
+                input_data_0.to("cuda"), input_data_1.to("cuda")
+            ).cpu()
+
+        trt_module.setup_engine()
+        assertions.assertTrue(trt_module.engine is not None, msg="Engine was not setup")
+
+        trt_output = trt_module(input_data_0.to("cuda"), input_data_1.to("cuda")).cpu()
+
+        # Inference on PyTorch model
+        model_output = model(input_data_0, input_data_1)
+
+        assert_close(trt_output, model_output)
+
+    def test_lazy_engine_init_py_e2e(self):
+        model = models.resnet18(pretrained=True).eval().to("cuda")
+        input = torch.randn((1, 3, 224, 224)).to("cuda")
+
+        compile_spec = {
+            "inputs": [
+                torchtrt.Input(
+                    input.shape, dtype=torch.float, format=torch.contiguous_format
+                )
+            ],
+            "device": torchtrt.Device("cuda:0"),
+            "enabled_precisions": {torch.float},
+            "pass_through_build_failures": True,
+            "optimization_level": 1,
+            "min_block_size": 1,
+            "ir": "dynamo",
+            "lazy_engine_init": True,
+            "use_python_runtime": True,
+        }
+
+        trt_mod = torchtrt.compile(model, **compile_spec)
+        cos_sim = cosine_similarity(model(input), trt_mod(input))
+        assertions.assertTrue(
+            cos_sim > COSINE_THRESHOLD,
+            msg=f"Resnet18 TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+        )
+
+        # Clean up model env
+        torch._dynamo.reset()
+
+    @unittest.skipIf(
+        not torch_tensorrt.ENABLED_FEATURES.torch_tensorrt_runtime,
+        "Torch-TensorRT Runtime is not available",
+    )
+    def test_lazy_engine_init_cpp_e2e(self):
+        model = models.resnet18(pretrained=False).eval().to("cuda")
+        input = torch.randn((1, 3, 224, 224)).to("cuda")
+
+        compile_spec = {
+            "inputs": [
+                torchtrt.Input(
+                    input.shape, dtype=torch.float, format=torch.contiguous_format
+                )
+            ],
+            "device": torchtrt.Device("cuda:0"),
+            "enabled_precisions": {torch.float},
+            "pass_through_build_failures": True,
+            "optimization_level": 1,
+            "min_block_size": 1,
+            "ir": "dynamo",
+            "lazy_engine_init": True,
+            "use_python_runtime": False,
+        }
+
+        trt_mod = torchtrt.compile(model, **compile_spec)
+        cos_sim = cosine_similarity(model(input), trt_mod(input))
+        assertions.assertTrue(
+            cos_sim > COSINE_THRESHOLD,
+            msg=f"Resnet18 TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+        )
+
+        # Clean up model env
+        torch._dynamo.reset()
+
+    @unittest.skipIf(
+        not torch_tensorrt.ENABLED_FEATURES.torch_tensorrt_runtime,
+        "Torch-TensorRT Runtime is not available",
+    )
+    def test_lazy_engine_init_cpp_serialization(self):
+        model = models.resnet18(pretrained=False).eval().to("cuda")
+        input = torch.randn((1, 3, 224, 224)).to("cuda")
+
+        compile_spec = {
+            "inputs": [
+                torchtrt.Input(
+                    input.shape, dtype=torch.float, format=torch.contiguous_format
+                )
+            ],
+            "device": torchtrt.Device("cuda:0"),
+            "enabled_precisions": {torch.float},
+            "pass_through_build_failures": True,
+            "optimization_level": 1,
+            "min_block_size": 1,
+            "ir": "dynamo",
+            "lazy_engine_init": True,
+            "use_python_runtime": False,
+        }
+
+        trt_mod = torchtrt.compile(model, **compile_spec)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            torch_tensorrt.save(
+                trt_mod, os.path.join(tmpdir, "tmp_trt_mod.ep"), inputs=[input]
+            )
+            new_trt_mod = torch.export.load(os.path.join(tmpdir, "tmp_trt_mod.ep"))
+
+        loaded_trt_mod = new_trt_mod.module()
+        cos_sim = cosine_similarity(model(input), trt_mod(input))
+        assertions.assertTrue(
+            cos_sim > COSINE_THRESHOLD,
+            msg=f"Resnet18 TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+        )
+        # Clean up model env
+        torch._dynamo.reset()
+
+    def test_lazy_engine_init_py_hybrid_graph(self):
+        class Test(torch.nn.Module):
+            def forward(self, a, b):
+                w = torch.add(a, b)
+                x = 2 * b
+                y = torch.sub(w, a)
+                z = torch.add(y, x)
+                return w, x, y, z
+
+        # Prepare the input data
+        input_data_0, input_data_1 = torch.randn((2, 4)).to("cuda"), torch.randn(
+            (2, 4)
+        ).to("cuda")
+
+        # Create a model
+        model = Test()
+        exp_program = torch.export.export(model, (input_data_0, input_data_1))
+
+        compile_spec = {
+            "inputs": (input_data_0, input_data_1),
+            "device": torchtrt.Device("cuda:0"),
+            "enabled_precisions": {torch.float},
+            "pass_through_build_failures": True,
+            "optimization_level": 1,
+            "min_block_size": 1,
+            "ir": "dynamo",
+            "lazy_engine_init": True,
+            "use_python_runtime": True,
+            "torch_executed_ops": [torch.ops.aten.sub.Tensor],
+        }
+
+        trt_mod = torchtrt.dynamo.compile(exp_program, **compile_spec)
+        assert_close(
+            trt_mod(input_data_0, input_data_1), model(input_data_0, input_data_1)
+        )
+
+        # Clean up model env
+        torch._dynamo.reset()
+
+    @unittest.skipIf(
+        not torch_tensorrt.ENABLED_FEATURES.torch_tensorrt_runtime,
+        "Torch-TensorRT Runtime is not available",
+    )
+    def test_lazy_engine_init_cpp_hybrid_graph(self):
+        class Test(torch.nn.Module):
+            def forward(self, a, b):
+                x = torch.add(a, b)
+                y = torch.sub(x, 2 * b)
+                z = torch.add(y, b)
+                return z
+
+        # Prepare the input data
+        input_data_0, input_data_1 = torch.randn((2, 4)).to("cuda"), torch.randn(
+            (2, 4)
+        ).to("cuda")
+
+        # Create a model
+        model = Test()
+        exp_program = torch.export.export(model, (input_data_0, input_data_1))
+
+        compile_spec = {
+            "inputs": (input_data_0, input_data_1),
+            "device": torchtrt.Device("cuda:0"),
+            "enabled_precisions": {torch.float},
+            "pass_through_build_failures": True,
+            "optimization_level": 1,
+            "min_block_size": 1,
+            "ir": "dynamo",
+            "lazy_engine_init": True,
+            "use_python_runtime": False,
+            "torch_executed_ops": [torch.ops.aten.sub.Tensor],
+        }
+
+        trt_mod = torchtrt.dynamo.compile(exp_program, **compile_spec)
+        assert_close(
+            trt_mod(input_data_0, input_data_1), model(input_data_0, input_data_1)
+        )
+
+        # Clean up model env
+        torch._dynamo.reset()

--- a/tests/py/ts/api/test_collections.py
+++ b/tests/py/ts/api/test_collections.py
@@ -13,7 +13,7 @@ def find_repo_root(max_depth=10):
     dir_path = os.path.dirname(os.path.realpath(__file__))
     for i in range(max_depth):
         files = os.listdir(dir_path)
-        if "WORKSPACE" in files:
+        if "MODULE.bazel" in files:
             return dir_path
         else:
             dir_path = os.path.dirname(dir_path)


### PR DESCRIPTION
# Description

Allows engines to not be setup immediately after compilation but all at once before the module is returned back to the user.

Fixes #2673 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
