### PR TITLE
feat: support dynamic shapes for avg poolNd

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -2546,13 +2546,19 @@ def avg_pool_param_validator(pool_node: Node) -> bool:
 
 # Note: AvgPool1d uses avg_pool2d as it converts to 2D first.
 @dynamo_tensorrt_converter(
-    torch.ops.aten.avg_pool1d.default, capability_validator=avg_pool_param_validator,supports_dynamic_shapes=True,
+    torch.ops.aten.avg_pool1d.default,
+    capability_validator=avg_pool_param_validator,
+    supports_dynamic_shapes=True,
 )
 @dynamo_tensorrt_converter(
-    torch.ops.aten.avg_pool2d.default, capability_validator=avg_pool_param_validator,supports_dynamic_shapes=True,
+    torch.ops.aten.avg_pool2d.default,
+    capability_validator=avg_pool_param_validator,
+    supports_dynamic_shapes=True,
 )
 @dynamo_tensorrt_converter(
-    torch.ops.aten.avg_pool3d.default, capability_validator=avg_pool_param_validator,supports_dynamic_shapes=True,
+    torch.ops.aten.avg_pool3d.default,
+    capability_validator=avg_pool_param_validator,
+    supports_dynamic_shapes=True,
 )
 def aten_ops_avg_pool(
     ctx: ConversionContext,

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -2546,13 +2546,13 @@ def avg_pool_param_validator(pool_node: Node) -> bool:
 
 # Note: AvgPool1d uses avg_pool2d as it converts to 2D first.
 @dynamo_tensorrt_converter(
-    torch.ops.aten.avg_pool1d.default, capability_validator=avg_pool_param_validator
+    torch.ops.aten.avg_pool1d.default, capability_validator=avg_pool_param_validator,supports_dynamic_shapes=True,
 )
 @dynamo_tensorrt_converter(
-    torch.ops.aten.avg_pool2d.default, capability_validator=avg_pool_param_validator
+    torch.ops.aten.avg_pool2d.default, capability_validator=avg_pool_param_validator,supports_dynamic_shapes=True,
 )
 @dynamo_tensorrt_converter(
-    torch.ops.aten.avg_pool3d.default, capability_validator=avg_pool_param_validator
+    torch.ops.aten.avg_pool3d.default, capability_validator=avg_pool_param_validator,supports_dynamic_shapes=True,
 )
 def aten_ops_avg_pool(
     ctx: ConversionContext,

--- a/py/torch_tensorrt/dynamo/conversion/impl/pool.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/pool.py
@@ -30,9 +30,6 @@ def avg_poolNd(
     count_include_pad: bool = True,
     divisor_override: Optional[int] = None,
 ) -> TRTTensor:
-    if has_dynamic_shape(input.shape):
-        assert input.shape[1] != -1, "Channel dim can't be dynamic for pooling."
-
     if ceil_mode is not False:
         raise RuntimeError("ceil_mode is not yet supported!")
 

--- a/tests/py/dynamo/conversion/test_pool_aten.py
+++ b/tests/py/dynamo/conversion/test_pool_aten.py
@@ -106,22 +106,30 @@ class TestPoolConverter(DispatchTestCase):
         inputs = [torch.randn(1, 3, 32, 32, 32)]
         self.run_test(TestModule(), inputs, use_dynamo_tracer=True)
 
-
     @parameterized.expand(
         [
             (
-                (1,1,1),
-                (2,2,2),
-                (3,3,3),
+                (1, 1, 1),
+                (2, 2, 2),
+                (3, 3, 3),
                 torch.float,
-                (3,), 
-                (1,), 
+                (3,),
+                (1,),
                 (1,),
             ),
         ]
     )
     def test_dynamic_shape_pool1d(
-        self, min_shape, opt_shape, max_shape, type, kernel_size, stride=1, padding=0, ceil_mode=False, count_include_pad=True,
+        self,
+        min_shape,
+        opt_shape,
+        max_shape,
+        type,
+        kernel_size,
+        stride=1,
+        padding=0,
+        ceil_mode=False,
+        count_include_pad=True,
     ):
         class pool1d(torch.nn.Module):
             def forward(self, x):
@@ -143,27 +151,36 @@ class TestPoolConverter(DispatchTestCase):
     @parameterized.expand(
         [
             (
-                (1,1,1,1),
-                (2,2,2,2),
-                (3,3,3,3),
+                (1, 1, 1, 1),
+                (2, 2, 2, 2),
+                (3, 3, 3, 3),
                 torch.float,
-                3, 
-                1, 
+                3,
+                1,
                 1,
             ),
             (
-                (1,1,1,1),
-                (2,2,2,2),
-                (3,3,3,3),
+                (1, 1, 1, 1),
+                (2, 2, 2, 2),
+                (3, 3, 3, 3),
                 torch.float,
-                (3, 3), 
-                (1, 1), 
+                (3, 3),
+                (1, 1),
                 (1, 1),
             ),
         ]
     )
     def test_dynamic_shape_pool2d(
-        self, min_shape, opt_shape, max_shape, type, kernel_size, stride=1, padding=0, ceil_mode=False, count_include_pad=True,
+        self,
+        min_shape,
+        opt_shape,
+        max_shape,
+        type,
+        kernel_size,
+        stride=1,
+        padding=0,
+        ceil_mode=False,
+        count_include_pad=True,
     ):
         class pool2d(torch.nn.Module):
             def forward(self, x):
@@ -185,28 +202,36 @@ class TestPoolConverter(DispatchTestCase):
     @parameterized.expand(
         [
             (
-                (1,1,1,1,1),
-                (2,2,2,2,2),
-                (3,3,3,3,3),
+                (1, 1, 1, 1, 1),
+                (2, 2, 2, 2, 2),
+                (3, 3, 3, 3, 3),
                 torch.float,
-                2, 
-                1, 
+                2,
+                1,
                 1,
             ),
             (
-                (1,1,1,1,1),
-                (2,2,2,2,2),
-                (3,3,3,3,3),
+                (1, 1, 1, 1, 1),
+                (2, 2, 2, 2, 2),
+                (3, 3, 3, 3, 3),
                 torch.float,
-                (2, 2, 2), 
-                (1, 1, 1), 
+                (2, 2, 2),
+                (1, 1, 1),
                 (1, 1, 1),
             ),
-            
         ]
     )
     def test_dynamic_shape_pool3d(
-        self, min_shape, opt_shape, max_shape, type, kernel_size, stride=1, padding=0, ceil_mode=False, count_include_pad=True,
+        self,
+        min_shape,
+        opt_shape,
+        max_shape,
+        type,
+        kernel_size,
+        stride=1,
+        padding=0,
+        ceil_mode=False,
+        count_include_pad=True,
     ):
         class pool3d(torch.nn.Module):
             def forward(self, x):
@@ -224,7 +249,6 @@ class TestPoolConverter(DispatchTestCase):
         ]
 
         self.run_test_with_dynamic_shape(pool3d(), input_specs, use_dynamo_tracer=True)
-    
 
     @parameterized.expand(
         [

--- a/tests/py/dynamo/conversion/test_pool_aten.py
+++ b/tests/py/dynamo/conversion/test_pool_aten.py
@@ -106,6 +106,126 @@ class TestPoolConverter(DispatchTestCase):
         inputs = [torch.randn(1, 3, 32, 32, 32)]
         self.run_test(TestModule(), inputs, use_dynamo_tracer=True)
 
+
+    @parameterized.expand(
+        [
+            (
+                (1,1,1),
+                (2,2,2),
+                (3,3,3),
+                torch.float,
+                (3,), 
+                (1,), 
+                (1,),
+            ),
+        ]
+    )
+    def test_dynamic_shape_pool1d(
+        self, min_shape, opt_shape, max_shape, type, kernel_size, stride=1, padding=0, ceil_mode=False, count_include_pad=True,
+    ):
+        class pool1d(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.avg_pool1d.default(
+                    x, kernel_size, stride, padding, ceil_mode, count_include_pad
+                )
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(pool1d(), input_specs, use_dynamo_tracer=True)
+
+    @parameterized.expand(
+        [
+            (
+                (1,1,1,1),
+                (2,2,2,2),
+                (3,3,3,3),
+                torch.float,
+                3, 
+                1, 
+                1,
+            ),
+            (
+                (1,1,1,1),
+                (2,2,2,2),
+                (3,3,3,3),
+                torch.float,
+                (3, 3), 
+                (1, 1), 
+                (1, 1),
+            ),
+        ]
+    )
+    def test_dynamic_shape_pool2d(
+        self, min_shape, opt_shape, max_shape, type, kernel_size, stride=1, padding=0, ceil_mode=False, count_include_pad=True,
+    ):
+        class pool2d(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.avg_pool2d.default(
+                    x, kernel_size, stride, padding, ceil_mode, count_include_pad
+                )
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(pool2d(), input_specs, use_dynamo_tracer=True)
+
+    @parameterized.expand(
+        [
+            (
+                (1,1,1,1,1),
+                (2,2,2,2,2),
+                (3,3,3,3,3),
+                torch.float,
+                2, 
+                1, 
+                1,
+            ),
+            (
+                (1,1,1,1,1),
+                (2,2,2,2,2),
+                (3,3,3,3,3),
+                torch.float,
+                (2, 2, 2), 
+                (1, 1, 1), 
+                (1, 1, 1),
+            ),
+            
+        ]
+    )
+    def test_dynamic_shape_pool3d(
+        self, min_shape, opt_shape, max_shape, type, kernel_size, stride=1, padding=0, ceil_mode=False, count_include_pad=True,
+    ):
+        class pool3d(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.avg_pool3d.default(
+                    x, kernel_size, stride, padding, ceil_mode, count_include_pad
+                )
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(pool3d(), input_specs, use_dynamo_tracer=True)
+    
+
     @parameterized.expand(
         [
             (3, 1, 0),


### PR DESCRIPTION
# Description

Dynamic shapes support for aten avg_pool1d, avg_pool2d and avg_pool3d

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
