### PR TITLE
chore: dynamic shape support for upsample_nearest2d/bilinear2d

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -3013,8 +3013,12 @@ def aten_ops_pad(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.upsample_nearest2d.default)
-@dynamo_tensorrt_converter(torch.ops.aten.upsample_nearest2d.vec)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.upsample_nearest2d.default, supports_dynamic_shapes=True
+)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.upsample_nearest2d.vec, supports_dynamic_shapes=True
+)
 def upsample_nearest2d(
     ctx: ConversionContext,
     target: Target,
@@ -3035,8 +3039,12 @@ def upsample_nearest2d(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.upsample_bilinear2d.default)
-@dynamo_tensorrt_converter(torch.ops.aten.upsample_bilinear2d.vec)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.upsample_bilinear2d.default, supports_dynamic_shapes=True
+)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.upsample_bilinear2d.vec, supports_dynamic_shapes=True
+)
 def upsample_bilinear2d(
     ctx: ConversionContext,
     target: Target,

--- a/py/torch_tensorrt/dynamo/conversion/impl/upsample.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/upsample.py
@@ -1,10 +1,15 @@
 from typing import Optional, Sequence
 
 import tensorrt as trt
+import torch_tensorrt.dynamo.conversion.impl as impl
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
-from torch_tensorrt.fx.converters.converter_utils import set_layer_name
+from torch_tensorrt.dynamo.conversion.impl.shape import get_shape_with_dynamic_shape
+from torch_tensorrt.fx.converters.converter_utils import (
+    has_dynamic_shape,
+    set_layer_name,
+)
 from torch_tensorrt.fx.types import TRTTensor
 
 
@@ -24,7 +29,33 @@ def upsample(
     # Pytorch assumes that one of out_shape/scale_factor is None
     # Pytorch assumes that dimensions match for out_shape/scale factor
     if out_shape is not None:
-        resize_layer.shape = list(input.shape)[:2] + list(out_shape)
+        new_out_shape = list(input.shape)[:2] + list(out_shape)
+        if has_dynamic_shape(new_out_shape):
+            output_shape = get_shape_with_dynamic_shape(
+                ctx, target, source_ir, name, input.shape, input
+            )
+            front_tensor = impl.slice.slice_op(
+                ctx,
+                target,
+                source_ir,
+                f"{name}_slice_front",
+                output_shape,
+                dim=0,
+                start=0,
+                stop=2,
+                step=1,
+            )
+            out_tensor = impl.cat.cat(
+                ctx,
+                target,
+                source_ir,
+                f"{name}_concat",
+                [front_tensor] + list(out_shape),
+                0,
+            )
+            resize_layer.set_input(1, out_tensor)
+        else:
+            resize_layer.shape = new_out_shape
     elif scale_factors is not None:
         resize_layer.scales = [1.0, 1.0] + list(scale_factors)
     else:

--- a/tests/py/dynamo/conversion/test_upsample.py
+++ b/tests/py/dynamo/conversion/test_upsample.py
@@ -1,6 +1,7 @@
 import torch
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
@@ -91,6 +92,101 @@ class TestUpsampleConverter(DispatchTestCase):
 
         input = [torch.randn([1, 1] + list(input_shape))]
         self.run_test(Upsample(), input)
+
+
+class TestDynamicShapeUpsampleConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            (
+                "nearest2d_outshape",
+                (1, 1, 1, 1),
+                (1, 2, 2, 2),
+                (2, 3, 4, 4),
+                (5, 5),
+                None,
+            ),
+            (
+                "nearest2d_scale",
+                (1, 2, 1, 1),
+                (1, 2, 2, 2),
+                (2, 2, 4, 4),
+                None,
+                (1.5, 1.5),
+            ),
+        ]
+    )
+    def test_upsample_nearest2d(
+        self, _, min_shape, opt_shape, max_shape, output_shape, scale_factor
+    ):
+        class UpsampleNearest(torch.nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.upsample_nearest2d.vec(
+                    input, output_shape, scale_factor
+                )
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=torch.float,
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            UpsampleNearest(),
+            input_specs,
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "bilinar2d_outshape",
+                (1, 1, 1, 1),
+                (1, 2, 2, 2),
+                (2, 3, 4, 4),
+                (5, 5),
+                True,
+                None,
+            ),
+            (
+                "bilinar2d_scale",
+                (1, 2, 1, 1),
+                (1, 2, 2, 2),
+                (2, 2, 4, 4),
+                None,
+                True,
+                (1.5, 1.5),
+            ),
+        ]
+    )
+    def test_upsample_bilinear2d(
+        self,
+        _,
+        min_shape,
+        opt_shape,
+        max_shape,
+        output_shape,
+        align_corners,
+        scale_factor,
+    ):
+        class UpsampleBilinear(torch.nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.upsample_bilinear2d.vec(
+                    input, output_shape, align_corners, scale_factor
+                )
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=torch.float,
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            UpsampleBilinear(),
+            input_specs,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

dynamic shape support for upsample_nearest2d/bilinear2d.
If dim 0 or 1 is dynamic shape, slice and cat are used to set output shape

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
