### PR TITLE
fix: Adjust reflection pad test cases to prevent runtime errors

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/impl/pad.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/pad.py
@@ -79,7 +79,7 @@ def get_padded_shape_tensors(
                     ).get_output(0)
                 )
         padded_shape_tensor = impl.cat.cat(
-            ctx, target, source_ir, f"{name}_cat", slices, 0
+            ctx, target, source_ir, f"{name}_cat_dim_{i}", slices, 0
         )
 
     start_indices_tensor = get_trt_tensor(

--- a/tests/py/dynamo/conversion/test_pad_aten.py
+++ b/tests/py/dynamo/conversion/test_pad_aten.py
@@ -146,9 +146,9 @@ class TestReflectionPadConverter(DispatchTestCase):
         [
             (
                 "4d",
-                (1, 1, 1, 1),
                 (2, 2, 2, 2),
-                (3, 3, 3, 3),
+                (4, 4, 4, 4),
+                (6, 6, 6, 6),
                 torch.float,
                 (1, 1, 2, 2),
             ),
@@ -199,9 +199,9 @@ class TestReflectionPadConverter(DispatchTestCase):
         [
             (
                 "5d",
-                (1, 1, 1, 1, 1),
                 (2, 2, 2, 2, 2),
-                (3, 3, 3, 3, 3),
+                (4, 4, 4, 4, 4),
+                (6, 6, 6, 6, 6),
                 torch.float,
                 (1, 2, 2, 1, 1, 2),
             ),


### PR DESCRIPTION
# Description

Adjust reflection pad test cases to prevent runtime errors due to padding size exceeding input dimensions

- These changes ensure that the padding size remains smaller than the corresponding input dimensions, as reflection padding requires sufficient input data to reflect. Padding size must be limited by the input dimension to avoid runtime errors like "Padding size should be less than the corresponding input dimension".

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
