### PR TITLE
fix: atan2 strong type support & bug fix for integer dynamic shape

### DIFF
--- a/py/torch_tensorrt/_Input.py
+++ b/py/torch_tensorrt/_Input.py
@@ -380,9 +380,13 @@ class Input(object):
                 )
             else:
                 if isinstance(self.shape, tuple):
-                    return torch.rand(self.shape).to(
-                        dtype=self.dtype.to(torch.dtype, use_default=True)
-                    )
+                    shape = self.shape
+                    dtype = self.dtype.to(torch.dtype, use_default=True)
+                    if dtype.is_floating_point:
+                        return torch.rand(shape).to(dtype=dtype)
+                    else:
+                        # For integer types, use randint to get a better range of values for testing
+                        return torch.randint(-10, 10, shape, dtype=dtype)
                 else:
                     RuntimeError(
                         f"Input shape is dynamic but shapes are not provided as sequence (found: {self.shape})"
@@ -400,9 +404,13 @@ class Input(object):
                     )
 
                 if isinstance(self.shape, dict):
-                    return torch.rand(self.shape[optimization_profile_field]).to(
-                        dtype=self.dtype.to(torch.dtype, use_default=True)
-                    )
+                    shape = self.shape[optimization_profile_field]
+                    dtype = self.dtype.to(torch.dtype, use_default=True)
+                    if dtype.is_floating_point:
+                        return torch.rand(shape).to(dtype=dtype)
+                    else:
+                        # For integer types, use randint to get a better range of values for testing
+                        return torch.randint(-10, 10, shape, dtype=dtype)
                 else:
                     raise RuntimeError(
                         f"Input shape is dynamic but shapes are not provided as dictionary (found: {self.shape})"
@@ -412,4 +420,3 @@ class Input(object):
                 raise ValueError(
                     "Requested an example tensor from a dynamic shaped input but did not specific which profile field to use."
                 )
-        raise

--- a/py/torch_tensorrt/dynamo/conversion/impl/elementwise/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/elementwise/ops.py
@@ -1,6 +1,6 @@
+import logging
 from typing import Optional, Union
 
-import numpy as np
 import tensorrt as trt
 import torch
 import torch_tensorrt.dynamo.conversion.impl as impl
@@ -15,6 +15,7 @@ from torch_tensorrt.dynamo.conversion.converter_utils import (
     cast_trt_tensor,
     get_trt_tensor,
     has_dynamic_shape,
+    set_layer_name,
 )
 from torch_tensorrt.dynamo.conversion.impl.elementwise.base import (
     convert_binary_elementwise,
@@ -22,6 +23,8 @@ from torch_tensorrt.dynamo.conversion.impl.elementwise.base import (
 from torch_tensorrt.dynamo.conversion.impl.unary import atan, sign
 from torch_tensorrt.dynamo.conversion.impl.unary.base import convert_unary
 from torch_tensorrt.fx.types import TRTTensor
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def trunc_div(
@@ -250,12 +253,26 @@ def atan2(
         A TensorRT tensor representing the result of the atan2 operation.
     """
     pi_value = 3.141592653589793
-    pi_tensor = get_trt_tensor(ctx, pi_value, f"{name}_pi")
 
-    if isinstance(input, TRTTensor):
-        input = cast_trt_tensor(ctx, input, trt.float32, f"{name}_input")
-    if isinstance(other, TRTTensor):
-        other = cast_trt_tensor(ctx, other, trt.float32, f"{name}_other")
+    promoted_type = _enums.dtype._from(
+        torch.promote_types(
+            _enums.dtype._from(input.dtype).to(torch.dtype),
+            _enums.dtype._from(other.dtype).to(torch.dtype),
+        )
+    )
+    # atan2's output is always float, so we promote any integer types to float32
+    # This mirrors PyTorch's behavior where atan2(int, int) -> float.
+    if not promoted_type.to(torch.dtype).is_floating_point:
+        promoted_type = _enums.dtype.float32
+
+    trt_promoted_type = promoted_type.to(trt.DataType)
+
+    pi_tensor = get_trt_tensor(ctx, pi_value, f"{name}_pi", dtype=trt_promoted_type)
+
+    if input.dtype != trt_promoted_type:
+        input = cast_trt_tensor(ctx, input, trt_promoted_type, f"{name}_input_casted")
+    if other.dtype != trt_promoted_type:
+        other = cast_trt_tensor(ctx, other, trt_promoted_type, f"{name}_other_casted")
 
     input, other = broadcast(ctx, input, other, f"{name}_input", f"{name}_other")
 
@@ -333,56 +350,43 @@ def atan2(
         y_positive,
     )
 
+    # Create constant tensors for boundary conditions (x=0 or y=0)
+    # Use impl.full which handles both dynamic and static shapes efficiently.
     if has_dynamic_shape(input.shape):
-        pi_over_2_tensor = convert_binary_elementwise(
-            ctx,
-            target,
-            source_ir,
-            f"{name}_pi_over_2_tensor",
-            trt.ElementWiseOperation.PROD,
-            (pi_value / 2),
-            input,
-        )
-
-        minus_pi_over_2_tensor = convert_binary_elementwise(
-            ctx,
-            target,
-            source_ir,
-            f"{name}_minus_pi_over_2_tensor",
-            trt.ElementWiseOperation.PROD,
-            (-pi_value / 2),
-            input,
-        )
-        zero_tensor = convert_binary_elementwise(
-            ctx,
-            target,
-            source_ir,
-            f"{name}_zero_tensor",
-            trt.ElementWiseOperation.PROD,
-            0,
-            input,
-        )
+        shape_layer = ctx.net.add_shape(input)
+        set_layer_name(shape_layer, target, f"{name}_shape", source_ir)
+        shape = shape_layer.get_output(0)
     else:
-        # on x or y-axis
-        pi_over_2_tensor = get_trt_tensor(
-            ctx,
-            (pi_value / 2) * np.ones(input.shape, dtype=np.float32),
-            f"{name}_pi_over_2_tensor",
-            dtype=trt.float32,
-        )
+        shape = list(input.shape)
 
-        minus_pi_over_2_tensor = get_trt_tensor(
-            ctx,
-            (-pi_value / 2) * np.ones(input.shape, dtype=np.float32),
-            f"{name}_minus_pi_over_2_tensor",
-            dtype=trt.float32,
-        )
-        zero_tensor = get_trt_tensor(
-            ctx,
-            np.zeros(input.shape, dtype=np.float32),
-            f"{name}_zero_tensor",
-            dtype=trt.float32,
-        )
+    pi_over_2_tensor = impl.full.full(
+        ctx,
+        target,
+        source_ir,
+        f"{name}_pi_over_2_tensor",
+        shape,
+        pi_value / 2,
+        dtype=trt_promoted_type,
+    )
+
+    minus_pi_over_2_tensor = impl.full.full(
+        ctx,
+        target,
+        source_ir,
+        f"{name}_minus_pi_over_2_tensor",
+        shape,
+        -pi_value / 2,
+        dtype=trt_promoted_type,
+    )
+    zero_tensor = impl.full.full(
+        ctx,
+        target,
+        source_ir,
+        f"{name}_zero_tensor",
+        shape,
+        0.0,
+        dtype=trt_promoted_type,
+    )
 
     # π/2 if x>0 and y=0,
     pi_over_2_output = impl.condition.select(

--- a/py/torch_tensorrt/dynamo/conversion/impl/full.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/full.py
@@ -34,7 +34,8 @@ def full(
         # in static shape scenario, shape is a list of int
         if all(isinstance(dim, int) for dim in shape):
             output_np_dtype = output_dtype.try_to(np.dtype, use_default=True)
-            return np.full(shape, fill_value, dtype=output_np_dtype)
+            np_array = np.full(shape, fill_value, dtype=output_np_dtype)
+            return get_trt_tensor(ctx, np_array, name, dtype=output_dtype)
         else:
             shape = impl.cat.cat(
                 ctx, target, source_ir, name + "_concat_shape", shape, 0


### PR DESCRIPTION
# Description

- Removed forced float32 casting in the `atan2` converter.
- Fixed a bug in the dynamic shape logic for `atan2`: previously used `π/2 * input` instead of creating a constant tensor filled with `π/2`. This only passed tests because the input was zero.
- Note: Replaced `torch.rand()` with `torch.randint()` for integer inputs in dynamic shape tests — this change may affect other converters using integer dynamic inputs.

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
