### PR TITLE
slice scatter support for dynamic cases 

### DIFF
--- a/py/torch_tensorrt/dynamo/lowering/_decompositions.py
+++ b/py/torch_tensorrt/dynamo/lowering/_decompositions.py
@@ -213,22 +213,26 @@ def slice_scatter_decomposition(
         return src_tensor
 
     # Ensure start, end, and step are all integers
-    assert isinstance(start, int), "start must be an integer"
-    assert isinstance(end, int), "end must be an integer"
-    assert isinstance(step, int), "step must be an integer"
+    # Ensure start, end, and step are all integers
+    assert isinstance(start, (int, torch.SymInt)), "start must be an int or SymInt"
+    assert isinstance(end, (int, torch.SymInt)), "end must be an int or SymInt"
+    assert isinstance(step, (int, torch.SymInt)), "step must be an int or SymInt"
 
-    cat_tensors = []
-    index_tensor_shape = []
-    for i, src_each_dim in enumerate(list(src_dim)):
-        if i != dim:
-            index_tensor_shape.append(src_each_dim)
-    for index in range(start, end, step):
-        cat_tensors.append(index * torch.ones(index_tensor_shape, dtype=torch.int64))
-    index_tensor = torch.stack(cat_tensors, dim)
-    index_tensor = index_tensor.to(device_input_tensor)
-    index_tensor_64 = index_tensor.to(torch.int64)
-    output_tensor = torch.scatter(input_tensor, dim, index_tensor_64, src_tensor)
-    return output_tensor
+    src_dim = src_tensor.shape
+    # step == 0 is not a valid torch case
+    # also src_dim should be equal to slice dimension
+
+    if start == 0 and end == dim_size and step == 1:
+        return src_tensor
+
+    indices = torch.arange(
+        start, end, step, device=device_input_tensor, dtype=torch.int64
+    )
+    index_tensor = indices.view(
+        [-1 if i == dim else 1 for i in range(input_tensor.dim())]
+    )
+    index_tensor = index_tensor.expand_as(src_tensor)
+    return torch.scatter(input_tensor.clone(), dim, index_tensor, src_tensor)
 
 
 @register_torch_trt_decomposition(

--- a/py/torch_tensorrt/dynamo/lowering/_decompositions.py
+++ b/py/torch_tensorrt/dynamo/lowering/_decompositions.py
@@ -223,7 +223,7 @@ def slice_scatter_decomposition(
         [-1 if i == dim else 1 for i in range(input_tensor.dim())]
     )
     index_tensor = index_tensor.expand_as(src_tensor)
-    return torch.scatter(input_tensor.clone(), dim, index_tensor, src_tensor)
+    return torch.scatter(input_tensor, dim, index_tensor, src_tensor)
 
 
 @register_torch_trt_decomposition(

--- a/py/torch_tensorrt/dynamo/lowering/_decompositions.py
+++ b/py/torch_tensorrt/dynamo/lowering/_decompositions.py
@@ -201,29 +201,20 @@ def slice_scatter_decomposition(
     start = get_positive_dim(start, input_tensor.shape[dim])
     if end is None:  # Ensure end is int
         end = dim_size
-    end = get_positive_dim(end, input_tensor.shape[dim])
+    end = (
+        get_positive_dim(end, input_tensor.shape[dim]) if isinstance(end, int) else end
+    )
     if step is None:
         step = 1
 
-    src_dim = src_tensor.shape
     # step == 0 is not a valid torch case
-    # also src_dim should be equal to slice dimension
-
     if start == 0 and end == dim_size and step == 1:
         return src_tensor
 
-    # Ensure start, end, and step are all integers
     # Ensure start, end, and step are all integers
     assert isinstance(start, (int, torch.SymInt)), "start must be an int or SymInt"
     assert isinstance(end, (int, torch.SymInt)), "end must be an int or SymInt"
     assert isinstance(step, (int, torch.SymInt)), "step must be an int or SymInt"
-
-    src_dim = src_tensor.shape
-    # step == 0 is not a valid torch case
-    # also src_dim should be equal to slice dimension
-
-    if start == 0 and end == dim_size and step == 1:
-        return src_tensor
 
     indices = torch.arange(
         start, end, step, device=device_input_tensor, dtype=torch.int64

--- a/tests/py/dynamo/lowering/test_decompositions.py
+++ b/tests/py/dynamo/lowering/test_decompositions.py
@@ -821,8 +821,6 @@ class TestLowering(TestCase):
                 y = torch.ops.aten.slice_scatter(x, src, 1, 6, None, 1)
                 return y
 
-        fx_graph = torch.fx.symbolic_trace(sliceScatter())
-
         dim1 = torch.export.Dim("dim1", min=8, max=10)
         dynamic_shapes = {
             "x": [torch.export.Dim.STATIC, dim1],

--- a/tests/py/dynamo/lowering/test_decompositions.py
+++ b/tests/py/dynamo/lowering/test_decompositions.py
@@ -812,6 +812,79 @@ class TestLowering(TestCase):
             f"Slice_scatter TRT outputs don't match with the original model.",
         )
 
+    def test_lowering_slice_scatter_dynamic_module(self):
+        class sliceScatter(torch.nn.Module):
+            def __init__(self, *args, **kwargs) -> None:
+                super().__init__(*args, **kwargs)
+
+            def forward(self, x, src, dim, start=None, end=None, step=1):
+                y = torch.ops.aten.slice_scatter(x, src, dim, start, end, step)
+                return y
+
+        # Operations expected to be removed in the traced graph after decompositions
+        expected_ops = {
+            torch.ops.aten.scatter.src,
+        }
+        unexpected_ops = {torch.ops.aten.select_scatter}
+
+        a = torch.zeros(8, 8).cuda()
+        b = torch.ones(8, 2).cuda()
+
+        # 0-D tensors for dynamic scalar values
+        start = torch.tensor(1, dtype=torch.int64).cuda()
+        end = torch.tensor(6, dtype=torch.int64).cuda()
+        step = torch.tensor(1, dtype=torch.int64).cuda()
+
+        # Mark scalar tensors as dynamic (note: shape = ())
+        torch._dynamo.mark_dynamic(start, (), min=1, max=3)
+        torch._dynamo.mark_dynamic(end, (), min=4, max=6)
+
+        inputs = (a, b, start, end, None, step)
+        fx_graph = torch.fx.symbolic_trace(sliceScatter())
+        unexpected_ops_seen, expected_ops_unseen = lower_graph_testing(
+            fx_graph,
+            inputs,
+            expected_ops=expected_ops,
+            unexpected_ops=unexpected_ops,
+            min_block_size=1,
+        )
+
+        self.assertEqual(
+            len(unexpected_ops_seen),
+            0,
+            f"The following unexpected ops were encountered: {unexpected_ops_seen}",
+        )
+
+        self.assertEqual(
+            len(expected_ops_unseen),
+            0,
+            f"The following expected ops were not encountered: {expected_ops_unseen}",
+        )
+
+        torch._dynamo.reset()
+
+        # Validate that the results between Torch and Torch-TRT are similar
+        optimized_model = torch_tensorrt.compile(
+            fx_graph,
+            "torch_compile",
+            inputs,
+            min_block_size=1,
+            truncate_double=True,
+            pass_through_build_failures=True,
+        )
+        optimized_model_results = optimized_model(*inputs).detach().cpu()
+        torch_model_results = fx_graph(*inputs).detach().cpu()
+
+        max_diff = float(
+            torch.max(torch.abs(optimized_model_results - torch_model_results))
+        )
+        self.assertAlmostEqual(
+            max_diff,
+            0,
+            DECIMALS_OF_AGREEMENT,
+            f"Slice_scatter TRT outputs don't match with the original model.",
+        )
+
     def test_lowering_select_scatter_dimZero_module(self):
         class selectScatter(torch.nn.Module):
             def __init__(self, *args, **kwargs) -> None:


### PR DESCRIPTION
This is with reference to #3448.
The error currently being faced is that-  (div_2, sym_size_int_3669, mul_102, mul_114, reshape_default_3, mul_213, div_113, mul_2962, clone_54, select_1, clone_67, expand_122, slice_16, clone_68, expand_123, mul_4869, expand_184,
 expand_185, mul_7245, expand_246, expand_247, mul_9621, expand_308, expand_309, mul_11997, expand_370, expand_371, mul_14373, expand_432, expand_433, mul_16749, expand_494, expand_495, expand_556, expand_557, 
mul_21501, expand_618, expand_619, mul_23877, expand_680, expand_681, mul_26253, expand_742, expand_743, mul_28629, expand_804, expand_805, mul_31005, expand_866, expand_867, mul_33381, expand_928, expand_929, 
mul_35757, expand_990, expand_991, mul_38133, expand_1052, expand_1053, mul_40509, expand_1114, expand_1115, mul_42885, expand_1176, expand_1177, mul_45261, expand_1238, expand_1239, mul_47637, expand_1300, exp
and_1301, mul_50013, expand_1362, expand_1363, mul_52389, expand_1424, expand_1425, mul_54765, expand_1486, expand_1487, mul_57141, expand_1548, expand_1549, mul_59517, expand_1610, expand_1611) 
There are symints in the output, whose dtype are not appended here
 ```
if "val" in output.meta:
            output_meta = output.meta["val"]
            if isinstance(output_meta, (FakeTensor, torch.Tensor)):
                if truncate_doulbe and output_meta.dtype == torch.float64:
                    output_dtypes.append(dtype.float32)
                else:
                    output_dtypes.append(dtype._from(output_meta.dtype))
```
but it is present in the engine output. So there are missing output dtypes.

Update: the above is corrected by https://github.com/pytorch/TensorRT/pull/3488