### PR TITLE
feat: add `--use_python_runtime` and `--enable_cuda_graph` args to the perf run script

### DIFF
--- a/tools/perf/perf_run.py
+++ b/tools/perf/perf_run.py
@@ -175,6 +175,7 @@ def run_ts_trt(model, input_tensors, params, precision, batch_size):
         "inputs": input_tensors,
         "enabled_precisions": {precision_to_dtype(precision)},
         "truncate_long_and_double": params.get("truncate", False),
+        "use_python_runtime": params.get("use_python_runtime", False),
     }
 
     if precision == "int8":
@@ -217,6 +218,7 @@ def run_hf_dynamo(model, input_tensors, params, precision, batch_size):
         inputs=input_tensors,
         enabled_precisions={precision_to_dtype(precision)},
         truncate_double=params.get("truncate", False),
+        use_python_runtime=params.get("use_python_runtime", False),
     )
     end_compile = timeit.default_timer()
     compile_time_s = end_compile - start_compile
@@ -262,6 +264,7 @@ def run_dynamo(model, input_tensors, params, precision, batch_size):
         ),
         cache_built_engines=params.get("cache_built_engines", False),
         reuse_cached_engines=params.get("reuse_cached_engines", False),
+        use_python_runtime=params.get("use_python_runtime", False),
     )
     end_compile = timeit.default_timer()
     compile_time_s = end_compile - start_compile
@@ -292,6 +295,7 @@ def run_torch_compile(model, input_tensors, params, precision, batch_size):
         "enabled_precisions": {precision_to_dtype(precision)},
         "truncate": params.get("truncate", False),
         "min_block_size": params.get("min_block_size", 1),
+        "use_python_runtime": params.get("use_python_runtime", False),
     }
     start_compile = timeit.default_timer()
     model = torch.compile(model, backend="tensorrt", dynamic=None, options=compile_spec)
