### PR TITLE
fix windows build failure: add /utf-8

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,7 +27,7 @@ build:linux --cxxopt="-std=c++17"
 build:linux --cxxopt="-fdiagnostics-color=always"
 
 build:windows --cxxopt="/GS-" --cxxopt="/std:c++17" --cxxopt="/permissive-"
-build:windows --cxxopt="/wd4244" --cxxopt="/wd4267" --cxxopt="/wd4819" 
+build:windows --cxxopt="/wd4244" --cxxopt="/wd4267" --cxxopt="/wd4819"
 build:windows --cxxopt="/utf-8"
 build:windows --features=windows_export_all_symbols
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -27,7 +27,7 @@ build:linux --cxxopt="-std=c++17"
 build:linux --cxxopt="-fdiagnostics-color=always"
 
 build:windows --cxxopt="/GS-" --cxxopt="/std:c++17" --cxxopt="/permissive-"
-build:windows --cxxopt="/wd4244" --cxxopt="/wd4267" --cxxopt="/wd4819"
+build:windows --cxxopt="/wd4244" --cxxopt="/wd4267" --cxxopt="/wd4819" -cxxopt="/utf-8"
 build:windows --features=windows_export_all_symbols
 
 build:python --define=target_lang=python

--- a/.bazelrc
+++ b/.bazelrc
@@ -27,7 +27,8 @@ build:linux --cxxopt="-std=c++17"
 build:linux --cxxopt="-fdiagnostics-color=always"
 
 build:windows --cxxopt="/GS-" --cxxopt="/std:c++17" --cxxopt="/permissive-"
-build:windows --cxxopt="/wd4244" --cxxopt="/wd4267" --cxxopt="/wd4819" -cxxopt="/utf-8"
+build:windows --cxxopt="/wd4244" --cxxopt="/wd4267" --cxxopt="/wd4819" 
+build:windows --cxxopt="/utf-8"
 build:windows --features=windows_export_all_symbols
 
 build:python --define=target_lang=python

--- a/setup.py
+++ b/setup.py
@@ -569,6 +569,7 @@ if not (PY_ONLY or NO_TS):
                     f'/DPYBIND11_BUILD_ABI=\\"{torch._C._PYBIND11_BUILD_ABI}\\"',
                     "/GS-",
                     "/permissive-",
+                    "/utf-8",
                 ]
                 if IS_WINDOWS
                 else [


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)
got the following error in CI:
`C:\actions-runner\_work\_temp\conda_environment_16299188041\lib\site-packages\torch\include\fmt\base.h(463): error C2338: static_assert failed: 'Unicode support requires compiling with /utf-8'`

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
