### PR TITLE
fix: replace add_identity by add_cast for type cast

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/converter_utils.py
+++ b/py/torch_tensorrt/dynamo/conversion/converter_utils.py
@@ -8,10 +8,11 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, 
 import numpy as np
 import tensorrt as trt
 import torch
-import torch_tensorrt.dynamo.conversion.impl as impl
 from torch.fx.experimental.proxy_tensor import unset_fake_temporarily
 from torch.fx.node import Argument, Target
 from torch.fx.passes.shape_prop import TensorMetadata
+
+import torch_tensorrt.dynamo.conversion.impl as impl
 from torch_tensorrt import _enums
 from torch_tensorrt.dynamo._settings import CompilationSettings
 from torch_tensorrt.dynamo._SourceIR import SourceIR
@@ -141,9 +142,9 @@ def cast_trt_tensor(
 ) -> TRTTensor:
     """Given a TRT Tensor, convert that Tensor to the specified dtype
 
-    Adds an Identity layer to the network which performs the conversion
-    if the input's dtype is different from the cast type. Otherwise returns
-    input unchanged
+    Adds a Cast layer to the network to convert the input tensor to the specified dtype.
+    If the input tensor already has the desired dtype, it is returned unchanged.
+    Otherwise, a Cast layer is added to perform the conversion
 
     Args:
         ctx (ConversionContext): A ConversionContext containing the TensorRT network

--- a/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
@@ -5,6 +5,7 @@ from typing import Optional, Sequence
 import numpy as np
 import tensorrt as trt
 from torch.fx.node import Target
+
 from torch_tensorrt.dynamo._SourceIR import SourceIR
 from torch_tensorrt.dynamo.conversion import impl
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
@@ -13,6 +14,9 @@ from torch_tensorrt.dynamo.conversion.converter_utils import (
     flatten_dims,
     get_positive_dim,
     get_trt_tensor,
+    has_dynamic_shape,
+    prepend_ones,
+    set_layer_name,
 )
 from torch_tensorrt.dynamo.conversion.impl.cat import cat
 from torch_tensorrt.dynamo.conversion.impl.elementwise import floor_divide
@@ -23,11 +27,6 @@ from torch_tensorrt.dynamo.conversion.impl.shape import get_shape_with_dynamic_s
 from torch_tensorrt.dynamo.conversion.impl.shape import shape as get_shape
 from torch_tensorrt.dynamo.conversion.impl.slice.base import slice
 from torch_tensorrt.dynamo.utils import DYNAMIC_DIM
-from torch_tensorrt.fx.converters.converter_utils import (
-    has_dynamic_shape,
-    prepend_ones,
-    set_layer_name,
-)
 from torch_tensorrt.fx.types import Shape, TRTTensor
 
 
@@ -230,7 +229,7 @@ def expand(
     # If the rank of the input tensor is less than the shape's rank, pad with ones
     if initial_tensor_rank < shape_rank:
         input_t = prepend_ones(
-            ctx.net,
+            ctx,
             input_t,
             name + "_expand_broadcast",
             shape_rank - initial_tensor_rank,

--- a/py/torch_tensorrt/fx/converters/converter_utils.py
+++ b/py/torch_tensorrt/fx/converters/converter_utils.py
@@ -909,7 +909,6 @@ def type_cast(
     """
     This function helps to cast the input type to cast_type
     """
-    layer_i = network.add_identity(input)
-    layer_i.set_output_type(0, cast_type)
+    layer_i = network.add_cast(input, cast_type)
     set_layer_name(layer_i, target, f"{name}_dtype_change")
     return layer_i.get_output(0)


### PR DESCRIPTION
# Description

This PR updates the `type_cast` helper function to ensure compatibility with TensorRT's strongly typed network mode.

`type_cast` used `add_identity()` followed by `set_output_type()` to perform the data type cast. However, in strongly typed mode, calling `set_output_type()` on the identity layer causes an error below:
```
ILayer::setOutputType: Error Code 3: API Usage Error (Parameter check failed, condition: !mNetwork->usingStronglyTyped(). INetworkLayer::setOutputType cannot be called for a strongly typed network.)
[graphShapeAnalyzer.cpp::checkCalculationStatusSanity::1962] Error Code 2: Internal Error (Assertion !isInFlight(p.second.symbolicRep) failed. )
```
`type_cast` is called by `expand` function in `torch_tensorrt/dynamo/conversion/impl/slice/ops.py` with dynamic dimension index.
https://github.com/pytorch/TensorRT/blob/f09be72451200d4f9a347a6141276e81ff2fd22b/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py#L232-L237

The following code snippet reproduces the error:
```Python
import torch
import torch_tensorrt
from torch.export._trace import _export
from torch_tensorrt.dynamo._compiler import CompilationSettings
from torch_tensorrt.dynamo.conversion import TRTInterpreter
from torch_tensorrt.dynamo.lowering import get_decompositions


class Model(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.visual = torch.nn.Linear(10, 10)

    def forward(self, input: torch.Tensor):
        return input.unsqueeze(1).repeat(1, 1, 2).unsqueeze(0)


model = Model().to("cuda")
x = torch.randn(1, 40).to("cuda")
ep = _export(model, (x,))
ep = ep.run_decompositions(get_decompositions(False))
gm = ep.module()


interpreter = TRTInterpreter(
    gm,
    [torch_tensorrt.Input(name="input", min_shape=(1, 40), opt_shape=(4, 40), max_shape=(8, 40), dtype=torch.float32)],
    compilation_settings=CompilationSettings(use_explicit_typing=True),
)
results = interpreter.run()
```

To address this, the function now uses `add_cast()` to explicitly insert a cast layer that converts the input tensor to the desired `cast_type`.

If there was a specific reason for using `add_identity()`, please let me know, as this change assumes that the identity layer was not essential beyond type casting.


## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project (You can use the linters)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
