### PR TITLE
Deprecate torchscript frontend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: ^.github/actions/assigner/dist
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.5.0
+      rev: v5.0.0
       hooks:
           - id: check-yaml
           - id: trailing-whitespace
@@ -32,7 +32,7 @@ repos:
       hooks:
           - id: validate-pyproject
     - repo: https://github.com/pycqa/isort
-      rev: 5.13.2
+      rev: 6.0.0
       hooks:
           - id: isort
             name: isort (python)
@@ -52,7 +52,7 @@ repos:
           - id: black
             exclude: ^examples/custom_converters/elu_converter/setup.py|^docs
     - repo: https://github.com/crate-ci/typos
-      rev: v1.22.9
+      rev: typos-dict-v0.12.4
       hooks:
           - id: typos
     - repo: https://github.com/astral-sh/uv-pre-commit

--- a/cpp/include/torch_tensorrt/macros.h
+++ b/cpp/include/torch_tensorrt/macros.h
@@ -30,6 +30,9 @@
   STR(TORCH_TENSORRT_MAJOR_VERSION) \
   "." STR(TORCH_TENSORRT_MINOR_VERSION) "." STR(TORCH_TENSORRT_PATCH_VERSION)
 
+#define TORCH_TENSORRT_PTQ_DEPRECATION \
+  [[deprecated(                        \
+      "Int8 PTQ Calibrator has been deprecated by TensorRT, please plan on porting to a NVIDIA Model Optimizer Toolkit based workflow. See: https://pytorch.org/TensorRT/tutorials/_rendered_examples/dynamo/vgg16_ptq.html for more details")]]
 // Setup namespace aliases for ease of use
 namespace torch_tensorrt {
 namespace torchscript {}

--- a/cpp/include/torch_tensorrt/ptq.h
+++ b/cpp/include/torch_tensorrt/ptq.h
@@ -308,9 +308,8 @@ class Int8CacheCalibrator : Algorithm {
  * @param use_cache: bool - use calibration cache
  * @return Int8Calibrator<Algorithm, DataLoader>
  */
-
 template <typename Algorithm = nvinfer1::IInt8EntropyCalibrator2, typename DataLoader>
-inline Int8Calibrator<Algorithm, DataLoader> make_int8_calibrator(
+TORCH_TENSORRT_PTQ_DEPRECATION inline Int8Calibrator<Algorithm, DataLoader> make_int8_calibrator(
     DataLoader dataloader,
     const std::string& cache_file_path,
     bool use_cache) {
@@ -344,7 +343,8 @@ inline Int8Calibrator<Algorithm, DataLoader> make_int8_calibrator(
  * @return Int8CacheCalibrator<Algorithm>
  */
 template <typename Algorithm = nvinfer1::IInt8EntropyCalibrator2>
-inline Int8CacheCalibrator<Algorithm> make_int8_cache_calibrator(const std::string& cache_file_path) {
+TORCH_TENSORRT_PTQ_DEPRECATION inline Int8CacheCalibrator<Algorithm> make_int8_cache_calibrator(
+    const std::string& cache_file_path) {
   return Int8CacheCalibrator<Algorithm>(cache_file_path);
 }
 

--- a/py/torch_tensorrt/ts/_compiler.py
+++ b/py/torch_tensorrt/ts/_compiler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Any, List, Optional, Sequence, Set, Tuple
 
 import torch
@@ -101,6 +102,12 @@ def compile(
     Returns:
         torch.jit.ScriptModule: Compiled TorchScript Module, when run it will execute via TensorRT
     """
+
+    warnings.warn(
+        'The torchscript frontend for Torch-TensorRT has been deprecated, please plan on porting to the dynamo frontend (torch_tensorrt.compile(..., ir="dynamo"). Torchscript will continue to be a supported deployment format via post compilation torchscript tracing, see: https://pytorch.org/TensorRT/user_guide/saving_models.html for more details',
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     input_list = list(inputs) if inputs is not None else []
     enabled_precisions_set = (
@@ -240,6 +247,12 @@ def convert_method_to_trt_engine(
     Returns:
         bytes: Serialized TensorRT engine, can either be saved to a file or deserialized via TensorRT APIs
     """
+    warnings.warn(
+        'The torchscript frontend for Torch-TensorRT has been deprecated, please plan on porting to the dynamo frontend (torch_tensorrt.convert_method_to_trt_engine(..., ir="dynamo"). Torchscript will continue to be a supported deployment format via post compilation torchscript tracing, see: https://pytorch.org/TensorRT/user_guide/saving_models.html for more details',
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     input_list = list(inputs) if inputs is not None else []
     enabled_precisions_set = (
         enabled_precisions if enabled_precisions is not None else {torch.float}

--- a/py/torch_tensorrt/ts/ptq.py
+++ b/py/torch_tensorrt/ts/ptq.py
@@ -7,6 +7,7 @@ else:
     from typing_extensions import Self
 
 import os
+import warnings
 from enum import Enum
 
 import torch
@@ -88,6 +89,11 @@ class DataLoaderCalibrator(object):
         pass
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Self:
+        warnings.warn(
+            "Int8 PTQ Calibrator has been deprecated by TensorRT, please plan on porting to a NVIDIA Model Optimizer Toolkit based workflow. See: https://pytorch.org/TensorRT/tutorials/_rendered_examples/dynamo/vgg16_ptq.html for more details",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         dataloader = args[0]
         algo_type = kwargs.get("algo_type", CalibrationAlgo.ENTROPY_CALIBRATION_2)
         cache_file = kwargs.get("cache_file", None)
@@ -175,6 +181,11 @@ class CacheCalibrator(object):
         pass
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Self:
+        warnings.warn(
+            "Int8 PTQ Calibrator has been deprecated by TensorRT, please plan on porting to a NVIDIA Model Optimizer Toolkit based workflow. See: https://pytorch.org/TensorRT/tutorials/_rendered_examples/dynamo/vgg16_ptq.html for more details",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         cache_file = args[0]
         algo_type = kwargs.get("algo_type", CalibrationAlgo.ENTROPY_CALIBRATION_2)
 


### PR DESCRIPTION
# Description

Deprecate the TS frontend, Dynamo can be used in conjunction with TorchScript to get the same deployment feature set + the extra operator support.  

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
