### PR TITLE
skip flashinfer-python for py3.9 due to upstream error

### DIFF
--- a/.github/workflows/build-test-linux-x86_64.yml
+++ b/.github/workflows/build-test-linux-x86_64.yml
@@ -146,7 +146,12 @@ jobs:
           echo "flashinfer-python is not supported for python version 3.13 or higher"
         else
           echo "Installing flashinfer-python"
-          python -m pip install flashinfer-python --no-deps
+          # flashinfer-python is broken on python 3.9 at the moment, so we skip it for now
+          if (major == 3 && minor == 9); then
+            echo "Skipping flashinfer-python for python 3.9"
+          else
+            python -m pip install flashinfer-python --no-deps
+          fi
         fi
         cd dynamo
         python -m pytest -ra --junitxml=${RUNNER_TEST_RESULTS_DIR}/dynamo_converters_test_results.xml -n 4 conversion/


### PR DESCRIPTION
# Description

Skip flashinfer-python for py3.9 due to upstream error:
 @dataclass(kw_only=True)  kw_only is only avaiable from py3.10+
 
https://github.com/flashinfer-ai/flashinfer/blob/0a754ce4fcae45fb0ce231de0bb03bc796bb44b3/flashinfer/autotuner.py#L19
```
_ ERROR collecting tests/py/dynamo/automatic_plugin/test_flashinfer_rmsnorm.py _
automatic_plugin/test_flashinfer_rmsnorm.py:3: in <module>
    flashinfer = pytest.importorskip("flashinfer")
/opt/python/cp39-cp39/lib/python3.9/site-packages/flashinfer/__init__.py:50: in <module>
    from .fused_moe import cutlass_fused_moe
/opt/python/cp39-cp39/lib/python3.9/site-packages/flashinfer/fused_moe.py:23: in <module>
    from .autotuner import AutoTuner, TunableRunner, TuningConfig
/opt/python/cp39-cp39/lib/python3.9/site-packages/flashinfer/autotuner.py:19: in <module>
    @dataclass(kw_only=True)
E   TypeError: dataclass() got an unexpected keyword argument 'kw_only'
--- generated xml file: /tmp/test_results/dynamo_converters_test_results.xml ---
=========================== short test summary info ============================
ERROR automatic_plugin/test_flashinfer_rmsnorm.py - TypeError: dataclass() got an unexpected keyword argument 'kw_only'
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
