### PR TITLE
docgen: Fix building docs by switching to legacy pip resolver 

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -5,67 +5,66 @@ name: Generate Docs
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
-    push:
-        branches: [main]
+  push:
+    branches: [main]
 
 jobs:
-    build-docs:
-        runs-on: linux.g5.4xlarge.nvidia.gpu
-        if: ${{ ! contains(github.actor, 'pytorchbot') }}
-        environment: pytorchbot-env
-        container:
-            image: docker.io/pytorch/manylinux2_28-builder:cuda13.0
-            options: --gpus all
-        env:
-            CUDA_HOME: /usr/local/cuda-13.0
-            VERSION_SUFFIX: cu130
-            CU_VERSION: cu130
-            CHANNEL: nightly
-            CI_BUILD: 1
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  ref: ${{github.head_ref}}
-                  token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-            - name: Select Python / CUDA
-              run: |
-                  git config --global --add safe.directory /__w/TensorRT/TensorRT
-                  echo "/opt/python/cp311-cp311/bin/" >> $GITHUB_PATH
-
-            - name: Install base deps
-              run: |
-                  python3 -m pip install pip --upgrade
-                  python3 -m pip install pyyaml numpy torch --pre --extra-index-url https://download.pytorch.org/whl/nightly/cu130
-                  ./packaging/pre_build_script.sh
-            - name: Get HEAD SHA
-              id: vars
-              run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-            - name: Build Python Package
-              run: |
-                  python3 -m pip install --pre . --extra-index-url https://download.pytorch.org/whl/nightly/cu130
-            - name: Generate New Docs
-              run: |
-                  cd docsrc
-                  dnf clean all
-                  dnf makecache --refresh
-                  dnf install yum-utils -y
-                  dnf config-manager --set-enabled powertools
-                  dnf update --skip-broken --nobest -y
-                  dnf install -y doxygen pandoc
-                  python3 -m pip install -r requirements.txt
-                  python3 -c "import torch_tensorrt; print(torch_tensorrt.__version__)"
-                  make html
-                  cd ..
-            - uses: stefanzweifel/git-auto-commit-action@v4
-              with:
-                  # Required
-                  commit_message: "docs: [Automated] Regenerating documenation for ${{ steps.vars.outputs.sha }}"
-                  commit_options: "--no-verify --signoff"
-                  file_pattern: docs/
-                  commit_user_name: Torch-TensorRT Github Bot
-                  commit_user_email: torch-tensorrt.github.bot@nvidia.com
-                  commit_author: Torch-TensorRT Github Bot <torch-tensorrt.github.bot@nvidia.com>
+  build-docs:
+    runs-on: linux.g5.4xlarge.nvidia.gpu
+    if: ${{ ! contains(github.actor, 'pytorchbot') }}
+    environment: pytorchbot-env
+    container:
+      image: docker.io/pytorch/manylinux2_28-builder:cuda13.0
+      options: --gpus all
+    env:
+      CUDA_HOME: /usr/local/cuda-13.0
+      VERSION_SUFFIX: cu130
+      CU_VERSION: cu130
+      CHANNEL: nightly
+      CI_BUILD: 1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{github.head_ref}}
+          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+      - name: Select Python / CUDA
+        run: |
+          git config --global --add safe.directory /__w/TensorRT/TensorRT
+          echo "/opt/python/cp311-cp311/bin/" >> $GITHUB_PATH
+      - name: Install base deps
+        run: |
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pyyaml numpy torch --use-deprecated=legacy-resolver --pre --extra-index-url https://download.pytorch.org/whl/nightly/cu130
+          ./packaging/pre_build_script.sh
+      - name: Get HEAD SHA
+        id: vars
+        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Build Python Package
+        run: |
+          python3 -m pip install --use-deprecated=legacy-resolver --pre . --extra-index-url https://download.pytorch.org/whl/nightly/cu130
+      - name: Generate New Docs
+        run: |
+          cd docsrc
+          dnf clean all
+          dnf makecache --refresh
+          dnf install yum-utils -y
+          dnf config-manager --set-enabled powertools
+          dnf update --skip-broken --nobest -y
+          dnf install -y doxygen pandoc
+          python3 -m pip install -r requirements.txt
+          python3 -c "import torch_tensorrt; print(torch_tensorrt.__version__)"
+          make html
+          cd ..
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          # Required
+          commit_message: "docs: [Automated] Regenerating documenation for ${{ steps.vars.outputs.sha }}"
+          commit_options: "--no-verify --signoff"
+          file_pattern: docs/
+          commit_user_name: Torch-TensorRT Github Bot
+          commit_user_email: torch-tensorrt.github.bot@nvidia.com
+          commit_author: Torch-TensorRT Github Bot <torch-tensorrt.github.bot@nvidia.com>
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref_name }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true


### PR DESCRIPTION
# Description
Stale version of pytorch are getting installed when you use the pip dep resolver. Switches to the legacy version for max compatibility (only for documentation generation)  

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
