### PR TITLE
chore: dynamic shape support for pdist ops

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -3569,7 +3569,9 @@ def aten_ops_any(
     )
 
 
-@dynamo_tensorrt_converter(torch.ops.aten._pdist_forward.default)
+@dynamo_tensorrt_converter(
+    torch.ops.aten._pdist_forward.default, supports_dynamic_shapes=True
+)
 @enforce_tensor_types(
     {
         0: (TRTTensor,),

--- a/tests/py/dynamo/conversion/test_pdist_aten.py
+++ b/tests/py/dynamo/conversion/test_pdist_aten.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
 
@@ -30,6 +31,63 @@ class TestPdistConverter(DispatchTestCase):
             Pdist(),
             inputs,
         )
+
+
+class TestDynamicShapePdistConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            (
+                "dim0_dynamic_dim1_static_p_0",
+                (1, 4),
+                (2, 4),
+                (4, 4),
+                0,
+            ),
+            (
+                "dim0_static_dim1_dynamic_p_1",
+                (1, 5),
+                (2, 5),
+                (6, 5),
+                1,
+            ),
+            (
+                "dim0_dynamic_dim1_static_p_other",
+                (1, 5),
+                (2, 5),
+                (6, 5),
+                0.4,
+            ),
+            (
+                "dim0_dynamic_dim1_dynamic_p_inf",
+                (1, 1),
+                (2, 2),
+                (5, 4),
+                float("inf"),
+            ),
+            (
+                "dim0_dynamic_dim1_dynamic_p_other",
+                (2, 1),
+                (3, 2),
+                (4, 7),
+                1.7,
+            ),
+        ]
+    )
+    def test_pdist_float(self, _, min_shape, opt_shape, max_shape, p):
+        class Pdist(nn.Module):
+            def forward(self, input):
+                return torch.ops.aten._pdist_forward.default(input, p)
+
+        input_specs = [
+            Input(
+                min_shape=min_shape,
+                opt_shape=opt_shape,
+                max_shape=max_shape,
+                dtype=torch.float,
+            ),
+        ]
+
+        self.run_test_with_dynamic_shape(Pdist(), input_specs)
 
 
 if __name__ == "__main__":

--- a/tests/py/dynamo/conversion/test_pdist_aten.py
+++ b/tests/py/dynamo/conversion/test_pdist_aten.py
@@ -45,9 +45,9 @@ class TestDynamicShapePdistConverter(DispatchTestCase):
             ),
             (
                 "dim0_static_dim1_dynamic_p_1",
-                (1, 5),
-                (2, 5),
-                (6, 5),
+                (3, 1),
+                (3, 2),
+                (3, 4),
                 1,
             ),
             (


### PR DESCRIPTION
# Description

np.triu_indices(dim0, k=1) is implemented by index calculation in loop layer when dim0 is dynamic shape

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
