### PR TITLE
fix: remove global logging setup

### DIFF
--- a/py/torch_tensorrt/fx/__init__.py
+++ b/py/torch_tensorrt/fx/__init__.py
@@ -12,5 +12,3 @@ from .input_tensor_spec import generate_input_specs, InputTensorSpec  # noqa
 from .lower_setting import LowerSetting  # noqa
 from .trt_module import TRTModule  # noqa
 from .lower import compile  # usort: skip  #noqa
-
-logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
Removes the global logging setup (which is initialized at import time). Solves #3145 