### PR TITLE
fix: torchtrtc precision setting logic

### DIFF
--- a/cpp/bin/torchtrtc/main.cpp
+++ b/cpp/bin/torchtrtc/main.cpp
@@ -356,6 +356,7 @@ int main(int argc, char** argv) {
   }
 
   if (enabled_precisions) {
+    compile_settings.enabled_precisions.clear();
     for (const auto& precision : args::get(enabled_precisions)) {
       auto dtype = torchtrtc::parserutil::parse_dtype(precision);
       if (dtype == torchtrt::DataType::kFloat) {


### PR DESCRIPTION
# Description

Ensures that `torchtrtc` precision settings do not always contain a default `fp32` precision when the precision is explicitly passed as an argument. This is particularly important when compiling a model to run on the DLA which does not allow `fp32` precision. Currently this must not have been possible to do with the `torchtrtc` cli.

Bug example:
```
torchtrtc ssd_traced.jit.pt ssd_trt_dla.ts "(1,3,300,300)@f16%contiguous" -p fp16 --device-type=dla -v
...
INFO: Settings requested for TensorRT engine:
    Enabled Precisions: Float32 Float16
    TF32 Floating Point Computation Enabled: 1
    Truncate Long and Double: 0
    Make Refittable Engine: 0
    Debuggable Engine: 0
    GPU ID: 0
    Allow GPU Fallback (if running on DLA): 0
    Avg Timing Iterations: 1
    Max Workspace Size: 0
    DLA SRAM Size: 1048576
    DLA Local DRAM Size: 1073741824
    DLA Global DRAM Size: 536870912
    Device Type: DLA
    GPU ID: 0
    DLACore: 0
    Engine Capability: standard
    Calibrator Created: 0
```
This should only report `Float16` enabled precision.

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
