### PR TITLE
fix: conv parameter check failure

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -2468,13 +2468,14 @@ def aten_ops_convolution(
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     is_transposed = args[6]
+    is_conv1d = len(args[0].shape) == 3
     if not is_transposed:
         return impl.conv.convNd(
             ctx,
             target,
             source_ir=SourceIR.ATEN,
             name=name,
-            is_conv1d=len(args[3]) == 1,
+            is_conv1d=is_conv1d,
             input=args[0],
             weight=args[1],
             bias=args_bounds_check(args, 2, None),
@@ -2489,7 +2490,7 @@ def aten_ops_convolution(
             target,
             source_ir=SourceIR.ATEN,
             name=name,
-            is_deconv1d=len(args[3]) == 1,
+            is_deconv1d=is_conv1d,
             input=args[0],
             weight=args[1],
             bias=args_bounds_check(args, 2, None),

--- a/py/torch_tensorrt/dynamo/conversion/impl/conv.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/conv.py
@@ -6,7 +6,6 @@ import numpy as np
 import tensorrt as trt
 import torch
 from torch.fx.node import Target
-
 from torch_tensorrt.dynamo.conversion import impl
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import (
@@ -44,6 +43,8 @@ def convNd(
 ) -> TRTTensor:
     if has_dynamic_shape(input.shape):
         assert input.shape[1] != -1, "Channel dim can't be dynamic for convolution."
+
+    num_dims = len(input.shape) - 2
 
     if is_conv1d:
         # Apply an unsqueeze operation to transform the conv1d problem into conv2d
@@ -104,7 +105,12 @@ def convNd(
         conv_layer.set_input(2, bias)
 
     # Cast certain fields to tuples, in accordance with TRT requirements
-    padding = (padding,) if isinstance(padding, int) else padding
+    if isinstance(padding, int):
+        padding = (padding,) * num_dims
+    elif isinstance(padding, (list, tuple)):
+        padding = tuple(padding)
+        if len(padding) == 1:
+            padding = (padding[0],) * num_dims
     stride = (stride,) if isinstance(stride, int) else stride
     dilation = (dilation,) if isinstance(dilation, int) else dilation
 

--- a/py/torch_tensorrt/dynamo/conversion/impl/conv.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/conv.py
@@ -111,8 +111,20 @@ def convNd(
         padding = tuple(padding)
         if len(padding) == 1:
             padding = (padding[0],) * num_dims
-    stride = (stride,) if isinstance(stride, int) else stride
-    dilation = (dilation,) if isinstance(dilation, int) else dilation
+
+    if isinstance(stride, int):
+        stride = (stride,) * num_dims
+    elif isinstance(stride, (list, tuple)):
+        stride = tuple(stride)
+        if len(stride) == 1:
+            stride = (stride[0],) * num_dims
+
+    if isinstance(dilation, int):
+        dilation = (dilation,) * num_dims
+    elif isinstance(dilation, (list, tuple)):
+        dilation = tuple(dilation)
+        if len(dilation) == 1:
+            dilation = (dilation[0],) * num_dims
 
     # Expand parameters manually for Conv1D computations
     if is_conv1d:

--- a/tests/py/dynamo/conversion/test_convolution_aten.py
+++ b/tests/py/dynamo/conversion/test_convolution_aten.py
@@ -1,7 +1,6 @@
 import torch
 from parameterized import param, parameterized
 from torch.testing._internal.common_utils import run_tests
-
 from torch_tensorrt import Input
 
 from .harness import DispatchTestCase
@@ -134,6 +133,8 @@ class TestConvolutionConverter(DispatchTestCase):
             param("no_bias", 1, bias=False),
             ("tuple_parameters", 1, (1, 1), (1, 1)),
             param("non_zero_padding", 1, padding=1),
+            param("list_zero_padding", 1, padding=[0]),
+            param("list_non_padding", 1, padding=[1]),
             param("dilation", 1, dilation=2),
             param("groups", 1, groups=3),
         ]
@@ -205,6 +206,8 @@ class TestConvolutionConverter(DispatchTestCase):
             param("no_bias", 1, bias=False),
             ("tuple_parameters", 1, (1, 1, 1), (1, 1, 1)),
             param("non_zero_padding", 1, padding=1),
+            param("list_zero_padding", 1, padding=[0]),
+            param("list_non_padding", 1, padding=[1]),
             param("dilation", 1, dilation=2),
             ## TODO TRT 8.4.1 will trigger issue with this test. T127981773
             # param("groups", 1, groups=3),

--- a/tests/py/dynamo/conversion/test_convolution_aten.py
+++ b/tests/py/dynamo/conversion/test_convolution_aten.py
@@ -132,10 +132,13 @@ class TestConvolutionConverter(DispatchTestCase):
             ("default", 1),
             param("no_bias", 1, bias=False),
             ("tuple_parameters", 1, (1, 1), (1, 1)),
+            param("list_stride", 2, stride=[2]),
             param("non_zero_padding", 1, padding=1),
             param("list_zero_padding", 1, padding=[0]),
             param("list_non_padding", 1, padding=[1]),
-            param("dilation", 1, dilation=2),
+            param("dilation", 2, dilation=3),
+            param("tuple_dilation", 2, dilation=(3, 3)),
+            param("list_dilation", 2, dilation=[3]),
             param("groups", 1, groups=3),
         ]
     )
@@ -205,10 +208,12 @@ class TestConvolutionConverter(DispatchTestCase):
             ("default", 1),
             param("no_bias", 1, bias=False),
             ("tuple_parameters", 1, (1, 1, 1), (1, 1, 1)),
+            param("list_stride", 2, stride=[2]),
             param("non_zero_padding", 1, padding=1),
             param("list_zero_padding", 1, padding=[0]),
             param("list_non_padding", 1, padding=[1]),
-            param("dilation", 1, dilation=2),
+            param("dilation", 2, dilation=2),
+            param("list_dilation", 2, dilation=[2]),
             ## TODO TRT 8.4.1 will trigger issue with this test. T127981773
             # param("groups", 1, groups=3),
         ]


### PR DESCRIPTION
## Description

This PR fixes an issue where padding values given as a single-element list (e.g., `[0]` and `[1]`) were not properly converted in `convNd`, leading to a TensorRT error:

```
ERROR:torch_tensorrt [TensorRT Conversion Context]:IConvolutionLayer::setPaddingNd: Error Code 3: API Usage Error (Parameter check failed, condition: (padding.nbDims == 2 || padding.nbDims == 3) && allDimsGtEq(padding, 0) && allDimsLtEq(padding, kMAX_PADDING). )
```

For the padding value `[1]`, this also caused shape mismatches, such as:

```
AssertionError: The values for attribute 'shape' do not match: torch.Size([1, 6, 32, 32]) != torch.Size([1, 6, 34, 34]).
```

If `padding` is `[0]`, it still triggers a TensorRT `paramater check failure error`, but the final output is correct. This is a minor issue that doesn’t affect functionality.

#### Fix
- Now, if `padding` is a list with one element, it is expanded properly (`(1,1)` for conv2d, `(1,1,1)` for conv3d, etc.).
- Verified with additional test cases

Fixes #([issue](https://github.com/pytorch/TensorRT/issues/3409))

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
