### PR TITLE
fix: attribute error caused by `trt.BuilderFlag.STRICT_TYPES`

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
+++ b/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
@@ -291,7 +291,7 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
             builder_config.set_flag(trt.BuilderFlag.REFIT)
 
         if strict_type_constraints:
-            builder_config.set_flag(trt.BuilderFlag.STRICT_TYPES)
+            builder_config.set_flag(trt.BuilderFlag.OBEY_PRECISION_CONSTRAINTS)
 
         if self.optimization_profiles is not None:
             if len(self.optimization_profiles) > 0:


### PR DESCRIPTION
# Description

When `strict_type_constraints` is `True`, accessing `trt.BuilderFlag.STRICT_TYPES` causes `AttributeError: type object 'tensorrt.tensorrt.BuilderFlag' has no attribute 'STRICT_TYPES'`. Indeed, there is no such builder flag in TensorRT, and it should be replaced by `trt.BuilderFlag.OBEY_PRECISION_CONSTRAINTS`.

## Type of change

Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
