### PR TITLE
feat: dynamic shape support for pad ops

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -2919,7 +2919,9 @@ def aten_ops_addmm(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.constant_pad_nd.default)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.constant_pad_nd.default, supports_dynamic_shapes=True
+)
 @enforce_tensor_types(
     {
         0: (TRTTensor,),
@@ -2943,9 +2945,15 @@ def aten_ops_constant_pad(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.reflection_pad1d.default)
-@dynamo_tensorrt_converter(torch.ops.aten.reflection_pad2d.default)
-@dynamo_tensorrt_converter(torch.ops.aten.reflection_pad3d.default)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.reflection_pad1d.default, supports_dynamic_shapes=True
+)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.reflection_pad2d.default, supports_dynamic_shapes=True
+)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.reflection_pad3d.default, supports_dynamic_shapes=True
+)
 @enforce_tensor_types(
     {
         0: (TRTTensor,),
@@ -2968,9 +2976,15 @@ def aten_ops_reflection_pad(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.replication_pad1d.default)
-@dynamo_tensorrt_converter(torch.ops.aten.replication_pad2d.default)
-@dynamo_tensorrt_converter(torch.ops.aten.replication_pad3d.default)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.replication_pad1d.default, supports_dynamic_shapes=True
+)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.replication_pad2d.default, supports_dynamic_shapes=True
+)
+@dynamo_tensorrt_converter(
+    torch.ops.aten.replication_pad3d.default, supports_dynamic_shapes=True
+)
 @enforce_tensor_types(
     {
         0: (TRTTensor,),
@@ -2993,7 +3007,9 @@ def aten_ops_replication_pad(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten._pad_circular.default)
+@dynamo_tensorrt_converter(
+    torch.ops.aten._pad_circular.default, supports_dynamic_shapes=True
+)
 @enforce_tensor_types(
     {
         0: (TRTTensor,),
@@ -3016,7 +3032,7 @@ def aten_ops_circular_pad(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten.pad.default)
+@dynamo_tensorrt_converter(torch.ops.aten.pad.default, supports_dynamic_shapes=True)
 @enforce_tensor_types(
     {
         0: (TRTTensor,),

--- a/py/torch_tensorrt/dynamo/conversion/impl/pad.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/pad.py
@@ -1,14 +1,13 @@
 from typing import Optional, Sequence, Union
 
+import numpy as np
 import tensorrt as trt
 from torch.fx.node import Target
 from torch_tensorrt.dynamo._SourceIR import SourceIR
+from torch_tensorrt.dynamo.conversion import impl
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import get_trt_tensor
-from torch_tensorrt.fx.converters.converter_utils import (
-    has_dynamic_shape,
-    set_layer_name,
-)
+from torch_tensorrt.fx.converters.converter_utils import set_layer_name
 from torch_tensorrt.fx.types import TRTTensor
 
 """
@@ -16,6 +15,71 @@ Note: IPaddingLayer is deprecated in TensorRT 8.2 and will be removed in TensorR
 Use ISliceLayer to pad the tensor, which supports new non-constant, reflects padding
 mode and clamp, and supports padding output with dynamic shape.
 """
+
+
+def get_padded_shape_tensors(
+    ctx: ConversionContext,
+    target: Union[Target, str],
+    source_ir: Optional[SourceIR],
+    name: str,
+    input: TRTTensor,
+    pad: Sequence[int],
+) -> TRTTensor:
+    rank = len(input.shape)
+    if len(pad) // 2 > rank:
+        raise RuntimeError(
+            f"Trying to pad last {len(pad) // 2} dimensions but the input only has {rank} dimensions."
+        )
+
+    input_shape_tensor = ctx.net.add_shape(input).get_output(0)
+    padded_shape_tensor = input_shape_tensor
+
+    start_list = [0] * rank
+    for i in range(len(pad) // 2):
+        dim_index = rank - (i + 1)
+        pad_before = pad[i * 2]
+        pad_after = pad[i * 2 + 1]
+
+        pad_sum = get_trt_tensor(
+            ctx, pad_before + pad_after, f"{name}_pad_sum_{i}", dtype=np.int64
+        )
+        dim_shape = ctx.net.add_slice(
+            input_shape_tensor,
+            start=(dim_index,),
+            shape=(1,),
+            stride=(1,),
+        ).get_output(0)
+
+        new_dim_shape = impl.elementwise.add(
+            ctx, target, source_ir, f"{name}_shape_dim_{i}", dim_shape, pad_sum
+        )
+        start_list[dim_index] = -pad_before
+
+        slices = []
+        for j in range(rank):
+            if j == dim_index:
+                slices.append(new_dim_shape)
+            else:
+                slices.append(
+                    ctx.net.add_slice(
+                        padded_shape_tensor,
+                        start=(j,),
+                        shape=(1,),
+                        stride=(1,),
+                    ).get_output(0)
+                )
+        padded_shape_tensor = impl.cat.cat(
+            ctx, target, source_ir, f"{name}_cat", slices, 0
+        )
+
+    start_indices_tensor = get_trt_tensor(
+        ctx,
+        np.array(start_list, dtype=np.int64),
+        f"{name}_start_indices_tensor",
+        dtype=np.int64,
+    )
+
+    return start_indices_tensor, padded_shape_tensor
 
 
 def constant_padNd(
@@ -27,30 +91,28 @@ def constant_padNd(
     pad: Sequence[int],
     value: Union[int, float] = 0,
 ) -> TRTTensor:
-    if has_dynamic_shape(input.shape):
-        assert input.shape[1] != -1, "Channel dim can't be dynamic for padding."
 
     rank = len(input.shape)
 
-    if len(pad) // 2 > rank:
-        raise RuntimeError(
-            f"Trying to pad last {len(pad) // 2} dimension but the input only has {rank} dimension."
-        )
-
-    start_list = [0] * rank
-    new_shape = list(input.shape)
-
-    for i in range(0, len(pad) // 2):
-        start_list[-i - 1] = -pad[i * 2]
-        new_shape[-i - 1] += pad[i * 2] + pad[i * 2 + 1]
+    start_indices_tensor, padded_shape_tensor = get_padded_shape_tensors(
+        ctx, target, source_ir, name, input, pad
+    )
 
     stride_list = [1] * rank
-    layer = ctx.net.add_slice(
-        input,
-        start=tuple(start_list),
-        shape=tuple(new_shape),
-        stride=tuple(stride_list),
+    stride_tensor = get_trt_tensor(
+        ctx,
+        np.array(stride_list, dtype=np.int64),
+        f"{name}_stride_tensor",
+        dtype=np.int64,
     )
+
+    layer = ctx.net.add_slice(
+        input, start=trt.Dims(), shape=trt.Dims(), stride=trt.Dims()
+    )
+    layer.set_input(1, start_indices_tensor)
+    layer.set_input(2, padded_shape_tensor)
+    layer.set_input(3, stride_tensor)
+
     value_const = get_trt_tensor(ctx, value, f"{name}_value", input.dtype)
     layer.set_input(4, value_const)
     layer.mode = trt.SampleMode.FILL
@@ -67,30 +129,26 @@ def reflection_padNd(
     input: TRTTensor,
     padding: Sequence[int],
 ) -> TRTTensor:
-    if has_dynamic_shape(input.shape):
-        assert input.shape[1] != -1, "Channel dim can't be dynamic for padding."
-
     rank = len(input.shape)
 
-    if len(padding) // 2 > rank:
-        raise RuntimeError(
-            f"Trying to pad last {len(padding) // 2} dimension but the input only has {rank} dimension."
-        )
-
-    start_list = [0] * rank
-    new_shape = list(input.shape)
-
-    for i in range(0, len(padding) // 2):
-        start_list[-i - 1] = -padding[i * 2]
-        new_shape[-i - 1] += padding[i * 2] + padding[i * 2 + 1]
+    start_indices_tensor, padded_shape_tensor = get_padded_shape_tensors(
+        ctx, target, source_ir, name, input, padding
+    )
 
     stride_list = [1] * rank
-    layer = ctx.net.add_slice(
-        input,
-        start=tuple(start_list),
-        shape=tuple(new_shape),
-        stride=tuple(stride_list),
+    stride_tensor = get_trt_tensor(
+        ctx,
+        np.array(stride_list, dtype=np.int64),
+        f"{name}_stride_tensor",
+        dtype=np.int64,
     )
+
+    layer = ctx.net.add_slice(
+        input, start=trt.Dims(), shape=trt.Dims(), stride=trt.Dims()
+    )
+    layer.set_input(1, start_indices_tensor)
+    layer.set_input(2, padded_shape_tensor)
+    layer.set_input(3, stride_tensor)
     layer.mode = trt.SampleMode.REFLECT
 
     set_layer_name(layer, target, name, source_ir)
@@ -105,30 +163,26 @@ def replication_padNd(
     input: TRTTensor,
     padding: Sequence[int],
 ) -> TRTTensor:
-    if has_dynamic_shape(input.shape):
-        assert input.shape[1] != -1, "Channel dim can't be dynamic for padding."
-
     rank = len(input.shape)
 
-    if len(padding) // 2 > rank:
-        raise RuntimeError(
-            f"Trying to pad last {len(padding) // 2} dimension but the input only has {rank} dimension."
-        )
-
-    start_list = [0] * rank
-    new_shape = list(input.shape)
-
-    for i in range(0, len(padding) // 2):
-        start_list[-i - 1] = -padding[i * 2]
-        new_shape[-i - 1] += padding[i * 2] + padding[i * 2 + 1]
+    start_indices_tensor, padded_shape_tensor = get_padded_shape_tensors(
+        ctx, target, source_ir, name, input, padding
+    )
 
     stride_list = [1] * rank
-    layer = ctx.net.add_slice(
-        input,
-        start=tuple(start_list),
-        shape=tuple(new_shape),
-        stride=tuple(stride_list),
+    stride_tensor = get_trt_tensor(
+        ctx,
+        np.array(stride_list, dtype=np.int64),
+        f"{name}_stride_tensor",
+        dtype=np.int64,
     )
+
+    layer = ctx.net.add_slice(
+        input, start=trt.Dims(), shape=trt.Dims(), stride=trt.Dims()
+    )
+    layer.set_input(1, start_indices_tensor)
+    layer.set_input(2, padded_shape_tensor)
+    layer.set_input(3, stride_tensor)
     layer.mode = trt.SampleMode.CLAMP
 
     set_layer_name(layer, target, name, source_ir)
@@ -141,32 +195,28 @@ def circular_padNd(
     source_ir: Optional[SourceIR],
     name: str,
     input: TRTTensor,
-    pad: Sequence[int],
+    padding: Sequence[int],
 ) -> TRTTensor:
-    if has_dynamic_shape(input.shape):
-        assert input.shape[1] != -1, "Channel dim can't be dynamic for padding."
-
     rank = len(input.shape)
 
-    if len(pad) // 2 > rank:
-        raise RuntimeError(
-            f"Trying to pad last {len(pad) // 2} dimension but the input only has {rank} dimension."
-        )
-
-    start_list = [0] * rank
-    new_shape = list(input.shape)
-
-    for i in range(0, len(pad) // 2):
-        start_list[-i - 1] = -pad[i * 2]
-        new_shape[-i - 1] += pad[i * 2] + pad[i * 2 + 1]
+    start_indices_tensor, padded_shape_tensor = get_padded_shape_tensors(
+        ctx, target, source_ir, name, input, padding
+    )
 
     stride_list = [1] * rank
-    layer = ctx.net.add_slice(
-        input,
-        start=tuple(start_list),
-        shape=tuple(new_shape),
-        stride=tuple(stride_list),
+    stride_tensor = get_trt_tensor(
+        ctx,
+        np.array(stride_list, dtype=np.int64),
+        f"{name}_stride_tensor",
+        dtype=np.int64,
     )
+
+    layer = ctx.net.add_slice(
+        input, start=trt.Dims(), shape=trt.Dims(), stride=trt.Dims()
+    )
+    layer.set_input(1, start_indices_tensor)
+    layer.set_input(2, padded_shape_tensor)
+    layer.set_input(3, stride_tensor)
     layer.mode = trt.SampleMode.WRAP
 
     set_layer_name(layer, target, name, source_ir)

--- a/py/torch_tensorrt/dynamo/conversion/impl/pad.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/pad.py
@@ -11,7 +11,7 @@ from torch_tensorrt.dynamo.conversion.converter_utils import (
     set_layer_name,
 )
 from torch_tensorrt.dynamo.conversion.impl.shape import get_shape_with_dynamic_shape
-from torch_tensorrt.fx.types import TRTTensor
+from torch_tensorrt.dynamo.types import TRTTensor
 
 """
 Note: IPaddingLayer is deprecated in TensorRT 8.2 and will be removed in TensorRT 10.0.

--- a/tests/py/dynamo/conversion/test_pad_aten.py
+++ b/tests/py/dynamo/conversion/test_pad_aten.py
@@ -2,6 +2,7 @@
 import torch
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
@@ -11,6 +12,8 @@ class TestConstantPadConverter(DispatchTestCase):
         [
             ((1, 2), (1, 1), 0),
             ((2, 1), (2, 1), 1),
+            ((2, 2), (1, 1), 0),
+            ((1, 2), (1, 1, 2, 0), 0),
             ((3, 4, 2), (1, 2), 2),
             ((3, 4, 2), (1, 2, 3, 1, 2, 3), 0),
             ((3, 3, 4, 2), (1, 2, 3, 4), 0),
@@ -29,6 +32,40 @@ class TestConstantPadConverter(DispatchTestCase):
             TestModule(),
             input,
         )
+
+    @parameterized.expand(
+        [
+            (
+                "3d",
+                (1, 1, 1),
+                (2, 2, 2),
+                (3, 3, 3),
+                torch.float,
+                (1, 1, 1, 1, 1, 1),
+                0,
+            ),
+        ]
+    )
+    def test_dynamic_shape_constant_pad(
+        self, _, min_shape, opt_shape, max_shape, type, pad, value
+    ):
+        class constant_pad(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, input):
+                return torch.ops.aten.constant_pad_nd.default(input, pad, value)
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(constant_pad(), input_specs)
 
 
 class TestReflectionPadConverter(DispatchTestCase):
@@ -54,6 +91,39 @@ class TestReflectionPadConverter(DispatchTestCase):
 
     @parameterized.expand(
         [
+            (
+                "3d",
+                (1, 1, 1),
+                (2, 2, 2),
+                (3, 3, 3),
+                torch.float,
+                (1, 1),
+            ),
+        ]
+    )
+    def test_dynamic_shape_reflection_pad1d(
+        self, _, min_shape, opt_shape, max_shape, type, padding
+    ):
+        class reflection_pad1d(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, input):
+                return torch.ops.aten.reflection_pad1d.default(input, padding)
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(reflection_pad1d(), input_specs)
+
+    @parameterized.expand(
+        [
             # Per pytorch doc, the input should be 3D or 4D
             ((2, 2, 2), (1, 1, 1, 1)),
             ((1, 2, 4), (2, 2, 1, 1)),
@@ -74,6 +144,39 @@ class TestReflectionPadConverter(DispatchTestCase):
 
     @parameterized.expand(
         [
+            (
+                "4d",
+                (1, 1, 1, 1),
+                (2, 2, 2, 2),
+                (3, 3, 3, 3),
+                torch.float,
+                (1, 1, 2, 2),
+            ),
+        ]
+    )
+    def test_dynamic_shape_reflection_pad2d(
+        self, _, min_shape, opt_shape, max_shape, type, padding
+    ):
+        class reflection_pad2d(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, input):
+                return torch.ops.aten.reflection_pad2d.default(input, padding)
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(reflection_pad2d(), input_specs)
+
+    @parameterized.expand(
+        [
             # Per pytorch doc, the input should be 4D or 5D
             ((2, 2, 2, 2), (1, 1, 1, 1, 1, 1)),
             ((1, 2, 3, 4), (3, 2, 2, 1, 1, 1)),
@@ -91,6 +194,39 @@ class TestReflectionPadConverter(DispatchTestCase):
             TestModule(),
             input,
         )
+
+    @parameterized.expand(
+        [
+            (
+                "5d",
+                (1, 1, 1, 1, 1),
+                (2, 2, 2, 2, 2),
+                (3, 3, 3, 3, 3),
+                torch.float,
+                (1, 2, 2, 1, 1, 2),
+            ),
+        ]
+    )
+    def test_dynamic_shape_reflection_pad3d(
+        self, _, min_shape, opt_shape, max_shape, type, padding
+    ):
+        class reflection_pad3d(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, input):
+                return torch.ops.aten.reflection_pad3d.default(input, padding)
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(reflection_pad3d(), input_specs)
 
 
 class TestReplicationPadConverter(DispatchTestCase):
@@ -116,6 +252,39 @@ class TestReplicationPadConverter(DispatchTestCase):
 
     @parameterized.expand(
         [
+            (
+                "3d",
+                (1, 1, 1),
+                (2, 2, 2),
+                (3, 3, 3),
+                torch.float,
+                (1, 1),
+            ),
+        ]
+    )
+    def test_dynamic_shape_replication_pad1d(
+        self, _, min_shape, opt_shape, max_shape, type, padding
+    ):
+        class replication_pad1d(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, input):
+                return torch.ops.aten.replication_pad1d.default(input, padding)
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(replication_pad1d(), input_specs)
+
+    @parameterized.expand(
+        [
             # Per pytorch doc, the input should be 3D or 4D
             ((2, 2, 2), (1, 1, 1, 1)),
             ((1, 2, 4), (2, 2, 1, 1)),
@@ -136,6 +305,39 @@ class TestReplicationPadConverter(DispatchTestCase):
 
     @parameterized.expand(
         [
+            (
+                "4d",
+                (1, 1, 1, 1),
+                (2, 2, 2, 2),
+                (3, 3, 3, 3),
+                torch.float,
+                (1, 1, 2, 2),
+            ),
+        ]
+    )
+    def test_dynamic_shape_replication_pad2d(
+        self, _, min_shape, opt_shape, max_shape, type, padding
+    ):
+        class replication_pad2d(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, input):
+                return torch.ops.aten.replication_pad2d.default(input, padding)
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(replication_pad2d(), input_specs)
+
+    @parameterized.expand(
+        [
             # Per pytorch doc, the input should be 4D or 5D
             ((2, 2, 2, 2), (1, 1, 1, 1, 1, 1)),
             ((1, 2, 3, 4), (3, 2, 2, 1, 1, 1)),
@@ -153,6 +355,39 @@ class TestReplicationPadConverter(DispatchTestCase):
             TestModule(),
             input,
         )
+
+    @parameterized.expand(
+        [
+            (
+                "5d",
+                (1, 1, 1, 1, 1),
+                (2, 2, 2, 2, 2),
+                (3, 3, 3, 3, 3),
+                torch.float,
+                (1, 1, 2, 2, 1, 2),
+            ),
+        ]
+    )
+    def test_dynamic_shape_replication_pad3d(
+        self, _, min_shape, opt_shape, max_shape, type, padding
+    ):
+        class replication_pad3d(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, input):
+                return torch.ops.aten.replication_pad3d.default(input, padding)
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(replication_pad3d(), input_specs)
 
 
 class TestCircularPadConverter(DispatchTestCase):
@@ -216,6 +451,55 @@ class TestCircularPadConverter(DispatchTestCase):
             input,
         )
 
+    @parameterized.expand(
+        [
+            (
+                "circular_pad_1d",
+                (1, 1, 1),
+                (2, 2, 2),
+                (3, 3, 3),
+                torch.float,
+                (1, 1),
+            ),
+            (
+                "circular_pad_2d",
+                (1, 1, 1, 1),
+                (2, 2, 2, 2),
+                (3, 3, 3, 3),
+                torch.float,
+                (1, 1, 2, 2),
+            ),
+            (
+                "circular_pad_3d",
+                (1, 1, 1, 1, 1),
+                (2, 2, 2, 2, 2),
+                (3, 3, 3, 3, 3),
+                torch.float,
+                (1, 1, 2, 2, 1, 2),
+            ),
+        ]
+    )
+    def test_dynamic_shape_circular_pad(
+        self, _, min_shape, opt_shape, max_shape, type, padding
+    ):
+        class circular_pad(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, input):
+                return torch.ops.aten._pad_circular.default(input, padding)
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(circular_pad(), input_specs)
+
 
 class TestPadConverter(DispatchTestCase):
     @parameterized.expand(
@@ -236,6 +520,67 @@ class TestPadConverter(DispatchTestCase):
             TestModule(),
             input,
         )
+
+    @parameterized.expand(
+        [
+            (
+                "constant_pad_nd",
+                (1, 1, 1),
+                (2, 2, 2),
+                (3, 3, 3),
+                torch.float,
+                (1, 1),
+                "constant",
+            ),
+            (
+                "reflection_padnd",
+                (1, 1, 1),
+                (2, 2, 2),
+                (3, 3, 3),
+                torch.float,
+                (1, 1),
+                "reflect",
+            ),
+            (
+                "replication_padnd",
+                (1, 1, 1),
+                (2, 2, 2),
+                (3, 3, 3),
+                torch.float,
+                (1, 1),
+                "replicate",
+            ),
+            (
+                "_pad_circular",
+                (1, 1, 1),
+                (2, 2, 2),
+                (3, 3, 3),
+                torch.float,
+                (1, 1),
+                "circular",
+            ),
+        ]
+    )
+    def test_dynamic_shape_pad(
+        self, _, min_shape, opt_shape, max_shape, type, padding, mode, value=None
+    ):
+        class pad(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, input):
+                return torch.ops.aten.pad.default(input, padding, mode, value)
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=type,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(pad(), input_specs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Added dynamic shape support for the following padding operations:
- `aten.constant_pad_nd`
- `aten.reflection_pad1d`
- `aten.reflection_pad2d`
- `aten.reflection_pad3d`
- `aten.replication_pad1d`
- `aten.replication_pad2d`
- `aten.replication_pad3d`
- `aten._pad_circular`
- `aten.pad`

A commonly used function, `get_padded_shape_tensors`, has been introduced to adjust the dimensions of the input tensor to account for padding in various padding modes. This function simplifies the handling of dynamic shapes across different padding operations.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
