### PR TITLE
Remove Bazel files from wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -613,8 +613,6 @@ if not (PY_ONLY or NO_TS):
     package_data.update(
         {
             "torch_tensorrt": [
-                "BUILD",
-                "WORKSPACE",
                 "include/torch_tensorrt/*.h",
                 "include/torch_tensorrt/core/*.h",
                 "include/torch_tensorrt/core/conversion/*.h",
@@ -644,8 +642,6 @@ elif NO_TS:
     package_data.update(
         {
             "torch_tensorrt": [
-                "BUILD",
-                "WORKSPACE",
                 "include/torch_tensorrt/*.h",
                 "include/torch_tensorrt/core/*.h",
                 "include/torch_tensorrt/core/runtime/*.h",


### PR DESCRIPTION
# Description

Once the wheel is built, the Bazel files are no longer needed.

Fixes #3477

## Type of change

Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
