### PR TITLE
fix: allow `dict` type `module_outputs` in `infer_module_output_dtypes`

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/_conversion.py
+++ b/py/torch_tensorrt/dynamo/conversion/_conversion.py
@@ -46,7 +46,9 @@ def infer_module_output_dtypes(
             kwarg_inputs = {}
         torch_kwarg_inputs = get_torch_inputs(kwarg_inputs, device)
         module_outputs = module(*torch_inputs, **torch_kwarg_inputs)
-        if not isinstance(module_outputs, (list, tuple)):
+        if isinstance(module_outputs, dict):
+            module_outputs = list(module_outputs.values())
+        elif not isinstance(module_outputs, (list, tuple)):
             module_outputs = [module_outputs]
 
     # Int64 outputs can sometimes be generated from within other operators


### PR DESCRIPTION
# Description

A graph module's output might have nested structures depending on the implementation. For example, many models from transformers returns output of type [ModelOutput](https://github.com/huggingface/transformers/blob/c409cd81777fb27aadc043ed3d8339dbc020fb3b/src/transformers/utils/generic.py#L310) (e.g. [CausalLMOutputsWithPast](https://github.com/huggingface/transformers/blob/c409cd81777fb27aadc043ed3d8339dbc020fb3b/src/transformers/modeling_outputs.py#L678)).
This PR doesn't aim to handle all possible nested pytree structures imposed by graph module outputs. However, this simple fix at least allows the model output to be a non-nested dictionary (or a subclass of `dict`) of tensors (or values that could be converted to tensor via `torch.tensor`).

P.S. the comment in the subsequent for loop in the code `# We don't need to check if output is nested here because the input module will be flattened` is misleading. We need to actually handle the nested outputs here.

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)


# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
