### PR TITLE
fix: remove refit validator

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -1088,16 +1088,8 @@ def aten_ops_slice(
     )
 
 
-def refit_validator(node: Node, settings: Optional[CompilationSettings] = None) -> bool:
-    # cumsum op is not refitable
-    if settings and not settings.immutable_weights:
-        return False
-    return True
-
-
 @dynamo_tensorrt_converter(
     torch.ops.aten.cumsum.default,
-    capability_validator=refit_validator,
     supports_dynamic_shapes=True,
 )
 @enforce_tensor_types(

--- a/tests/py/dynamo/conversion/test_cumsum_aten.py
+++ b/tests/py/dynamo/conversion/test_cumsum_aten.py
@@ -26,7 +26,7 @@ class TestCumsumConverter(DispatchTestCase):
         self.run_test(
             Cumsum(),
             inputs,
-            immutable_weights=True,
+            immutable_weights=False,
         )
 
     @parameterized.expand(
@@ -97,7 +97,7 @@ class TestCumsumConverter(DispatchTestCase):
         self.run_test_with_dynamic_shape(
             Cumsum(),
             inputs,
-            immutable_weights=True,
+            immutable_weights=False,
         )
 
 


### PR DESCRIPTION
# Description

Remove refit validator for supporting mutable weights for `cumsum` op.

Fixes #4053 

## Type of change


- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
