### PR TITLE
Fix code example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ import torch_tensorrt
 model = MyModel().eval().cuda() # define your model here
 inputs = [torch.randn((1, 3, 224, 224)).cuda()] # define a list of representative inputs here
 
-trt_gm = torch_tensorrt.compile(model, ir="dynamo", inputs)
+trt_gm = torch_tensorrt.compile(model, ir="dynamo", inputs=inputs)
 torch_tensorrt.save(trt_gm, "trt.ep", inputs=inputs) # PyTorch only supports Python runtime for an ExportedProgram. For C++ deployment, use a TorchScript file
 torch_tensorrt.save(trt_gm, "trt.ts", output_format="torchscript", inputs=inputs)
 ```


### PR DESCRIPTION
# Description

The current version of the code example in the README.md (Option 2: Export, Step 1) results in an error:

```
SyntaxError: positional argument follows keyword argument
```

## Type of change

Minor change of the code example.
