### PR TITLE
feat: support dynamic shape for replication and circular pad

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -2963,9 +2963,15 @@ def aten_ops_reflection_pad(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.replication_pad1d.default)
-@dynamo_tensorrt_converter(torch.ops.aten.replication_pad2d.default)
-@dynamo_tensorrt_converter(torch.ops.aten.replication_pad3d.default)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.replication_pad1d.default, supports_dynamic_shapes=True
+)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.replication_pad2d.default, supports_dynamic_shapes=True
+)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.replication_pad3d.default, supports_dynamic_shapes=True
+)
 @enforce_tensor_types(
     {
         0: (TRTTensor,),
@@ -2988,7 +2994,9 @@ def aten_ops_replication_pad(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten._pad_circular.default)
+@dynamo_tensorrt_converter(
+    torch.ops.aten._pad_circular.default, supports_dynamic_shapes=True
+)
 @enforce_tensor_types(
     {
         0: (TRTTensor,),

--- a/py/torch_tensorrt/dynamo/conversion/impl/pad.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/pad.py
@@ -1,8 +1,10 @@
 from typing import Optional, Sequence, Union
 
+import numpy as np
 import tensorrt as trt
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.dynamo.conversion import impl
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import get_trt_tensor
 from torch_tensorrt.fx.converters.converter_utils import (
@@ -105,30 +107,74 @@ def replication_padNd(
     input: TRTTensor,
     padding: Sequence[int],
 ) -> TRTTensor:
-    if has_dynamic_shape(input.shape):
-        assert input.shape[1] != -1, "Channel dim can't be dynamic for padding."
-
     rank = len(input.shape)
 
     if len(padding) // 2 > rank:
         raise RuntimeError(
-            f"Trying to pad last {len(padding) // 2} dimension but the input only has {rank} dimension."
+            f"Trying to pad last {len(padding) // 2} dimensions but the input only has {rank} dimensions."
         )
 
+    input_shape_tensor = ctx.net.add_shape(input).get_output(0)
+    new_shape_tensor = input_shape_tensor
+
     start_list = [0] * rank
-    new_shape = list(input.shape)
-
-    for i in range(0, len(padding) // 2):
-        start_list[-i - 1] = -padding[i * 2]
-        new_shape[-i - 1] += padding[i * 2] + padding[i * 2 + 1]
-
     stride_list = [1] * rank
-    layer = ctx.net.add_slice(
-        input,
-        start=tuple(start_list),
-        shape=tuple(new_shape),
-        stride=tuple(stride_list),
+
+    for i in range(len(padding) // 2):
+        dim_index = rank - (i + 1)
+        pad_before = padding[i * 2]
+        pad_after = padding[i * 2 + 1]
+
+        pad_sum = get_trt_tensor(
+            ctx, pad_before + pad_after, f"{name}_pad_sum_{i}", dtype=np.int64
+        )
+        dim_shape = ctx.net.add_slice(
+            input_shape_tensor,
+            start=(dim_index,),
+            shape=(1,),
+            stride=(1,),
+        ).get_output(0)
+
+        new_dim_shape = impl.elementwise.add(
+            ctx, target, source_ir, f"{name}_shape_dim_{i}", dim_shape, pad_sum
+        )
+        start_list[dim_index] = -pad_before
+
+        slices = []
+        for j in range(rank):
+            if j == dim_index:
+                slices.append(new_dim_shape)
+            else:
+                slices.append(
+                    ctx.net.add_slice(
+                        new_shape_tensor,
+                        start=(j,),
+                        shape=(1,),
+                        stride=(1,),
+                    ).get_output(0)
+                )
+        new_shape_tensor = ctx.net.add_concatenation(slices).get_output(0)
+
+    start_tensor = get_trt_tensor(
+        ctx,
+        np.array(start_list, dtype=np.int64),
+        f"{name}_start_tensor",
+        dtype=np.int64,
     )
+
+    stride_tensor = get_trt_tensor(
+        ctx,
+        np.array(stride_list, dtype=np.int64),
+        f"{name}_stride_tensor",
+        dtype=np.int64,
+    )
+
+    layer = ctx.net.add_slice(
+        input, start=trt.Dims(), shape=trt.Dims(), stride=trt.Dims()
+    )
+    layer.set_input(1, start_tensor)
+    layer.set_input(2, new_shape_tensor)
+    layer.set_input(3, stride_tensor)
     layer.mode = trt.SampleMode.CLAMP
 
     set_layer_name(layer, target, name, source_ir)
@@ -141,32 +187,76 @@ def circular_padNd(
     source_ir: Optional[SourceIR],
     name: str,
     input: TRTTensor,
-    pad: Sequence[int],
+    padding: Sequence[int],
 ) -> TRTTensor:
-    if has_dynamic_shape(input.shape):
-        assert input.shape[1] != -1, "Channel dim can't be dynamic for padding."
-
     rank = len(input.shape)
 
-    if len(pad) // 2 > rank:
+    if len(padding) // 2 > rank:
         raise RuntimeError(
-            f"Trying to pad last {len(pad) // 2} dimension but the input only has {rank} dimension."
+            f"Trying to pad last {len(padding) // 2} dimensions but the input only has {rank} dimensions."
         )
 
+    input_shape_tensor = ctx.net.add_shape(input).get_output(0)
+    new_shape_tensor = input_shape_tensor
+
     start_list = [0] * rank
-    new_shape = list(input.shape)
-
-    for i in range(0, len(pad) // 2):
-        start_list[-i - 1] = -pad[i * 2]
-        new_shape[-i - 1] += pad[i * 2] + pad[i * 2 + 1]
-
     stride_list = [1] * rank
-    layer = ctx.net.add_slice(
-        input,
-        start=tuple(start_list),
-        shape=tuple(new_shape),
-        stride=tuple(stride_list),
+
+    for i in range(len(padding) // 2):
+        dim_index = rank - (i + 1)
+        pad_before = padding[i * 2]
+        pad_after = padding[i * 2 + 1]
+
+        pad_sum = get_trt_tensor(
+            ctx, pad_before + pad_after, f"{name}_pad_sum_{i}", dtype=np.int64
+        )
+        dim_shape = ctx.net.add_slice(
+            input_shape_tensor,
+            start=(dim_index,),
+            shape=(1,),
+            stride=(1,),
+        ).get_output(0)
+
+        new_dim_shape = impl.elementwise.add(
+            ctx, target, source_ir, f"{name}_shape_dim_{i}", dim_shape, pad_sum
+        )
+        start_list[dim_index] = -pad_before
+
+        slices = []
+        for j in range(rank):
+            if j == dim_index:
+                slices.append(new_dim_shape)
+            else:
+                slices.append(
+                    ctx.net.add_slice(
+                        new_shape_tensor,
+                        start=(j,),
+                        shape=(1,),
+                        stride=(1,),
+                    ).get_output(0)
+                )
+        new_shape_tensor = ctx.net.add_concatenation(slices).get_output(0)
+
+    start_tensor = get_trt_tensor(
+        ctx,
+        np.array(start_list, dtype=np.int64),
+        f"{name}_start_tensor",
+        dtype=np.int64,
     )
+
+    stride_tensor = get_trt_tensor(
+        ctx,
+        np.array(stride_list, dtype=np.int64),
+        f"{name}_stride_tensor",
+        dtype=np.int64,
+    )
+
+    layer = ctx.net.add_slice(
+        input, start=trt.Dims(), shape=trt.Dims(), stride=trt.Dims()
+    )
+    layer.set_input(1, start_tensor)
+    layer.set_input(2, new_shape_tensor)
+    layer.set_input(3, stride_tensor)
     layer.mode = trt.SampleMode.WRAP
 
     set_layer_name(layer, target, name, source_ir)

--- a/tests/py/dynamo/conversion/test_pad_aten.py
+++ b/tests/py/dynamo/conversion/test_pad_aten.py
@@ -2,6 +2,7 @@
 import torch
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
@@ -116,6 +117,39 @@ class TestReplicationPadConverter(DispatchTestCase):
 
     @parameterized.expand(
         [
+            (
+                "3d",
+                (1, 1, 1),
+                (2, 2, 2),
+                (3, 3, 3),
+                torch.float,
+                (1, 1),
+            ),
+        ]
+    )
+    def test_dynamic_shape_replication_pad1d(
+        self, _, min_shape, opt_shape, max_shape, type, padding
+    ):
+        class replication_pad1d(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, input):
+                return torch.ops.aten.replication_pad1d.default(input, padding)
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(replication_pad1d(), input_specs)
+
+    @parameterized.expand(
+        [
             # Per pytorch doc, the input should be 3D or 4D
             ((2, 2, 2), (1, 1, 1, 1)),
             ((1, 2, 4), (2, 2, 1, 1)),
@@ -136,6 +170,39 @@ class TestReplicationPadConverter(DispatchTestCase):
 
     @parameterized.expand(
         [
+            (
+                "4d",
+                (1, 1, 1, 1),
+                (2, 2, 2, 2),
+                (3, 3, 3, 3),
+                torch.float,
+                (1, 1, 2, 2),
+            ),
+        ]
+    )
+    def test_dynamic_shape_replication_pad2d(
+        self, _, min_shape, opt_shape, max_shape, type, padding
+    ):
+        class replication_pad2d(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, input):
+                return torch.ops.aten.replication_pad2d.default(input, padding)
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(replication_pad2d(), input_specs)
+
+    @parameterized.expand(
+        [
             # Per pytorch doc, the input should be 4D or 5D
             ((2, 2, 2, 2), (1, 1, 1, 1, 1, 1)),
             ((1, 2, 3, 4), (3, 2, 2, 1, 1, 1)),
@@ -153,6 +220,39 @@ class TestReplicationPadConverter(DispatchTestCase):
             TestModule(),
             input,
         )
+
+    @parameterized.expand(
+        [
+            (
+                "5d",
+                (1, 1, 1, 1, 1),
+                (2, 2, 2, 2, 2),
+                (3, 3, 3, 3, 3),
+                torch.float,
+                (1, 1, 2, 2, 1, 2),
+            ),
+        ]
+    )
+    def test_dynamic_shape_replication_pad3d(
+        self, _, min_shape, opt_shape, max_shape, type, padding
+    ):
+        class replication_pad3d(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, input):
+                return torch.ops.aten.replication_pad3d.default(input, padding)
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(replication_pad3d(), input_specs)
 
 
 class TestCircularPadConverter(DispatchTestCase):
@@ -215,6 +315,55 @@ class TestCircularPadConverter(DispatchTestCase):
             TestModule(),
             input,
         )
+
+    @parameterized.expand(
+        [
+            (
+                "circular_pad_1d",
+                (1, 1, 1),
+                (2, 2, 2),
+                (3, 3, 3),
+                torch.float,
+                (1, 1),
+            ),
+            (
+                "circular_pad_2d",
+                (1, 1, 1, 1),
+                (2, 2, 2, 2),
+                (3, 3, 3, 3),
+                torch.float,
+                (1, 1, 2, 2),
+            ),
+            (
+                "circular_pad_3d",
+                (1, 1, 1, 1, 1),
+                (2, 2, 2, 2, 2),
+                (3, 3, 3, 3, 3),
+                torch.float,
+                (1, 1, 2, 2, 1, 2),
+            ),
+        ]
+    )
+    def test_dynamic_shape_circular_pad(
+        self, _, min_shape, opt_shape, max_shape, type, padding
+    ):
+        class circular_pad(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, input):
+                return torch.ops.aten._pad_circular.default(input, padding)
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(circular_pad(), input_specs)
 
 
 class TestPadConverter(DispatchTestCase):


### PR DESCRIPTION
# Description

The operations `aten.replication_pad1d`, `aten.replication_pad2d`, `aten.replication_pad3d`, and `aten._pad_circular` have been updated to support dynamic shapes across all dimensions. 

There are duplicated functions from other padding-related PRs (https://github.com/pytorch/TensorRT/pull/3029, https://github.com/pytorch/TensorRT/pull/3028). Therefore, we plan to refactor when adding dynamic support for the `aten.pad` operation.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
