### PR TITLE
[oncall] Fix vulnerability in the transformers dependency for examples/dynamo

### DIFF
--- a/examples/dynamo/requirements.txt
+++ b/examples/dynamo/requirements.txt
@@ -1,7 +1,7 @@
 cupy==13.1.0
 triton==2.3.0
 diffusers==0.30.3
-transformers==4.44.2
+transformers==4.48.0
 matplotlib
 pandas
 huggingface_hub


### PR DESCRIPTION
- CVE-2024-11394
- References
https://nvd.nist.gov/vuln/detail/CVE-2024-11394
https://www.zerodayinitiative.com/advisories/ZDI-24-1515 https://github.com/pypa/advisory-database/tree/main/vulns/transformers/PYSEC-2024-229.yaml GHSA-hxxf-235m-72v3
