### PR TITLE
chore: add source_ir in slice layer name

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/impl/slice/base.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/slice/base.py
@@ -32,5 +32,5 @@ def slice(
     )
     if dynamic_shape:
         layer.set_input(2, shape)
-    set_layer_name(layer, target, name)
+    set_layer_name(layer, target, name, source_ir)
     return layer.get_output(0)


### PR DESCRIPTION
# Description

Minor change for giving correct names for slice layers.

[Example]
* Before: `[SLICE]-[unknown_ir_ops.slice.Tensor]-[slice_tensor]`
* After: `[SLICE]-[aten_ops.slice.Tensor]-[slice_tensor]`

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
