### PR TITLE
fix: allow `torch.Symint` in `slice_scatter_decomposition`

### DIFF
--- a/py/torch_tensorrt/dynamo/lowering/_decompositions.py
+++ b/py/torch_tensorrt/dynamo/lowering/_decompositions.py
@@ -199,9 +199,9 @@ def slice_scatter_decomposition(
         step = 1
 
     # Ensure start, end, and step are all integers
-    assert isinstance(start, int), "start must be an integer"
-    assert isinstance(end, int), "end must be an integer"
-    assert isinstance(step, int), "step must be an integer"
+    assert isinstance(start, (int, torch.SymInt)), "start must be an integer"
+    assert isinstance(end, (int, torch.SymInt)), "end must be an integer"
+    assert isinstance(step, (int, torch.SymInt)), "step must be an integer"
 
     src_dim = src_tensor.shape
     # step == 0 is not a valid torch case


### PR DESCRIPTION
fix: allow `torch.Symint` objects for `start`, `end` and `step` in `slice_scatter_decomposition`

# Description

When an exported program is `torch.export`ed with dynamic shapes, the `start`, `end` and `step` could be `torch.SymInt` instead of `int`. As a result, the assertions on `start`, `end` and `step` in `slice_scatter_decomposition` aborts the lowering pass.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [v] My code follows the style guidelines of this project (You can use the linters)
- [v] I have performed a self-review of my own code
- [v] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [v] I have added the relevant labels to my PR in so that relevant reviewers are notified
