### PR TITLE
Fix assertEquals AttributeError on Python 3.12

### DIFF
--- a/tests/py/dynamo/lowering/test_decompositions.py
+++ b/tests/py/dynamo/lowering/test_decompositions.py
@@ -1093,13 +1093,13 @@ class TestLowering(TestCase):
             min_block_size=2,
         )
 
-        self.assertEquals(
+        self.assertEqual(
             len(expected_ops_unseen),
             0,
             f"The following expected ops were not encountered: {expected_ops_unseen}",
         )
 
-        self.assertEquals(
+        self.assertEqual(
             len(unexpected_ops_seen),
             0,
             f"The following expected ops were not encountered: {unexpected_ops_seen}",


### PR DESCRIPTION
# Description

```python
FAILED lowering/test_decompositions.py::TestLowering::test_scatter_add_0_scatter_add_zero_dim_indexOne_constant - AttributeError: 'TestLowering' object has no attribute 'assertEquals'
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified