### PR TITLE
fix: handle device in the same way as dtype in `aten.full_like` decomposition

### DIFF
--- a/py/torch_tensorrt/dynamo/lowering/_decompositions.py
+++ b/py/torch_tensorrt/dynamo/lowering/_decompositions.py
@@ -434,7 +434,7 @@ def full_like_decomposition(*args, **kwargs) -> torch.Tensor:
     shape = args[0].shape
     fill_value = args[1]
     kwargs["dtype"] = kwargs.get("dtype", None) or input.dtype
-    kwargs["device"] = input.device
+    kwargs["device"] = kwargs.get("device", None) or input.device
     return torch.full(shape, fill_value, dtype=kwargs["dtype"], device=kwargs["device"])
 
 


### PR DESCRIPTION
# Description

This PR extends the changes introduced in [PR #3535](https://github.com/pytorch/TensorRT/pull/3535) by applying similar handling for the `device`, which was previously missed.

In the original PR, the focus was on ensuring the correct propagation of `dtype` when using `torch.full_like`. However, `torch.full_like` also accepts a `device` argument, and if a `device` is explicitly passed, it may differ from the input tensor's `device`. This can result in the output tensor being created on a different device than the input, leading to device mismatch issues.

```Python
import torch
from torch.export._trace import _export
from torch_tensorrt.dynamo.lowering import get_decompositions

device0 = torch.device("cuda", index=0)
device1 = torch.device("cuda", index=1)


class MyModel(torch.nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, x):
        return torch.ones_like(x, dtype=torch.bool, device=torch.device("cuda", index=1))


model = MyModel().to(device0)
x = torch.randn(1, 10, dtype=torch.float16).to(device0)
ep = _export(model, (x,))
ep = ep.run_decompositions(get_decompositions(False))
gm = ep.module()
y = gm(x)

assert y.device == device1, f"{device1} expected, but got {y.device}"
```

Results:
```
AssertionError: cuda:1 expected, but got cuda:0
```

To prevent this, this PR ensures that the `device` is handled in the same way as `dtype` in the previous PR.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project (You can use the linters)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
