### PR TITLE
tool: uv setting to avoid the pip install -e

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ package-dir = { "" = "py" }
 include-package-data = false
 
 [tool.uv]
+package = true
 environments = ["sys_platform == 'linux'", "sys_platform == 'windows'"]
 prerelease = "if-necessary-or-explicit"
 index-strategy = "unsafe-best-match"                                    # Needed for TRT-LLM


### PR DESCRIPTION
# Description

Adds a setting to the pyproject.toml so that you do not need to manually install a torch-tensorrt build into a venv before running a test script 

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
