### PR TITLE
feat: support dynamics for all inputs for embedding_bag converter

### DIFF
--- a/tests/py/dynamo/conversion/test_embedding_bag_aten.py
+++ b/tests/py/dynamo/conversion/test_embedding_bag_aten.py
@@ -438,16 +438,20 @@ class TestEmbeddingBagConverter(DispatchTestCase):
                 weights=torch.randn((5, 2), dtype=torch.float32),
                 # weights_1 is for inference
                 weights_1=torch.randn((6, 3), dtype=torch.float32),
+                indices=torch.tensor([1, 2, 4, 2, 3, 4], dtype=torch.int32),
+                offsets=torch.tensor([0, 2, 4], dtype=torch.int32),
                 dynamic_shapes={
                     "weights": {
                         0: torch.export.Dim("dyn_dim", min=2, max=8),
                         1: torch.export.Dim("dyn_dim_1", min=1, max=3),
                     },
-                    "indices": {},
-                    "offsets": {},
+                    "indices": {
+                        0: torch.export.Dim("dyn_dim_in", min=2, max=32),
+                    },
+                    "offsets": {
+                        0: torch.export.Dim("dyn_dim_off", min=2, max=32),
+                    },
                 },
-                indices=torch.tensor([1, 2, 4, 2, 3, 4], dtype=torch.int32),
-                offsets=torch.tensor([0, 2, 4], dtype=torch.int32),
                 mode=1,
                 per_sample_weights=None,
             ),


### PR DESCRIPTION
# Description

The existing implementation only supports `weights` to be dynamic. In this PR, all dims of all inputs including `weights`, `indices`, and `offsets` are supported to be dynamic.

Fixes #3683

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
