### PR TITLE
fix: batch norm issue encountered in RAFT

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -127,6 +127,33 @@ def aten_ops_batch_norm_legit_no_training(
 
 
 @dynamo_tensorrt_converter(
+    torch.ops.aten._native_batch_norm_legit.no_stats,
+    capability_validator=one_user_validator,
+    supports_dynamic_shapes=True,
+)
+def aten_ops_batch_norm_legit_no_stats(
+    ctx: ConversionContext,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    return impl.normalization.batch_norm(
+        ctx,
+        target,
+        SourceIR.ATEN,
+        name,
+        input=args[0],
+        weight=args[1],
+        bias=args[2],
+        training=False,
+        momentum=args[4],
+        eps=args[5],
+        return_mean_rstd=True,
+    )
+
+
+@dynamo_tensorrt_converter(
     torch.ops.aten.native_layer_norm.default,
     supports_dynamic_shapes=True,
 )

--- a/py/torch_tensorrt/dynamo/conversion/converter_utils.py
+++ b/py/torch_tensorrt/dynamo/conversion/converter_utils.py
@@ -19,11 +19,10 @@ from typing import (
 import numpy as np
 import tensorrt as trt
 import torch
+import torch_tensorrt.dynamo.conversion.impl as impl
 from torch.fx.experimental.proxy_tensor import unset_fake_temporarily
 from torch.fx.node import Argument, Target
 from torch.fx.passes.shape_prop import TensorMetadata
-
-import torch_tensorrt.dynamo.conversion.impl as impl
 from torch_tensorrt import _enums
 from torch_tensorrt.dynamo._settings import CompilationSettings
 from torch_tensorrt.dynamo._SourceIR import SourceIR
@@ -345,7 +344,7 @@ def to_trt_weights(
     count: Optional[int] = None,
 ) -> trt.Weights:
     """
-    Convert a PyTorch tensor or NumPy array to TensorRT weights.
+    Convert a PyTorch tensor to TensorRT weights.
 
     Args:
         value (Union[torch.Tensor, np.ndarray]): The tensor or array to convert to TRT weights

--- a/py/torch_tensorrt/dynamo/lowering/_decomposition_groups.py
+++ b/py/torch_tensorrt/dynamo/lowering/_decomposition_groups.py
@@ -91,7 +91,6 @@ torch_enabled_decompositions: Set[Union[OpOverload, OpOverloadPacket]] = {
     aten.narrow,
     # TODO: Disable the below operators once freezing is done
     aten.native_batch_norm_backward,
-    aten._native_batch_norm_legit,
     aten._native_batch_norm_legit_functional,
     aten.native_dropout_backward,
     aten.native_group_norm_backward,


### PR DESCRIPTION
# Description

Pytorch decomposes `torch.ops.aten._native_batch_norm_legit.no_stats` into a bunch of aten ops, which makes it way slow. See the issue below for details.

Fixes #3731 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
