### PR TITLE
fix MutableTorchTensorRTModule load issue

### DIFF
--- a/py/torch_tensorrt/dynamo/runtime/_MutableTorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_MutableTorchTensorRTModule.py
@@ -498,7 +498,7 @@ class MutableTorchTensorRTModule(object):
     def load(path: str) -> Any:
         # When the model get saved, init_finished is set to False.
         # Class is restored to MutableTorchTensorRTModule, and some attribute is deleted
-        module = torch.load(path)
+        module = torch.load(path, weights_only=False)
         module.pytorch_model = _make_refit_change_trigger(
             module.original_model, module.refit_state
         )


### PR DESCRIPTION
# Description

got the following test issue due to the upstream pytorch change:
```
except pickle.UnpicklingError as e:
>                           raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
E                           _pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, [1mdo those steps only if you trust the source of the checkpoint[0m.
E                               (1) Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
E                               (2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
E                               WeightsUnpickler error: Unsupported global: GLOBAL torch_tensorrt.dynamo.runtime._MutableTorchTensorRTModule.MutableTorchTensorRTModule was not an allowed global by default. Please use `torch.serialization.add_safe_globals([MutableTorchTensorRTModule])` or the `torch.serialization.safe_globals([MutableTorchTensorRTModule])` context manager to allowlist this global if you trust this class/function.
E
E                           Check the documentation of torch.load to learn more about types accepted by default with weights_only https://pytorch.org/docs/stable/generated/torch.load.html.
```
Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
