### PR TITLE
extend the timeout-minutes in build/test from 60 min to 120 min

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -73,9 +73,9 @@ jobs:
     container:
       image: ${{ matrix.container_image }}
       options: ${{ matrix.gpu_arch_type == 'cuda' && '--gpus all' || ' ' }}
-    # If a build is taking longer than 60 minutes on these runners we need
+    # If a build is taking longer than 120 minutes on these runners we need
     # to have a conversation
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Clean workspace
         run: |
@@ -167,7 +167,7 @@ jobs:
           fi
 
           upload_docs=0
-          # Check if there are things in the documentation folder to uplaod
+          # Check if there are things in the documentation folder to upload
           if find "${RUNNER_DOCS_DIR}" -mindepth 1 -maxdepth 1 | read -r; then
             # TODO: Add a check here to test if on ec2 because if we're not on ec2 then this
             # upload will probably not work correctly

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -9,7 +9,7 @@ jobs:
   cut_nightly:
     runs-on: ubuntu-latest
     environment: trigger-nightly
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -58,9 +58,9 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-    # If a build is taking longer than 60 minutes on these runners we need
+    # If a build is taking longer than 120 minutes on these runners we need
     # to have a conversation
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Clean workspace
         run: |


### PR DESCRIPTION
# Description

extend the timeout-minutes in build/test from 60 min to 120 min


## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
