### PR TITLE
fix: Destory cuda graphs before setting weight streaming

### DIFF
--- a/core/runtime/TRTEngine.cpp
+++ b/core/runtime/TRTEngine.cpp
@@ -453,7 +453,7 @@ std::vector<std::string> TRTEngine::serialize() {
   return serialized_info;
 }
 
-void TRTEngine::reset_cudagraph() {
+void TRTEngine::reset_captured_graph() {
   cudagraph.reset();
 }
 

--- a/core/runtime/TRTEngine.cpp
+++ b/core/runtime/TRTEngine.cpp
@@ -453,6 +453,10 @@ std::vector<std::string> TRTEngine::serialize() {
   return serialized_info;
 }
 
+void TRTEngine::reset_cudagraph() {
+  cudagraph.reset();
+}
+
 } // namespace runtime
 } // namespace core
 } // namespace torch_tensorrt

--- a/core/runtime/TRTEngine.h
+++ b/core/runtime/TRTEngine.h
@@ -185,6 +185,7 @@ struct TRTEngine : torch::CustomClassHolder {
   // c10::List<at::Tensor> Run(c10::List<at::Tensor> inputs);
 
   void set_profiling_paths();
+  void reset_cudagraph();
 #ifndef NDEBUG
   bool profile_execution = true;
 #else

--- a/core/runtime/TRTEngine.h
+++ b/core/runtime/TRTEngine.h
@@ -185,7 +185,7 @@ struct TRTEngine : torch::CustomClassHolder {
   // c10::List<at::Tensor> Run(c10::List<at::Tensor> inputs);
 
   void set_profiling_paths();
-  void reset_cudagraph();
+  void reset_captured_graph();
 #ifndef NDEBUG
   bool profile_execution = true;
 #else

--- a/core/runtime/register_jit_hooks.cpp
+++ b/core/runtime/register_jit_hooks.cpp
@@ -88,7 +88,7 @@ static auto TORCHTRT_UNUSED TRTEngineTSRegistrtion =
         .def("dump_engine_layer_info", &TRTEngine::dump_engine_layer_info)
         .def("get_engine_layer_info", &TRTEngine::get_engine_layer_info)
         .def("infer_outputs", &TRTEngine::infer_outputs)
-        .def("reset_cudagraph", &TRTEngine::reset_cudagraph)
+        .def("reset_captured_graph", &TRTEngine::reset_captured_graph)
         .def_readwrite("use_pre_allocated_outputs", &TRTEngine::use_pre_allocated_outputs)
         .def_readwrite("use_output_allocator_outputs", &TRTEngine::use_output_allocator_outputs)
         .def_property(

--- a/core/runtime/register_jit_hooks.cpp
+++ b/core/runtime/register_jit_hooks.cpp
@@ -88,6 +88,7 @@ static auto TORCHTRT_UNUSED TRTEngineTSRegistrtion =
         .def("dump_engine_layer_info", &TRTEngine::dump_engine_layer_info)
         .def("get_engine_layer_info", &TRTEngine::get_engine_layer_info)
         .def("infer_outputs", &TRTEngine::infer_outputs)
+        .def("reset_cudagraph", &TRTEngine::reset_cudagraph)
         .def_readwrite("use_pre_allocated_outputs", &TRTEngine::use_pre_allocated_outputs)
         .def_readwrite("use_output_allocator_outputs", &TRTEngine::use_output_allocator_outputs)
         .def_property(

--- a/py/torch_tensorrt/dynamo/runtime/_CudaGraphsTorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_CudaGraphsTorchTensorRTModule.py
@@ -103,13 +103,13 @@ class CudaGraphsTorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
 
         return False
 
-    def reset_cudagraph(self) -> None:
+    def reset_captured_graph(self) -> None:
         if self.cudagraph:
             self.cudagraph.reset()
             self.cudagraph = None
 
     def __del__(self) -> None:
-        self.reset_cudagraph()
+        self.reset_captured_graph()
 
     def set_use_output_allocator(self, enable: bool) -> None:
         self.use_output_allocator_outputs = enable
@@ -123,7 +123,7 @@ class CudaGraphsTorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
             shape_changed = self.validate_input_shapes(inputs)
             need_cudagraphs_record = shape_changed or self.is_weight_streaming_set
             if need_cudagraphs_record:
-                self.reset_cudagraph()
+                self.reset_captured_graph()
                 self._input_buffers = [None] * len(inputs)
 
             self.is_weight_streaming_set = False
@@ -199,5 +199,5 @@ class CudaGraphsTorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
                 return outputs[0]
             return outputs
         else:
-            self.reset_cudagraph()
+            self.reset_captured_graph()
             return self.compiled_module(*args, **kwargs)

--- a/py/torch_tensorrt/dynamo/runtime/_CudaGraphsTorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_CudaGraphsTorchTensorRTModule.py
@@ -103,13 +103,13 @@ class CudaGraphsTorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
 
         return False
 
-    def reset_captured_graph(self) -> None:
+    def _reset_captured_graph(self) -> None:
         if self.cudagraph:
             self.cudagraph.reset()
             self.cudagraph = None
 
     def __del__(self) -> None:
-        self.reset_captured_graph()
+        self._reset_captured_graph()
 
     def set_use_output_allocator(self, enable: bool) -> None:
         self.use_output_allocator_outputs = enable
@@ -123,7 +123,7 @@ class CudaGraphsTorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
             shape_changed = self.validate_input_shapes(inputs)
             need_cudagraphs_record = shape_changed or self.is_weight_streaming_set
             if need_cudagraphs_record:
-                self.reset_captured_graph()
+                self._reset_captured_graph()
                 self._input_buffers = [None] * len(inputs)
 
             self.is_weight_streaming_set = False
@@ -199,5 +199,5 @@ class CudaGraphsTorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
                 return outputs[0]
             return outputs
         else:
-            self.reset_captured_graph()
+            self._reset_captured_graph()
             return self.compiled_module(*args, **kwargs)

--- a/py/torch_tensorrt/dynamo/runtime/_PythonTorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_PythonTorchTensorRTModule.py
@@ -333,9 +333,13 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
         result.__setstate__(self.__getstate__())
         return result
 
-    def __del__(self) -> None:
+    def reset_cudagraph(self) -> None:
         if self.cudagraph:
             self.cudagraph.reset()
+            self.cudagraph = None
+
+    def __del__(self) -> None:
+        self.reset_cudagraph()
 
     def setup_input_tensors(
         self,
@@ -426,9 +430,8 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
                 self.cudagraphs_enabled, self.use_pre_allocated_outputs, shape_changed
             )
 
-            if need_cudagraphs_reset and self.cudagraph:
-                self.cudagraph.reset()
-                self.cudagraph = None
+            if need_cudagraphs_reset:
+                self.reset_cudagraph()
 
             if need_cudagraphs_record:
                 self._input_buffers = [None] * len(self.input_names)

--- a/py/torch_tensorrt/dynamo/runtime/_PythonTorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_PythonTorchTensorRTModule.py
@@ -333,13 +333,13 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
         result.__setstate__(self.__getstate__())
         return result
 
-    def reset_captured_graph(self) -> None:
+    def _reset_captured_graph(self) -> None:
         if self.cudagraph:
             self.cudagraph.reset()
             self.cudagraph = None
 
     def __del__(self) -> None:
-        self.reset_captured_graph()
+        self._reset_captured_graph()
 
     def setup_input_tensors(
         self,
@@ -431,7 +431,7 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
             )
 
             if need_cudagraphs_reset:
-                self.reset_captured_graph()
+                self._reset_captured_graph()
 
             if need_cudagraphs_record:
                 self._input_buffers = [None] * len(self.input_names)

--- a/py/torch_tensorrt/dynamo/runtime/_PythonTorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_PythonTorchTensorRTModule.py
@@ -333,13 +333,13 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
         result.__setstate__(self.__getstate__())
         return result
 
-    def reset_cudagraph(self) -> None:
+    def reset_captured_graph(self) -> None:
         if self.cudagraph:
             self.cudagraph.reset()
             self.cudagraph = None
 
     def __del__(self) -> None:
-        self.reset_cudagraph()
+        self.reset_captured_graph()
 
     def setup_input_tensors(
         self,
@@ -431,7 +431,7 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
             )
 
             if need_cudagraphs_reset:
-                self.reset_cudagraph()
+                self.reset_captured_graph()
 
             if need_cudagraphs_record:
                 self._input_buffers = [None] * len(self.input_names)

--- a/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
@@ -209,8 +209,8 @@ class TorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
 
         return budget_bytes
 
-    def reset_cudagraph(self) -> None:
-        self.engine.reset_cudagraph()
+    def reset_captured_graph(self) -> None:
+        self.engine.reset_captured_graph()
 
     def setup_engine(self) -> None:
         """

--- a/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
@@ -209,7 +209,7 @@ class TorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
 
         return budget_bytes
 
-    def reset_captured_graph(self) -> None:
+    def _reset_captured_graph(self) -> None:
         self.engine.reset_captured_graph()
 
     def setup_engine(self) -> None:

--- a/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
@@ -209,6 +209,9 @@ class TorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
 
         return budget_bytes
 
+    def reset_cudagraph(self) -> None:
+        self.engine.reset_cudagraph()
+
     def setup_engine(self) -> None:
         """
         Setup engine for a module which has deferred engine setup.

--- a/py/torch_tensorrt/dynamo/runtime/meta_ops/register_meta_ops.py
+++ b/py/torch_tensorrt/dynamo/runtime/meta_ops/register_meta_ops.py
@@ -142,7 +142,7 @@ class FakeTRTEngine:
     def infer_outputs(self, input_shapes: List[Any]) -> Any:
         pass
 
-    def reset_cudagraph(self) -> Any:
+    def reset_captured_graph(self) -> Any:
         pass
 
     def __setstate__(self, serialized_state: List[str]) -> Any:

--- a/py/torch_tensorrt/dynamo/runtime/meta_ops/register_meta_ops.py
+++ b/py/torch_tensorrt/dynamo/runtime/meta_ops/register_meta_ops.py
@@ -142,6 +142,9 @@ class FakeTRTEngine:
     def infer_outputs(self, input_shapes: List[Any]) -> Any:
         pass
 
+    def reset_cudagraph(self) -> Any:
+        pass
+
     def __setstate__(self, serialized_state: List[str]) -> Any:
         pass
 

--- a/py/torch_tensorrt/runtime/_cudagraphs.py
+++ b/py/torch_tensorrt/runtime/_cudagraphs.py
@@ -117,7 +117,7 @@ class _CudagraphsContextManager(object):
         set_cudagraphs_mode(self.old_mode)
         # __del__ is not entirely predictable, so we reset cudagraph here
         if self.cudagraphs_module:
-            self.cudagraphs_module.reset_captured_graph()
+            self.cudagraphs_module._reset_captured_graph()
 
 
 def enable_cudagraphs(

--- a/py/torch_tensorrt/runtime/_cudagraphs.py
+++ b/py/torch_tensorrt/runtime/_cudagraphs.py
@@ -117,7 +117,7 @@ class _CudagraphsContextManager(object):
         set_cudagraphs_mode(self.old_mode)
         # __del__ is not entirely predictable, so we reset cudagraph here
         if self.cudagraphs_module:
-            self.cudagraphs_module.reset_cudagraph()
+            self.cudagraphs_module.reset_captured_graph()
 
 
 def enable_cudagraphs(

--- a/py/torch_tensorrt/runtime/_weight_streaming.py
+++ b/py/torch_tensorrt/runtime/_weight_streaming.py
@@ -78,10 +78,10 @@ class _WeightStreamingContextManager(object):
         ]
         if self.cuda_graphs_module:
             self.cuda_graphs_module.is_weight_streaming_set = True
-            self.cuda_graphs_module.reset_captured_graph()
+            self.cuda_graphs_module._reset_captured_graph()
 
         for i, (name, rt_mod) in enumerate(self.rt_mods):
-            rt_mod.reset_captured_graph()
+            rt_mod._reset_captured_graph()
             ws_budget_bytes += rt_mod.set_device_memory_budget(normalized_size[i])
             logger.debug(f"Set weight streaming size {normalized_size[i]} for {name}")
 

--- a/py/torch_tensorrt/runtime/_weight_streaming.py
+++ b/py/torch_tensorrt/runtime/_weight_streaming.py
@@ -78,10 +78,10 @@ class _WeightStreamingContextManager(object):
         ]
         if self.cuda_graphs_module:
             self.cuda_graphs_module.is_weight_streaming_set = True
-            self.cuda_graphs_module.reset_cudagraph()
+            self.cuda_graphs_module.reset_captured_graph()
 
         for i, (name, rt_mod) in enumerate(self.rt_mods):
-            rt_mod.reset_cudagraph()
+            rt_mod.reset_captured_graph()
             ws_budget_bytes += rt_mod.set_device_memory_budget(normalized_size[i])
             logger.debug(f"Set weight streaming size {normalized_size[i]} for {name}")
 

--- a/py/torch_tensorrt/runtime/_weight_streaming.py
+++ b/py/torch_tensorrt/runtime/_weight_streaming.py
@@ -76,12 +76,15 @@ class _WeightStreamingContextManager(object):
             int(streamable_bytes / total_bytes * requested_budget)
             for streamable_bytes in self.streamable_budget
         ]
+        if self.cuda_graphs_module:
+            self.cuda_graphs_module.is_weight_streaming_set = True
+            self.cuda_graphs_module.reset_cudagraph()
+
         for i, (name, rt_mod) in enumerate(self.rt_mods):
+            rt_mod.reset_cudagraph()
             ws_budget_bytes += rt_mod.set_device_memory_budget(normalized_size[i])
             logger.debug(f"Set weight streaming size {normalized_size[i]} for {name}")
 
-        if self.cuda_graphs_module:
-            self.cuda_graphs_module.is_weight_streaming_set = True
         return ws_budget_bytes
 
     def __setattr__(self, name: str, value: Any) -> None:


### PR DESCRIPTION
# Description

When cuda graphs and weigh streaming are used together, cuda graphs is destroyed after setting the weight streaming.
Weight streaming recreates the context and load new module. Destroying cudagraphs with old reference caused application crash. Fix is to move cuda graphs reset before the weight streaming setting. 

The timing of __del__ is not entirely predictable in python. Moved cudagraph reset logic from __del__ to dedicated reset_cudagraph method and it's called when exiting from CudaGraphsTorchTensorRTModule context block

Fixes #3460

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
