### PR TITLE
fix enabled_precisions error in test cases

### DIFF
--- a/tests/py/dynamo/runtime/test_mutable_torchtrt_module.py
+++ b/tests/py/dynamo/runtime/test_mutable_torchtrt_module.py
@@ -299,6 +299,9 @@ def test_save():
     not torch_trt.ENABLED_FEATURES.refit,
     "Refit feature is not supported in Python 3.13 or higher",
 )
+@unittest.skipIf(
+    not importlib.util.find_spec("torchvision"), "torchvision not installed"
+)
 @pytest.mark.unit
 def test_resnet18_modify_attribute():
     torch.manual_seed(0)
@@ -342,6 +345,9 @@ def test_resnet18_modify_attribute():
 @unittest.skipIf(
     not torch_trt.ENABLED_FEATURES.refit,
     "Refit feature is not supported in Python 3.13 or higher",
+)
+@unittest.skipIf(
+    not importlib.util.find_spec("torchvision"), "torchvision not installed"
 )
 @pytest.mark.unit
 def test_resnet18_modify_attribute_no_refit():


### PR DESCRIPTION
# Description

fix the enabled_precisions error in the test:
```
        if (
>           torch.float8_e4m3fn in self.additional_settings["enabled_precisions"]
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            or torch.int8 in self.additional_settings["enabled_precisions"]
        ):
E       KeyError: 'enabled_precisions'

/opt/python/cp312-cp312/lib/python3.12/site-packages/torch_tensorrt/dynamo/runtime/_MutableTorchTensorRTModule.py:329: KeyError
```
Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
