### PR TITLE
fix conv1d/deconv1d bug with stride more than 1

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/impl/conv.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/conv.py
@@ -11,7 +11,6 @@ from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContex
 from torch_tensorrt.dynamo.conversion.converter_utils import (
     SourceIR,
     cast_trt_tensor,
-    extend_attr_to_tuple,
     get_trt_tensor,
     has_dynamic_shape,
     set_layer_name,
@@ -159,10 +158,9 @@ def convNd(
     # Expand parameters manually for Conv1D computations
     if is_conv1d:
         padding = (tuple(padding) + (0,)) if padding is not None else padding
-        stride = extend_attr_to_tuple(stride, 2) if stride is not None else stride
-        dilation = (
-            extend_attr_to_tuple(dilation, 2) if dilation is not None else dilation
-        )
+        # stride in conv1d is (2,) -> need to change to (2, 1) in conv2d
+        stride = (stride[0], 1) if stride is not None else stride
+        dilation = (dilation[0], 1) if dilation is not None else dilation
 
     # Set relevant attributes of convolution layer
     if padding is not None:

--- a/py/torch_tensorrt/dynamo/conversion/impl/deconv.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/deconv.py
@@ -10,7 +10,6 @@ from torch_tensorrt.dynamo.conversion import impl
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import (
     SourceIR,
-    extend_attr_to_tuple,
     get_trt_tensor,
     has_dynamic_shape,
     to_torch,
@@ -142,10 +141,9 @@ def deconvNd(
     # Expand parameters manually for Conv1D computations
     if is_deconv1d:
         padding = (tuple(padding) + (0,)) if padding is not None else padding
-        stride = extend_attr_to_tuple(stride, 2) if stride is not None else stride
-        dilation = (
-            extend_attr_to_tuple(dilation, 2) if dilation is not None else dilation
-        )
+        # stride in deconv1d is (2,) -> need to change to (2, 1) in deconv2d
+        stride = (stride[0], 1) if stride is not None else stride
+        dilation = (dilation[0], 1) if dilation is not None else dilation
         output_padding = (
             (tuple(output_padding) + (0,))
             if output_padding is not None

--- a/tests/py/dynamo/conversion/test_convolution_aten.py
+++ b/tests/py/dynamo/conversion/test_convolution_aten.py
@@ -15,6 +15,9 @@ class TestConvolutionConverter(DispatchTestCase):
             param("non_zero_padding", 1, padding=1),
             param("dilation", 1, dilation=2),
             param("groups", 1, groups=3),
+            param("stride", 1, stride=1),
+            param("stride_2", 1, stride=2),
+            param("stride_tuple", 1, stride=(2,)),
         ]
     )
     def test_conv1d(
@@ -52,6 +55,7 @@ class TestConvolutionConverter(DispatchTestCase):
             ("tuple_parameters", 1, (1), (1)),
             param("non_zero_padding", 1, padding=1),
             param("dilation", 1, dilation=2),
+            param("stride", 1, stride=2),
         ]
     )
     def test_conv1d_TRTTensor_weight(
@@ -140,6 +144,7 @@ class TestConvolutionConverter(DispatchTestCase):
             param("tuple_dilation", 2, dilation=(3, 3)),
             param("list_dilation", 2, dilation=[3]),
             param("groups", 1, groups=3),
+            param("stride", 1, stride=(2, 2)),
         ]
     )
     def test_conv2d(


### PR DESCRIPTION
# Description

in conv1d/deconv1d, 
input_tensor is (N,C,H) ---> (N, C, H, 1)
if stride is 2, once we moved to 2d, it should be (2, 1) not (2, 2)

This bug is only appear when we have a conv1d/deconv1d with stride more than 1

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
