### PR TITLE
Fix TypeError in MutableTorchTensorRTModule on Python 3.9

### DIFF
--- a/py/torch_tensorrt/dynamo/runtime/_MutableTorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_MutableTorchTensorRTModule.py
@@ -1,7 +1,7 @@
 import logging
 from copy import deepcopy
 from enum import Enum, auto
-from typing import Any, Collection, Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import Any, Collection, Dict, Iterator, List, Optional, Set, Union
 
 import numpy as np
 import torch
@@ -57,9 +57,9 @@ class MutableTorchTensorRTModule(object):
         disable_tf32: bool = _defaults.DISABLE_TF32,
         assume_dynamic_shape_support: bool = _defaults.ASSUME_DYNAMIC_SHAPE_SUPPORT,
         sparse_weights: bool = _defaults.SPARSE_WEIGHTS,
-        enabled_precisions: (
-            Set[torch.dtype | dtype] | Tuple[torch.dtype | dtype]
-        ) = _defaults.ENABLED_PRECISIONS,
+        enabled_precisions: Set[
+            Union[torch.dtype, dtype]
+        ] = _defaults.ENABLED_PRECISIONS,
         engine_capability: EngineCapability = _defaults.ENGINE_CAPABILITY,
         make_refitable: bool = _defaults.MAKE_REFITABLE,
         debug: bool = _defaults.DEBUG,


### PR DESCRIPTION
# Description

```python
    import torch_tensorrt as torchtrt
/__w/_temp/conda_environment_10423996349/lib/python3.9/site-packages/torch_tensorrt/__init__.py:137: in <module>
    from torch_tensorrt.dynamo.runtime._MutableTorchTensorRTModule import (
/__w/_temp/conda_environment_10423996349/lib/python3.9/site-packages/torch_tensorrt/dynamo/runtime/_MutableTorchTensorRTModule.py:40: in <module>
    class MutableTorchTensorRTModule(object):
/__w/_temp/conda_environment_10423996349/lib/python3.9/site-packages/torch_tensorrt/dynamo/runtime/_MutableTorchTensorRTModule.py:61: in MutableTorchTensorRTModule
    Set[torch.dtype | dtype] | Tuple[torch.dtype | dtype]
E   TypeError: unsupported operand type(s) for |: 'type' and 'EnumMeta'
```

Type union operator was not supported on Python 3.9 since it's introduced on Python 3.10. Additionally, the allowed type for `enabled_precisions` should only be `Set`, not `Tuple`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified