### PR TITLE
feat: support dynamic shape for aten.linear

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -2502,8 +2502,8 @@ def aten_ops_convolution(
         )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.linear.default)
-@dynamo_tensorrt_converter(torch.ops.aten.linear)
+@dynamo_tensorrt_converter(torch.ops.aten.linear.default, supports_dynamic_shapes=True)
+@dynamo_tensorrt_converter(torch.ops.aten.linear, supports_dynamic_shapes=True)
 def aten_ops_linear(
     ctx: ConversionContext,
     target: Target,

--- a/tests/py/dynamo/conversion/test_linear_aten.py
+++ b/tests/py/dynamo/conversion/test_linear_aten.py
@@ -104,12 +104,6 @@ class TestLinearConverter(DispatchTestCase):
             def __init__(self):
                 super().__init__()
                 self.weight = torch.rand(weight_shape)
-                # self.weight = torch.randn(weight_shape)
-                # # Note: When using torch.randn for weight initialization, the following assertion error occurs:
-                # AssertionError: Tensor-likes are not close!
-                # Mismatched elements: 323 / 2304 (14.0%)
-                # Greatest absolute difference: 0.015128374099731445 at index (1, 1, 139) (up to 0.001 allowed)
-                # Greatest relative difference: 3.242828845977783 at index (1, 1, 154) (up to 0.001 allowed)
 
                 if bias_shape:
                     self.bias = torch.randn(bias_shape)


### PR DESCRIPTION
# Description

Dynamic shape support for aten.linear 

When using `torch.randn` for `weight` initialization, an assertion error occurs. 
```
AssertionError: Tensor-likes are not close! 
Mismatched elements: 323 / 2304 (14.0%)
Greatest absolute difference: 0.015128374099731445 at index (1, 1, 139) (up to 0.001 allowed) 
Greatest relative difference: 3.242828845977783 at index (1, 1, 154) (up to 0.001 allowed)
```
However, no error occurs with `torch.rand` initialization. 
This is likely due to a numerical error, but I haven't pinpointed the exact cause yet.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
