### PR TITLE
adding rotary embedding example, with graph rewrite for complex subgraph [WIP]

### DIFF
--- a/examples/distributed_inference/rotary_embedding.py
+++ b/examples/distributed_inference/rotary_embedding.py
@@ -1,0 +1,112 @@
+import time
+
+import tensorrt as trt
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch_tensorrt
+from tensor_parallel_initialize_dist import initialize_distributed_env
+from torch.distributed._tensor import Shard
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    RowwiseParallel,
+    parallelize_module,
+)
+
+"""
+This example covers the rotary embedding and rotary attention case for tensor parallel
+"""
+
+
+def precompute_freqs_cis(
+    dim: int, end: int, theta: float = 10000.0, n_parallel=1
+) -> torch.Tensor:
+    """Precompute the frequency tensor for complex exponentials (cis) with given dimensions.
+    This function calculates a frequency tensor with complex exponentials using the given dimension 'dim'
+    and the end index 'end'. The 'theta' parameter scales the frequencies.
+    The returned tensor contains complex values in complex64 data type.
+    Args:
+        dim (int): Dimension of the frequency tensor.
+        end (int): End index for precomputing frequencies.
+        theta (float, optional): Scaling factor for frequency computation. Defaults to 10000.0.
+        n_parallel (int, optional): Number of GPUs for parallel computation. Defaults to 1.
+    Returns:
+        torch.Tensor: Precomputed frequency tensor with complex exponentials.
+    """
+    freqs = 1.0 / (theta ** (torch.arange(0, dim // n_parallel, 2).float() / dim))
+    t = torch.arange(end, device=freqs.device)
+    freqs = torch.outer(t, freqs).float()
+    return torch.polar(torch.ones_like(freqs), freqs)
+
+
+def rotary_embedding(xq, xk, dim, freqs_cis=None):
+    """This calculates the rotary embedding for the query and key tensors.
+    Args:
+        xq (torch.Tensor): Query tensor.
+        xk (torch.Tensor): Key tensor.
+        dim (int): Dimension of the query and key tensors.
+        freqs_cis (torch.Tensor, optional): Precomputed frequency tensor. Defaults to None.
+    Returns:
+        tuple: Tuple containing the rotated query and key tensors.
+    """
+    freqs_cis = freqs_cis[None, :, None, :]  # [1, seq, 1, dim/2]
+    xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
+    xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
+
+    xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(3)
+    xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
+    return xq_out.type_as(xq), xk_out.type_as(xk)
+
+
+########Tensor Parallel########
+def parallel_rotary_block(rotary_block, tp_mesh):
+    """Parallel rotary block for tensor parallel
+    Args:
+        rotary_block: Rotary block to parallelize
+        tp_mesh: Tensor parallel mesh
+    """
+    if tp_mesh.size() <= 1:
+        return
+
+    plan = {
+        "wq": ColwiseParallel(),
+        "wk": ColwiseParallel(),
+        "wo": RowwiseParallel(output_layouts=Shard(0)),
+    }
+    rotary_block.n_parallel = 2
+
+    parallelize_module(rotary_block, tp_mesh, plan)
+
+
+class RotaryAttention(nn.Module):
+    def __init__(self, dim: int, seq_len: int):
+        super().__init__()
+        self.dim = dim
+        # self.rotary = RotaryEmbedding(dim)
+        self.wq = nn.Linear(dim, dim)
+        self.wk = nn.Linear(dim, dim)
+        self.wo = nn.Linear(dim, dim)
+        self.seq_len = seq_len
+        self.n_parallel = 1
+        self.register_buffer(
+            "freqs_cis",
+            self._precompute_freqs_cis(),
+            persistent=True,
+        )
+        self.init_weights()
+
+    def init_weights(self):
+        with torch.device(self.freqs_cis.device):
+            self.freqs_cis = self._precompute_freqs_cis()
+
+    def _precompute_freqs_cis(self) -> torch.Tensor:
+        theta = 10000.0
+        return precompute_freqs_cis(self.dim, self.seq_len, theta, self.n_parallel)
+
+    def forward(self, x):
+        q = self.wq(x)
+        k = self.wk(x)
+        # calculate rotary embedding
+        freqs_cis = self._precompute_freqs_cis().to(q.device)
+        q, k = rotary_embedding(q, k, self.dim, freqs_cis=freqs_cis)
+        return self.wo(q)

--- a/examples/distributed_inference/tensor_parallel_rotary_embedding.py
+++ b/examples/distributed_inference/tensor_parallel_rotary_embedding.py
@@ -1,0 +1,57 @@
+import logging
+import os
+import time
+
+import torch
+import torch_tensorrt
+from rotary_embedding import RotaryAttention, parallel_rotary_block
+from tensor_parallel_initialize_dist import initialize_distributed_env
+
+device_mesh, _world_size, _rank, logger = initialize_distributed_env(
+    "./tensor_parallel_rotary_embedding"
+)
+
+
+"""
+This example covers the rotary embedding in Llama3 model and is derived from https://lightning.ai/lightning-ai/studios/tensor-parallelism-supercharging-large-model-training-with-pytorch-lightning
+"""
+
+BATCH = 2
+SEQ_LEN = 128
+HEADS = 4
+DIM = 128
+
+with torch.no_grad():
+    xq = torch.randn(BATCH, SEQ_LEN, HEADS, DIM)
+    xk = torch.randn(BATCH, SEQ_LEN, HEADS, DIM)
+    model = RotaryAttention(DIM, SEQ_LEN)
+    parallel_rotary_block(model, device_mesh)
+    device = torch.device("cuda", device_mesh.get_rank())
+    model.to(device)
+    x = torch.randn(BATCH, SEQ_LEN, HEADS, DIM).to(device)
+
+    python_result = model(x)
+
+    logger.info("Torch-tensorrt compilation for rotary embedding")
+
+    # Compile the model
+    # for single GPU let us first try without this optiob
+
+    model = torch.compile(model, backend="torch_tensorrt", options={"debug": True})
+    # model = torch_tensorrt.compile(model, target_ir="torch_compile", options={
+    #     "debug": True,
+    # })
+
+    for i in range(15):
+        # seeding with dp_rank to ensure identical inputs for TP groups
+        torch.manual_seed(i)
+        start = time.time()
+        output = model(x)
+        end = time.time()
+        if i == 0:
+            logger.info(f"Compilation time is {end-start}")
+            assert (
+                python_result - output
+            ).std() < 0.01, "Compilation result is not correct."
+        elif _rank == 0:
+            logger.info(f"Inference time is {end-start}")

--- a/py/torch_tensorrt/dynamo/lowering/passes/__init__.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/__init__.py
@@ -1,4 +1,3 @@
 from ._aten_lowering_pass import *
-from ._modify_reshape_complex_nodes import modify_reshape_complex_nodes
 from .remove_sym_nodes import remove_sym_nodes
 from .repair_input_aliasing import repair_input_aliasing

--- a/py/torch_tensorrt/dynamo/lowering/passes/_aten_lowering_pass.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/_aten_lowering_pass.py
@@ -6,6 +6,7 @@ from torch_tensorrt.dynamo._settings import CompilationSettings
 from torch_tensorrt.dynamo.utils import is_tegra_platform
 
 from .accumulate_fp32_matmul import accumulate_fp32_matmul
+from .complex_graph_rewrite import complex_graph_detection
 from .constant_folding import constant_fold
 from .fuse_distributed_ops import fuse_distributed_ops
 from .fuse_prims_broadcast import fuse_prims_broadcast
@@ -26,6 +27,7 @@ pass_list = [
     remove_assert_nodes,
     accumulate_fp32_matmul,
     remove_num_users_is_0_nodes,
+    complex_graph_detection,
 ]
 
 if not is_tegra_platform():

--- a/py/torch_tensorrt/dynamo/lowering/passes/complex_graph_rewrite.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/complex_graph_rewrite.py
@@ -1,0 +1,271 @@
+import logging
+from typing import Callable, List, Optional, Set, Tuple
+
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx import GraphModule, Node
+from torch.fx.subgraph_rewriter import Match
+from torch_tensorrt.dynamo._settings import CompilationSettings
+from torch_tensorrt.dynamo.lowering.passes.pass_utils import (
+    clean_up_graph_after_modifications,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ComplexSubGraphInfo:
+    def __init__(
+        self,
+        anchor_nodes: List[Node],
+        subgraph_nodes: List[Node],
+        input_nodes: List[Node],
+    ):
+        self.anchor_nodes = anchor_nodes
+        self.subgraph_nodes = subgraph_nodes
+        self.input_nodes = input_nodes
+
+    def __repr__(self):
+        return (
+            f"ComplexOpSubGraphInfo(anchor_nodes={[n.name for n in self.anchor_nodes]}, "
+            f"subgraph={[n.name for n in self.subgraph_nodes]}, "
+            f"inputs={[n.name for n in self.input_nodes]})"
+        )
+
+
+class ComplexOpDetector:
+    def __init__(self, logger):
+        self.logger = logger
+        pass
+
+    def is_complex_dtype(self, node: Node) -> bool:
+        # Check if node's metadata or dtype is complex
+        dtype = None
+        if "val" in node.meta:
+            val = node.meta["val"]
+            if hasattr(val, "dtype"):
+                dtype = val.dtype
+
+        self.logger.debug(f"dtype of node: {dtype}")
+        return dtype in {torch.complex64, torch.complex128}
+
+    def node_include_in_subgraph(self, node: Node) -> bool:
+        # Include only call_function ops on complex tensors
+        self.logger.debug(f"node.op: {node.op}, node name: {node.name}")
+        self.logger.debug(f"is_complex_dtype: {self.is_complex_dtype(node)}")
+        if node.op == "call_function" and self.is_complex_dtype(node):
+            self.logger.debug(
+                f"node.op is added to subgraph: {node.op}, node name: {node.name} is complex"
+            )
+        return node.op == "call_function" and self.is_complex_dtype(node)
+
+    def subgraph_from_anchor(self, anchor_node: Node) -> ComplexSubGraphInfo:
+        subgraph_nodes: Set[Node] = set()
+        input_nodes: Set[Node] = set()
+        stack = [anchor_node]
+        while stack:
+            n = stack.pop()
+            if n in subgraph_nodes:
+                continue
+            subgraph_nodes.add(n)
+            self.logger.debug(f"node {n.name} is added to subgraph")
+            for inp in n.all_input_nodes:
+                if self.node_include_in_subgraph(inp):
+                    print("node inp is added to stack:", inp.name)
+                    stack.append(inp)
+                else:
+                    print("node inp is not added to stack BUT INP:", inp.name)
+                    input_nodes.add(inp)
+        return ComplexSubGraphInfo(
+            [anchor_node], list(subgraph_nodes), list(input_nodes)
+        )
+
+    def find_complex_op_subgraphs(
+        self, gm: GraphModule, anchor_target: str
+    ) -> List[ComplexSubGraphInfo]:
+        complex_op_subgraphs: List[ComplexSubGraphInfo] = []
+        for node in gm.graph.nodes:
+            if node.target == anchor_target:
+                self.logger.debug(f"node.target {node.target} node.name: {node.name}")
+                new_sub = self.subgraph_from_anchor(node)
+                # if any intersecting nodes between seen and sub.subgraph_nodes they should be merged
+                merged = False
+                for existing_sub in complex_op_subgraphs:
+                    if set(existing_sub.subgraph_nodes) & set(new_sub.subgraph_nodes):
+                        self.logger.debug(f"merging subgraphs {existing_sub} {new_sub}")
+                        # merge the two subgraphs
+                        existing_sub.subgraph_nodes = list(
+                            set(existing_sub.subgraph_nodes)
+                            | set(new_sub.subgraph_nodes)
+                        )
+                        existing_sub.input_nodes = list(
+                            set(existing_sub.input_nodes) | set(new_sub.input_nodes)
+                        )
+                        existing_sub.anchor_nodes = list(
+                            set(existing_sub.anchor_nodes) | set(new_sub.anchor_nodes)
+                        )
+                        merged = True
+                        break
+                if not merged:
+                    complex_op_subgraphs.append(new_sub)
+        return complex_op_subgraphs
+
+
+def complex_graph_detection(
+    gm: GraphModule, settings: CompilationSettings
+) -> List[ComplexSubGraphInfo]:
+    complex_op_detector = ComplexOpDetector(logger)
+    complex_subgraphs = complex_op_detector.find_complex_op_subgraphs(
+        gm, anchor_target=torch.ops.aten.view_as_real.default
+    )
+    complex_graph_rewriter = ComplexGraphRewriter(gm, settings.truncate_double)
+    complex_graph_rewriter.rewrite_subgraph_nodes(complex_subgraphs)
+    return gm
+
+
+class ComplexGraphRewriter:
+    def __init__(self, gm: GraphModule, truncate_double: bool = False):
+        self.gm = gm
+        self.truncate_double = truncate_double
+
+    def extract_shape_and_dtype(self, input_node):
+        if input_node.op == "placeholder":
+            tensor_val = input_node.meta["val"]
+
+        elif input_node.op == "get_attr":
+            tensor_val = self.get_attr_tensor(input_node.target)
+
+        else:
+            raise ValueError(f"Unsupported node type: {input_node.op}")
+
+        node_shape = tensor_val.size()
+        dtype = tensor_val.dtype
+        new_node_shape = node_shape + (2,)
+
+        if dtype == torch.complex64:
+            new_node_dtype = torch.float32
+        elif dtype == torch.complex128 and self.truncate_double:
+            new_node_dtype = torch.float32
+        else:
+            new_node_dtype = torch.float64
+
+        return new_node_shape, new_node_dtype
+
+    def get_attr_tensor(self, target):
+        # Check if target is param or buffer
+        if target in dict(self.gm.named_parameters()):
+            return self.gm.get_parameter(target)
+        elif target in dict(self.gm.named_buffers()):
+            return self.gm.get_buffer(target)
+        else:
+            raise ValueError(
+                f"Attribute {target} not found in gm parameters or buffers."
+            )
+
+    def replace_input_node(self, input_node):
+        logger.debug(f"Replacing input node: {input_node.name}")
+        new_shape, new_dtype = self.extract_shape_and_dtype(input_node)
+        real_tensor = torch.empty(new_shape, dtype=new_dtype)
+
+        if input_node.op == "placeholder":
+            with FakeTensorMode() as fake_mode:
+                fake_tensor = fake_mode.from_tensor(real_tensor)
+            new_node = self.gm.graph.placeholder(input_node.target + "_reshaped")
+            new_node.meta["val"] = fake_tensor
+
+        elif input_node.op == "get_attr":
+            new_attr_name = input_node.target + "_reshaped"
+            original_tensor = self.get_attr_tensor(input_node.target)
+            stacked_tensor = torch.stack(
+                [original_tensor.real, original_tensor.imag], dim=-1
+            )
+            self.gm.register_buffer(new_attr_name, stacked_tensor)
+            with self.gm.graph.inserting_after(input_node):
+                new_node = self.gm.graph.get_attr(new_attr_name)
+
+        else:
+            logger.debug(f"Unsupported node type: {input_node.op}")
+            logger.debug("This node type does not need to replaced")
+
+        input_node.replace_all_uses_with(new_node)
+        self.gm.graph.erase_node(input_node)
+
+    def rewrite_subgraph_nodes(self, subgraphs):
+        modified = False
+        for subgraph in subgraphs:
+            for input_node in subgraph.input_nodes:
+                logger.debug(f"Input node rewrite: {input_node.name}")
+                if input_node.op not in ("call_function"):
+                    self.replace_input_node(input_node)
+                    modified = True
+            for node in subgraph.subgraph_nodes:
+                logger.debug(f"Subgraph Node rewrite: {node.name}")
+                if node.target == torch.ops.aten.view_as_complex.default:
+                    node.replace_all_uses_with(node.args[0])
+                    self.gm.graph.erase_node(node)
+                elif node.target == torch.ops.aten.mul.Tensor:
+                    # this is complex mul where inputs = a+ib and output = c+id.
+                    # complex mul returns (ac - bd) + (ad + bc)i
+                    # which is then view_as_real as (ac-bd), ad+bc stacked along the last dimension with last dimension size 2
+                    replaced_nodes = []
+                    original_mul, replacement = complex_mul_replacement()
+
+                    def match_complex_mul(
+                        match: torch.fx.subgraph_rewriter.Match,
+                    ) -> bool:
+                        for original_node in match.nodes_map.values():
+                            if original_node.name == node.name:
+                                return True
+                        return False
+
+                    nodes = torch.fx.subgraph_rewriter.replace_pattern_with_filters(
+                        self.gm,
+                        original_mul,
+                        replacement,
+                        match_filters=[match_complex_mul],
+                        ignore_literals=True,
+                    )
+                    replaced_nodes += nodes
+                elif node.target == torch.ops.aten.view_as_real.default:
+                    node.replace_all_uses_with(node.args[0])
+                    self.gm.graph.erase_node(node)
+                else:
+                    logger.debug(f"Unsupported node target: {node.target}")
+                    logger.debug(f"This node type does not need to replaced")
+            if modified:
+                self.gm.graph.lint()
+                self.gm.recompile()
+
+        if modified:
+            self.gm.graph.lint()
+            self.gm.recompile()
+
+
+def complex_mul_replacement() -> Tuple[
+    Callable[[torch.Tensor, torch.Tensor], torch.Tensor],
+    Callable[[torch.Tensor, torch.Tensor], torch.Tensor],
+]:
+    """Constructs the original and replacement functions for complex multiplication.
+
+    The original functions correspond to native complex multiplication
+    via torch.mul or operator.mul on complex tensors.
+
+    The replacement function assumes x and y are real tensors with the last
+    dimension size 2 representing real and imaginary parts, and performs
+    complex multiplication manually returning the same shaped tensor.
+    """
+
+    # Original pattern: torch.mul for complex tensors
+    def original_mul(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return torch.mul(x, y)
+
+    # Replacement function: manual complex multiplication on real/imag stacked tensors
+    def replacement(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        x_real, x_imag = x[..., 0], x[..., 1]
+        y_real, y_imag = y[..., 0], y[..., 1]
+
+        real = x_real * y_real - x_imag * y_imag
+        imag = x_real * y_imag + x_imag * y_real
+
+        return torch.stack((real, imag), dim=-1)
+
+    return (original_mul, replacement)


### PR DESCRIPTION
This PR-
1. Adds an example for parallel rotary embedding
2. Adds logic for complex graph detection
3. Adds a pass for complex graph rewrite in aten_lowering_pass
Please note that this PR is currently for the single GPU case where there is no DTensor in the inputs of the torch module. Ideally this should not require runtime changes.
This should avoid the graph breaks caused due to view_as_complex and view_as_real nodes.