### PR TITLE
register_jit_hooks: Remove confusing error message

### DIFF
--- a/core/runtime/register_jit_hooks.cpp
+++ b/core/runtime/register_jit_hooks.cpp
@@ -112,7 +112,6 @@ static auto TORCHTRT_UNUSED TRTEngineTSRegistrtion =
               return serialize_info;
             },
             [](std::vector<std::string> serialized_info) -> c10::intrusive_ptr<TRTEngine> {
-              LOG_ERROR(serialized_info[TARGET_PLATFORM_IDX]);
               serialized_info[ENGINE_IDX] = base64_decode(serialized_info[ENGINE_IDX]);
               TRTEngine::verify_serialization_fmt(serialized_info);
               return c10::make_intrusive<TRTEngine>(serialized_info);


### PR DESCRIPTION
# Description

```python
import torch
import torch_tensorrt

model = torch.nn.ReLU().eval().cuda()

inputs = [torch.randn(1, 3, 224, 224, device="cuda")]

trt_model = torch_tensorrt.compile(
    model,
    ir="dynamo",
    inputs=inputs,
    enabled_precisions={torch.float},
    min_block_size=1,
    make_refitable=False,
    cache_built_engines=False,
    reuse_cached_engines=False,
)

torch_tensorrt.save(trt_model, "trt.ts", output_format="torchscript", inputs=inputs)
loaded_model = torch_tensorrt.load("trt.ts")
```

```
holywu@HOLYWU:~$ python3 test.py
Unable to import quantization op. Please install modelopt library (https://github.com/NVIDIA/TensorRT-Model-Optimizer?tab=readme-ov-file#installation) to add support for compiling quantized models
WARNING:torch_tensorrt.dynamo.utils:Could not detect the device on which the model exists. Assuming the model is on CPU
WARNING: [Torch-TensorRT] - Using default stream in enqueueV3() may lead to performance issues due to additional calls to cudaStreamSynchronize() by TensorRT to ensure correct synchronization. Please use non-default stream instead.
ERROR: [Torch-TensorRT] - linux_x86_64
holywu@HOLYWU:~$
```