### PR TITLE
fix: expand dim for scalar numpy when freezing tensors to IConstantLayers

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/converter_utils.py
+++ b/py/torch_tensorrt/dynamo/conversion/converter_utils.py
@@ -505,6 +505,13 @@ def enforce_tensor_types(
                         _LOGGER.debug(
                             f"Freezing tensor {name}_constant_{index} to TRT IConstantLayer"
                         )
+                        # If the candidate is a scalar Numpy array, handle it accordingly
+                        if isinstance(candidate, np.ndarray) and candidate.shape == ():
+                            _LOGGER.debug(
+                                f"Scalar numpy detected at {name}_constant_{index}, adding rank (1,)"
+                            )
+                            # Convert the scalar to a 1D array (with a single element)
+                            candidate = np.expand_dims(candidate, axis=0)
                         new_value = get_trt_tensor(
                             ctx, candidate, name + f"_constant_{index}"
                         )


### PR DESCRIPTION
# Description
When compiling `facebook/bart-base` with Torch-TensorRT, I encountered an error similar to the one in [this issue](https://github.com/pytorch/TensorRT/issues/3184), where `aten_ops.scatter.src` fails within `impl.elementwise.eq`. Upon investigation, I found that the issue arises when a scalar Numpy value is used in a slice operation as a constant layer. The output of this constant layer, which has a shape of `()` (scalar), is passed into `aten_ops.scatter.src`, causing the error. To fix this, I modified the shape to `(1,)` to avoid the issue.

I confirmed that after the modification, the TensorRT engine is successfully obtained using the Torch-TensorRT backend with the following code:

```python
import torch
from transformers import BartTokenizer, BartModel
import torch_tensorrt

# Set device and backend
backend = "torch_tensorrt"
device = "cuda:0"

# Load tokenizer and model
tokenizer = BartTokenizer.from_pretrained('facebook/bart-base')
model = BartModel.from_pretrained('facebook/bart-base')
model.eval()
model = model.to(device)

# Prepare input
inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
inputs = {k: v.to(device) for k, v in inputs.items()} 

# Run inference before Torch-TensorRT
outputs_before = model(**inputs)

# Apply Torch-TensorRT optimization
model = torch.compile(
    model,
    backend=backend,
    options={
        "truncate_long_and_double": True,
        "enabled_precisions": {torch.float16, torch.float32},
    },
    dynamic=False,
)

# Run inference after Torch-TensorRT
outputs_after = model(**inputs)

# Compare outputs
last_hidden_states_before = outputs_before.last_hidden_state
last_hidden_states_after = outputs_after.last_hidden_state

# Calculate the maximum absolute difference
max_diff = torch.max(torch.abs(last_hidden_states_before - last_hidden_states_after)).item()

# Calculate the mean absolute difference
mean_abs_diff = torch.mean(torch.abs(last_hidden_states_before - last_hidden_states_after)).item()

# Calculate the plain mean of the differences (not absolute)
mean_diff = torch.mean(last_hidden_states_before - last_hidden_states_after).item()

# Print the outputs, max difference, mean absolute difference, and plain mean difference
print("Outputs before Torch-TensorRT:")
print(last_hidden_states_before)
print("\nOutputs after Torch-TensorRT:")
print(last_hidden_states_after)

print(f"\nMaximum absolute difference: {max_diff}")
print(f"Mean absolute difference: {mean_abs_diff}")
print(f"Mean difference: {mean_diff}")
```

This code compares the model's outputs before and after applying Torch-TensorRT optimization.

Fixes # ([issue](https://github.com/pytorch/TensorRT/issues/3184))

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
