### PR TITLE
fix: typing issue in Python 3.9 and earlier

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/_ConverterRegistry.py
+++ b/py/torch_tensorrt/dynamo/conversion/_ConverterRegistry.py
@@ -519,7 +519,7 @@ class ConverterRegistry:
     def get_all_converters_with_target(
         self, key: Target, return_registry_info: bool = False
     ) -> Tuple[
-        List[Any], Dict[str, int] | None
+        Union[List[Any], Dict[str, int], None]
     ]:  # TODO: Narrow to ConverterImplSignature this when we can remove FX converters
         """Get all converters across all registries for the target
 

--- a/py/torch_tensorrt/dynamo/runtime/_MutableTorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_MutableTorchTensorRTModule.py
@@ -252,7 +252,7 @@ class MutableTorchTensorRTModule(object):
 
         self.refit_state.set_state(RefitFlag.NEEDS_RECOMPILE)
 
-    def _get_total_dynamic_shapes(self) -> dict[str, Any] | None:
+    def _get_total_dynamic_shapes(self) -> Union[dict[str, Any], None]:
         if not self.arg_dynamic_shapes and not self.kwarg_dynamic_shapes:
             return None
         total_dynamic_shape = {}


### PR DESCRIPTION
# Description
This PR changed `List[Any], Dict[str, int] | None` to `Union[List[Any], Dict[str, int], None]`

Python 3.9 and earlier don't support this way. For compatibility, we need to use the Union style.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
