### PR TITLE
Fix assertions in slice_scatter decomposition

### DIFF
--- a/py/torch_tensorrt/dynamo/lowering/_decompositions.py
+++ b/py/torch_tensorrt/dynamo/lowering/_decompositions.py
@@ -203,17 +203,17 @@ def slice_scatter_decomposition(
     if step is None:
         step = 1
 
-    # Ensure start, end, and step are all integers
-    assert isinstance(start, int), "start must be an integer"
-    assert isinstance(end, int), "end must be an integer"
-    assert isinstance(step, int), "step must be an integer"
-
     src_dim = src_tensor.shape
     # step == 0 is not a valid torch case
     # also src_dim should be equal to slice dimension
 
     if start == 0 and end == dim_size and step == 1:
         return src_tensor
+
+    # Ensure start, end, and step are all integers
+    assert isinstance(start, int), "start must be an integer"
+    assert isinstance(end, int), "end must be an integer"
+    assert isinstance(step, int), "step must be an integer"
 
     cat_tensors = []
     index_tensor_shape = []


### PR DESCRIPTION
- [fix: allow slice_scatter decomposition with SymInt parameters for the case when returning the source tensor](https://github.com/pytorch/TensorRT/commit/d3454ddfab75569e1e4a343af24484ae7497edc2)

# Description

Originally, the assertions only allowed `int` types for `start`, `end`, and `step`.  However, `end` can be a `SymInt` when set to `dim_size`, which only causes issues latter with `range(start, end, step)`. This PR allows returning `src_tensor` when the condition is met with a `SymInt` typed `end`.
