### PR TITLE
Fix a few CI issues

### DIFF
--- a/.github/pr-labels.yml
+++ b/.github/pr-labels.yml
@@ -1,57 +1,89 @@
 "component: torchtrtc":
-    - cpp/torchtrtc/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - cpp/torchtrtc/**/*
 
 "component: api [C++]":
-    - cpp/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - cpp/**/*
 
 "component: api [Python]":
-    - py/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - py/**/*
 
 "component: core":
-    - core/**/*
-    - py/torch_tensorrt/dynamo/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - core/**/*
+          - py/torch_tensorrt/dynamo/**/*
 
 "component: conversion":
-    - core/conversion/**/*
-    - py/torch_tensorrt/dynamo/conversion/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - core/conversion/**/*
+          - py/torch_tensorrt/dynamo/conversion/**/*
 
 "component: converters":
-    - core/conversion/converters/**/*
-    - py/torch_tensorrt/dynamo/conversion/impl/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - core/conversion/converters/**/*
+          - py/torch_tensorrt/dynamo/conversion/impl/**/*
 
 "component: evaluators":
-    - core/conversion/evaluators/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - core/conversion/evaluators/**/*
 
 "component: fx":
-    - py/torch_tensorrt/fx/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - py/torch_tensorrt/fx/**/*
 
 "component: dynamo":
-    - py/torch_tensorrt/dynamo/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - py/torch_tensorrt/dynamo/**/*
 
 "component: torch_compile":
-    - py/torch_tensorrt/dynamo/backend/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - py/torch_tensorrt/dynamo/backend/*
 
 "component: partitioning":
-    - core/partitioning/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - core/partitioning/**/*
 
 "component: runtime":
-    - core/runtime/**/*
-    - py/torch_tensorrt/dynamo/runtime/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - core/runtime/**/*
+          - py/torch_tensorrt/dynamo/runtime/**/*
 
 "component: lowering":
-    - core/lowering/**/*
-    - py/torch_tensorrt/dynamo/lowering/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - core/lowering/**/*
+          - py/torch_tensorrt/dynamo/lowering/**/*
 
 "component: tests":
-    - tests/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - tests/**/*
 
 "component: build system":
-    - MODULE.bazel
-    - BUILD
-    - pyproject.toml
-    - setup.py
-    - toolchain/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - MODULE.bazel
+          - BUILD
+          - pyproject.toml
+          - setup.py
+          - toolchain/**/*
 
 "documentation":
-    - docs/**/*
-    - docsrc/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**/*
+          - docsrc/**/*

--- a/.github/scripts/filter-matrix.py
+++ b/.github/scripts/filter-matrix.py
@@ -13,6 +13,8 @@ disabled_cuda_versions: List[str] = []
 # jetpack 6.2 only officially supports python 3.10 and cu126
 jetpack_python_versions: List[str] = ["3.10"]
 jetpack_cuda_versions: List[str] = ["cu126"]
+# rtx 1.2 currently only supports cu129 and cu130
+rtx_cuda_versions: List[str] = ["cu129", "cu130"]
 
 jetpack_container_image: str = "nvcr.io/nvidia/l4t-jetpack:r36.4.0"
 sbsa_container_image: str = "quay.io/pypa/manylinux_2_39_aarch64"
@@ -32,6 +34,7 @@ def filter_matrix_item(
     item: Dict[str, Any],
     is_jetpack: bool,
     limit_pr_builds: bool,
+    use_rtx: bool,
 ) -> bool:
     """Filter a single matrix item based on the build type and requirements."""
     if item["python_version"] in disabled_python_versions:
@@ -51,6 +54,10 @@ def filter_matrix_item(
             return True
         return False
     else:
+        if use_rtx:
+            if item["desired_cuda"] in rtx_cuda_versions:
+                return True
+            return False
         if item["gpu_arch_type"] == "cuda-aarch64":
             # pytorch image:pytorch/manylinuxaarch64-builder:cuda12.8 comes with glibc2.28
             # however, TensorRT requires glibc2.31 on aarch64 platform
@@ -85,6 +92,14 @@ def main(args: list[str]) -> None:
         default=os.getenv("LIMIT_PR_BUILDS", "false"),
     )
 
+    parser.add_argument(
+        "--use-rtx",
+        help="use rtx",
+        type=str,
+        choices=["true", "false"],
+        default="false",
+    )
+
     options = parser.parse_args(args)
     if options.matrix == "":
         raise ValueError("--matrix needs to be provided")
@@ -105,6 +120,7 @@ def main(args: list[str]) -> None:
             item,
             options.jetpack == "true",
             options.limit_pr_builds == "true",
+            options.use_rtx == "true",
         ):
             filtered_includes.append(item)
 

--- a/.github/workflows/build-test-linux-x86_64_rtx.yml
+++ b/.github/workflows/build-test-linux-x86_64_rtx.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           set -eou pipefail
           MATRIX_BLOB=${{ toJSON(needs.generate-matrix.outputs.matrix) }}
-          MATRIX_BLOB="$(python3 .github/scripts/filter-matrix.py --matrix "${MATRIX_BLOB}")"
+          MATRIX_BLOB="$(python3 .github/scripts/filter-matrix.py --use-rtx true --matrix "${MATRIX_BLOB}")"
           echo "${MATRIX_BLOB}"
           echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/build-test-windows_rtx.yml
+++ b/.github/workflows/build-test-windows_rtx.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           set -eou pipefail
           MATRIX_BLOB=${{ toJSON(needs.generate-matrix.outputs.matrix) }}
-          MATRIX_BLOB="$(python3 .github/scripts/filter-matrix.py --matrix "${MATRIX_BLOB}")"
+          MATRIX_BLOB="$(python3 .github/scripts/filter-matrix.py --use-rtx true --matrix "${MATRIX_BLOB}")"
           echo "${MATRIX_BLOB}"
           echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -15,6 +15,10 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout base branch
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
     - uses: actions/labeler@v6
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/uv-update.yml
+++ b/.github/workflows/uv-update.yml
@@ -5,8 +5,6 @@ on:
     # Every Monday at 03:00 UTC; adjust as needed
     - cron: "0 3 * * 1"
   push:
-    # to remvoe: test only
-    tags: [uv-update-v1]
     branches: [main]
     paths:
       - 'pyproject.toml'

--- a/tests/py/dynamo/models/test_models.py
+++ b/tests/py/dynamo/models/test_models.py
@@ -425,6 +425,10 @@ def test_resnet18_half(ir):
 
 
 @pytest.mark.unit
+@unittest.skipIf(
+    torch_trt.ENABLED_FEATURES.tensorrt_rtx,
+    "tensorrt_rtx does not support bfloat16",
+)
 def test_cosmos_true_div(ir):
     class CosmosLearnablePositionalEmbed(torch.nn.Module):
         def __init__(


### PR DESCRIPTION
# Description

1) pytorch upstream has added cu126, cu128 back, 
    since rtx does not support cu126, cu128, we need to filter it out
2) pr labeler schema change
3) rtx does not support bfloat16 so skip the test for it

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
