### PR TITLE
feat: support masked_scatter by lowering path

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/impl/condition/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/condition/ops.py
@@ -11,6 +11,7 @@ from torch_tensorrt.dynamo.conversion.converter_utils import (
     cast_trt_tensor,
     get_trt_tensor,
     prepend_ones,
+    promote_trt_tensors_to_same_dtype,
     set_layer_name,
 )
 from torch_tensorrt.dynamo.conversion.impl.elementwise import ne
@@ -56,6 +57,9 @@ def where(
     diff = max_shape_len - len(y_shape)
     if diff > 0:
         other = prepend_ones(ctx, other, f"{name}_other_broadcast", diff)
+
+    # Ensure that input and other have the same TRT dtype
+    input, other = promote_trt_tensors_to_same_dtype(ctx, input, other, name)
 
     return select(ctx, target, source_ir, name, input, other, condition)
 

--- a/py/torch_tensorrt/dynamo/conversion/impl/select.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/select.py
@@ -462,6 +462,7 @@ def gather(
 ) -> TRTTensor:
     input_shape = input.shape
     dim = get_positive_dim(dim, len(input_shape))
+    index = cast_trt_tensor(ctx, index, trt.int32, name + "_cast_index_tensor")
     gather_layer = ctx.net.add_gather(input, index, axis=dim)
     gather_layer.mode = trt.GatherMode.ELEMENT
     set_layer_name(gather_layer, target, name + "_gather_layer_element", source_ir)

--- a/py/torch_tensorrt/dynamo/lowering/_decompositions.py
+++ b/py/torch_tensorrt/dynamo/lowering/_decompositions.py
@@ -196,8 +196,10 @@ def slice_scatter_decomposition(
 ) -> torch.Tensor:
     dim_size = input_tensor.shape[dim]
     device_input_tensor = input_tensor.device
+
+    start = 0 if start is None else start  # Ensure start is int
     start = get_positive_dim(start, input_tensor.shape[dim])
-    if end is None:
+    if end is None:  # Ensure end is int
         end = dim_size
     end = get_positive_dim(end, input_tensor.shape[dim])
     if step is None:
@@ -584,34 +586,41 @@ def masked_scatter_decomposition(
     source: torch.Tensor,
 ) -> torch.Tensor:
     """
-    Performs an operation equivalent to `input[mask] = source`.
+    Decomposition of `aten.masked_scatter` for TensorRT.
+
+    Emulates the behavior of `input[mask] = source` using only TensorRT-compatible ops.
+
     Steps:
-      1) Broadcast `input` and `mask` to a common shape
-      2) Flatten them
-      3) Convert `mask` to int64, compute its cumsum, and subtract 1 to get gather indices
-      4) Use `gather` to select elements from `source`
-      5) Use `torch.where` to place gathered elements where `mask` is True
-      6) Reshape the result to the original shape
+      1) Broadcast `input` and `mask` to a common shape.
+      2) Flatten all tensors for uniform indexing.
+      3) Compute gather indices for `source` by applying cumsum to the boolean mask.
+         - Use `masked_fill` to avoid invalid indices in positions where `mask` is False.
+      4) Gather values from `source` at valid positions.
+      5) Use `torch.where` to insert gathered values into `input` where `mask` is True.
+      6) Reshape the result back to the original broadcasted shape.
     """
 
-    # 1) Broadcast `input` and `mask` to a common shape
+    # 1) Broadcast input and mask to the same shape
     input_b, mask_b = aten.broadcast_tensors([input, mask])
 
-    # 2) Flatten the broadcasted tensors and the source tensor
+    # 2) Flatten tensors for element-wise operations
     input_flat = input_b.flatten()
     mask_flat = mask_b.flatten()
     source_flat = source.flatten()
 
-    # 3) Compute gather indices: (cumsum of mask as int64) - 1
-    source_idx = mask_flat.to(torch.int64).cumsum(0) - 1
+    # 3) Compute gather indices from cumsum of the mask
+    # Subtract 1 so that the first True position maps to index 0 in source
+    source_idx = mask_flat.cumsum(0) - 1
+    # Set gather index to 0 where mask is False (these will be ignored later)
+    safe_idx = source_idx.masked_fill(~mask_flat, 0)
 
-    # 4) Gather elements from source_flat using these indices
-    gathered = source_flat.gather(0, source_idx)
+    # 4) Gather values from source using computed indices
+    gathered = source_flat.gather(0, safe_idx)
 
-    # 5) Replace positions where mask is True with gathered values, otherwise keep original
+    # 5) Replace masked positions in input with gathered values
     replaced = torch.where(mask_flat, gathered, input_flat)
 
-    # 6) Reshape the result back to the broadcasted shape
+    # 6) Reshape the result to match the original broadcasted shape
     return replaced.view(input_b.shape)
 
 

--- a/tests/py/dynamo/lowering/test_decompositions.py
+++ b/tests/py/dynamo/lowering/test_decompositions.py
@@ -2167,7 +2167,6 @@ class TestLowering(TestCase):
             msg="Cudnn_grid_sampler TRT outputs don't match with the original model.",
         )
 
