### PR TITLE
Adding rank based logging for torch distributed examples

### DIFF
--- a/examples/distributed_inference/tensor_parallel_initialize_dist.py
+++ b/examples/distributed_inference/tensor_parallel_initialize_dist.py
@@ -48,7 +48,9 @@ def initialize_logger(
 
     # console handler
     ch = logging.StreamHandler()
-    ch.setLevel(console_level)  # Console handler controls what's printed in console output
+    ch.setLevel(
+        console_level
+    )  # Console handler controls what's printed in console output
     ch.setFormatter(logging.Formatter(f"[Rank {rank}] %(levelname)s: %(message)s"))
     logger.addHandler(ch)
 
@@ -123,21 +125,12 @@ def initialize_distributed_env(
     torch.cuda.set_device(device_id)
 
     # Set C++ TensorRT runtime log level based on most verbose handler
-    # this is similar to set_log_level()
+    # Use the most verbose level to ensure all important logs are captured
     cpp_level = min(file_level_int, console_level_int)
     try:
-        import tensorrt as trt
-        from torch_tensorrt._features import ENABLED_FEATURES
+        import torch_tensorrt.logging as torchtrt_logging
 
-        if ENABLED_FEATURES.torch_tensorrt_runtime:
-            if cpp_level == logging.DEBUG:
-                torch.ops.tensorrt.set_logging_level(int(trt.ILogger.Severity.VERBOSE))
-            elif cpp_level == logging.INFO:
-                torch.ops.tensorrt.set_logging_level(int(trt.ILogger.Severity.INFO))
-            elif cpp_level == logging.WARNING:
-                torch.ops.tensorrt.set_logging_level(int(trt.ILogger.Severity.WARNING))
-            else:
-                torch.ops.tensorrt.set_logging_level(int(trt.ILogger.Severity.ERROR))
+        torchtrt_logging.set_level(cpp_level)
     except Exception as e:
         logger.warning(f"Could not set C++ TensorRT log level: {e}")
 

--- a/py/torch_tensorrt/_features.py
+++ b/py/torch_tensorrt/_features.py
@@ -78,6 +78,25 @@ def _enabled_features_str() -> str:
     return out_str
 
 
+# Inline helper functions for checking feature availability
+def has_torch_tensorrt_runtime() -> bool:
+    """Check if Torch-TensorRT C++ runtime is available.
+
+    Returns:
+        bool: True if libtorchtrt_runtime.so or libtorchtrt.so is available
+    """
+    return bool(ENABLED_FEATURES.torch_tensorrt_runtime)
+
+
+def has_torchscript_frontend() -> bool:
+    """Check if TorchScript frontend is available.
+
+    Returns:
+        bool: True if libtorchtrt.so is available
+    """
+    return bool(ENABLED_FEATURES.torchscript_frontend)
+
+
 def needs_tensorrt_rtx(f: Callable[..., Any]) -> Callable[..., Any]:
     def wrapper(*args: List[Any], **kwargs: Dict[str, Any]) -> Any:
         if ENABLED_FEATURES.tensorrt_rtx:
@@ -180,6 +199,7 @@ def needs_trtllm_for_nccl(f: Callable[..., Any]) -> Callable[..., Any]:
         if ENABLED_FEATURES.trtllm_for_nccl:
             return f(*args, **kwargs)
         else:
+
             def not_implemented(*args: List[Any], **kwargs: Dict[str, Any]) -> Any:
                 raise NotImplementedError(
                     "TensorRT-LLM plugin for NCCL is not available"

--- a/py/torch_tensorrt/dynamo/backend/backends.py
+++ b/py/torch_tensorrt/dynamo/backend/backends.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Sequence
 
 import torch
 import torch._dynamo as td
+import torch_tensorrt.logging as torchtrt_logging
 from torch._dynamo.backends.common import aot_autograd
 from torch._dynamo.utils import detect_fake_mode
 from torch._functorch.aot_autograd import aot_export_joint_simple
@@ -23,7 +24,6 @@ from torch_tensorrt.dynamo.lowering import (
 from torch_tensorrt.dynamo.utils import (
     parse_dynamo_kwargs,
     prepare_inputs,
-    set_log_level,
 )
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ def torch_tensorrt_backend(
         and "debug" in kwargs["options"]
         and kwargs["options"]["debug"]
     ) or ("debug" in kwargs and kwargs["debug"]):
-        set_log_level(logger.parent, logging.DEBUG)
+        torchtrt_logging.set_level(logging.DEBUG)
 
     DEFAULT_BACKEND = aot_torch_tensorrt_aten_backend
 

--- a/py/torch_tensorrt/dynamo/conversion/custom_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/custom_ops_converters.py
@@ -5,7 +5,7 @@ from typing import Dict, Sequence, Tuple, Union
 
 import tensorrt as trt
 from torch.fx.node import Argument, Target
-from torch_tensorrt._features import needs_trtllm_for_nccl
+from torch_tensorrt._features import ENABLED_FEATURES
 from torch_tensorrt.dynamo._SourceIR import SourceIR
 from torch_tensorrt.dynamo.conversion import impl
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
@@ -20,37 +20,53 @@ from torch_tensorrt.dynamo.lowering.passes.fuse_distributed_ops import (
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
-@needs_trtllm_for_nccl
-@dynamo_tensorrt_converter(tensorrt_fused_nccl_all_gather_op)
-def fused_nccl_gather(
-    ctx: ConversionContext,
-    target: Target,
-    args: Tuple[Argument, ...],
-    kwargs: Dict[str, Argument],
-    name: str,
-) -> Union[trt.ITensor, Sequence[trt.ITensor]]:
-    return impl.nccl_ops.nccl_gather(
-        ctx,
-        target,
-        SourceIR.ATEN,
-        name,
-        [args[0]],
+# Conditionally register NCCL converters only if TensorRT-LLM plugin is available.
+# We use an `if` statement instead of @needs_trtllm_for_nccl decorator because
+# @dynamo_tensorrt_converter ALWAYS registers at import time regardless of decorator
+# order. Conditional registration prevents registration when TRTLLM is unavailable,
+# allowing fallback to PyTorch execution for NCCL ops.
+
+# Order 1: @needs_trtllm_for_nccl followed by registering the converter leads to plugin registry not finding nccl ops plugins since we register the bare converter, without the decorator
+# Order 2: registering the converter first followed by @needs_trtllm_for_nccl leads to  "NotImplementedError: TensorRT-LLM plugin for NCCL is not available :TensorRT-LLM plugin for NCCL is not available" and no fall back to pytorch
+if ENABLED_FEATURES.trtllm_for_nccl:
+    _LOGGER.debug(
+        "TensorRT-LLM plugin for NCCL is available. Registering NCCL converters."
     )
 
+    @dynamo_tensorrt_converter(tensorrt_fused_nccl_all_gather_op)
+    def fused_nccl_gather(
+        ctx: ConversionContext,
+        target: Target,
+        args: Tuple[Argument, ...],
+        kwargs: Dict[str, Argument],
+        name: str,
+    ) -> Union[trt.ITensor, Sequence[trt.ITensor]]:
+        return impl.nccl_ops.nccl_gather(
+            ctx,
+            target,
+            SourceIR.ATEN,
+            name,
+            [args[0]],
+        )
 
-@needs_trtllm_for_nccl
-@dynamo_tensorrt_converter(tensorrt_fused_nccl_reduce_scatter_op)
-def fused_nccl_reduce_scatter(
-    ctx: ConversionContext,
-    target: Target,
-    args: Tuple[Argument, ...],
-    kwargs: Dict[str, Argument],
-    name: str,
-) -> Union[trt.ITensor, Sequence[trt.ITensor]]:
-    return impl.nccl_ops.nccl_reduce_scatter(
-        ctx,
-        target,
-        SourceIR.ATEN,
-        name,
-        [args[0]],
+    @dynamo_tensorrt_converter(tensorrt_fused_nccl_reduce_scatter_op)
+    def fused_nccl_reduce_scatter(
+        ctx: ConversionContext,
+        target: Target,
+        args: Tuple[Argument, ...],
+        kwargs: Dict[str, Argument],
+        name: str,
+    ) -> Union[trt.ITensor, Sequence[trt.ITensor]]:
+        return impl.nccl_ops.nccl_reduce_scatter(
+            ctx,
+            target,
+            SourceIR.ATEN,
+            name,
+            [args[0]],
+        )
+
+else:
+    _LOGGER.info(
+        "TensorRT-LLM plugin for NCCL is not available. "
+        "NCCL operations will fall back to PyTorch execution."
     )

--- a/py/torch_tensorrt/dynamo/utils.py
+++ b/py/torch_tensorrt/dynamo/utils.py
@@ -28,7 +28,6 @@ from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx.experimental.proxy_tensor import unset_fake_temporarily
 from torch_tensorrt._Device import Device
 from torch_tensorrt._enums import dtype
-from torch_tensorrt._features import ENABLED_FEATURES
 from torch_tensorrt._Input import Input
 from torch_tensorrt._utils import is_tensorrt_version_supported
 from torch_tensorrt.dynamo import _defaults
@@ -268,33 +267,6 @@ def get_model_device(module: torch.fx.GraphModule) -> torch.device:
         device = to_torch_device(default_device())
 
     return device
-
-
-def set_log_level(parent_logger: Any, level: Any) -> None:
-    """
-    Sets the log level to the user provided level.
-    This is used to set debug logging at a global level
-    at entry points of tracing, dynamo and torch_compile compilation.
-    And set log level for c++ torch trt logger if runtime is available.
-    """
-    if parent_logger:
-        parent_logger.setLevel(level)
-
-    if ENABLED_FEATURES.torch_tensorrt_runtime:
-        if level == logging.DEBUG:
-            log_level = trt.ILogger.Severity.VERBOSE
-        elif level == logging.INFO:
-            log_level = trt.ILogger.Severity.INFO
-        elif level == logging.WARNING:
-            log_level = trt.ILogger.Severity.WARNING
-        elif level == logging.ERROR:
-            log_level = trt.ILogger.Severity.ERROR
-        elif level == logging.CRITICAL:
-            log_level = trt.ILogger.Severity.INTERNAL_ERROR
-        else:
-            raise AssertionError(f"{level} is not valid log level")
-
-        torch.ops.tensorrt.set_logging_level(int(log_level))
 
 
 def prepare_inputs(

--- a/py/torch_tensorrt/logging.py
+++ b/py/torch_tensorrt/logging.py
@@ -3,7 +3,10 @@ from typing import Any
 
 import tensorrt as trt
 import torch
-from torch_tensorrt._features import ENABLED_FEATURES
+from torch_tensorrt._features import (
+    has_torch_tensorrt_runtime,
+    has_torchscript_frontend,
+)
 
 logging.captureWarnings(True)
 _LOGGER = logging.getLogger("torch_tensorrt [TensorRT Conversion Context]")
@@ -31,6 +34,81 @@ class _TRTLogger(trt.ILogger):  # type: ignore[misc]
 TRT_LOGGER = _TRTLogger()
 
 
+def set_level(level: int, logger: Any = None) -> None:
+    """Set log level for both Python and C++ torch_tensorrt loggers.
+
+    Permanently sets the log level until changed again or process exits.
+    Automatically handles runtime availability checks.
+
+    This sets the log level for:
+    - Specified Python logger (or root torch_tensorrt logger if None)
+    - TorchScript frontend C++ logger (if available)
+    - Dynamo runtime C++ logger (if available)
+
+    Args:
+        level: Python logging level (logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL)
+        logger: Optional logger to set level for. If None, sets the root torch_tensorrt logger.
+
+    Example:
+
+        # Set debug logging for entire session
+        torch_tensorrt.logging.set_level(logging.DEBUG)
+
+        # Or set for a specific logger
+        my_logger = logging.getLogger("torch_tensorrt.dynamo")
+        torch_tensorrt.logging.set_level(logging.DEBUG, logger=my_logger)
+    """
+    # Set the specified logger or default to root torch_tensorrt logger
+    if logger is None:
+        logging.getLogger("torch_tensorrt").setLevel(level)
+        _LOGGER.setLevel(level)
+    else:
+        logger.setLevel(level)
+
+    if has_torchscript_frontend():
+        from torch_tensorrt.ts import logging as ts_logging
+
+        if level == logging.CRITICAL:
+            ts_logging.set_reportable_log_level(ts_logging.Level.InternalError)
+        elif level == logging.ERROR:
+            ts_logging.set_reportable_log_level(ts_logging.Level.Error)
+        elif level == logging.WARNING:
+            ts_logging.set_reportable_log_level(ts_logging.Level.Warning)
+        elif level == logging.INFO:
+            ts_logging.set_reportable_log_level(ts_logging.Level.Info)
+        elif level == logging.DEBUG:
+            ts_logging.set_reportable_log_level(ts_logging.Level.Debug)
+        elif level == logging.NOTSET:
+            ts_logging.set_reportable_log_level(ts_logging.Level.Graph)
+        else:
+            raise ValueError(
+                f"Invalid log level: {level}. Must be one of: "
+                f"logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL, logging.NOTSET"
+            )
+
+    elif has_torch_tensorrt_runtime():
+        if level == logging.CRITICAL:
+            torch.ops.tensorrt.set_logging_level(
+                int(trt.ILogger.Severity.INTERNAL_ERROR)
+            )
+        elif level == logging.ERROR:
+            torch.ops.tensorrt.set_logging_level(int(trt.ILogger.Severity.ERROR))
+        elif level == logging.WARNING:
+            torch.ops.tensorrt.set_logging_level(int(trt.ILogger.Severity.WARNING))
+        elif level == logging.INFO:
+            torch.ops.tensorrt.set_logging_level(int(trt.ILogger.Severity.INFO))
+        elif level == logging.DEBUG:
+            torch.ops.tensorrt.set_logging_level(int(trt.ILogger.Severity.VERBOSE))
+        elif level == logging.NOTSET:
+            # Graph level (most verbose)
+            torch.ops.tensorrt.set_logging_level(int(trt.ILogger.Severity.VERBOSE) + 1)
+        else:
+            raise ValueError(
+                f"Invalid log level: {level}. Must be one of: "
+                f"logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL, logging.NOTSET"
+            )
+
+
 class internal_errors:
     """Context-manager to limit displayed log messages to just internal errors
 
@@ -46,13 +124,13 @@ class internal_errors:
         self.external_lvl = _LOGGER.getEffectiveLevel()
         _LOGGER.setLevel(logging.CRITICAL)
 
-        if ENABLED_FEATURES.torchscript_frontend:
+        if has_torchscript_frontend():
             from torch_tensorrt.ts import logging as ts_logging
 
             self.ts_level = ts_logging.get_reportable_log_level()
             ts_logging.set_reportable_log_level(ts_logging.Level.InternalError)
 
-        elif ENABLED_FEATURES.torch_tensorrt_runtime:
+        elif has_torch_tensorrt_runtime():
             self.rt_level = torch.ops.tensorrt.get_logging_level()
             torch.ops.tensorrt.set_logging_level(
                 int(trt.ILogger.Severity.INTERNAL_ERROR)
@@ -61,12 +139,12 @@ class internal_errors:
     def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
         _LOGGER.setLevel(self.external_lvl)
 
-        if ENABLED_FEATURES.torchscript_frontend:
+        if has_torchscript_frontend():
             from torch_tensorrt.ts import logging as ts_logging
 
             ts_logging.set_reportable_log_level(self.ts_level)
 
-        elif ENABLED_FEATURES.torch_tensorrt_runtime:
+        elif has_torch_tensorrt_runtime():
             torch.ops.tensorrt.set_logging_level(self.rt_level)
 
 
@@ -85,25 +163,25 @@ class errors:
         self.external_lvl = _LOGGER.getEffectiveLevel()
         _LOGGER.setLevel(logging.ERROR)
 
-        if ENABLED_FEATURES.torchscript_frontend:
+        if has_torchscript_frontend():
             from torch_tensorrt.ts import logging as ts_logging
 
             self.ts_level = ts_logging.get_reportable_log_level()
             ts_logging.set_reportable_log_level(ts_logging.Level.Error)
 
-        elif ENABLED_FEATURES.torch_tensorrt_runtime:
+        elif has_torch_tensorrt_runtime():
             self.rt_level = torch.ops.tensorrt.get_logging_level()
             torch.ops.tensorrt.set_logging_level(int(trt.ILogger.Severity.ERROR))
 
     def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
         _LOGGER.setLevel(self.external_lvl)
 
-        if ENABLED_FEATURES.torchscript_frontend:
+        if has_torchscript_frontend():
             from torch_tensorrt.ts import logging as ts_logging
 
             ts_logging.set_reportable_log_level(self.ts_level)
 
-        elif ENABLED_FEATURES.torch_tensorrt_runtime:
+        elif has_torch_tensorrt_runtime():
             torch.ops.tensorrt.set_logging_level(self.rt_level)
 
 
@@ -122,25 +200,25 @@ class warnings:
         self.external_lvl = _LOGGER.getEffectiveLevel()
         _LOGGER.setLevel(logging.WARNING)
 
-        if ENABLED_FEATURES.torchscript_frontend:
+        if has_torchscript_frontend():
             from torch_tensorrt.ts import logging as ts_logging
 
             self.ts_level = ts_logging.get_reportable_log_level()
             ts_logging.set_reportable_log_level(ts_logging.Level.Warning)
 
-        elif ENABLED_FEATURES.torch_tensorrt_runtime:
+        elif has_torch_tensorrt_runtime():
             self.rt_level = torch.ops.tensorrt.get_logging_level()
             torch.ops.tensorrt.set_logging_level(int(trt.ILogger.Severity.WARNING))
 
     def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
         _LOGGER.setLevel(self.external_lvl)
 
-        if ENABLED_FEATURES.torchscript_frontend:
+        if has_torchscript_frontend():
             from torch_tensorrt.ts import logging as ts_logging
 
             ts_logging.set_reportable_log_level(self.ts_level)
 
-        elif ENABLED_FEATURES.torch_tensorrt_runtime:
+        elif has_torch_tensorrt_runtime():
             torch.ops.tensorrt.set_logging_level(self.rt_level)
 
 
@@ -159,25 +237,25 @@ class info:
         self.external_lvl = _LOGGER.getEffectiveLevel()
         _LOGGER.setLevel(logging.INFO)
 
-        if ENABLED_FEATURES.torchscript_frontend:
+        if has_torchscript_frontend():
             from torch_tensorrt.ts import logging as ts_logging
 
             self.ts_level = ts_logging.get_reportable_log_level()
             ts_logging.set_reportable_log_level(ts_logging.Level.Info)
 
-        elif ENABLED_FEATURES.torch_tensorrt_runtime:
+        elif has_torch_tensorrt_runtime():
             self.rt_level = torch.ops.tensorrt.get_logging_level()
             torch.ops.tensorrt.set_logging_level(int(trt.ILogger.Severity.INFO))
 
     def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
         _LOGGER.setLevel(self.external_lvl)
 
-        if ENABLED_FEATURES.torchscript_frontend:
+        if has_torchscript_frontend():
             from torch_tensorrt.ts import logging as ts_logging
 
             ts_logging.set_reportable_log_level(self.ts_level)
 
-        elif ENABLED_FEATURES.torch_tensorrt_runtime:
+        elif has_torch_tensorrt_runtime():
             torch.ops.tensorrt.set_logging_level(self.rt_level)
 
 
@@ -196,25 +274,25 @@ class debug:
         self.external_lvl = _LOGGER.getEffectiveLevel()
         _LOGGER.setLevel(logging.DEBUG)
 
-        if ENABLED_FEATURES.torchscript_frontend:
+        if has_torchscript_frontend():
             from torch_tensorrt.ts import logging as ts_logging
 
             self.ts_level = ts_logging.get_reportable_log_level()
             ts_logging.set_reportable_log_level(ts_logging.Level.Debug)
 
-        elif ENABLED_FEATURES.torch_tensorrt_runtime:
+        elif has_torch_tensorrt_runtime():
             self.rt_level = torch.ops.tensorrt.get_logging_level()
             torch.ops.tensorrt.set_logging_level(int(trt.ILogger.Severity.VERBOSE))
 
     def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
         _LOGGER.setLevel(self.external_lvl)
 
-        if ENABLED_FEATURES.torchscript_frontend:
+        if has_torchscript_frontend():
             from torch_tensorrt.ts import logging as ts_logging
 
             ts_logging.set_reportable_log_level(self.ts_level)
 
-        elif ENABLED_FEATURES.torch_tensorrt_runtime:
+        elif has_torch_tensorrt_runtime():
             torch.ops.tensorrt.set_logging_level(self.rt_level)
 
 
@@ -234,23 +312,23 @@ class graphs:
         self.external_lvl = _LOGGER.getEffectiveLevel()
         _LOGGER.setLevel(logging.NOTSET)
 
-        if ENABLED_FEATURES.torchscript_frontend:
+        if has_torchscript_frontend():
             from torch_tensorrt.ts import logging as ts_logging
 
             self.ts_level = ts_logging.get_reportable_log_level()
             ts_logging.set_reportable_log_level(ts_logging.Level.Graph)
 
-        elif ENABLED_FEATURES.torch_tensorrt_runtime:
+        elif has_torch_tensorrt_runtime():
             self.rt_level = torch.ops.tensorrt.get_logging_level()
             torch.ops.tensorrt.set_logging_level(int(trt.ILogger.Severity.VERBOSE) + 1)
 
     def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
         _LOGGER.setLevel(self.external_lvl)
 
-        if ENABLED_FEATURES.torchscript_frontend:
+        if has_torchscript_frontend():
             from torch_tensorrt.ts import logging as ts_logging
 
             ts_logging.set_reportable_log_level(self.ts_level)
 
-        elif ENABLED_FEATURES.torch_tensorrt_runtime:
+        elif has_torch_tensorrt_runtime():
             torch.ops.tensorrt.set_logging_level(self.rt_level)

--- a/tests/py/dynamo/distributed/test_nccl_ops.py
+++ b/tests/py/dynamo/distributed/test_nccl_ops.py
@@ -26,6 +26,7 @@ from distributed_utils import (
 )
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt._features import ENABLED_FEATURES
 
 
 def is_distributed_nccl_available():
@@ -90,10 +91,14 @@ class DistributedReduceScatterModel(nn.Module):
 
 class TestNcclOpsConverter(DispatchTestCase):
     # 1. Skip if NCCL backend is not available (e.g., Windows, Jetson) - hard requirement
-    # 2. Don't skip if TRTLLM is unavailable (e.g., CUDA 13) - falls back to PyTorch
+    # 2. Skip if TRTLLM is unavailable (e.g., CUDA 13) - no converters registered
     @unittest.skipIf(
         not is_distributed_nccl_available(),
         "Skipped: NCCL backend is not available (Windows/Jetson Orin not supported).",
+    )
+    @unittest.skipIf(
+        not ENABLED_FEATURES.trtllm_for_nccl,
+        "Skipped: TensorRT-LLM plugin for NCCL is not available (e.g., CUDA 13).",
     )
     @classmethod
     def setUpClass(cls):

--- a/tests/py/dynamo/distributed/test_nccl_ops.py
+++ b/tests/py/dynamo/distributed/test_nccl_ops.py
@@ -45,6 +45,7 @@ def is_distributed_nccl_available():
     except (ImportError, AttributeError):
         return False
 
+
 if "OMPI_COMM_WORLD_SIZE" in os.environ:
     set_environment_variables_pytest_multi_process()
 else:
@@ -92,7 +93,7 @@ class TestNcclOpsConverter(DispatchTestCase):
     # 2. Don't skip if TRTLLM is unavailable (e.g., CUDA 13) - falls back to PyTorch
     @unittest.skipIf(
         not is_distributed_nccl_available(),
-        "Skipped: NCCL backend is not available (Windows/Jetson not supported).",
+        "Skipped: NCCL backend is not available (Windows/Jetson Orin not supported).",
     )
     @classmethod
     def setUpClass(cls):

--- a/tests/py/dynamo/distributed/test_nccl_ops.py
+++ b/tests/py/dynamo/distributed/test_nccl_ops.py
@@ -26,7 +26,24 @@ from distributed_utils import (
 )
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
-from torch_tensorrt._utils import is_platform_supported_for_trtllm
+
+
+def is_distributed_nccl_available():
+    """
+    Check if torch.distributed with NCCL backend is available.
+
+    Note: torch.distributed is available on Windows but NCCL backend is not.
+    NCCL (NVIDIA Collective Communications Library) is Linux/Unix only.
+    This function returns False on Windows, Jetson, and other platforms
+    where NCCL backend is not supported.
+    """
+    try:
+        import torch.distributed as dist
+
+        # Check if NCCL backend is available (False on Windows, since its gloo. For ORIN some torch distribution it is available
+        return dist.is_nccl_available()
+    except (ImportError, AttributeError):
+        return False
 
 if "OMPI_COMM_WORLD_SIZE" in os.environ:
     set_environment_variables_pytest_multi_process()
@@ -71,9 +88,11 @@ class DistributedReduceScatterModel(nn.Module):
 
 
 class TestNcclOpsConverter(DispatchTestCase):
+    # 1. Skip if NCCL backend is not available (e.g., Windows, Jetson) - hard requirement
+    # 2. Don't skip if TRTLLM is unavailable (e.g., CUDA 13) - falls back to PyTorch
     @unittest.skipIf(
-        not is_platform_supported_for_trtllm(),
-        "Skipped on Windows, Jetson and CUDA13: NCCL backend is not supported.",
+        not is_distributed_nccl_available(),
+        "Skipped: NCCL backend is not available (Windows/Jetson not supported).",
     )
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
This PR 
1. Adds rank based logging for the distributed examples
2. Corrects the fallback to pytorch case for NCCL converters
3. This with #3830 provides utilities for running distributed tensor parallel examples using torch.distributed