### PR TITLE
allow null arg_inputs if kwarg_inputs is set

### DIFF
--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -223,8 +223,8 @@ def compile(
             "When enable_weight_streaming is enabled, it requires use_explicit_typing to be set to True"
         )
     # Aliasing inputs to arg_inputs for better understanding
-    if not arg_inputs and not inputs:
-        raise AssertionError("'arg_inputs' and 'inputs' should not both be None.")
+    if not arg_inputs and not kwarg_inputs and not inputs:
+        raise AssertionError("'arg_inputs', 'kwarg_inputs' and 'inputs' should not all be None.")
 
     elif arg_inputs and inputs:
         raise AssertionError(


### PR DESCRIPTION
# Description

Currently, a module cannot be compiled if it is called with only kwarg inputs, because arg_inputs must not be none. This prevents some usages of MutableTorchTensorRTModule. arg_inputs should be allowed to be None if kwarg_inputs is not none.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
