### PR TITLE
disable python 3.13 for linux

### DIFF
--- a/.github/scripts/filter-matrix.py
+++ b/.github/scripts/filter-matrix.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+
+disabled_python_versions = "3.13"
+
+
+def main(args: list[str]) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--matrix",
+        help="matrix blob",
+        type=str,
+        default="",
+    )
+
+    options = parser.parse_args(args)
+
+    if options.matrix == "":
+        raise Exception("--matrix needs to be provided")
+    matrix_dict = json.loads(options.matrix)
+    includes = matrix_dict["include"]
+    filtered_includes = []
+    for item in includes:
+        if item["python_version"] not in disabled_python_versions:
+            filtered_includes.append(item)
+    filtered_matrix_dict = {}
+    filtered_matrix_dict["include"] = filtered_includes
+    print(json.dumps(filtered_matrix_dict))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -24,8 +24,29 @@ jobs:
       with-rocm: false
       with-cpu: false
 
+  filter-matrix:
+    needs: [generate-matrix]
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - uses: actions/checkout@v3
+        with:
+          repository: pytorch/tensorrt
+      - name: Generate release matrix
+        id: generate
+        run: |
+          set -eou pipefail
+          MATRIX_BLOB=${{ toJSON(needs.generate-matrix.outputs.matrix) }}
+          MATRIX_BLOB="$(python3 .github/scripts/filter-matrix.py --matrix "${MATRIX_BLOB}")"
+          echo "${MATRIX_BLOB}"
+          echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
+
   build:
-    needs: generate-matrix
+    needs: filter-matrix
     permissions:
       id-token: write
       contents: read
@@ -46,7 +67,7 @@ jobs:
       ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       env-var-script: ${{ matrix.env-var-script }}
       post-script: ${{ matrix.post-script }}
@@ -56,7 +77,7 @@ jobs:
 
   tests-py-torchscript-fe:
     name: Test torchscript frontend [Python]
-    needs: [generate-matrix, build]
+    needs: [filter-matrix, build]
     strategy:
       fail-fast: false
       matrix:
@@ -73,7 +94,7 @@ jobs:
       ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       script: |
         export USE_HOST_DEPS=1
@@ -92,7 +113,7 @@ jobs:
 
   tests-py-dynamo-converters:
     name: Test dynamo converters [Python]
-    needs: [generate-matrix, build]
+    needs: [filter-matrix, build]
     strategy:
       fail-fast: false
       matrix:
@@ -109,7 +130,7 @@ jobs:
       ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       script: |
         export USE_HOST_DEPS=1
@@ -121,7 +142,7 @@ jobs:
 
   tests-py-dynamo-fe:
     name: Test dynamo frontend [Python]
-    needs: [generate-matrix, build]
+    needs: [filter-matrix, build]
     strategy:
       fail-fast: false
       matrix:
@@ -138,7 +159,7 @@ jobs:
       ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       script: |
         export USE_HOST_DEPS=1
@@ -150,7 +171,7 @@ jobs:
 
   tests-py-dynamo-serde:
     name: Test dynamo export serde [Python]
-    needs: [generate-matrix, build]
+    needs: [filter-matrix, build]
     strategy:
       fail-fast: false
       matrix:
@@ -167,7 +188,7 @@ jobs:
       ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       script: |
         export USE_HOST_DEPS=1
@@ -179,7 +200,7 @@ jobs:
 
   tests-py-torch-compile-be:
     name: Test torch compile backend [Python]
-    needs: [generate-matrix, build]
+    needs: [filter-matrix, build]
     strategy:
       fail-fast: false
       matrix:
@@ -196,7 +217,7 @@ jobs:
       ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       script: |
         export USE_HOST_DEPS=1
@@ -210,7 +231,7 @@ jobs:
 
   tests-py-dynamo-core:
     name: Test dynamo core [Python]
-    needs: [generate-matrix, build]
+    needs: [filter-matrix, build]
     strategy:
       fail-fast: false
       matrix:
@@ -227,7 +248,7 @@ jobs:
       ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       script: |
         export USE_HOST_DEPS=1
@@ -241,7 +262,7 @@ jobs:
 
   tests-py-dynamo-cudagraphs:
     name: Test dynamo cudagraphs [Python]
-    needs: [generate-matrix, build]
+    needs: [filter-matrix, build]
     strategy:
       fail-fast: false
       matrix:
@@ -258,7 +279,7 @@ jobs:
       ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       script: |
         export USE_HOST_DEPS=1
@@ -272,7 +293,7 @@ jobs:
 
   tests-py-core:
     name: Test core [Python]
-    needs: [generate-matrix, build]
+    needs: [filter-matrix, build]
     strategy:
       fail-fast: false
       matrix:
@@ -289,7 +310,7 @@ jobs:
       ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       script: |
         export USE_HOST_DEPS=1


### PR DESCRIPTION
# Description

Currently Tensorrt does not support python 3.13, disable it for now.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
