### PR TITLE
Fix typo in _compile.py

### DIFF
--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -388,7 +388,7 @@ def convert_method_to_trt_engine(
         torchtrt_kwarg_inputs = prepare_inputs(kwarg_inputs)
 
         exp_program = torch_tensorrt.dynamo.trace(
-            module, torchtrt_arg_inputs, kwarg_inputs=torchtrt_kwarg_inputs**kwargs
+            module, torchtrt_arg_inputs, kwarg_inputs=torchtrt_kwarg_inputs, **kwargs
         )
 
         return dynamo_convert_exported_program_to_serialized_trt_engine(


### PR DESCRIPTION
# Description

There is a typo in the `convert_method_to_trt_engine` function in `_compile.py` causing a Python syntax error.

Adding a comma fixes the issue.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
