### PR TITLE
don't initialize cuda at import time

### DIFF
--- a/py/torch_tensorrt/ts/_compile_spec.py
+++ b/py/torch_tensorrt/ts/_compile_spec.py
@@ -307,7 +307,7 @@ def _parse_compile_spec(compile_spec_: Dict[str, Any]) -> _ts_C.CompileSpec:
 def TensorRTCompileSpec(
     inputs: Optional[List[torch.Tensor | Input]] = None,
     input_signature: Optional[Any] = None,
-    device: torch.device | Device = Device._current_device(),
+    device: Optional[torch.device | Device] = None,
     disable_tf32: bool = False,
     sparse_weights: bool = False,
     enabled_precisions: Optional[Set[torch.dtype | dtype]] = None,
@@ -365,7 +365,7 @@ def TensorRTCompileSpec(
     compile_spec = {
         "inputs": inputs if inputs is not None else [],
         # "input_signature": input_signature,
-        "device": device,
+        "device": Device._current_device() if device is None else device,
         "disable_tf32": disable_tf32,  # Force FP32 layers to use traditional as FP32 format vs the default behavior of rounding the inputs to 10-bit mantissas before multiplying, but accumulates the sum using 23-bit mantissas
         "sparse_weights": sparse_weights,  # Enable sparsity for convolution and fully connected layers.
         "enabled_precisions": (


### PR DESCRIPTION
# Description

Currently importing `torch_tensorrt` calls `_cuda_init`, which can fail, preventing torch_tensorrt being imported in environments without a (working) GPU. This makes it slow to import torch_tensorrt and isn't necessary. This change switches to determining the current devices when TensorRTCompileSpec is called rather than when it's defined.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