-
     @parameterized.expand(
         [
             ("float32_2d", torch.float32, (4, 4)),

--- a/tests/py/dynamo/lowering/test_decompositions.py
+++ b/tests/py/dynamo/lowering/test_decompositions.py
@@ -2168,5 +2168,86 @@ class TestLowering(TestCase):
         )
 
 
+    @parameterized.expand(
+        [
+            ("float32_2d", torch.float32, (4, 4)),
+            ("float16_3d", torch.float16, (2, 3, 4)),
+        ]
+    )
+    def test_masked_scatter(self, _, dtype, shape):
+        """
+        Test that masked_scatter.default is correctly decomposed into
+        (cumsum, gather, where, etc.) and that final TRT results match PyTorch.
+        """
+
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, mask, source):
+                return torch.ops.aten.masked_scatter.default(x, mask, source)
+
+        x = torch.randn(*shape, dtype=dtype, device="cuda")
+
+        mask = torch.rand(*shape, device="cuda") > 0.5
+        num_trues = mask.sum().item()
+        if num_trues == 0:
+            mask[0] = True
+            num_trues = 1
+        source = torch.arange(num_trues, dtype=dtype, device="cuda")
+
+        inputs = [x, mask, source]
+
+        fx_graph = torch.fx.symbolic_trace(TestModule())
+
+        expected_ops = {
+            torch.ops.aten.where.self,
+            torch.ops.aten.gather.default,
+            torch.ops.aten.cumsum.default,
+        }
+        unexpected_ops = {torch.ops.aten.masked_scatter.default}
+
+        unexpected_ops_seen, expected_ops_unseen = lower_graph_testing(
+            fx_graph,
+            inputs,
+            expected_ops=expected_ops,
+            unexpected_ops=unexpected_ops,
+            min_block_size=1,
+        )
+
+        self.assertEqual(
+            len(unexpected_ops_seen),
+            0,
+            f"The following unexpected ops were encountered: {unexpected_ops_seen}",
+        )
+
+        self.assertEqual(
+            len(expected_ops_unseen),
+            0,
+            f"The following expected ops were not encountered: {expected_ops_unseen}",
+        )
+
+        torch._dynamo.reset()
+
+        trt_model = torch_tensorrt.compile(
+            fx_graph,
+            "torch_compile",
+            inputs,
+            min_block_size=1,
+            pass_through_build_failures=True,
+        )
+        with torch.no_grad():
+            trt_results = trt_model(*inputs).detach().cpu()
+            torch_results = fx_graph(*inputs).detach().cpu()
+
+        max_diff = float(torch.max(torch.abs(trt_results - torch_results)))
+        self.assertAlmostEqual(
+            max_diff,
+            0,
+            DECIMALS_OF_AGREEMENT,
+            f"Masked_scatter TRT outputs don't match with the original model. (diff={max_diff})",
+        )
+
+
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
# Description

Implemented support for `masked_scatter` in the lowering path, referring to [this implementation in PyTorch Inductor](https://github.com/pytorch/pytorch/blob/924a247fbbe32063966533535b1cc0cf474ef1ed/torch/_inductor/decomposition.py#L831).

Fixes # ([issue](https://github.com/pytorch/TensorRT/issues/3410))

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
