### PR TITLE
Fix the converter issue caused by this missing unset_fake_temporarily

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/converter_utils.py
+++ b/py/torch_tensorrt/dynamo/conversion/converter_utils.py
@@ -516,7 +516,8 @@ def get_trt_tensor(
     # If the input is 64-bit, cast it to 32-bit for TRT freezing
     if isinstance(input_val, torch.Tensor) and ctx.compilation_settings.truncate_double:
         if input_val.dtype == torch.float64:
-            input_val = input_val.to(torch.float32)
+            with unset_fake_temporarily():
+                input_val = input_val.to(torch.float32)
     elif isinstance(input_val, np.ndarray) and ctx.compilation_settings.truncate_double:
         if input_val.dtype == np.float64:
             input_val = input_val.astype(np.float32)


### PR DESCRIPTION
# Description

On torch.compile(Flux2Pipeline.from_pretrained("black-forest-labs/FLUX.2-dev", torch_dtype=torch.bfloat16).transformer), it will report RuntimeError: Cannot access data pointer of Tensor (e.g. FakeTensor, FunctionalTensor). the root cause is the missing unset_fake_temporarily on truncating the float64 data type.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project (You can use the linters)
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
