### PR TITLE
disabling dla args for hope igx platform

### DIFF
--- a/tests/py/dynamo/runtime/test_000_compilation_settings.py
+++ b/tests/py/dynamo/runtime/test_000_compilation_settings.py
@@ -1,6 +1,10 @@
+import unittest
+
+import tensorrt as trt
 import torch
 import torch_tensorrt
 from torch.testing._internal.common_utils import TestCase, run_tests
+from torch_tensorrt.dynamo.utils import is_tegra_platform
 
 from ..testing_utilities import DECIMALS_OF_AGREEMENT
 
@@ -53,6 +57,10 @@ class TestEnableTRTFlags(TestCase):
         )
         torch._dynamo.reset()
 
+    @unittest.skipIf(
+        is_tegra_platform() and trt._version_ > "10.8",
+        "DLA is not supported on Jetson platform starting TRT 10.8",
+    )
     def test_dla_args(self):
         class AddSoftmax(torch.nn.Module):
             def forward(self, x):


### PR DESCRIPTION
This PR disables the test for hope igx platform for TRT > 10.8