### PR TITLE
Fix the build name issue: cherry pick from 3041 back to main

### DIFF
--- a/.github/workflows/release-wheel-linux.yml
+++ b/.github/workflows/release-wheel-linux.yml
@@ -201,12 +201,12 @@ jobs:
           if [[ "${{ inputs.cxx11-tarball-release }}" == "true" ]]; then
               bazel build //:libtorchtrt --compilation_mode opt --config=default
               cp bazel-bin/libtorchtrt.tar.gz \
-              release/tarball/libtorchtrt-${BUILD_VERSION}-tensorrt${TRT_VERSION}-cuda${CU_VERSION}-libtorch${PYTORCH_VERSION}-x86_64-linux.tar.gz
+              release/tarball/libtorchtrt-${BUILD_VERSION}-tensorrt${TRT_VERSION}-cuda${CU_VERSION:2}-libtorch${PYTORCH_VERSION}-x86_64-linux.tar.gz
           else
               ${CONDA_RUN} python setup.py bdist_wheel --release
 
               cp bazel-bin/libtorchtrt.tar.gz \
-              release/tarball/libtorchtrt-${BUILD_VERSION}-pre-cxx11-abi-tensorrt${TRT_VERSION}-cuda${CU_VERSION}-libtorch${PYTORCH_VERSION}-x86_64-linux.tar.gz
+              release/tarball/libtorchtrt-${BUILD_VERSION}-pre-cxx11-abi-tensorrt${TRT_VERSION}-cuda${CU_VERSION:2}-libtorch${PYTORCH_VERSION}-x86_64-linux.tar.gz
 
               ${CONDA_RUN} python -m pip install auditwheel
               ${CONDA_RUN} python -m auditwheel repair \

--- a/.github/workflows/release-wheel-linux.yml
+++ b/.github/workflows/release-wheel-linux.yml
@@ -201,12 +201,12 @@ jobs:
           if [[ "${{ inputs.cxx11-tarball-release }}" == "true" ]]; then
               bazel build //:libtorchtrt --compilation_mode opt --config=default
               cp bazel-bin/libtorchtrt.tar.gz \
-              release/tarball/libtorchtrt-${TORCHTRT_VERSION}-tensorrt${TENSORRT_VERSION}-cuda${CU_VERSION}-libtorch${PYTORCH_VERSION}-x86_64-linux.tar.gz
+              release/tarball/libtorchtrt-${BUILD_VERSION}-tensorrt${TRT_VERSION}-cuda${CU_VERSION}-libtorch${PYTORCH_VERSION}-x86_64-linux.tar.gz
           else
               ${CONDA_RUN} python setup.py bdist_wheel --release
 
               cp bazel-bin/libtorchtrt.tar.gz \
-              release/tarball/libtorchtrt-${BUILD_VERSION}-pre-cxx11-abi-tensorrt${TRT_VERSION}-cuda${CU_VERSION}-libtorch${BUILD_VERSION}-x86_64-linux.tar.gz
+              release/tarball/libtorchtrt-${BUILD_VERSION}-pre-cxx11-abi-tensorrt${TRT_VERSION}-cuda${CU_VERSION}-libtorch${PYTORCH_VERSION}-x86_64-linux.tar.gz
 
               ${CONDA_RUN} python -m pip install auditwheel
               ${CONDA_RUN} python -m auditwheel repair \


### PR DESCRIPTION
# Description

Fixes # (issue)
fix the build name issue:
BUILD_VERSION: this is the our torch_tensorrt version
PYTORCH_VERSION: this is the torch version

most of the time torch_tensorrt and torch version are the same
but in case in release2.3: BUILD_VERSION is 2.3.0 PYTORCH_VERSION:2.3.1

hence here make the change so that it is clear.

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
