### PR TITLE
Cross compile guard

### DIFF
--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -6,3 +6,4 @@ torch>=2.8.0.dev,<2.9.0
 torchvision>=0.22.0.dev,<0.23.0
 --extra-index-url https://pypi.ngc.nvidia.com
 pyyaml
+dllist

--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, List, Optional, Sequence, Set
 import torch
 import torch.fx
 from torch_tensorrt._enums import dtype
-from torch_tensorrt._features import ENABLED_FEATURES
+from torch_tensorrt._features import ENABLED_FEATURES, needs_cross_compile
 from torch_tensorrt._Input import Input
 from torch_tensorrt.dynamo import _defaults
 from torch_tensorrt.dynamo.runtime._CudaGraphsTorchTensorRTModule import (
@@ -301,6 +301,7 @@ def compile(
         raise RuntimeError("Module is an unknown format or the ir requested is unknown")
 
 
+@needs_cross_compile
 def cross_compile_for_windows(
     module: torch.nn.Module,
     file_path: str,
@@ -525,6 +526,7 @@ def convert_method_to_trt_engine(
         raise RuntimeError("Module is an unknown format or the ir requested is unknown")
 
 
+@needs_cross_compile
 def load_cross_compiled_exported_program(file_path: str = "") -> Any:
     """
     Load an ExportedProgram file in Windows which was previously cross compiled in Linux

--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -526,7 +526,6 @@ def convert_method_to_trt_engine(
         raise RuntimeError("Module is an unknown format or the ir requested is unknown")
 
 
-@needs_cross_compile
 def load_cross_compiled_exported_program(file_path: str = "") -> Any:
     """
     Load an ExportedProgram file in Windows which was previously cross compiled in Linux

--- a/py/torch_tensorrt/_features.py
+++ b/py/torch_tensorrt/_features.py
@@ -43,8 +43,13 @@ _TS_FE_AVAIL = os.path.isfile(linked_file_full_path)
 _TORCHTRT_RT_AVAIL = _TS_FE_AVAIL or os.path.isfile(linked_file_runtime_full_path)
 _DYNAMO_FE_AVAIL = version.parse(sanitized_torch_version()) >= version.parse("2.1.dev")
 _FX_FE_AVAIL = True
+<<<<<<< HEAD
 _REFIT_AVAIL = True
 _WINDOWS_CROSS_COMPILE = check_cross_compile_trt_win_lib
+=======
+_REFIT_AVAIL = version.parse(sys.version.split()[0]) < version.parse("3.13")
+_WINDOWS_CROSS_COMPILE = check_cross_compile_trt_win_lib()
+>>>>>>> 0e180c5f1 (correcting CI failures)
 
 if importlib.util.find_spec("tensorrt.plugin"):
     _QDP_PLUGIN_AVAIL = True

--- a/py/torch_tensorrt/_features.py
+++ b/py/torch_tensorrt/_features.py
@@ -4,7 +4,10 @@ import sys
 from collections import namedtuple
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar
 
-from torch_tensorrt._utils import sanitized_torch_version
+from torch_tensorrt._utils import (
+    check_cross_compile_trt_win_lib,
+    sanitized_torch_version,
+)
 
 from packaging import version
 
@@ -17,6 +20,7 @@ FeatureSet = namedtuple(
         "fx_frontend",
         "refit",
         "qdp_plugin",
+        "windows_cross_compile",
     ],
 )
 
@@ -40,6 +44,7 @@ _TORCHTRT_RT_AVAIL = _TS_FE_AVAIL or os.path.isfile(linked_file_runtime_full_pat
 _DYNAMO_FE_AVAIL = version.parse(sanitized_torch_version()) >= version.parse("2.1.dev")
 _FX_FE_AVAIL = True
 _REFIT_AVAIL = True
+_WINDOWS_CROSS_COMPILE = check_cross_compile_trt_win_lib
 
 if importlib.util.find_spec("tensorrt.plugin"):
     _QDP_PLUGIN_AVAIL = True
@@ -53,6 +58,7 @@ ENABLED_FEATURES = FeatureSet(
     _FX_FE_AVAIL,
     _REFIT_AVAIL,
     _QDP_PLUGIN_AVAIL,
+    _WINDOWS_CROSS_COMPILE,
 )
 
 
@@ -101,6 +107,22 @@ def needs_refit(f: Callable[..., Any]) -> Callable[..., Any]:
             def not_implemented(*args: List[Any], **kwargs: Dict[str, Any]) -> Any:
                 raise NotImplementedError(
                     "Refit feature is currently not available in Python 3.13 or higher"
+                )
+
+            return not_implemented(*args, **kwargs)
+
+    return wrapper
+
+
+def needs_cross_compile(f: Callable[..., Any]) -> Callable[..., Any]:
+    def wrapper(*args: List[Any], **kwargs: Dict[str, Any]) -> Any:
+        if ENABLED_FEATURES.windows_cross_compile:
+            return f(*args, **kwargs)
+        else:
+
+            def not_implemented(*args: List[Any], **kwargs: Dict[str, Any]) -> Any:
+                raise NotImplementedError(
+                    "Windows cross compilation feature is not available"
                 )
 
             return not_implemented(*args, **kwargs)

--- a/py/torch_tensorrt/_features.py
+++ b/py/torch_tensorrt/_features.py
@@ -43,13 +43,8 @@ _TS_FE_AVAIL = os.path.isfile(linked_file_full_path)
 _TORCHTRT_RT_AVAIL = _TS_FE_AVAIL or os.path.isfile(linked_file_runtime_full_path)
 _DYNAMO_FE_AVAIL = version.parse(sanitized_torch_version()) >= version.parse("2.1.dev")
 _FX_FE_AVAIL = True
-<<<<<<< HEAD
 _REFIT_AVAIL = True
-_WINDOWS_CROSS_COMPILE = check_cross_compile_trt_win_lib
-=======
-_REFIT_AVAIL = version.parse(sys.version.split()[0]) < version.parse("3.13")
 _WINDOWS_CROSS_COMPILE = check_cross_compile_trt_win_lib()
->>>>>>> 0e180c5f1 (correcting CI failures)
 
 if importlib.util.find_spec("tensorrt.plugin"):
     _QDP_PLUGIN_AVAIL = True

--- a/py/torch_tensorrt/_utils.py
+++ b/py/torch_tensorrt/_utils.py
@@ -15,7 +15,7 @@ def sanitized_torch_version() -> Any:
     )
 
 
-def check_cross_compile_trt_win_lib(lib_name):
+def check_cross_compile_trt_win_lib():
     if sys.platform.startswith("linux"):
         LINUX_PATHS = ["/usr/local/cuda-12.8/lib64", "/usr/lib", "/usr/lib64"]
 

--- a/py/torch_tensorrt/_utils.py
+++ b/py/torch_tensorrt/_utils.py
@@ -1,9 +1,7 @@
-import ctypes
-import platform
-import sys
 from typing import Any
 
 import torch
+from torch_tensorrt._enums import Platform
 
 
 def sanitized_torch_version() -> Any:
@@ -14,12 +12,14 @@ def sanitized_torch_version() -> Any:
     )
 
 
-def check_cross_compile_trt_win_lib():
+def check_cross_compile_trt_win_lib() -> bool:
     # cross compile feature is only available on linux
     # build engine on linux and run on windows
     import dllist
 
-    if sys.platform.startswith("linux"):
+    platform = Platform.current_platform()
+    platform = str(platform).lower()
+    if platform.startswith("linux"):
         loaded_libs = dllist.dllist()
         target_lib = "libnvinfer_builder_resource_win.so.*"
         if target_lib in loaded_libs:

--- a/py/torch_tensorrt/_utils.py
+++ b/py/torch_tensorrt/_utils.py
@@ -4,7 +4,6 @@ import sys
 from typing import Any
 
 import torch
-from torch_tensorrt import _find_lib
 
 
 def sanitized_torch_version() -> Any:
@@ -16,24 +15,13 @@ def sanitized_torch_version() -> Any:
 
 
 def check_cross_compile_trt_win_lib():
+    # cross compile feature is only available on linux
+    # build engine on linux and run on windows
+    import dllist
+
     if sys.platform.startswith("linux"):
-        LINUX_PATHS = ["/usr/local/cuda-12.8/lib64", "/usr/lib", "/usr/lib64"]
-
-    if platform.uname().processor == "x86_64":
-        LINUX_PATHS += [
-            "/usr/lib/x86_64-linux-gnu",
-        ]
-    elif platform.uname().processor == "aarch64":
-        LINUX_PATHS += ["/usr/lib/aarch64-linux-gnu"]
-
-    LINUX_LIBS = [
-        f"libnvinfer_builder_resource_win.so.*",
-    ]
-
-    for lib in LINUX_LIBS:
-        try:
-            ctypes.CDLL(_find_lib(lib, LINUX_PATHS))
+        loaded_libs = dllist.dllist()
+        target_lib = "libnvinfer_builder_resource_win.so.*"
+        if target_lib in loaded_libs:
             return True
-        except:
-            continue
     return False

--- a/py/torch_tensorrt/_utils.py
+++ b/py/torch_tensorrt/_utils.py
@@ -1,6 +1,10 @@
+import ctypes
+import platform
+import sys
 from typing import Any
 
 import torch
+from torch_tensorrt import _find_lib
 
 
 def sanitized_torch_version() -> Any:
@@ -9,3 +13,27 @@ def sanitized_torch_version() -> Any:
         if ".nv" not in torch.__version__
         else torch.__version__.split(".nv")[0]
     )
+
+
+def check_cross_compile_trt_win_lib(lib_name):
+    if sys.platform.startswith("linux"):
+        LINUX_PATHS = ["/usr/local/cuda-12.8/lib64", "/usr/lib", "/usr/lib64"]
+
+    if platform.uname().processor == "x86_64":
+        LINUX_PATHS += [
+            "/usr/lib/x86_64-linux-gnu",
+        ]
+    elif platform.uname().processor == "aarch64":
+        LINUX_PATHS += ["/usr/lib/aarch64-linux-gnu"]
+
+    LINUX_LIBS = [
+        f"libnvinfer_builder_resource_win.so.*",
+    ]
+
+    for lib in LINUX_LIBS:
+        try:
+            ctypes.CDLL(_find_lib(lib, LINUX_PATHS))
+            return True
+        except:
+            continue
+    return False

--- a/py/torch_tensorrt/_utils.py
+++ b/py/torch_tensorrt/_utils.py
@@ -1,7 +1,8 @@
 from typing import Any
+import sys
+import platform
 
 import torch
-from torch_tensorrt._enums import Platform
 
 
 def sanitized_torch_version() -> Any:
@@ -17,9 +18,7 @@ def check_cross_compile_trt_win_lib() -> bool:
     # build engine on linux and run on windows
     import dllist
 
-    platform = Platform.current_platform()
-    platform = str(platform).lower()
-    if platform.startswith("linux"):
+    if sys.platform.startswith("linux"):
         loaded_libs = dllist.dllist()
         target_lib = "libnvinfer_builder_resource_win.so.*"
         if target_lib in loaded_libs:

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -1247,7 +1247,6 @@ def save_cross_compiled_exported_program(
     logger.debug(f"successfully saved the module for windows at {file_path}")
 
 
-@needs_cross_compile
 def load_cross_compiled_exported_program(file_path: str = "") -> Any:
     """
     Load an ExportedProgram file in Windows which was previously cross compiled in Linux

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -11,6 +11,7 @@ from torch.export import ExportedProgram
 from torch.fx.node import Target
 from torch_tensorrt._Device import Device
 from torch_tensorrt._enums import EngineCapability, dtype
+from torch_tensorrt._features import needs_cross_compile
 from torch_tensorrt._Input import Input
 from torch_tensorrt.dynamo import _defaults, partitioning
 from torch_tensorrt.dynamo._DryRunTracker import (
@@ -50,6 +51,7 @@ from torch_tensorrt.dynamo.utils import (
 logger = logging.getLogger(__name__)
 
 
+@needs_cross_compile
 def cross_compile_for_windows(
     exported_program: ExportedProgram,
     inputs: Optional[Sequence[Sequence[Any]]] = None,
@@ -1223,6 +1225,7 @@ def convert_exported_program_to_serialized_trt_engine(
     return serialized_engine
 
 
+@needs_cross_compile
 def save_cross_compiled_exported_program(
     gm: torch.fx.GraphModule,
     file_path: str,
@@ -1244,6 +1247,7 @@ def save_cross_compiled_exported_program(
     logger.debug(f"successfully saved the module for windows at {file_path}")
 
 
+@needs_cross_compile
 def load_cross_compiled_exported_program(file_path: str = "") -> Any:
     """
     Load an ExportedProgram file in Windows which was previously cross compiled in Linux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires = [
     "pybind11==2.6.2",
     "numpy",
     "sympy",
+    "dllist",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -63,6 +64,7 @@ dependencies = [
     "packaging>=23",
     "numpy",
     "typing-extensions>=4.7.0",
+    "dllist",
 ]
 
 dynamic = ["version"]

--- a/tests/py/dynamo/runtime/test_003_cross_compile_for_windows.py
+++ b/tests/py/dynamo/runtime/test_003_cross_compile_for_windows.py
@@ -8,6 +8,7 @@ import torch
 import torch_tensorrt
 from torch.testing._internal.common_utils import TestCase
 from torch_tensorrt.dynamo.utils import get_model_device
+from torch_tensorrt._utils import check_cross_compile_trt_win_lib
 
 from ..testing_utilities import DECIMALS_OF_AGREEMENT
 
@@ -16,6 +17,9 @@ class TestCrossCompileSaveForWindows(TestCase):
     @unittest.skipIf(
         platform.system() != "Linux" or platform.architecture()[0] != "64bit",
         "Cross compile for windows can only be enabled on linux x86-64 platform",
+    )
+    @unittest.skipIf(
+        not (check_cross_compile_trt_win_lib()),
     )
     @pytest.mark.unit
     def test_cross_compile_for_windows(self):
@@ -40,6 +44,9 @@ class TestCrossCompileSaveForWindows(TestCase):
     @unittest.skipIf(
         platform.system() != "Linux" or platform.architecture()[0] != "64bit",
         "Cross compile for windows can only be enabled on linux x86-64 platform",
+    )
+    @unittest.skipIf(
+        not (check_cross_compile_trt_win_lib()),
     )
     @pytest.mark.unit
     def test_dynamo_cross_compile_for_windows(self):

--- a/tests/py/dynamo/runtime/test_003_cross_compile_for_windows.py
+++ b/tests/py/dynamo/runtime/test_003_cross_compile_for_windows.py
@@ -20,6 +20,7 @@ class TestCrossCompileSaveForWindows(TestCase):
     )
     @unittest.skipIf(
         not (check_cross_compile_trt_win_lib()),
+        "TRT windows lib for cross compile not found",
     )
     @pytest.mark.unit
     def test_cross_compile_for_windows(self):
@@ -46,7 +47,10 @@ class TestCrossCompileSaveForWindows(TestCase):
         "Cross compile for windows can only be enabled on linux x86-64 platform",
     )
     @unittest.skipIf(
-        not (check_cross_compile_trt_win_lib()),
+        not (
+            check_cross_compile_trt_win_lib(),
+            "TRT windows lib for cross compile not found",
+        ),
     )
     @pytest.mark.unit
     def test_dynamo_cross_compile_for_windows(self):

--- a/tests/py/dynamo/runtime/test_003_cross_compile_for_windows.py
+++ b/tests/py/dynamo/runtime/test_003_cross_compile_for_windows.py
@@ -47,10 +47,8 @@ class TestCrossCompileSaveForWindows(TestCase):
         "Cross compile for windows can only be enabled on linux x86-64 platform",
     )
     @unittest.skipIf(
-        not (
-            check_cross_compile_trt_win_lib(),
-            "TRT windows lib for cross compile not found",
-        ),
+        not (check_cross_compile_trt_win_lib()),
+        "TRT windows lib for cross compile not found",
     )
     @pytest.mark.unit
     def test_dynamo_cross_compile_for_windows(self):
@@ -79,6 +77,10 @@ class TestCrossCompileSaveForWindows(TestCase):
     @unittest.skipIf(
         platform.system() != "Linux" or platform.architecture()[0] != "64bit",
         "Cross compile for windows can only be enabled on linux x86-64 platform",
+    )
+    @unittest.skipIf(
+        not (check_cross_compile_trt_win_lib()),
+        "TRT windows lib for cross compile not found",
     )
     @pytest.mark.unit
     def test_dynamo_cross_compile_for_windows_cpu_offload(self):


### PR DESCRIPTION
The PR addresses the following-
1. Enables the windows cross compile feature based on if platform linux and libnvinfer_builder_resource_win.so.* is present
2. Adds this as a decorator for the cross compile API
3. This utility is also added for skip tests