### PR TITLE
chore: Make substitute-runner in Windows CI work again

### DIFF
--- a/.github/workflows/build-test-windows.yml
+++ b/.github/workflows/build-test-windows.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Substitute runner
         id: substitute
         run: |
-          echo matrix="$(echo '${{ needs.generate-matrix.outputs.matrix }}' | sed -e 's/windows.8xlarge.nvidia.gpu/windows.g5.4xlarge.nvidia.gpu/g')" >> ${GITHUB_OUTPUT}
+          echo matrix="$(echo '${{ needs.generate-matrix.outputs.matrix }}' | sed -e 's/windows.g4dn.xlarge/windows.g5.4xlarge.nvidia.gpu/g')" >> ${GITHUB_OUTPUT}
 
   build:
     needs: substitute-runner

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Substitute runner
         id: substitute
         run: |
-          echo matrix="$(echo '${{ needs.generate-release-matrix.outputs.matrix }}' | sed -e 's/windows.8xlarge.nvidia.gpu/windows.g5.4xlarge.nvidia.gpu/g')" >> ${GITHUB_OUTPUT}
+          echo matrix="$(echo '${{ needs.generate-release-matrix.outputs.matrix }}' | sed -e 's/windows.g4dn.xlarge/windows.g5.4xlarge.nvidia.gpu/g')" >> ${GITHUB_OUTPUT}
 
   release-wheel-artifacts:
     needs: substitute-runner


### PR DESCRIPTION
# Description

Since https://github.com/pytorch/test-infra/pull/5722, the `substitute-runner` job failed to replace the runner due to the string changed. When running on G5 instance, the time spent on building the wheel were less than 10 mins, and the job could usually complete in less than 15 mins, like https://github.com/pytorch/TensorRT/actions/runs/10998678934/job/30537276131#step:11:1. But when running on G4dn instance, the time spent on building the wheel became more than 30 mins, and the job took around 1 hour to complete, like https://github.com/pytorch/TensorRT/actions/runs/11220833237/job/31189943670#step:12:1.