### PR TITLE
fix: get_padded_shape_tensors can now handle dynamic pads

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/impl/pad.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/pad.py
@@ -50,7 +50,9 @@ def get_padded_shape_tensors(
         pad_before = get_trt_tensor(ctx, pad[i * 2], f"{name}_pad_before_{i}")
         pad_after = get_trt_tensor(ctx, pad[i * 2 + 1], f"{name}_pad_after_{i}")
 
-        pad_sum = impl.elementwise.add(ctx, target, source_ir, f"{name}_pad_sum_{i}", pad_before, pad_after)
+        pad_sum = impl.elementwise.add(
+            ctx, target, source_ir, f"{name}_pad_sum_{i}", pad_before, pad_after
+        )
         dim_shape = ctx.net.add_slice(
             input_shape_tensor,
             start=(dim_index,),
@@ -61,7 +63,9 @@ def get_padded_shape_tensors(
         new_dim_shape = impl.elementwise.add(
             ctx, target, source_ir, f"{name}_shape_dim_{i}", dim_shape, pad_sum
         )
-        start_list[dim_index] = impl.elementwise.sub(ctx, target, source_ir, f"{name}_pad_before_neg_{i}", 0, pad_before)
+        start_list[dim_index] = impl.elementwise.sub(
+            ctx, target, source_ir, f"{name}_pad_before_neg_{i}", 0, pad_before
+        )
 
         slices = []
         for j in range(rank):
@@ -77,11 +81,23 @@ def get_padded_shape_tensors(
                     ).get_output(0)
                 )
         padded_shape_tensor = impl.cat.cat(
-            ctx, target, source_ir, f"{name}_cat_dim_{i}", slices, 0, cast_dtype=np.int32
+            ctx,
+            target,
+            source_ir,
+            f"{name}_cat_dim_{i}",
+            slices,
+            0,
+            cast_dtype=padded_shape_tensor.dtype,
         )
 
     start_indices_tensor = impl.cat.cat(
-        ctx, target, source_ir, f"{name}_start_indices_tensor", start_list, 0, cast_dtype=np.int32
+        ctx,
+        target,
+        source_ir,
+        f"{name}_start_indices_tensor",
+        start_list,
+        0,
+        cast_dtype=padded_shape_tensor.dtype,
     )
 
     return start_indices_tensor, padded_shape_tensor


### PR DESCRIPTION
# Description

Exported programs with dynamic shapes often include aten.constant_pad_nd with the argument `pad` containing mixture of `int` and `TRTTensor` values. This makes `pad_before + pad_after` fails in `get_padded_shape_tensors`.

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
