### PR TITLE
debug flag is deprecated, remove it so that test won't complain

### DIFF
--- a/tests/py/dynamo/backend/test_specialized_models.py
+++ b/tests/py/dynamo/backend/test_specialized_models.py
@@ -393,7 +393,6 @@ class TestDeconvolution(TestCase):
             backend="torch_tensorrt",
             options={
                 "min_block_size": 1,
-                "debug": True,
             },
         )
         with torch.no_grad():

--- a/tests/py/dynamo/models/test_engine_cache.py
+++ b/tests/py/dynamo/models/test_engine_cache.py
@@ -423,7 +423,6 @@ class TestEngineCache(TestCase):
                 options={
                     "use_python_runtime": False,
                     "enabled_precisions": {torch.float},
-                    "debug": False,
                     "min_block_size": 1,
                     "immutable_weights": False,
                     "cache_built_engines": cache_built_engines,
@@ -490,7 +489,6 @@ class TestEngineCache(TestCase):
                 options={
                     "use_python_runtime": False,
                     "enabled_precisions": {torch.float},
-                    "debug": False,
                     "min_block_size": 1,
                     "immutable_weights": False,
                     "cache_built_engines": cache_built_engines,
@@ -547,7 +545,6 @@ class TestEngineCache(TestCase):
                 **{
                     "use_python_runtime": True,
                     "enabled_precisions": {torch.float},
-                    "debug": False,
                     "min_block_size": 1,
                     "immutable_weights": False,
                     "cache_built_engines": True,
@@ -590,7 +587,6 @@ class TestEngineCache(TestCase):
                 options={
                     "use_python_runtime": True,
                     "enabled_precisions": {torch.float},
-                    "debug": False,
                     "min_block_size": 1,
                     "immutable_weights": False,
                     "cache_built_engines": True,

--- a/tests/py/dynamo/models/test_weight_stripped_engine.py
+++ b/tests/py/dynamo/models/test_weight_stripped_engine.py
@@ -35,7 +35,6 @@ class TestWeightStrippedEngine(TestCase):
         settings = {
             "use_python_runtime": False,
             "enabled_precisions": {torch.float},
-            "debug": False,
             "min_block_size": 1,
             "immutable_weights": False,
             "strip_engine_weights": False,
@@ -83,7 +82,6 @@ class TestWeightStrippedEngine(TestCase):
         settings = {
             "use_python_runtime": False,
             "enabled_precisions": {torch.float},
-            "debug": False,
             "min_block_size": 1,
             "immutable_weights": False,
             "strip_engine_weights": True,
@@ -203,7 +201,6 @@ class TestWeightStrippedEngine(TestCase):
             options={
                 "use_python_runtime": False,
                 "enabled_precisions": {torch.float},
-                "debug": False,
                 "min_block_size": 1,
                 "immutable_weights": False,
                 "cache_built_engines": False,
@@ -410,7 +407,6 @@ class TestWeightStrippedEngine(TestCase):
                 options={
                     "use_python_runtime": False,
                     "enabled_precisions": {torch.float},
-                    "debug": False,
                     "min_block_size": 1,
                     "immutable_weights": False,
                     "cache_built_engines": cache_built_engines,
@@ -488,7 +484,6 @@ class TestWeightStrippedEngine(TestCase):
                 options={
                     "use_python_runtime": True,
                     "enabled_precisions": {torch.float},
-                    "debug": False,
                     "min_block_size": 1,
                     "immutable_weights": False,
                     "cache_built_engines": True,

--- a/tests/py/ts/integrations/test_to_backend_api.py
+++ b/tests/py/ts/integrations/test_to_backend_api.py
@@ -22,7 +22,6 @@ class TestToBackendLowering(unittest.TestCase):
                     "inputs": [torchtrt.Input([1, 3, 300, 300])],
                     "enabled_precisions": {torch.float},
                     "refit": False,
-                    "debug": False,
                     "device": {
                         "device_type": torchtrt.DeviceType.GPU,
                         "gpu_id": 0,


### PR DESCRIPTION
# Description

debug flag is being deprecated, remove it, otherwise test failed:

` AttributeError: 'CompilationSettings' object has no attribute 'debug'`

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