@@ -525,6 +529,7 @@ def run(
 
 
 if __name__ == "__main__":
+    torchtrt.runtime.set_cudagraphs_mode(True)
     arg_parser = argparse.ArgumentParser(
         description="Run inference on a model with random input values"
     )
@@ -586,6 +591,11 @@ if __name__ == "__main__":
         "--is_trt_engine",
         action="store_true",
         help="Boolean flag to determine if the user provided model is a TRT engine or not",
+    )
+    arg_parser.add_argument(
+        "--use_python_runtime",
+        action="store_true",
+        help="Whether to use Python runtime or not. Using C++ runtime by default",
     )
     arg_parser.add_argument(
         "--report",

--- a/tools/perf/perf_run.py
+++ b/tools/perf/perf_run.py
@@ -529,7 +529,6 @@ def run(
 
 
 if __name__ == "__main__":
-    torchtrt.runtime.set_cudagraphs_mode(True)
     arg_parser = argparse.ArgumentParser(
         description="Run inference on a model with random input values"
     )
@@ -598,6 +597,11 @@ if __name__ == "__main__":
         help="Whether to use Python runtime or not. Using C++ runtime by default",
     )
     arg_parser.add_argument(
+        "--enable_cuda_graph",
+        action="store_true",
+        help="Whether to enable CUDA Graph. It is not used by default",
+    )
+    arg_parser.add_argument(
         "--report",
         type=str,
         help="Path of the output file where performance summary is written.",
@@ -662,6 +666,8 @@ if __name__ == "__main__":
         raise ValueError(
             "No Pytorch model (nn.Module) is provided for torchdynamo compilation. Please provide a pytorch model using --model_torch argument"
         )
+
+    torchtrt.runtime.set_cudagraphs_mode(params.get("enable_cuda_graph", False))
 
     batch_size = params["batch_size"]
     is_trt_engine = params["is_trt_engine"]

--- a/tools/perf/perf_run.py
+++ b/tools/perf/perf_run.py
@@ -188,15 +188,27 @@ def run_ts_trt(model, input_tensors, params, precision, batch_size):
 
     iters = params.get("iterations", 20)
 
-    record_perf(
-        model,
-        "Torchscript",
-        input_tensors,
-        precision,
-        iters,
-        batch_size,
-        compile_time_s,
-    )
+    if params.get("enable_cuda_graph", False):
+        with torchtrt.runtime.enable_cudagraphs(model) as cudagraphs_module:
+            record_perf(
+                cudagraphs_module,
+                "Torchscript",
+                input_tensors,
+                precision,
+                iters,
+                batch_size,
+                compile_time_s,
+            )
+    else:
+        record_perf(
+            model,
+            "Torchscript",
+            input_tensors,
+            precision,
+            iters,
+            batch_size,
+            compile_time_s,
+        )
 
 
 @run_with_try_except
@@ -222,16 +234,30 @@ def run_hf_dynamo(model, input_tensors, params, precision, batch_size):
     )
     end_compile = timeit.default_timer()
     compile_time_s = end_compile - start_compile
-    record_llm_perf(
-        trt_model,
-        "Dynamo",
-        input_tensors,
-        precision,
-        osl,
-        batch_size,
-        iters,
-        compile_time_s,
-    )
+
+    if params.get("enable_cuda_graph", False):
+        with torchtrt.runtime.enable_cudagraphs(trt_model) as cudagraphs_module:
+            record_llm_perf(
+                cudagraphs_module,
+                "Dynamo",
+                input_tensors,
+                precision,
+                osl,
+                batch_size,
+                iters,
+                compile_time_s,
+            )
+    else:
+        record_llm_perf(
+            trt_model,
+            "Dynamo",
+            input_tensors,
+            precision,
+            osl,
+            batch_size,
+            iters,
+            compile_time_s,
+        )
 
 
 @run_with_try_except
@@ -270,9 +296,21 @@ def run_dynamo(model, input_tensors, params, precision, batch_size):
     compile_time_s = end_compile - start_compile
     iters = params.get("iterations", 20)
 
-    record_perf(
-        model, "Dynamo", input_tensors, precision, iters, batch_size, compile_time_s
-    )
+    if params.get("enable_cuda_graph", False):
+        with torchtrt.runtime.enable_cudagraphs(model) as cudagraphs_module:
+            record_perf(
+                cudagraphs_module,
+                "Dynamo",
+                input_tensors,
+                precision,
+                iters,
+                batch_size,
+                compile_time_s,
+            )
+    else:
+        record_perf(
+            model, "Dynamo", input_tensors, precision, iters, batch_size, compile_time_s
+        )
 
 
 @run_with_try_except
@@ -304,15 +342,27 @@ def run_torch_compile(model, input_tensors, params, precision, batch_size):
     compile_time_s = end_compile - start_compile
     iters = params.get("iterations", 20)
 
-    record_perf(
-        model,
-        "torch_compile",
-        input_tensors,
-        precision,
-        iters,
-        batch_size,
-        compile_time_s,
-    )
+    if params.get("enable_cuda_graph", False):
+        with torchtrt.runtime.enable_cudagraphs(model) as cudagraphs_module:
+            record_perf(
+                cudagraphs_module,
+                "torch_compile",
+                input_tensors,
+                precision,
+                iters,
+                batch_size,
+                compile_time_s,
+            )
+    else:
+        record_perf(
+            model,
+            "torch_compile",
+            input_tensors,
+            precision,
+            iters,
+            batch_size,
+            compile_time_s,
+        )
 
 
 @run_with_try_except
@@ -332,16 +382,29 @@ def run_hf_inductor(model, input_tensors, params, precision, batch_size):
     compile_time_s = end_compile - start_compile
     iters = params.get("iterations", 20)
 
-    record_llm_perf(
-        model,
-        "Inductor",
-        input_tensors,
-        precision,
-        osl,
-        batch_size,
-        iters,
-        compile_time_s,
-    )
+    if params.get("enable_cuda_graph", False):
+        with torchtrt.runtime.enable_cudagraphs(model) as cudagraphs_module:
+            record_llm_perf(
+                cudagraphs_module,
+                "Inductor",
+                input_tensors,
+                precision,
+                osl,
+                batch_size,
+                iters,
+                compile_time_s,
+            )
+    else:
+        record_llm_perf(
+            model,
+            "Inductor",
+            input_tensors,
+            precision,
+            osl,
+            batch_size,
+            iters,
+            compile_time_s,
+        )
 
 
 @run_with_try_except
@@ -367,9 +430,27 @@ def run_inductor(model, input_tensors, params, precision, batch_size):
     compile_time_s = end_compile - start_compile
     iters = params.get("iterations", 20)
 
-    record_perf(
-        model, "inductor", input_tensors, precision, iters, batch_size, compile_time_s
-    )
+    if params.get("enable_cuda_graph", False):
+        with torchtrt.runtime.enable_cudagraphs(model) as cudagraphs_module:
+            record_perf(
+                cudagraphs_module,
+                "inductor",
+                input_tensors,
+                precision,
+                iters,
+                batch_size,
+                compile_time_s,
+            )
+    else:
+        record_perf(
+            model,
+            "inductor",
+            input_tensors,
+            precision,
+            iters,
+            batch_size,
+            compile_time_s,
+        )
 
 
 @run_with_try_except
@@ -666,8 +747,6 @@ if __name__ == "__main__":
         raise ValueError(
             "No Pytorch model (nn.Module) is provided for torchdynamo compilation. Please provide a pytorch model using --model_torch argument"
         )
-
-    torchtrt.runtime.set_cudagraphs_mode(params.get("enable_cuda_graph", False))
 
     batch_size = params["batch_size"]
     is_trt_engine = params["is_trt_engine"]


### PR DESCRIPTION
# Description

Add `--use_python_runtime` and `--enable_cuda_graph` args to the perf run script.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
