### PR TITLE
fix: test_get_layer_info() in test_classes.py

### DIFF
--- a/tests/py/ts/api/test_classes.py
+++ b/tests/py/ts/api/test_classes.py
@@ -309,10 +309,8 @@ class TestTorchTensorRTModule(unittest.TestCase):
         """
         {
             "Layers": [
-                "reshape_before_%26 : Tensor = aten::matmul(%x.1, %25)",
-                "%26 : Tensor = aten::matmul(%x.1, %25) + [Freeze Tensor %27 : Tensor = trt::const(%10) ] + (Unnamed Layer* 4) [Shuffle] + unsqueeze_node_after_[Freeze Tensor %27 : Tensor = trt::const(%10) ] + (Unnamed Layer* 4) [Shuffle]_(Unnamed Layer* 4) [Shuffle]_output + %28 : Tensor = aten::add(%27, %26, %24)",
-                "%31 : Tensor = aten::matmul(%28, %30) + [Freeze Tensor %32 : Tensor = trt::const(%12) ] + (Unnamed Layer* 10) [Shuffle] + unsqueeze_node_after_[Freeze Tensor %32 : Tensor = trt::const(%12) ] + (Unnamed Layer* 10) [Shuffle]_(Unnamed Layer* 10) [Shuffle]_output + %33 : Tensor = aten::add(%32, %31, %29)",
-                "copied_squeeze_after_%33 : Tensor = aten::add(%32, %31, %29)"
+                "%26 : Tensor = aten::matmul(%x.1, %25)_myl0_0",
+                "%31 : Tensor = aten::matmul(%28, %30)_myl0_1"
             ],
             "Bindings": [
                 "input_0",
@@ -326,7 +324,7 @@ class TestTorchTensorRTModule(unittest.TestCase):
         trt_mod = TestTorchTensorRTModule._get_trt_mod()
         trt_json = json.loads(trt_mod.get_layer_info())
         [self.assertTrue(k in trt_json.keys()) for k in ["Layers", "Bindings"]]
-        self.assertTrue(len(trt_json["Layers"]) == 4)
+        self.assertTrue(len(trt_json["Layers"]) == 2)
         self.assertTrue(len(trt_json["Bindings"]) == 2)
 
 

--- a/tests/py/ts/api/test_classes.py
+++ b/tests/py/ts/api/test_classes.py
@@ -324,6 +324,8 @@ class TestTorchTensorRTModule(unittest.TestCase):
         trt_mod = TestTorchTensorRTModule._get_trt_mod()
         trt_json = json.loads(trt_mod.get_layer_info())
         [self.assertTrue(k in trt_json.keys()) for k in ["Layers", "Bindings"]]
+        print(1111111111111111, trt_json["Layers"])
+        print(2222222222222222, trt_json["Bindings"])
         self.assertTrue(len(trt_json["Layers"]) == 2)
         self.assertTrue(len(trt_json["Bindings"]) == 2)
 


### PR DESCRIPTION
# Description

```
FAILED api/test_classes.py::TestTorchTensorRTModule::test_get_layer_info - AssertionError: False is not true
trt_mod = TestTorchTensorRTModule._get_trt_mod()
        trt_json = json.loads(trt_mod.get_layer_info())
        [self.assertTrue(k in trt_json.keys()) for k in ["Layers", "Bindings"]]
>       self.assertTrue(len(trt_json["Layers"]) == 4)
E       AssertionError: False is not true
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
