### PR TITLE
fix issue#3269: unwrap tensor shape without opt val

### DIFF
--- a/py/torch_tensorrt/dynamo/partitioning/common.py
+++ b/py/torch_tensorrt/dynamo/partitioning/common.py
@@ -31,7 +31,8 @@ def construct_dynamic_input(
         if isinstance(dim, torch.SymInt):
             min_max_opt = extract_var_range_info(dim)
             min_shape.append(min_max_opt["min"])
-            opt_shape.append(min_max_opt["opt"])
+            # opt might not exist
+            opt_shape.append(min_max_opt.get("opt"))
             max_shape.append(min_max_opt["max"])
         else:
             min_shape.append(dim)


### PR DESCRIPTION
# Description

Fixes #3269
extract_var_range_info is used by unwrap_tensor_shape and construct_dynamic_input
for the unwrap_tensor_shape, it only needs min and max
for the construct_dynamic_input, it needs min, opt and max
So added a flag to mark whether opt val is optional or not.
If it is optional then if cannot get the opt val(if got exception), we can still continue
if it is not optional then it will raise Error(if got exception)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
