### PR TITLE
assertEquals is deprecated in TestCase in Python 3.12

### DIFF
--- a/tests/py/dynamo/lowering/test_decompositions.py
+++ b/tests/py/dynamo/lowering/test_decompositions.py
@@ -1039,13 +1039,13 @@ class TestLowering(TestCase):
             min_block_size=2,
         )
 
-        self.assertEquals(
+        self.assertEqual(
             len(expected_ops_unseen),
             0,
             f"The following expected ops were not encountered: {expected_ops_unseen}",
         )
 
-        self.assertEquals(
+        self.assertEqual(
             len(unexpected_ops_seen),
             0,
             f"The following expected ops were not encountered: {unexpected_ops_seen}",
@@ -1446,13 +1446,13 @@ class TestLowering(TestCase):
             unexpected_ops=unexpected_ops,
         )
 
-        self.assertEquals(
+        self.assertEqual(
             len(expected_ops_unseen),
             0,
             f"The following expected ops were not encountered: {expected_ops_unseen}",
         )
 
-        self.assertEquals(
+        self.assertEqual(
             len(unexpected_ops_seen),
             0,
             f"The following expected ops were not encountered: {unexpected_ops_seen}",


### PR DESCRIPTION

# Description

Fixes # (issue)
assertEquals is deprecated in TestCase in python 3.12
should use assertEqual instead

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
