### PR TITLE
fix: change floordiv to divmod for `//tests/core/lowering:test_remove_unnecessary_casts`

### DIFF
--- a/core/lowering/passes/remove_unnecessary_casts.cpp
+++ b/core/lowering/passes/remove_unnecessary_casts.cpp
@@ -129,7 +129,7 @@ void RemoveSingleUse0DTensors(std::shared_ptr<torch::jit::Graph>& g) {
                             new_node->outputs()[0]->setType(c10::IntType::get());
                             user->outputs()[0]->replaceAllUsesWith(new_node->outputs()[0]);
                             user->destroy();
-                          } else if (user->kind() == c10::Symbol::fromQualString("aten::floordiv")) {
+                          } else if (user->kind() == c10::Symbol::fromQualString("aten::floor_divide")) {
                             new_node = g->create(c10::aten::floordiv, user->inputs(), 1);
                             new_node->insertAfter(user);
                             new_node->outputs()[0]->setType(c10::IntType::get());


### PR DESCRIPTION
# Description

An error was reported on NVBug:
```
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] LoweringPasses.RemoveSingleUse0DTensorsFloorDivIntCorrectly
[  FAILED  ] LoweringPasses.RemoveSingleUse0DTensorsFloorDivFloatCorrectly

With log:
unknown file: Failure
C++ exception with description "
Schema not found for node. File a bug report.
Node: %7 : int = aten::floor_divide(%6, %0)

Input types:int, int
candidates were:
  aten::floor_divide(Tensor self, Tensor other) -> Tensor
  aten::floor_divide.Scalar(Tensor self, Scalar other) -> Tensor
  aten::floor_divide.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
  aten::floor_divide.Scalar_out(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
within the graph:
graph(%0 : int):
  %6 : int = prim::Constant[value=7]()
  %7 : int = aten::floor_divide(%6, %0)
  %4 : int = aten::Int(%7)
  return (%4)

:
" thrown in the test body.
```

The error is because Pytorch changed the schema of `aten::floor_divide`. Previously it supported two ints/floats as inputs, but the new schema requires the first input to be Tensor, while the lowering pass `RemoveSingleUse0DTensors` lowers two inputs to int/float.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
