### PR TITLE
Fix: Revert conv/deconv to use get_trt_weights for refit to record weights

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/impl/conv.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/conv.py
@@ -16,7 +16,6 @@ from torch_tensorrt.dynamo.conversion.converter_utils import (
     has_dynamic_shape,
     set_layer_name,
     to_torch,
-    to_trt_weights,
 )
 from torch_tensorrt.fx.converters.converter_utils import (
     get_dyn_range,
@@ -55,7 +54,8 @@ def convNd(
     # Process bias terms
     if isinstance(bias, (torch.Tensor, np.ndarray)):
         bias = to_torch(bias, dtype=input.dtype)
-        bias = get_trt_tensor(ctx, bias, f"{name}_bias")
+        # This should return a trt.Weights object
+        bias = get_trt_tensor(ctx, bias, f"{name}_bias", return_trt_weights=True)
 
     elif isinstance(bias, TRTTensor):
         bias = get_trt_tensor(ctx, bias, f"{name}_bias")
@@ -85,7 +85,8 @@ def convNd(
 
         num_output_maps = weight.shape[0]
         kernel_shape = weight.shape[2:]
-        weight = to_trt_weights(weight)
+        # This should return a trt.Weights object
+        weight = get_trt_tensor(ctx, weight, f"{name}_weight", return_trt_weights=True)
 
     else:
         raise RuntimeError(

--- a/py/torch_tensorrt/dynamo/conversion/impl/deconv.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/deconv.py
@@ -14,7 +14,6 @@ from torch_tensorrt.dynamo.conversion.converter_utils import (
     get_trt_tensor,
     has_dynamic_shape,
     to_torch,
-    to_trt_weights,
 )
 from torch_tensorrt.fx.converters.converter_utils import (
     get_dyn_range,
@@ -55,7 +54,8 @@ def deconvNd(
     if isinstance(bias, (torch.Tensor, np.ndarray)):
         # Transform the bias constant into a Numpy array
         bias = to_torch(bias, dtype=input.dtype)
-        bias = get_trt_tensor(ctx, bias, f"{name}_bias")
+        # This should return a trt.Weights object
+        bias = get_trt_tensor(ctx, bias, f"{name}_bias", return_trt_weights=True)
 
     elif isinstance(bias, TRTTensor):
         bias = get_trt_tensor(ctx, bias, f"{name}_bias")
@@ -85,7 +85,8 @@ def deconvNd(
             weight = torch.unsqueeze(weight, -1)
         num_output_maps = weight.shape[1]
         kernel_shape = weight.shape[2:]
-        weight = to_trt_weights(weight)
+        # This should return a trt.Weights object
+        weight = get_trt_tensor(ctx, weight, f"{name}_weight", return_trt_weights=True)
 
     else:
         raise RuntimeError(


### PR DESCRIPTION
# Description

This PR fixes refit tests by using get_trt_tensor to record weights while maintaining the performance

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
