### PR TITLE
cache shape expressions for reexport 

### DIFF
--- a/core/runtime/TRTEngine.cpp
+++ b/core/runtime/TRTEngine.cpp
@@ -325,6 +325,10 @@ std::string TRTEngine::get_engine_layer_info() {
   return inspector->getEngineInformation(nvinfer1::LayerInformationFormat::kJSON);
 }
 
+std::string TRTEngine::get_serialized_metadata() {
+  return this->serialized_metadata;
+}
+
 std::vector<at::Tensor> TRTEngine::infer_outputs(std::vector<std::vector<int64_t>> input_shapes) {
   std::vector<at::Tensor> outputs;
   TORCHTRT_CHECK(

--- a/core/runtime/TRTEngine.h
+++ b/core/runtime/TRTEngine.h
@@ -158,6 +158,7 @@ struct TRTEngine : torch::CustomClassHolder {
   void set_profile_format(std::string profile_format);
   void disable_profiling();
   std::string get_engine_layer_info();
+  std::string get_serialized_metadata();
 
   void dump_engine_layer_info_to_file(const std::string& path);
   void dump_engine_layer_info();

--- a/core/runtime/register_jit_hooks.cpp
+++ b/core/runtime/register_jit_hooks.cpp
@@ -88,6 +88,7 @@ static auto TORCHTRT_UNUSED TRTEngineTSRegistrtion =
         .def("dump_engine_layer_info_to_file", &TRTEngine::dump_engine_layer_info_to_file)
         .def("dump_engine_layer_info", &TRTEngine::dump_engine_layer_info)
         .def("get_engine_layer_info", &TRTEngine::get_engine_layer_info)
+        .def("get_serialized_metadata", &TRTEngine::get_serialized_metadata)
         .def("infer_outputs", &TRTEngine::infer_outputs)
         .def("reset_captured_graph", &TRTEngine::reset_captured_graph)
         .def("set_output_tensors_as_unowned", &TRTEngine::set_output_tensors_as_unowned)

--- a/examples/dynamo/save_dynamic_shapes_both_methods.py
+++ b/examples/dynamo/save_dynamic_shapes_both_methods.py
@@ -1,0 +1,172 @@
+"""
+.. _save_dynamic_shapes_both_methods:
+
+Saving Models with Dynamic Shapes - Both Methods
+=================================================
+
+This example demonstrates BOTH methods for saving Torch-TensorRT compiled models
+with dynamic input shapes:
+
+1. **Method 1**: Using torch.export.Dim (explicit dynamic_shapes parameter)
+2. **Method 2**: Using torch_tensorrt.Input with min/opt/max (automatic inference)
+
+"""
+
+# %%
+# Imports and Model Definition
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+import tempfile
+
+import torch
+import torch.nn as nn
+import torch_tensorrt
+
+
+# %%
+# Define a simple model
+class SimpleModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(10, 5)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+model = SimpleModel().eval().cuda()
+
+# %%
+# Method 1: Explicit dynamic_shapes with torch.export.Dim
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# This follows torch.export's API pattern
+
+example_input = torch.randn(4, 10).cuda()
+
+# Define dynamic dimension explicitly
+dyn_batch = torch.export.Dim("batch", min=1, max=32)
+dynamic_shapes = {"x": {0: dyn_batch}}
+
+# Export with dynamic shapes
+exp_program = torch.export.export(
+    model, (example_input,), dynamic_shapes=dynamic_shapes, strict=False
+)
+
+# Compile with TensorRT
+trt_module_method1 = torch_tensorrt.dynamo.compile(
+    exp_program,
+    inputs=[
+        torch_tensorrt.Input(
+            min_shape=(1, 10),
+            opt_shape=(8, 10),
+            max_shape=(32, 10),
+            dtype=torch.float32,
+        )
+    ],
+    enabled_precisions={torch.float32},
+    min_block_size=1,
+)
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    save_path = f"{tmpdir}/model_method1.ep"
+
+    # Save with explicit dynamic_shapes parameter
+    torch_tensorrt.save(
+        trt_module_method1,
+        save_path,
+        output_format="exported_program",
+        arg_inputs=[example_input],
+        dynamic_shapes=dynamic_shapes,  # Explicit!
+        retrace=True,
+    )
+
+    # Load and test
+    loaded_model = torch_tensorrt.load(save_path).module()
+    output_bs4 = loaded_model(torch.randn(4, 10).cuda())
+    output_bs16 = loaded_model(torch.randn(16, 10).cuda())
+
+
+# %%
+# Method 2: Automatic inference from torch_tensorrt.Input
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+# Redefine model for fresh compile
+model2 = SimpleModel().eval().cuda()
+
+inputs = [
+    torch_tensorrt.Input(
+        min_shape=(1, 10),
+        opt_shape=(8, 10),
+        max_shape=(32, 10),
+        dtype=torch.float32,
+        name="x",
+    )
+]
+
+# Compile directly with torch_tensorrt.compile
+trt_module_method2 = torch_tensorrt.compile(model2, ir="dynamo", inputs=inputs)
+
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    save_path = f"{tmpdir}/model_method2.ep"
+
+    # Save with Input objects - dynamic_shapes inferred automatically!
+    # No need to specify dynamic_shapes explicitly
+    torch_tensorrt.save(
+        trt_module_method2,
+        save_path,
+        output_format="exported_program",
+        arg_inputs=inputs,  # Pass the same Input objects used for compile
+        retrace=True,
+    )
+
+    # Load and test
+    loaded_model = torch_tensorrt.load(save_path).module()
+    output_bs4 = loaded_model(torch.randn(4, 10).cuda())
+    output_bs16 = loaded_model(torch.randn(16, 10).cuda())
+
+
+# %%
+# Multiple Dynamic Dimensions Example
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+class ConvModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 16, 3, padding=1)
+
+    def forward(self, x):
+        return self.conv(x)
+
+
+model3 = ConvModel().eval().cuda()
+
+# Multiple dynamic dimensions: batch, height, width
+inputs_multi = [
+    torch_tensorrt.Input(
+        min_shape=(1, 3, 64, 64),
+        opt_shape=(8, 3, 256, 256),
+        max_shape=(16, 3, 512, 512),
+        dtype=torch.float32,
+        name="image",
+    )
+]
+
+trt_module_multi = torch_tensorrt.compile(model3, ir="dynamo", inputs=inputs_multi)
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    save_path = f"{tmpdir}/model_multi_dim.ep"
+
+    torch_tensorrt.save(
+        trt_module_multi,
+        save_path,
+        arg_inputs=inputs_multi,  # Automatically infers all 3 dynamic dims!
+        retrace=True,
+    )
+
+    loaded_model = torch_tensorrt.load(save_path).module()
+
+    # Test with different shapes
+    out1 = loaded_model(torch.randn(4, 3, 128, 128).cuda())
+    out2 = loaded_model(torch.randn(12, 3, 384, 384).cuda())

--- a/examples/dynamo/save_dynamic_shapes_example.py
+++ b/examples/dynamo/save_dynamic_shapes_example.py
@@ -1,0 +1,183 @@
+"""
+.. _save_dynamic_shapes:
+
+Saving and Loading Models with Dynamic Shapes
+==============================================
+
+This example demonstrates how to save and load Torch-TensorRT compiled models
+with dynamic input shapes. When you compile a model with dynamic shapes,
+you need to preserve the dynamic shape specifications when saving the model
+to ensure it can handle variable input sizes after deserialization.
+
+The API is designed to feel similar to torch.export's handling of dynamic shapes
+for consistency and ease of use.
+"""
+
+# %%
+# Imports and Model Definition
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+import tempfile
+
+import torch
+import torch.nn as nn
+import torch_tensorrt
+
+
+# %%
+# Define a simple model that we'll compile with dynamic batch size
+class MyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 16, 3, stride=1, padding=1)
+        self.relu = nn.ReLU()
+        self.linear = nn.Linear(16 * 224 * 224, 10)
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.relu(x)
+        x = x.flatten(1)
+        x = self.linear(x)
+        return x
+
+
+# %%
+# Compile with Dynamic Shapes
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# First, we compile the model with dynamic batch dimension
+
+model = MyModel().eval().cuda()
+
+# Define example input with batch size 2
+example_input = torch.randn(2, 3, 224, 224).cuda()
+
+# Define dynamic batch dimension using torch.export.Dim
+# This allows batch sizes from 1 to 32
+dyn_batch = torch.export.Dim("batch", min=1, max=32)
+
+# Specify which dimensions are dynamic
+dynamic_shapes = {"x": {0: dyn_batch}}
+
+# Export the model with dynamic shapes
+exp_program = torch.export.export(
+    model, (example_input,), dynamic_shapes=dynamic_shapes, strict=False
+)
+
+# Compile with Torch-TensorRT
+compile_spec = {
+    "inputs": [
+        torch_tensorrt.Input(
+            min_shape=(1, 3, 224, 224),
+            opt_shape=(8, 3, 224, 224),
+            max_shape=(32, 3, 224, 224),
+            dtype=torch.float32,
+        )
+    ],
+    "enabled_precisions": {torch.float32},
+    "min_block_size": 1,
+}
+
+trt_gm = torch_tensorrt.dynamo.compile(exp_program, **compile_spec)
+
+# %%
+# Test Compiled Model with Different Batch Sizes
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+# Test with batch size 4
+input_bs4 = torch.randn(4, 3, 224, 224).cuda()
+output_bs4 = trt_gm(input_bs4)
+
+# Test with batch size 16
+input_bs16 = torch.randn(16, 3, 224, 224).cuda()
+output_bs16 = trt_gm(input_bs16)
+
+# %%
+# Save the Model with Dynamic Shapes
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# The key is to pass the same dynamic_shapes specification to save()
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    save_path = f"{tmpdir}/dynamic_model.ep"
+
+    # Save with dynamic_shapes parameter - this is crucial for preserving dynamic behavior
+    torch_tensorrt.save(
+        trt_gm,
+        save_path,
+        output_format="exported_program",
+        arg_inputs=[example_input],
+        dynamic_shapes=dynamic_shapes,  # Same as used during export
+    )
+
+    # %%
+    # Load and Test the Saved Model
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    # Load the saved model
+    loaded_model = torch_tensorrt.load(save_path).module()
+
+    # Test with the same batch sizes to verify dynamic shapes are preserved
+    output_loaded_bs4 = loaded_model(input_bs4)
+
+    output_loaded_bs16 = loaded_model(input_bs16)
+
+    assert torch.allclose(output_bs4, output_loaded_bs4, rtol=1e-3, atol=1e-3)
+    assert torch.allclose(output_bs16, output_loaded_bs16, rtol=1e-3, atol=1e-3)
+
+# %%
+# Example with Multiple Dynamic Dimensions
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+class MultiDimModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 16, 3, stride=1, padding=1)
+
+    def forward(self, x):
+        return self.conv(x)
+
+
+model2 = MultiDimModel().eval().cuda()
+example_input2 = torch.randn(2, 3, 128, 128).cuda()
+
+# Define dynamic dimensions for batch and spatial dimensions
+dyn_batch2 = torch.export.Dim("batch", min=1, max=16)
+dyn_height = torch.export.Dim("height", min=64, max=512)
+dyn_width = torch.export.Dim("width", min=64, max=512)
+
+dynamic_shapes2 = {"x": {0: dyn_batch2, 2: dyn_height, 3: dyn_width}}
+
+exp_program2 = torch.export.export(
+    model2, (example_input2,), dynamic_shapes=dynamic_shapes2, strict=False
+)
+
+compile_spec2 = {
+    "inputs": [
+        torch_tensorrt.Input(
+            min_shape=(1, 3, 64, 64),
+            opt_shape=(8, 3, 256, 256),
+            max_shape=(16, 3, 512, 512),
+            dtype=torch.float32,
+        )
+    ],
+    "enabled_precisions": {torch.float32},
+}
+
+trt_gm2 = torch_tensorrt.dynamo.compile(exp_program2, **compile_spec2)
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    save_path2 = f"{tmpdir}/multi_dim_model.ep"
+
+    torch_tensorrt.save(
+        trt_gm2,
+        save_path2,
+        output_format="exported_program",
+        arg_inputs=[example_input2],
+        dynamic_shapes=dynamic_shapes2,
+    )
+
+    loaded_model2 = torch_tensorrt.load(save_path2).module()
+
+    # Test with different input shapes
+    test_input = torch.randn(4, 3, 256, 256).cuda()
+    output = loaded_model2(test_input)

--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -5,7 +5,7 @@ import logging
 import platform
 import warnings
 from enum import Enum
-from typing import Any, Callable, List, Optional, Sequence, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import torch
 from torch_tensorrt._enums import dtype
@@ -23,9 +23,9 @@ if ENABLED_FEATURES.fx_frontend:
     from torch_tensorrt.fx.lower import compile as fx_compile
     from torch_tensorrt.fx.utils import LowerPrecision
 
-    InputType = Union[Input, torch.Tensor, InputTensorSpec]
-else:
     InputType = Union[Input, torch.Tensor]
+else:
+    InputType = Union[Input, torch.Tensor]  # type: ignore
 
 if ENABLED_FEATURES.torchscript_frontend:
     import torch_tensorrt.ts
@@ -49,7 +49,13 @@ if ENABLED_FEATURES.dynamo_frontend:
     from torch_tensorrt.dynamo._compiler import (
         save_cross_compiled_exported_program as dynamo_save_cross_compiled_exported_program,
     )
+    from torch_tensorrt.dynamo._defaults import default_device
+    from torch_tensorrt.dynamo._tracer import (
+        get_dynamic_shapes_args,
+        get_dynamic_shapes_kwargs,
+    )
     from torch_tensorrt.dynamo._tracer import trace as dynamo_trace
+    from torch_tensorrt.dynamo.utils import get_torch_inputs
 
 logger = logging.getLogger(__name__)
 
@@ -175,7 +181,7 @@ def compile(
     ir: str = "default",
     inputs: Optional[Sequence[InputType]] = None,
     arg_inputs: Optional[Sequence[Sequence[Any]]] = None,
-    kwarg_inputs: Optional[dict[Any, Any]] = None,
+    kwarg_inputs: Optional[Dict[str, Any]] = None,
     enabled_precisions: Optional[Set[Union[torch.dtype, dtype]]] = None,
     **kwargs: Any,
 ) -> (
@@ -301,13 +307,18 @@ def compile(
         if not isinstance(arg_inputs, collections.abc.Sequence):
             arg_inputs = [arg_inputs]  # type: ignore
 
-        # Export the module
         torchtrt_arg_inputs = prepare_inputs(arg_inputs)
         torchtrt_kwarg_inputs = prepare_inputs(kwarg_inputs)
 
-        exp_program = dynamo_trace(
-            module, torchtrt_arg_inputs, kwarg_inputs=torchtrt_kwarg_inputs, **kwargs
-        )
+        if module_type == _ModuleType.ep:
+            exp_program = module
+        else:
+            exp_program = dynamo_trace(
+                module,
+                torchtrt_arg_inputs,
+                kwarg_inputs=torchtrt_kwarg_inputs,
+                **kwargs,
+            )
         trt_graph_module = dynamo_compile(
             exp_program,
             arg_inputs=torchtrt_arg_inputs,
@@ -323,7 +334,7 @@ def compile(
         raise RuntimeError("Module is an unknown format or the ir requested is unknown")
 
 
-@needs_cross_compile
+@needs_cross_compile  # type: ignore[misc]
 def cross_compile_for_windows(
     module: torch.nn.Module,
     file_path: str,
@@ -573,16 +584,6 @@ def load(file_path: str = "") -> Any:
     Raises:
         ValueError: If there is no file or the file is not either a TorchScript file or ExportedProgram file
     """
-    try:
-        logger.debug(f"Loading the provided file {file_path} using torch.jit.load()")
-        ts_module = torch.jit.load(file_path)
-        return ts_module
-    except Exception:
-        logger.info(
-            f"Loading the provided file {file_path} via torch.jit.load() failed with the following error",
-            exc_info=True,
-        )
-        pass
 
     try:
         logger.debug(f"Loading the provided file {file_path} using torch.export.load()")
@@ -591,6 +592,17 @@ def load(file_path: str = "") -> Any:
     except Exception:
         logger.info(
             f"Loading the provided file {file_path} via torch.export.load() failed with the following error",
+            exc_info=True,
+        )
+        pass
+
+    try:
+        logger.debug(f"Loading the provided file {file_path} using torch.jit.load()")
+        ts_module = torch.jit.load(file_path)
+        return ts_module
+    except Exception:
+        logger.info(
+            f"Loading the provided file {file_path} via torch.jit.load() (after failing to load with torch.export.load()) failed with the following error",
             exc_info=True,
         )
         raise ValueError(
@@ -603,11 +615,13 @@ def save(
     file_path: str = "",
     *,
     output_format: str = "exported_program",
-    inputs: Optional[Sequence[torch.Tensor]] = None,
-    arg_inputs: Optional[Sequence[torch.Tensor]] = None,
-    kwarg_inputs: Optional[dict[str, Any]] = None,
+    inputs: Optional[Sequence[torch.Tensor | Input]] = None,
+    arg_inputs: Optional[Sequence[torch.Tensor | Input]] = None,
+    kwarg_inputs: Optional[Dict[str, Any]] = None,
     retrace: bool = True,
+    use_legacy_exporter: Optional[bool] = None,
     pickle_protocol: int = 2,
+    dynamic_shapes: Optional[Dict[str, Any]] = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -615,23 +629,88 @@ def save(
 
     Arguments:
         module (Optional(torch.jit.ScriptModule | torch.export.ExportedProgram | torch.fx.GraphModule | CudaGraphsTorchTensorRTModule)): Compiled Torch-TensorRT module
-        inputs (torch.Tensor): Torch input tensors
-        arg_inputs (Tuple[Any, ...]): Same as inputs. Alias for better understanding with kwarg_inputs.
-        kwarg_inputs (dict[Any, ...]): Optional, kwarg inputs to the module forward function.
+        inputs (Union[torch.Tensor, torch_tensorrt.Input]): Torch input tensors or Input specifications
+        arg_inputs (Tuple[Union[torch.Tensor, torch_tensorrt.Input], ...]): Same as inputs. Alias for better understanding with kwarg_inputs.
+        kwarg_inputs (dict[str, Union[torch.Tensor, torch_tensorrt.Input]]): Optional, kwarg inputs to the module forward function.
         output_format (str): Format to save the model. Options include exported_program | torchscript | aot_inductor.
         retrace (bool): When the module type is a fx.GraphModule, this option re-exports the graph using torch.export.export(strict=False) to save it.
-                This flag is experimental for now.
+
+                For TRT-compiled modules with dynamic shapes, both retrace=True and retrace=False are supported:
+
+                - **retrace=True**: Automatically detects symbolic shape metadata in the TRT module and preserves it
+                  without retracing. This is the recommended approach as it maintains the exact symbolic shapes
+                  from the original compilation.
+
+                - **retrace=False**: Directly serializes the existing graph metadata without any re-export.
+                  This is faster but may not be compatible with all torch.export consumers.
+
+                For static shape models, retrace=True performs a standard torch.export.export() call.
+
+        use_legacy_exporter (Optional[bool]): Override the exporter used when serializing a torch.fx.GraphModule.
+                By default (None) the choice is made automatically:
+
+                - ``retrace=False`` always uses the legacy exporter (pure graph surgery, no re-execution).
+                - ``retrace=True`` with dynamic shapes uses ``torch.export.export`` on the inlined graph,
+                  which produces a fully standards-compliant ExportedProgram.
+
+                Set to ``True`` to force the legacy exporter regardless of ``retrace``.
+                Set to ``False`` to force ``torch.export.export`` on the inlined graph; this requires
+                example inputs and a live CUDA device.
+
         pickle_protocol (int): The pickle protocol to use to save the model. Default is 2. Increase this to 4 or higher for large models
+        dynamic_shapes (Optional[Union[dict[str, Any], tuple[Any, ...]]]): Dynamic shape specifications for re-exporting the model.
+
+                **Method 1: Explicit dynamic_shapes (torch.export style)**
+
+                Provide explicit torch.export.Dim specifications::
+
+                    # For a single input with dynamic batch dimension
+                    dyn_batch = torch.export.Dim("batch", min=1, max=32)
+                    dynamic_shapes = {"x": {0: dyn_batch}}
+                    torch_tensorrt.save(model, "model.ep", arg_inputs=[example_tensor], dynamic_shapes=dynamic_shapes)
+
+                    # For multiple inputs
+                    dynamic_shapes = ({"x": {0: dyn_batch}}, {"y": {0: dyn_batch}})
+
+                **Method 2: Inferred from torch_tensorrt.Input**
+
+                Pass torch_tensorrt.Input objects with min/opt/max shapes in arg_inputs/kwarg_inputs,
+                and dynamic_shapes will be inferred automatically::
+
+                    inputs = [
+                        torch_tensorrt.Input(
+                            min_shape=(1, 3, 224, 224),
+                            opt_shape=(8, 3, 224, 224),
+                            max_shape=(32, 3, 224, 224),
+                            name="x"  # Optional: name for better dim naming
+                        )
+                    ]
+                    torch_tensorrt.save(model, "model.ep", arg_inputs=inputs)  # dynamic_shapes inferred!
+
+                **Important Limitations:**
+
+                - Automatic inference creates **separate Dim objects for each input**. If your model requires
+                  multiple inputs to share the same dimension (e.g., matching batch sizes), you MUST use
+                  Method 1 with explicit shared Dim objects::
+
+                      batch = torch.export.Dim("batch", min=1, max=8)
+                      dynamic_shapes = {"x": {0: batch}, "mask": {0: batch}}  # Shared batch dimension
+
+                - Automatic inference is **disabled for mixed Input/Tensor inputs** to avoid spurious
+                  equality constraints. Use explicit dynamic_shapes for these cases.
+
+                - If both dynamic_shapes and Input objects are provided, the explicit dynamic_shapes
+                  parameter takes precedence.
     """
     if isinstance(module, CudaGraphsTorchTensorRTModule):
         module = module.compiled_module
     module_type = _parse_module_type(module)
     accepted_formats = {"exported_program", "torchscript", "aot_inductor"}
     if arg_inputs is not None and not all(
-        isinstance(input, torch.Tensor) for input in arg_inputs
+        isinstance(input, (torch.Tensor, Input)) for input in arg_inputs
     ):
         raise ValueError(
-            "Not all inputs provided are torch.tensors. Please provide torch.tensors as inputs"
+            "Not all inputs provided are torch.Tensor or torch_tensorrt.Input objects. Please provide inputs of a valid type"
         )
     if arg_inputs and inputs:
         raise AssertionError(
@@ -645,6 +724,106 @@ def save(
 
     if kwarg_inputs and any(value is None for value in kwarg_inputs.values()):
         raise ValueError("kwargs should not include None.")
+
+    def _all_are_input_objects(obj: Any) -> bool:
+        """Recursively check if all elements in nested collections are Input objects."""
+        if isinstance(obj, Input):
+            return True
+        elif isinstance(obj, (list, tuple)):
+            return all(_all_are_input_objects(item) for item in obj)
+        elif isinstance(obj, dict):
+            return all(_all_are_input_objects(value) for value in obj.values())
+        else:
+            # Not an Input object or collection
+            return False
+
+    all_inputs_are_input_objects = _all_are_input_objects(arg_inputs)
+    if kwarg_inputs:
+        all_inputs_are_input_objects = (
+            all_inputs_are_input_objects and _all_are_input_objects(kwarg_inputs)
+        )
+
+    # Infer dynamic_shapes from Input objects if not explicitly provided
+    # Only infer if ALL inputs are Input objects (not mixed with Tensors)
+    #
+    # Why? When we have mixed Input/Tensor inputs, torch.export may detect that
+    # a dynamic Input's dimension always equals a static Tensor's dimension during
+    # tracing, and enforce an equality constraint. Since we create separate Dim
+    # objects for each input, this causes a constraint violation. Users must use
+    # explicit dynamic_shapes for these cases.
+
+    # Warn if user provides both dynamic_shapes and Input objects with dynamic shapes
+
+    arg_tensors: Tuple[torch.Tensor | int, ...] = ()
+    kwarg_tensors: Dict[str, Any] = {}
+
+    if all_inputs_are_input_objects:
+        if dynamic_shapes is not None:
+            has_dynamic_input_objects = any(
+                isinstance(inp, Input) and inp.shape_mode == Input._ShapeMode.DYNAMIC
+                for inp in arg_inputs  # type: ignore[union-attr]
+            )
+            if kwarg_inputs:
+                has_dynamic_input_objects = has_dynamic_input_objects or any(
+                    isinstance(inp, Input)
+                    and inp.shape_mode == Input._ShapeMode.DYNAMIC
+                    for inp in kwarg_inputs.values()
+                )
+            if has_dynamic_input_objects:
+                logger.warning(
+                    "Both explicit dynamic_shapes and torch_tensorrt.Input objects with min/opt/max shapes were provided. "
+                    "The explicit dynamic_shapes parameter takes precedence and Input shape specifications will be ignored."
+                )
+        else:
+            inferred_dynamic_shapes = get_dynamic_shapes_args(module, arg_inputs)
+            inferred_dynamic_shapes.update(get_dynamic_shapes_kwargs(kwarg_inputs))
+
+            if inferred_dynamic_shapes is not None:
+                dynamic_shapes = inferred_dynamic_shapes
+                logger.info(
+                    f"Inferred dynamic_shapes from torch_tensorrt.Input objects with min/opt/max specifications: {dynamic_shapes}"
+                )
+
+        arg_tensors = tuple(get_torch_inputs(arg_inputs, default_device()))  # type: ignore
+        kwarg_tensors = get_torch_inputs(kwarg_inputs, default_device())  # type: ignore
+
+    else:
+        # Mixed case: some inputs are Tensors, some are Input objects
+        # Extract tensors from Input objects and use provided tensors as-is
+        def _extract_tensor(obj: Any) -> Any:
+            """Recursively extract tensors from Input objects or pass through tensors."""
+            if isinstance(obj, Input):
+                if (
+                    obj.shape_mode == Input._ShapeMode.DYNAMIC
+                    and dynamic_shapes is None
+                ):
+                    logger.warning(
+                        "Mixed torch.Tensor and torch_tensorrt.Input objects provided in the example arguments without explicit dynamic_shapes. "
+                        "We cannot infer the dynamic shape specs from these mixed cases "
+                        "Consider providing explicit dynamic_shapes parameter or using Input objects for all inputs."
+                    )
+                return obj.example_tensor()
+            elif isinstance(obj, torch.Tensor):
+                return obj
+            elif isinstance(obj, (list, tuple)):
+                extracted = [_extract_tensor(item) for item in obj]
+                return type(obj)(extracted)
+            elif isinstance(obj, dict):
+                return {key: _extract_tensor(value) for key, value in obj.items()}
+            else:
+                raise TypeError(
+                    f"Unsupported input type: {type(obj)}. Expected torch.Tensor or torch_tensorrt.Input"
+                )
+
+        arg_tensors = _extract_tensor(arg_inputs) if arg_inputs is not None else ()
+        kwarg_tensors = (
+            _extract_tensor(kwarg_inputs) if kwarg_inputs is not None else {}
+        )
+
+    # Extract tensors from Input objects for actual execution
+    # When inferring dynamic shapes, use different sizes for args vs kwargs to avoid
+    # torch.export detecting spurious equality constraints
+
     if output_format not in accepted_formats:
         raise ValueError(
             f"Provided output_format {output_format} is not supported. Supported options are exported_program | torchscript"
@@ -666,10 +845,6 @@ def save(
                 "Provided model is a torch.jit.ScriptModule but the output_format specified is not torchscript. Other output formats are not supported"
             )
         else:
-            if arg_inputs is not None:
-                logger.warning(
-                    "Provided model is a torch.jit.ScriptModule, inputs or arg_inputs is not necessary during save."
-                )
             torch.jit.save(module, file_path)
     elif module_type == _ModuleType.ep:
         if output_format == "torchscript":
@@ -712,7 +887,19 @@ def save(
                     logger.warning(
                         "Provided model is a torch.fx.GraphModule and retrace is False, inputs or arg_inputs is not necessary during save."
                     )
-                exp_program = export(module)
+
+                # Default for retrace=False is the legacy exporter (pure graph surgery,
+                # no re-execution). Override with use_legacy_exporter if provided.
+                _use_legacy = (
+                    use_legacy_exporter if use_legacy_exporter is not None else True
+                )
+                exp_program = export(
+                    module,
+                    arg_inputs=arg_tensors,
+                    kwarg_inputs=kwarg_tensors,
+                    dynamic_shapes=dynamic_shapes,
+                    use_legacy_exporter=_use_legacy,
+                )
                 if output_format == "exported_program":
                     torch.export.save(
                         exp_program, file_path, pickle_protocol=pickle_protocol
@@ -732,16 +919,60 @@ def save(
                         "Attempted to serialize an exported program with an unsupported format. Exported programs support exported_program and aot_inductor"
                     )
             else:
-                if arg_inputs is None:
-                    raise ValueError(
-                        "Provided model is a torch.fx.GraphModule and retrace is True, however the inputs or arg_inputs are empty. Please provide valid torch.tensors as inputs or arg_inputs to trace and save the model"
-                    )
-                exp_program = torch.export.export(
-                    module,
-                    tuple(arg_inputs),
-                    kwargs=kwarg_inputs,
-                    strict=False,
+                # When retrace=True with a TRT-compiled GraphModule that has dynamic shapes,
+                # use torch.export.export on the inlined graph to get a fully
+                # standards-compliant ExportedProgram. Override with use_legacy_exporter
+                # if provided.
+                has_symbolic_metadata = any(
+                    isinstance(dim, torch.SymInt)
+                    for node in module.graph.nodes
+                    if node.op == "placeholder" and "val" in node.meta
+                    for dim in getattr(node.meta["val"], "shape", [])
                 )
+                if has_symbolic_metadata and dynamic_shapes is not None:
+                    from torch_tensorrt.dynamo._exporter import export
+
+                    if arg_inputs is not None:
+                        logger.info(
+                            "Provided model is a torch.fx.GraphModule with dynamic shapes and retrace is True. "
+                            "Using existing symbolic metadata instead of retracing. Input specs are not necessary."
+                        )
+                    # Default for this path is the non-legacy exporter.
+                    _use_legacy = (
+                        use_legacy_exporter
+                        if use_legacy_exporter is not None
+                        else False
+                    )
+                    exp_program = export(
+                        module,
+                        arg_inputs=arg_tensors,
+                        kwarg_inputs=kwarg_tensors,
+                        dynamic_shapes=dynamic_shapes,
+                        use_legacy_exporter=_use_legacy,
+                    )
+                else:
+                    # Regular GraphModule or no dynamic shapes - retrace normally
+                    if has_symbolic_metadata:
+                        logger.warning(
+                            "The provided module has symbolic metadata and retrace is True, however there is no dynamic shapes information available either explicitly or derived from arg/kwarg inputs (torch_tensorrt.Input) "
+                            "This may lead to incorrect tracing and overly restrictive shape guards when the exported program is loaded. Please specify the dynamic shapes either explicitly or derived from arg/kwarg inputs"
+                        )
+
+                    if (arg_inputs is None or arg_inputs == ()) and (
+                        kwarg_tensors is None or kwarg_tensors == {}
+                    ):
+                        raise ValueError(
+                            "Provided model is a torch.fx.GraphModule without existing shape metadata and retrace is True, however no inputs specs were provided. "
+                            "Please provide valid torch.Tensors or torch_tensorrt.Input objects as inputs to retrace and save the model"
+                        )
+
+                    exp_program = torch.export.export(
+                        module,
+                        args=tuple(arg_tensors),
+                        kwargs=kwarg_tensors,
+                        dynamic_shapes=dynamic_shapes,
+                        strict=False,
+                    )
 
                 if output_format == "exported_program":
                     torch.export.save(

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -568,7 +568,7 @@ def compile(
 
     if not kwargs.get("use_explicit_typing", False):
         warnings.warn(
-            "`use_explicit_typing` is deprecated. This setting will be removed and you should enable autocast instead.",
+            "`use_explicit_typing` is deprecated. use_explicit_types is now on by default, this setting will be removed and you should enable autocast to recover weak typing behavior.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -1046,7 +1046,6 @@ def compile_module(
             trt_modules[name] = trt_module
 
             if _debugger_config:
-
                 if _debugger_config.save_engine_profile:
                     if settings.use_python_runtime:
                         if _debugger_config.profile_format != "cudagraph":
@@ -1433,6 +1432,9 @@ def convert_exported_program_to_serialized_trt_engine(
             logger.warning(
                 "Remaining GPU memory may not be enough to compile the TensorRT engine for this model resulting in an OOM error, Consider setting offload_module_to_cpu=True"
             )
+
+    if trt_kwarg_inputs is None:
+        trt_kwarg_inputs = {}
 
     flattened_input_list = get_flat_args_with_check(
         exported_program, list(trt_arg_inputs), trt_kwarg_inputs

--- a/py/torch_tensorrt/dynamo/conversion/_symbolic_shape_capture.py
+++ b/py/torch_tensorrt/dynamo/conversion/_symbolic_shape_capture.py
@@ -1,0 +1,121 @@
+"""
+Capture symbolic shape expressions from FX graphs for TRT meta kernel.
+
+This module extracts the symbolic relationship between input and output shapes
+at compile time, which can then be used by the meta kernel to correctly infer
+output shapes without pattern matching.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def extract_symbolic_shape_expressions(
+    module: torch.fx.GraphModule,
+) -> Optional[Dict[str, List[Dict[str, Any]]]]:
+    """
+    Extract symbolic shape expressions from an FX graph.
+
+    This captures the symbolic expressions (as sympy expressions) for input and output shapes
+    that can be applied to input fake tensors at runtime.
+
+    Args:
+        module: FX GraphModule with symbolic shapes in node metadata
+
+    Returns:
+        Dict with 'inputs' and 'outputs' keys, each containing a list of dicts with shape_exprs and dtype,
+        or None if extraction fails
+    """
+    # Find input nodes (placeholders)
+    input_nodes = [node for node in module.graph.nodes if node.op == "placeholder"]
+
+    # Find output node
+    output_nodes = [node for node in module.graph.nodes if node.op == "output"]
+    if not output_nodes:
+        return None
+
+    output_node = output_nodes[0]
+
+    # Collect shape expressions and dtypes for each input
+    input_info = []
+    for input_node in input_nodes:
+        if not hasattr(input_node, "meta") or "val" not in input_node.meta:
+            logger.warning(
+                "When processing symbolic shapes for TensorRT engine, found no metadata in input node"
+            )
+            return None
+
+        input_val = input_node.meta["val"]
+        if not isinstance(input_val, torch.Tensor):
+            logger.warning(
+                "When processing symbolic shapes for TensorRT engine, input is not a tensor"
+            )
+            return None
+
+        # Extract shape as sympy expressions (can be pickled)
+        shape_exprs = []
+        for dim_size in input_val.shape:
+            if isinstance(dim_size, torch.SymInt):
+                # Store the sympy expression, which can be pickled
+                shape_exprs.append(dim_size.node.expr)
+            else:
+                # Store concrete integer
+                shape_exprs.append(int(dim_size))
+
+        input_info.append(
+            {
+                "shape_exprs": shape_exprs,
+                "dtype": input_val.dtype,
+                "name": input_node.name,
+            }
+        )
+
+    # Extract output values from output node
+    output_args = output_node.args[0]
+    if not isinstance(output_args, (tuple, list)):
+        output_args = (output_args,)
+
+    # Collect shape expressions and dtypes for each output
+    output_info = []
+    for out_arg in output_args:
+        if not hasattr(out_arg, "meta") or "val" not in out_arg.meta:
+            logger.warning(
+                "When processing symbolic shapes for TensorRT engine, found no metadata in FX Graph"
+            )
+            return None
+
+        out_val = out_arg.meta["val"]
+        if not isinstance(out_val, torch.Tensor):
+            logger.warning(
+                "When processing symbolic shapes for TensorRT engine, output is not a tensor"
+            )
+            return None
+
+        # Extract shape as sympy expressions (can be pickled)
+        shape_exprs = []
+        for dim_size in out_val.shape:
+            if isinstance(dim_size, torch.SymInt):
+                # Store the sympy expression, which can be pickled
+                shape_exprs.append(dim_size.node.expr)
+            else:
+                # Store concrete integer
+                shape_exprs.append(int(dim_size))
+
+        output_info.append(
+            {
+                "shape_exprs": shape_exprs,
+                "dtype": out_val.dtype,
+            }
+        )
+
+    if not output_info:
+        return None
+
+    return {
+        "inputs": input_info,
+        "outputs": output_info,
+    }

--- a/py/torch_tensorrt/dynamo/utils.py
+++ b/py/torch_tensorrt/dynamo/utils.py
@@ -22,7 +22,6 @@ from typing import (
 import numpy as np
 import psutil
 import sympy
-import tensorrt as trt
 import torch
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx.experimental.proxy_tensor import unset_fake_temporarily
@@ -36,6 +35,7 @@ from torch_tensorrt.dynamo._defaults import default_device
 from torch_tensorrt.dynamo._engine_cache import BaseEngineCache
 from torch_tensorrt.dynamo._settings import CompilationSettings
 
+import tensorrt as trt
 from packaging import version
 
 from .types import TRTDataType
@@ -708,8 +708,9 @@ def check_module_output(
     arg_inputs: Any,
     kwarg_inputs: Any = None,
 ) -> bool:
-    old_outputs, new_outputs = refitted_module(*arg_inputs), new_module(
-        *arg_inputs, **kwarg_inputs
+    old_outputs, new_outputs = (
+        refitted_module(*arg_inputs),
+        new_module(*arg_inputs, **kwarg_inputs),
     )
     if type(old_outputs) != type(new_outputs):
         logger.warning("The output types are different. Output check is skipped.")

--- a/tests/py/dynamo/models/test_export_kwargs_serde.py
+++ b/tests/py/dynamo/models/test_export_kwargs_serde.py
@@ -528,6 +528,556 @@ def test_custom_model_compile_engine():
     )
 
 
+@pytest.mark.unit
+@pytest.mark.critical
+def test_save_load_pure_kwarg_inputs_retrace_false(tmpdir):
+    """
+    Test save/load with pure kwarg inputs (no positional args) and retrace=False.
+    This exercises the code path where arg_inputs is None during save, which previously
+    triggered a TypeError in _extract_tensor when called with None.
+    """
+
+    class KwargOnlyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(10, 5)
+
+        def forward(self, *, x):
+            return self.linear(x)
+
+    model = KwargOnlyModel().eval().cuda()
+    kwargs = {"x": torch.randn(4, 10).cuda()}
+
+    exp_program = torch.export.export(model, args=(), kwargs=kwargs)
+
+    compile_spec = {
+        "arg_inputs": (),
+        "kwarg_inputs": kwargs,
+        "device": torchtrt.Device("cuda:0"),
+        "enabled_precisions": {torch.float},
+        "min_block_size": 1,
+        "ir": "dynamo",
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+
+    trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
+
+    # Save with retrace=False and no positional inputs — the previously broken path
+    trt_ep_path = os.path.join(tmpdir, "compiled_kwarg_only.ep")
+    torchtrt.save(trt_gm, trt_ep_path, retrace=False)
+
+    # Load and verify outputs match
+    deser_trt_module = torchtrt.load(trt_ep_path).module()
+    ref_out = model(**kwargs)
+    # Pure kwarg model returns a tensor directly (not wrapped in a tuple)
+    trt_out = trt_gm(**kwargs)
+    deser_out = deser_trt_module(**kwargs)
+
+    cos_sim = cosine_similarity(ref_out, trt_out)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"Pure kwarg save/load (retrace=False): TRT output mismatch. Cosine sim: {cos_sim}",
+    )
+    cos_sim = cosine_similarity(ref_out, deser_out)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"Pure kwarg save/load (retrace=False): deserialized output mismatch. Cosine sim: {cos_sim}",
+    )
+    torch._dynamo.reset()
+
+
+@pytest.mark.unit
+@pytest.mark.critical
+def test_save_load_pure_kwarg_inputs_retrace_true(tmpdir):
+    """
+    Test save/load with pure kwarg inputs (no positional args) and retrace=True.
+    Exercises the retrace path when only kwarg_inputs are provided (no positional args).
+    """
+
+    class KwargOnlyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(10, 5)
+
+        def forward(self, *, x):
+            return self.linear(x)
+
+    model = KwargOnlyModel().eval().cuda()
+    kwargs = {"x": torch.randn(4, 10).cuda()}
+
+    exp_program = torch.export.export(model, args=(), kwargs=kwargs)
+
+    compile_spec = {
+        "arg_inputs": (),
+        "kwarg_inputs": kwargs,
+        "device": torchtrt.Device("cuda:0"),
+        "enabled_precisions": {torch.float},
+        "min_block_size": 1,
+        "ir": "dynamo",
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+
+    trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
+
+    trt_ep_path = os.path.join(tmpdir, "compiled_kwarg_only_retrace.ep")
+    torchtrt.save(trt_gm, trt_ep_path, kwarg_inputs=kwargs, retrace=True)
+
+    deser_trt_module = torchtrt.load(trt_ep_path).module()
+    ref_out = model(**kwargs)
+    # Pure kwarg model returns a tensor directly (not wrapped in a tuple)
+    trt_out = trt_gm(**kwargs)
+    deser_out = deser_trt_module(**kwargs)
+
+    cos_sim = cosine_similarity(ref_out, trt_out)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"Pure kwarg save/load (retrace=True): TRT output mismatch. Cosine sim: {cos_sim}",
+    )
+    cos_sim = cosine_similarity(ref_out, deser_out)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"Pure kwarg save/load (retrace=True): deserialized output mismatch. Cosine sim: {cos_sim}",
+    )
+    torch._dynamo.reset()
+
+
+@pytest.mark.unit
+@pytest.mark.critical
+def test_save_load_mixed_args_kwargs_retrace_false(tmpdir):
+    """
+    Test save/load with mixed positional + kwarg inputs and retrace=False.
+    Exercises the _extract_tensor path where arg_inputs is a list of tensors
+    (not None, not all Input objects).
+    """
+
+    class MixedModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(10, 5)
+
+        def forward(self, x, *, scale):
+            return self.linear(x) * scale
+
+    model = MixedModel().eval().cuda()
+    args = [torch.randn(4, 10).cuda()]
+    kwargs = {"scale": torch.tensor(2.0).cuda()}
+
+    exp_program = torch.export.export(model, args=tuple(args), kwargs=kwargs)
+
+    compile_spec = {
+        "inputs": args,
+        "kwarg_inputs": kwargs,
+        "device": torchtrt.Device("cuda:0"),
+        "enabled_precisions": {torch.float},
+        "min_block_size": 1,
+        "ir": "dynamo",
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+
+    trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
+
+    trt_ep_path = os.path.join(tmpdir, "compiled_mixed.ep")
+    torchtrt.save(trt_gm, trt_ep_path, retrace=False)
+
+    deser_trt_module = torchtrt.load(trt_ep_path).module()
+    ref_out = model(*args, **kwargs)
+    trt_out = trt_gm(*args, **kwargs)
+    deser_out = deser_trt_module(*args, **kwargs)
+
+    cos_sim = cosine_similarity(ref_out, trt_out)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"Mixed args+kwargs save/load (retrace=False): TRT output mismatch. Cosine sim: {cos_sim}",
+    )
+    cos_sim = cosine_similarity(ref_out, deser_out)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"Mixed args+kwargs save/load (retrace=False): deserialized output mismatch. Cosine sim: {cos_sim}",
+    )
+    torch._dynamo.reset()
+
+
+@pytest.mark.unit
+@pytest.mark.critical
+def test_save_load_input_objects_retrace_false(tmpdir):
+    """
+    Test save/load where arg_inputs are torch_tensorrt.Input objects (not Tensors) with retrace=False.
+    Exercises the all_inputs_are_input_objects=True branch in save().
+    """
+
+    class SimpleModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(10, 5)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    model = SimpleModel().eval().cuda()
+    example = torch.randn(4, 10).cuda()
+
+    exp_program = torch.export.export(model, args=(example,))
+
+    compile_spec = {
+        "inputs": [torchtrt.Input(shape=(4, 10), dtype=torch.float)],
+        "device": torchtrt.Device("cuda:0"),
+        "enabled_precisions": {torch.float},
+        "min_block_size": 1,
+        "ir": "dynamo",
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+
+    trt_gm = torchtrt.dynamo.compile(exp_program, **compile_spec)
+
+    trt_ep_path = os.path.join(tmpdir, "compiled_input_objects.ep")
+    # Pass Input objects — exercises all_inputs_are_input_objects=True path
+    torchtrt.save(
+        trt_gm,
+        trt_ep_path,
+        inputs=[torchtrt.Input(shape=(4, 10), dtype=torch.float)],
+        retrace=False,
+    )
+
+    deser_trt_module = torchtrt.load(trt_ep_path).module()
+    ref_out = model(example)
+    trt_out = trt_gm(example)
+    deser_out = deser_trt_module(example)
+
+    cos_sim = cosine_similarity(ref_out, trt_out)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"Input objects save/load (retrace=False): TRT output mismatch. Cosine sim: {cos_sim}",
+    )
+    cos_sim = cosine_similarity(ref_out, deser_out)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"Input objects save/load (retrace=False): deserialized output mismatch. Cosine sim: {cos_sim}",
+    )
+    torch._dynamo.reset()
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by use_legacy_exporter combination tests
+# ---------------------------------------------------------------------------
+
+
+def _make_simple_model_and_inputs():
+    """Static-shape linear model, args only."""
+
+    class SimpleModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(10, 5)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    model = SimpleModel().eval().cuda()
+    example = torch.randn(4, 10).cuda()
+    return model, example
+
+
+def _make_dynamic_model_and_inputs():
+    """Dynamic-batch linear model, args only."""
+
+    class DynModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(10, 5)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    model = DynModel().eval().cuda()
+    example = torch.randn(4, 10).cuda()
+    batch = torch.export.Dim("batch", min=1, max=8)
+    dynamic_shapes = {"x": {0: batch}}
+    trt_inputs = [
+        torchtrt.Input(
+            min_shape=(1, 10),
+            opt_shape=(4, 10),
+            max_shape=(8, 10),
+            dtype=torch.float32,
+        )
+    ]
+    return model, example, dynamic_shapes, trt_inputs
+
+
+def _compile_simple(model, example):
+    ep = torch.export.export(model, args=(example,))
+    compile_spec = {
+        "inputs": [torchtrt.Input(shape=(4, 10), dtype=torch.float)],
+        "device": torchtrt.Device("cuda:0"),
+        "enabled_precisions": {torch.float},
+        "min_block_size": 1,
+        "ir": "dynamo",
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+    return torchtrt.dynamo.compile(ep, **compile_spec)
+
+
+def _compile_dynamic(model, example, dynamic_shapes, trt_inputs):
+    ep = torch.export.export(model, args=(example,), dynamic_shapes=dynamic_shapes)
+    compile_spec = {
+        "inputs": trt_inputs,
+        "device": torchtrt.Device("cuda:0"),
+        "enabled_precisions": {torch.float},
+        "min_block_size": 1,
+        "ir": "dynamo",
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+    return torchtrt.dynamo.compile(ep, **compile_spec)
+
+
+def _check_outputs(assertions, ref_out, trt_out, deser_out, label):
+    cos_sim = cosine_similarity(ref_out, trt_out)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"{label}: TRT output mismatch. Cosine sim: {cos_sim}",
+    )
+    cos_sim = cosine_similarity(ref_out, deser_out)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"{label}: deserialized output mismatch. Cosine sim: {cos_sim}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# retrace=False, use_legacy_exporter combinations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.critical
+def test_save_load_retrace_false_legacy_true_static(tmpdir):
+    """retrace=False, use_legacy_exporter=True (explicit), static shapes.
+    Same effective path as the default; verifies the explicit override is wired through.
+    """
+    model, example = _make_simple_model_and_inputs()
+    trt_gm = _compile_simple(model, example)
+
+    trt_ep_path = os.path.join(tmpdir, "model.ep")
+    torchtrt.save(trt_gm, trt_ep_path, retrace=False, use_legacy_exporter=True)
+
+    deser = torchtrt.load(trt_ep_path).module()
+    _check_outputs(
+        assertions,
+        model(example),
+        trt_gm(example),
+        deser(example),
+        "retrace=False, use_legacy_exporter=True, static",
+    )
+    torch._dynamo.reset()
+
+
+@pytest.mark.unit
+@pytest.mark.critical
+def test_save_load_retrace_false_legacy_false_static(tmpdir):
+    """retrace=False, use_legacy_exporter=False (override to non-legacy), static shapes.
+    Forces torch.export.export on the inlined graph instead of graph surgery."""
+    model, example = _make_simple_model_and_inputs()
+    trt_gm = _compile_simple(model, example)
+
+    trt_ep_path = os.path.join(tmpdir, "model.ep")
+    torchtrt.save(
+        trt_gm,
+        trt_ep_path,
+        inputs=[example],
+        retrace=False,
+        use_legacy_exporter=False,
+    )
+
+    deser = torchtrt.load(trt_ep_path).module()
+    _check_outputs(
+        assertions,
+        model(example),
+        trt_gm(example),
+        deser(example),
+        "retrace=False, use_legacy_exporter=False, static",
+    )
+    torch._dynamo.reset()
+
+
+@pytest.mark.unit
+@pytest.mark.critical
+def test_save_load_retrace_false_default_dynamic(tmpdir):
+    """retrace=False, use_legacy_exporter=None (default → legacy), dynamic shapes.
+    Verifies the legacy exporter correctly preserves range_constraints for dynamic dims.
+    """
+    model, example, dynamic_shapes, trt_inputs = _make_dynamic_model_and_inputs()
+    trt_gm = _compile_dynamic(model, example, dynamic_shapes, trt_inputs)
+
+    trt_ep_path = os.path.join(tmpdir, "model.ep")
+    torchtrt.save(trt_gm, trt_ep_path, retrace=False)
+
+    deser = torchtrt.load(trt_ep_path).module()
+    # Run at a different batch size to exercise the dynamic range
+    x_alt = torch.randn(2, 10).cuda()
+    _check_outputs(
+        assertions,
+        model(x_alt),
+        trt_gm(x_alt),
+        deser(x_alt),
+        "retrace=False, use_legacy_exporter=None, dynamic",
+    )
+    torch._dynamo.reset()
+
+
+@pytest.mark.unit
+@pytest.mark.critical
+def test_save_load_retrace_false_legacy_true_dynamic(tmpdir):
+    """retrace=False, use_legacy_exporter=True (explicit), dynamic shapes."""
+    model, example, dynamic_shapes, trt_inputs = _make_dynamic_model_and_inputs()
+    trt_gm = _compile_dynamic(model, example, dynamic_shapes, trt_inputs)
+
+    trt_ep_path = os.path.join(tmpdir, "model.ep")
+    torchtrt.save(trt_gm, trt_ep_path, retrace=False, use_legacy_exporter=True)
+
+    deser = torchtrt.load(trt_ep_path).module()
+    x_alt = torch.randn(2, 10).cuda()
+    _check_outputs(
+        assertions,
+        model(x_alt),
+        trt_gm(x_alt),
+        deser(x_alt),
+        "retrace=False, use_legacy_exporter=True, dynamic",
+    )
+    torch._dynamo.reset()
+
+
+@pytest.mark.unit
+@pytest.mark.critical
+def test_save_load_retrace_false_legacy_false_dynamic(tmpdir):
+    """retrace=False, use_legacy_exporter=False (override), dynamic shapes.
+    Forces non-legacy (torch.export.export on the inlined graph) even with retrace=False.
+    """
+    model, example, dynamic_shapes, trt_inputs = _make_dynamic_model_and_inputs()
+    trt_gm = _compile_dynamic(model, example, dynamic_shapes, trt_inputs)
+
+    trt_ep_path = os.path.join(tmpdir, "model.ep")
+    torchtrt.save(
+        trt_gm,
+        trt_ep_path,
+        inputs=[example],
+        dynamic_shapes=dynamic_shapes,
+        retrace=False,
+        use_legacy_exporter=False,
+    )
+
+    deser = torchtrt.load(trt_ep_path).module()
+    x_alt = torch.randn(2, 10).cuda()
+    _check_outputs(
+        assertions,
+        model(x_alt),
+        trt_gm(x_alt),
+        deser(x_alt),
+        "retrace=False, use_legacy_exporter=False, dynamic",
+    )
+    torch._dynamo.reset()
+
+
+# ---------------------------------------------------------------------------
+# retrace=True, use_legacy_exporter combinations (dynamic shapes)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.critical
+def test_save_load_retrace_true_default_dynamic(tmpdir):
+    """retrace=True, use_legacy_exporter=None (default → non-legacy), dynamic shapes.
+    The has_symbolic_metadata + dynamic_shapes path uses torch.export.export on
+    the inlined graph."""
+    model, example, dynamic_shapes, trt_inputs = _make_dynamic_model_and_inputs()
+    trt_gm = _compile_dynamic(model, example, dynamic_shapes, trt_inputs)
+
+    trt_ep_path = os.path.join(tmpdir, "model.ep")
+    torchtrt.save(
+        trt_gm,
+        trt_ep_path,
+        inputs=[example],
+        dynamic_shapes=dynamic_shapes,
+        retrace=True,
+    )
+
+    deser = torchtrt.load(trt_ep_path).module()
+    x_alt = torch.randn(2, 10).cuda()
+    _check_outputs(
+        assertions,
+        model(x_alt),
+        trt_gm(x_alt),
+        deser(x_alt),
+        "retrace=True, use_legacy_exporter=None, dynamic",
+    )
+    torch._dynamo.reset()
+
+
+@pytest.mark.unit
+@pytest.mark.critical
+def test_save_load_retrace_true_legacy_true_dynamic(tmpdir):
+    """retrace=True, use_legacy_exporter=True (override to legacy), dynamic shapes.
+    Forces graph surgery even though retrace=True."""
+    model, example, dynamic_shapes, trt_inputs = _make_dynamic_model_and_inputs()
+    trt_gm = _compile_dynamic(model, example, dynamic_shapes, trt_inputs)
+
+    trt_ep_path = os.path.join(tmpdir, "model.ep")
+    torchtrt.save(
+        trt_gm,
+        trt_ep_path,
+        inputs=[example],
+        dynamic_shapes=dynamic_shapes,
+        retrace=True,
+        use_legacy_exporter=True,
+    )
+
+    deser = torchtrt.load(trt_ep_path).module()
+    x_alt = torch.randn(2, 10).cuda()
+    _check_outputs(
+        assertions,
+        model(x_alt),
+        trt_gm(x_alt),
+        deser(x_alt),
+        "retrace=True, use_legacy_exporter=True, dynamic",
+    )
+    torch._dynamo.reset()
+
+
+@pytest.mark.unit
+@pytest.mark.critical
+def test_save_load_retrace_true_legacy_false_dynamic(tmpdir):
+    """retrace=True, use_legacy_exporter=False (explicit non-legacy), dynamic shapes.
+    Same path as the default for this combination; verifies explicit False is wired through.
+    """
+    model, example, dynamic_shapes, trt_inputs = _make_dynamic_model_and_inputs()
+    trt_gm = _compile_dynamic(model, example, dynamic_shapes, trt_inputs)
+
+    trt_ep_path = os.path.join(tmpdir, "model.ep")
+    torchtrt.save(
+        trt_gm,
+        trt_ep_path,
+        inputs=[example],
+        dynamic_shapes=dynamic_shapes,
+        retrace=True,
+        use_legacy_exporter=False,
+    )
+
+    deser = torchtrt.load(trt_ep_path).module()
+    x_alt = torch.randn(2, 10).cuda()
+    _check_outputs(
+        assertions,
+        model(x_alt),
+        trt_gm(x_alt),
+        deser(x_alt),
+        "retrace=True, use_legacy_exporter=False, dynamic",
+    )
+    torch._dynamo.reset()
+
+
 def test_custom_model_compile_engine_with_pure_kwarg_inputs():
     class net(nn.Module):
         def __init__(self):

--- a/tests/py/dynamo/models/test_meta_kernel_shape_inference.py
+++ b/tests/py/dynamo/models/test_meta_kernel_shape_inference.py
@@ -1,0 +1,298 @@
+"""
+Test meta kernel shape inference by running TRT modules in fake mode.
+
+Each test exports a model, compiles with TRT, then runs the TRT module in fake
+mode to verify the meta kernel correctly infers symbolic output shapes.
+
+The test approach:
+1. Export a model with dynamic shapes to get an exported program with symbolic SymInts
+2. Compile the exported program with Torch-TensorRT
+3. Extract the symbolic fake input from the exported program
+4. Run both the exported program and TRT module with the same symbolic fake input
+5. Verify that both produce the same symbolic output shapes
+
+Currently, tests with dynamic shapes are marked as xfail because the meta kernel
+does not preserve symbolic SymInt dimensions - it creates new unbacked symints instead
+of reusing the input SymInts. This is a known limitation.
+"""
+
+import pytest
+import torch
+import torch_tensorrt
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.export import Dim
+
+
+class TestMetaKernelShapeInference:
+    """Test meta kernel by running TRT modules in fake mode"""
+
+    def _test_in_fake_mode(self, model, test_input, dynamic_shapes=None):
+        """
+        Helper that exports model, compiles with TRT, runs in fake mode.
+        Returns (exported_output, trt_output, fake_input) for shape comparison.
+        """
+        # Export with dynamic shapes
+        if dynamic_shapes:
+            exported = torch.export.export(
+                model, args=(test_input,), dynamic_shapes=dynamic_shapes
+            )
+        else:
+            exported = torch.export.export(model, args=(test_input,))
+
+        # Compile with TRT
+        compiled = torch_tensorrt.compile(
+            exported, inputs=[test_input], min_block_size=1
+        )
+
+        # Get the fake input from the exported program - it has symbolic shapes
+        from torch._guards import detect_fake_mode
+
+        fake_input = None
+        for node in exported.graph.nodes:
+            if node.op == "placeholder" and node.name == "x" and "val" in node.meta:
+                fake_input = node.meta["val"]
+                break
+
+        assert (
+            fake_input is not None
+        ), "Could not find input placeholder 'x' in exported program"
+
+        # Get the fake mode
+        fake_mode = detect_fake_mode((fake_input,))
+        assert fake_mode is not None, "Could not detect fake mode from exported program"
+
+        # Run both exported and compiled in the same fake mode
+        with fake_mode:
+            exported_output = exported.module()(fake_input)
+            trt_output = compiled(fake_input)
+
+            return exported_output, trt_output, fake_input
+
+    def test_identity_static(self):
+        """Test meta kernel with static shapes (identity operation)"""
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 64, kernel_size=1)
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                return self.relu(self.conv(x))
+
+        model = Model().eval().cuda()
+        test_input = torch.randn(4, 3, 64, 64).cuda()
+
+        exported_output, trt_output, fake_input = self._test_in_fake_mode(
+            model, test_input
+        )
+
+        print(f"Input shape: {fake_input.shape}")
+        print(f"Exported output shape: {exported_output.shape}")
+        print(f"TRT output shape: {trt_output.shape}")
+
+        # Both should produce same shape
+        assert exported_output.shape == trt_output.shape
+        assert trt_output.shape == (4, 64, 64, 64)
+
+    def test_downsample_static(self):
+        """Test meta kernel with static shapes (stride=2 downsampling)"""
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 64, kernel_size=3, stride=2, padding=1)
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                return self.relu(self.conv(x))
+
+        model = Model().eval().cuda()
+        test_input = torch.randn(4, 3, 64, 64).cuda()
+
+        exported_output, trt_output, fake_input = self._test_in_fake_mode(
+            model, test_input
+        )
+
+        print(f"Input shape: {fake_input.shape}")
+        print(f"Exported output shape: {exported_output.shape}")
+        print(f"TRT output shape: {trt_output.shape}")
+
+        # Both should produce same downsampled shape
+        assert exported_output.shape == trt_output.shape
+        assert trt_output.shape == (4, 64, 32, 32)
+
+    def test_dynamic_batch(self):
+        """Test meta kernel preserves symbolic batch dimension"""
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 64, kernel_size=1)
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                return self.relu(self.conv(x))
+
+        model = Model().eval().cuda()
+        test_input = torch.randn(4, 3, 64, 64).cuda()
+
+        batch = Dim("batch", min=1, max=8)
+        dynamic_shapes = {"x": {0: batch}}
+
+        exported_output, trt_output, fake_input = self._test_in_fake_mode(
+            model, test_input, dynamic_shapes
+        )
+
+        print(f"Input shape: {fake_input.shape}")
+        print(f"Exported output shape: {exported_output.shape}")
+        print(f"TRT output shape: {trt_output.shape}")
+
+        # Both should have symbolic batch
+        assert isinstance(
+            fake_input.shape[0], torch.SymInt
+        ), "Input batch should be symbolic"
+        assert isinstance(
+            exported_output.shape[0], torch.SymInt
+        ), "Exported output batch should be symbolic"
+        assert isinstance(
+            trt_output.shape[0], torch.SymInt
+        ), "TRT output batch should be symbolic"
+
+        # Shapes should match
+        assert exported_output.shape == trt_output.shape
+
+    def test_arithmetic_h_div_2(self):
+        """Test meta kernel infers h//2 symbolic relationship"""
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 64, kernel_size=1)
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                x = self.relu(self.conv(x))
+                h = x.shape[2]
+                return x[:, :, : h // 2, :]
+
+        model = Model().eval().cuda()
+        test_input = torch.randn(4, 3, 64, 64).cuda()
+
+        batch = Dim("batch", min=1, max=8)
+        h_base = Dim("h_base", min=16, max=64)
+        w_base = Dim("w_base", min=16, max=64)
+        dynamic_shapes = {"x": {0: batch, 2: 2 * h_base, 3: 2 * w_base}}
+
+        exported_output, trt_output, fake_input = self._test_in_fake_mode(
+            model, test_input, dynamic_shapes
+        )
+
+        print(f"Input shape (height=2*h_base): {fake_input.shape}")
+        print(f"Exported output shape (height=h_base): {exported_output.shape}")
+        print(f"TRT output shape: {trt_output.shape}")
+
+        # Height should be symbolic and correctly inferred
+        assert isinstance(
+            fake_input.shape[2], torch.SymInt
+        ), "Input height should be symbolic"
+        assert isinstance(
+            exported_output.shape[2], torch.SymInt
+        ), "Exported output height should be symbolic"
+        assert isinstance(
+            trt_output.shape[2], torch.SymInt
+        ), "TRT output height should be symbolic"
+
+        # Shapes should match
+        assert exported_output.shape == trt_output.shape
+
+    def test_stride_2_dynamic(self):
+        """Test meta kernel infers h//2 from stride=2 convolution"""
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 64, kernel_size=3, stride=2, padding=1)
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                return self.relu(self.conv(x))
+
+        model = Model().eval().cuda()
+        test_input = torch.randn(4, 3, 64, 64).cuda()
+
+        batch = Dim("batch", min=1, max=8)
+        h_base = Dim("h_base", min=16, max=64)
+        w_base = Dim("w_base", min=16, max=64)
+        # Input must be even for stride=2
+        dynamic_shapes = {"x": {0: batch, 2: 2 * h_base, 3: 2 * w_base}}
+
+        exported_output, trt_output, fake_input = self._test_in_fake_mode(
+            model, test_input, dynamic_shapes
+        )
+
+        print(f"Input shape (2*h_base): {fake_input.shape}")
+        print(f"Exported output shape (h_base): {exported_output.shape}")
+        print(f"TRT output shape: {trt_output.shape}")
+
+        # Height should be symbolic
+        assert isinstance(
+            fake_input.shape[2], torch.SymInt
+        ), "Input height should be symbolic"
+        assert isinstance(
+            exported_output.shape[2], torch.SymInt
+        ), "Exported output height should be symbolic"
+        assert isinstance(
+            trt_output.shape[2], torch.SymInt
+        ), "TRT output height should be symbolic"
+
+        # Shapes should match
+        assert exported_output.shape == trt_output.shape
+
+    def test_concat(self):
+        """Test meta kernel with concat operation (concatenates on height dimension)"""
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 64, kernel_size=1)
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                x = self.relu(self.conv(x))
+                # Concatenate x with itself on height dimension to double the height
+                return torch.cat([x, x], dim=2)
+
+        model = Model().eval().cuda()
+        test_input = torch.randn(4, 3, 32, 32).cuda()
+
+        batch = Dim("batch", min=1, max=8)
+        h = Dim("h", min=16, max=64)
+        w = Dim("w", min=16, max=64)
+        dynamic_shapes = {"x": {0: batch, 2: h, 3: w}}
+
+        exported_output, trt_output, fake_input = self._test_in_fake_mode(
+            model, test_input, dynamic_shapes
+        )
+
+        print(f"Input shape: {fake_input.shape}")
+        print(f"Exported output shape (2*h): {exported_output.shape}")
+        print(f"TRT output shape: {trt_output.shape}")
+
+        # Height should be symbolic (2x input from concat)
+        assert isinstance(
+            fake_input.shape[2], torch.SymInt
+        ), "Input height should be symbolic"
+        assert isinstance(
+            exported_output.shape[2], torch.SymInt
+        ), "Exported output height should be symbolic"
+        assert isinstance(
+            trt_output.shape[2], torch.SymInt
+        ), "TRT output height should be symbolic"
+
+        # Shapes should match
+        assert exported_output.shape == trt_output.shape
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/py/dynamo/models/test_reexport.py
+++ b/tests/py/dynamo/models/test_reexport.py
@@ -478,7 +478,86 @@ def test_resnet18_dynamic(ir, tmpdir):
     )
     trt_module = torchtrt.dynamo.compile(exp_program, **compile_spec)
 
-    # Reexport with dynamic dimensions
+    # Save with torch_tensorrt.save() which handles dynamic shapes properly
+    torchtrt.save(
+        trt_module,
+        trt_ep_path,
+        output_format="exported_program",
+        arg_inputs=[input_bs2],
+        dynamic_shapes=({0: dyn_batch},),
+        retrace=True,
+    )
+
+    # TODO: Enable this serialization issues are fixed
+    deser_trt_module = torchtrt.load(trt_ep_path).module()
+    outputs_pyt = model(input_bs2)
+    outputs_trt = trt_module(input_bs2)
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_resnet18_dynamic TRT outputs don't match with the original model for batch size=2. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+    outputs_trt_deser = deser_trt_module(input_bs2)
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt_deser)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_resnet18_dynamic TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+    input_bs6 = torch.randn((6, 3, 224, 224)).to("cuda")
+    outputs_pyt = model(input_bs6)
+    outputs_trt = trt_module(input_bs6)
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_resnet18_dynamic TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+    outputs_trt_deser = deser_trt_module(input_bs6)
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt_deser)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_resnet18_dynamic TRT outputs don't match with the original model. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+
+@pytest.mark.unit
+@unittest.skipIf(
+    not importlib.util.find_spec("torchvision"),
+    "torchvision is not installed",
+)
+def test_resnet18_dynamic_manual_retrace(ir, tmpdir):
+    """
+    This tests export save and load functionality on Resnet18 model with dynamic shapes
+    """
+
+    trt_ep_path = os.path.join(tmpdir, "trt.ep")
+    model = models.resnet18().eval().cuda()
+    input_bs2 = torch.randn((2, 3, 224, 224)).to("cuda")
+
+    compile_spec = {
+        "inputs": [
+            torchtrt.Input(
+                min_shape=(1, 3, 224, 224),
+                opt_shape=(4, 3, 224, 224),
+                max_shape=(8, 3, 224, 224),
+                dtype=torch.float32,
+                name="x",
+            )
+        ],
+        "ir": ir,
+        "min_block_size": 1,
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+
+    dyn_batch = torch.export.Dim("batch", min=1, max=8)
+    exp_program = torch.export.export(
+        model, (input_bs2,), dynamic_shapes=({0: dyn_batch},), strict=False
+    )
+    trt_module = torchtrt.dynamo.compile(exp_program, **compile_spec)
+
     trt_exp_program = torch.export.export(
         trt_module, (input_bs2,), dynamic_shapes=({0: dyn_batch},), strict=False
     )
@@ -556,14 +635,14 @@ def test_resnet18_dynamic_fallback(ir, tmpdir):
     )
     trt_module = torchtrt.dynamo.compile(exp_program, **compile_spec)
 
-    # Reexport with dynamic dimensions
-    trt_exp_program = torch.export.export(
+    torchtrt.save(
         trt_module,
-        (input_bs2,),
-        strict=False,
+        trt_ep_path,
+        output_format="exported_program",
+        arg_inputs=[input_bs2],
         dynamic_shapes=({0: dyn_batch},),
+        retrace=True,
     )
-    torch.export.save(trt_exp_program, trt_ep_path)
 
     deser_trt_module = torchtrt.load(trt_ep_path).module()
     outputs_pyt = model(input_bs2)
@@ -635,12 +714,94 @@ def test_bitwise_and_dynamic_fallback(ir, tmpdir):
     )
     trt_module = torchtrt.dynamo.compile(exp_program, **compile_spec)
 
-    # Reexport with dynamic dimensions
+    # Save with torch_tensorrt.save() which handles dynamic shapes properly
+    torchtrt.save(
+        trt_module,
+        trt_ep_path,
+        output_format="exported_program",
+        arg_inputs=list(inputs_4),
+        dynamic_shapes={"lhs_val": {1: dyn_dim}, "rhs_val": {0: dyn_dim}},
+        retrace=True,
+    )
+
+    deser_trt_module = torchtrt.load(trt_ep_path).module()
+    outputs_pyt = model(*inputs_4)
+    outputs_trt = trt_module(*inputs_4)
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_bitwise_and_dynamic_fallback TRT outputs don't match with the original model with inputs_4. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+    outputs_trt_deser = deser_trt_module(*inputs_4)
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt_deser)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_bitwise_and_dynamic_fallback TRT outputs don't match with the original model with inputs_4. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+    lhs_6 = torch.randint(0, 2, (2, 6, 2), dtype=bool, device="cuda")
+    rhs_6 = torch.randint(0, 2, (6, 2), dtype=bool, device="cuda")
+    inputs_6 = (lhs_6, rhs_6)
+
+    outputs_pyt = model(*inputs_6)
+    outputs_trt = trt_module(*inputs_6)
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_bitwise_and_dynamic_fallback TRT outputs don't match with the original model with inputs_6. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+    outputs_trt_deser = deser_trt_module(*inputs_6)
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt_deser)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_bitwise_and_dynamic_fallback TRT outputs don't match with the original model with inputs_6. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+
+@pytest.mark.unit
+def test_bitwise_and_dynamic_fallback_manual_reexport(ir, tmpdir):
+    """
+    This tests export save and load functionality on a bitwise_and model with dynamic shapes and fallback
+    """
+
+    trt_ep_path = os.path.join(tmpdir, "trt.ep")
+
+    class bitwise_and(torch.nn.Module):
+        def forward(self, lhs_val, rhs_val):
+            return torch.ops.aten.bitwise_and.Tensor(lhs_val, rhs_val)
+
+    dyn_dim = torch.export.Dim("dyn_dim", min=3, max=6)
+    lhs_4 = torch.randint(0, 2, (2, 4, 2), dtype=bool, device="cuda")
+    rhs_4 = torch.randint(0, 2, (4, 2), dtype=bool, device="cuda")
+    inputs_4 = (lhs_4, rhs_4)
+    torchtrt_inputs = [
+        torchtrt.Input(shape=lhs_4.shape, dtype=torch.bool),
+        torchtrt.Input(shape=rhs_4.shape, dtype=torch.bool),
+    ]
+    model = bitwise_and()
+    compile_spec = {
+        "inputs": torchtrt_inputs,
+        "ir": ir,
+        "min_block_size": 1,
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+
+    exp_program = torch.export.export(
+        model,
+        inputs_4,
+        dynamic_shapes={"lhs_val": {1: dyn_dim}, "rhs_val": {0: dyn_dim}},
+        strict=False,
+    )
+    trt_module = torchtrt.dynamo.compile(exp_program, **compile_spec)
+
     trt_exp_program = torch.export.export(
         trt_module,
         inputs_4,
-        strict=False,
         dynamic_shapes={"lhs_val": {1: dyn_dim}, "rhs_val": {0: dyn_dim}},
+        strict=False,
     )
     torch.export.save(trt_exp_program, trt_ep_path)
 
@@ -727,14 +888,15 @@ def test_random_dynamic_fallback(ir, tmpdir):
     )
     trt_module = torchtrt.dynamo.compile(exp_program, **compile_spec)
 
-    # Reexport with dynamic dimensions
-    trt_exp_program = torch.export.export(
+    # Save with torch_tensorrt.save() which handles dynamic shapes properly
+    torchtrt.save(
         trt_module,
-        torch_inputs_bs50,
-        strict=False,
+        trt_ep_path,
+        output_format="exported_program",
+        arg_inputs=list(torch_inputs_bs50),
         dynamic_shapes=({0: dyn_dim},),
+        retrace=True,
     )
-    torch.export.save(trt_exp_program, trt_ep_path)
 
     # Test with BS=50
     deser_trt_module = torchtrt.load(trt_ep_path).module()
@@ -768,4 +930,587 @@ def test_random_dynamic_fallback(ir, tmpdir):
     assertions.assertTrue(
         cos_sim > COSINE_THRESHOLD,
         msg=f"test_random_dynamic_fallback TRT outputs don't match with the original model with inputs bs=62. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+
+@pytest.mark.unit
+@unittest.skipIf(
+    not importlib.util.find_spec("torchvision"),
+    "torchvision is not installed",
+)
+def test_save_with_dynamic_shapes_api(ir, tmpdir):
+    """
+    This tests the torch_tensorrt.save() API with dynamic_shapes parameter
+    to preserve dynamic shape specifications during serialization
+    """
+
+    trt_ep_path = os.path.join(tmpdir, "trt_dynamic.ep")
+    model = models.resnet18().eval().cuda()
+    input_bs2 = torch.randn((2, 3, 224, 224)).to("cuda")
+
+    compile_spec = {
+        "inputs": [
+            torchtrt.Input(
+                min_shape=(1, 3, 224, 224),
+                opt_shape=(4, 3, 224, 224),
+                max_shape=(8, 3, 224, 224),
+                dtype=torch.float32,
+                name="x",
+            )
+        ],
+        "ir": ir,
+        "min_block_size": 1,
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+
+    # Define dynamic shapes
+    dyn_batch = torch.export.Dim("batch", min=1, max=8)
+    dynamic_shapes = {"x": {0: dyn_batch}}
+
+    # Export with dynamic shapes
+    exp_program = torch.export.export(
+        model, (input_bs2,), dynamic_shapes=dynamic_shapes, strict=False
+    )
+    trt_module = torchtrt.dynamo.compile(exp_program, **compile_spec)
+
+    # Use the new torch_tensorrt.save() API with dynamic_shapes parameter
+    # Using retrace=True (should work now with fixed meta kernel and symbolic input handling)
+    torchtrt.save(
+        trt_module,
+        trt_ep_path,
+        output_format="exported_program",
+        arg_inputs=[input_bs2],
+        dynamic_shapes=dynamic_shapes,  # Preserve dynamic shapes
+        retrace=True,
+    )
+
+    # Load and test with different batch sizes
+    deser_trt_module = torchtrt.load(trt_ep_path).module()
+
+    # Test with batch size 2
+    outputs_pyt = model(input_bs2)
+    outputs_trt = trt_module(input_bs2)
+    outputs_trt_deser = deser_trt_module(input_bs2)
+
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_save_with_dynamic_shapes_api TRT outputs don't match with the original model for batch size=2. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt_deser)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_save_with_dynamic_shapes_api deserialized TRT outputs don't match with the original model for batch size=2. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+    # Test with batch size 6
+    input_bs6 = torch.randn((6, 3, 224, 224)).to("cuda")
+    outputs_pyt = model(input_bs6)
+    outputs_trt = trt_module(input_bs6)
+    outputs_trt_deser = deser_trt_module(input_bs6)
+
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_save_with_dynamic_shapes_api TRT outputs don't match with the original model for batch size=6. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt_deser)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_save_with_dynamic_shapes_api deserialized TRT outputs don't match with the original model for batch size=6. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+
+@pytest.mark.unit
+@unittest.skipIf(
+    not importlib.util.find_spec("torchvision"),
+    "torchvision is not installed",
+)
+def test_save_with_input_objects_inferred_dynamic_shapes(ir, tmpdir):
+    """
+    This tests the torch_tensorrt.save() API with torch_tensorrt.Input objects
+    that have min/opt/max shapes. The dynamic_shapes should be inferred automatically.
+    This is Method 2 - the recommended approach.
+    """
+
+    trt_ep_path = os.path.join(tmpdir, "trt_input_inferred.ep")
+    model = models.resnet18().eval().cuda()
+
+    # Define Input objects with dynamic shapes
+    compile_inputs = [
+        torchtrt.Input(
+            min_shape=(1, 3, 224, 224),
+            opt_shape=(4, 3, 224, 224),
+            max_shape=(8, 3, 224, 224),
+            dtype=torch.float32,
+            name="x",
+        )
+    ]
+
+    compile_spec = {
+        "arg_inputs": compile_inputs,
+        "ir": ir,
+        "min_block_size": 1,
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+
+    # Note: We're NOT using torch.export.export here, going directly through compile
+    trt_module = torchtrt.compile(model, **compile_spec)
+
+    # Use the new torch_tensorrt.save() API with Input objects
+    # Dynamic shapes should be inferred automatically - no explicit dynamic_shapes needed!
+    # Note: retrace=False because retracing a TRT-compiled module with dynamic shapes
+    # causes issues with unbacked symints from TensorRT runtime
+    torchtrt.save(
+        trt_module,
+        trt_ep_path,
+        output_format="exported_program",
+        arg_inputs=compile_inputs,  # Pass Input objects, not tensors
+        retrace=True,
+    )
+
+    # Load and test with different batch sizes
+    deser_trt_module = torchtrt.load(trt_ep_path).module()
+
+    # Test with batch size 2
+    input_bs2 = torch.randn((2, 3, 224, 224)).to("cuda")
+    outputs_pyt = model(input_bs2)
+    outputs_trt = trt_module(input_bs2)
+    outputs_trt_deser = deser_trt_module(input_bs2)
+
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_save_with_input_objects_inferred_dynamic_shapes TRT outputs don't match for batch size=2. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt_deser)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_save_with_input_objects_inferred_dynamic_shapes deserialized TRT outputs don't match for batch size=2. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+    # Test with batch size 7
+    input_bs7 = torch.randn((7, 3, 224, 224)).to("cuda")
+    outputs_pyt = model(input_bs7)
+    outputs_trt = trt_module(input_bs7)
+    outputs_trt_deser = deser_trt_module(input_bs7)
+
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_save_with_input_objects_inferred_dynamic_shapes TRT outputs don't match for batch size=7. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt_deser)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_save_with_input_objects_inferred_dynamic_shapes deserialized TRT outputs don't match for batch size=7. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+    )
+
+
+@pytest.mark.unit
+def test_save_inferred_dynamic_shapes_multiple_dimensions(ir, tmpdir):
+    """
+    Test automatic dynamic shape inference with multiple dynamic dimensions
+    (batch, height, width)
+
+    NOTE: This test is skipped because torch.export cannot properly serialize
+    ExportedPrograms with multiple dynamic dimensions when retrace=False (causes
+    missing value range info), and retrace=True causes unbacked symint issues with
+    TRT-compiled modules. Use test_save_with_dynamic_shapes_api with explicit
+    dynamic_shapes parameter instead.
+    """
+
+    trt_ep_path = os.path.join(tmpdir, "trt_multi_dim.ep")
+
+    class ConvModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 16, 3, padding=1)
+
+        def forward(self, x):
+            return self.conv(x)
+
+    model = ConvModel().eval().cuda()
+
+    # Define Input with 3 dynamic dimensions
+    compile_inputs = [
+        torchtrt.Input(
+            min_shape=(1, 3, 64, 64),
+            opt_shape=(4, 3, 256, 256),
+            max_shape=(8, 3, 512, 512),
+            dtype=torch.float32,
+            name="x",
+        )
+    ]
+
+    compile_spec = {
+        "inputs": compile_inputs,
+        "ir": ir,
+        "min_block_size": 1,
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+
+    # Generate dynamic shape specs
+    dyn_batch = torch.export.Dim("batch", min=1, max=8)
+    dyn_height = torch.export.Dim("height", min=64, max=512)
+    dyn_width = torch.export.Dim("width", min=64, max=512)
+    dynamic_shapes = {"x": {0: dyn_batch, 2: dyn_height, 3: dyn_width}}
+
+    trt_module = torchtrt.compile(model, **compile_spec)
+
+    # Save with automatic inference of all 3 dynamic dimensions
+    # retrace=True now works correctly with dynamic shapes
+    torchtrt.save(
+        trt_module,
+        trt_ep_path,
+        output_format="exported_program",
+        arg_inputs=compile_inputs,
+        dynamic_shapes=dynamic_shapes,
+        retrace=True,
+    )
+
+    # Load and test with various sizes
+    deser_trt_module = torchtrt.load(trt_ep_path).module()
+
+    # Test different combinations of batch, height, width
+    test_shapes = [
+        (2, 3, 128, 128),
+        (6, 3, 384, 384),
+        (1, 3, 64, 64),  # Min
+        (8, 3, 512, 512),  # Max
+    ]
+
+    for shape in test_shapes:
+        input_tensor = torch.randn(shape).to("cuda")
+        outputs_pyt = model(input_tensor)
+        outputs_trt = trt_module(input_tensor)
+        outputs_trt_deser = deser_trt_module(input_tensor)
+
+        cos_sim = cosine_similarity(outputs_pyt, outputs_trt)
+        assertions.assertTrue(
+            cos_sim > COSINE_THRESHOLD,
+            msg=f"test_save_inferred_dynamic_shapes_multiple_dimensions TRT outputs don't match for shape {shape}. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+        )
+
+        cos_sim = cosine_similarity(outputs_pyt, outputs_trt_deser)
+        assertions.assertTrue(
+            cos_sim > COSINE_THRESHOLD,
+            msg=f"test_save_inferred_dynamic_shapes_multiple_dimensions deserialized TRT outputs don't match for shape {shape}. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+        )
+
+
+@pytest.mark.unit
+def test_save_mixed_static_dynamic_inputs(ir, tmpdir):
+    """
+    Test saving with mixed static (tensor) and dynamic (Input) inputs
+
+    NOTE: This scenario requires explicit dynamic_shapes because automatic inference
+    cannot distinguish between dimensions that should be independent vs. equal.
+    """
+
+    trt_ep_path = os.path.join(tmpdir, "trt_mixed.ep")
+
+    class MixedInputModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(10, 5)
+
+        def forward(self, x, bias):
+            # x has dynamic batch, bias is a fixed-size tensor that broadcasts
+            out = self.linear(x)
+            # bias shape [1, 5] broadcasts to [batch, 5]
+            return out + bias
+
+    model = MixedInputModel().eval().cuda()
+
+    compile_inputs = [
+        torchtrt.Input(
+            min_shape=(1, 10),
+            opt_shape=(4, 10),
+            max_shape=(8, 10),
+            dtype=torch.float32,
+            name="x",
+        ),
+        torchtrt.Input(
+            shape=(1, 5),  # Fixed size bias
+            dtype=torch.float32,
+            name="bias",
+        ),
+    ]
+
+    compile_spec = {
+        "inputs": compile_inputs,
+        "ir": ir,
+        "min_block_size": 1,
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+
+    trt_module = torchtrt.compile(model, **compile_spec)
+
+    # Save with explicit dynamic_shapes
+    torchtrt.save(
+        trt_module,
+        trt_ep_path,
+        output_format="exported_program",
+        arg_inputs=compile_inputs,
+        retrace=True,
+    )
+
+    deser_trt_module = torchtrt.load(trt_ep_path).module()
+
+    # Test with different batch sizes for dynamic input
+    for batch_size in [2, 6]:
+        input_x = torch.randn(batch_size, 10).cuda()
+        input_bias = torch.randn(1, 5).cuda()  # Same fixed bias
+
+        outputs_pyt = model(input_x, input_bias)
+        outputs_trt_deser = deser_trt_module(input_x, input_bias)
+
+        cos_sim = cosine_similarity(outputs_pyt, outputs_trt_deser)
+        assertions.assertTrue(
+            cos_sim > COSINE_THRESHOLD,
+            msg=f"test_save_mixed_static_dynamic_inputs outputs don't match for batch size {batch_size}. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+        )
+
+
+@pytest.mark.unit
+def test_save_with_kwarg_inputs_dynamic(ir, tmpdir):
+    """
+    Test saving with dynamic shapes in kwarg_inputs
+
+    NOTE: When multiple inputs share the same dynamic dimension (e.g., batch size),
+    you must explicitly declare this by sharing a Dim object:
+
+        batch = Dim("batch", min=1, max=8)
+        dynamic_shapes = {"x": {0: batch}, "mask": {0: batch}}
+
+    Automatic inference creates separate Dim objects which causes torch.export
+    to detect an equality constraint violation.
+    """
+
+    trt_ep_path = os.path.join(tmpdir, "trt_kwargs.ep")
+
+    class KwargModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(10, 5)
+
+        def forward(self, x, *, mask):
+            # Apply linear transformation and multiply by mask
+            out = self.linear(x)
+            out = out * mask
+            return out
+
+    model = KwargModel().eval().cuda()
+
+    # Create example tensors for export
+    example_x = torch.randn(4, 10).cuda()
+    example_mask = torch.randn(4, 5).cuda()
+
+    # Define dynamic shapes with shared batch dimension
+    # Both inputs share the same batch Dim object to express equality constraint
+    batch = torch.export.Dim("batch", min=1, max=8)
+    dynamic_shapes = {"x": {0: batch}, "mask": {0: batch}}
+
+    # Step 1: Export with torch.export
+    exp_program = torch.export.export(
+        model,
+        (example_x,),
+        {"mask": example_mask},
+        dynamic_shapes=dynamic_shapes,
+        strict=False,
+    )
+
+    # Step 2: Compile with TensorRT using torch_tensorrt.dynamo.compile
+    compile_inputs = [
+        torchtrt.Input(
+            min_shape=(1, 10),
+            opt_shape=(4, 10),
+            max_shape=(8, 10),
+            dtype=torch.float32,
+            name="x",
+        ),
+        torchtrt.Input(
+            min_shape=(1, 5),
+            opt_shape=(4, 5),
+            max_shape=(8, 5),
+            dtype=torch.float32,
+            name="mask",
+        ),
+    ]
+
+    compile_spec = {
+        "inputs": compile_inputs,
+        "ir": ir,
+        "min_block_size": 1,
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+
+    trt_module = torchtrt.dynamo.compile(exp_program, **compile_spec)
+
+    # Save with explicit dynamic_shapes
+    torchtrt.save(
+        trt_module,
+        trt_ep_path,
+        output_format="exported_program",
+        arg_inputs=(example_x,),
+        kwarg_inputs={"mask": example_mask},
+        dynamic_shapes=dynamic_shapes,
+        retrace=True,
+    )
+
+    deser_trt_module = torchtrt.load(trt_ep_path).module()
+
+    # Test with different batch sizes
+    for batch_size in [2, 6]:
+        input_x = torch.randn(batch_size, 10).cuda()
+        input_mask = torch.randn(batch_size, 5).cuda()
+
+        outputs_pyt = model(input_x, mask=input_mask)
+        outputs_trt_deser = deser_trt_module(input_x, mask=input_mask)
+
+        cos_sim = cosine_similarity(outputs_pyt, outputs_trt_deser)
+        assertions.assertTrue(
+            cos_sim > COSINE_THRESHOLD,
+            msg=f"test_save_with_kwarg_inputs_dynamic outputs don't match for batch size {batch_size}. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+        )
+
+
+@pytest.mark.unit
+def test_explicit_dynamic_shapes_takes_precedence(ir, tmpdir):
+    """
+    Test that explicit dynamic_shapes parameter takes precedence over
+    inferred dynamic shapes from Input objects
+    """
+
+    trt_ep_path = os.path.join(tmpdir, "trt_precedence.ep")
+
+    class SimpleModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(10, 5)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    model = SimpleModel().eval().cuda()
+    example_input = torch.randn(4, 10).cuda()
+
+    # Define both Input objects AND explicit dynamic_shapes
+    compile_inputs = [
+        torchtrt.Input(
+            min_shape=(1, 10),
+            opt_shape=(4, 10),
+            max_shape=(8, 10),
+            dtype=torch.float32,
+            name="x",
+        )
+    ]
+
+    # Explicit dynamic_shapes with custom naming
+    dyn_batch = torch.export.Dim("custom_batch_name", min=1, max=8)
+    dynamic_shapes = {"x": {0: dyn_batch}}
+
+    exp_program = torch.export.export(
+        model, (example_input,), dynamic_shapes=dynamic_shapes, strict=False
+    )
+
+    compile_spec = {
+        "inputs": compile_inputs,
+        "ir": ir,
+        "min_block_size": 1,
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+
+    trt_module = torchtrt.dynamo.compile(exp_program, **compile_spec)
+
+    # Save with BOTH compile_inputs and explicit dynamic_shapes
+    # Explicit should take precedence
+    # retrace=True now works correctly with dynamic shapes
+    torchtrt.save(
+        trt_module,
+        trt_ep_path,
+        output_format="exported_program",
+        arg_inputs=[example_input],
+        dynamic_shapes=dynamic_shapes,  # Explicit takes precedence
+        retrace=True,
+    )
+
+    deser_trt_module = torchtrt.load(trt_ep_path).module()
+
+    # Test with different batch sizes
+    for batch_size in [2, 7]:
+        input_tensor = torch.randn(batch_size, 10).cuda()
+        outputs_pyt = model(input_tensor)
+        outputs_trt_deser = deser_trt_module(input_tensor)
+
+        cos_sim = cosine_similarity(outputs_pyt, outputs_trt_deser)
+        assertions.assertTrue(
+            cos_sim > COSINE_THRESHOLD,
+            msg=f"test_explicit_dynamic_shapes_takes_precedence outputs don't match for batch size {batch_size}. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
+        )
+
+
+@pytest.mark.unit
+def test_save_static_inputs_no_dynamic_inference(ir, tmpdir):
+    """
+    Test that static Input objects (without min/opt/max) don't trigger
+    dynamic shape inference
+    """
+
+    trt_ep_path = os.path.join(tmpdir, "trt_static.ep")
+
+    class SimpleModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(10, 5)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    model = SimpleModel().eval().cuda()
+
+    # Static Input (single shape, not min/opt/max)
+    compile_inputs = [torchtrt.Input(shape=(4, 10), dtype=torch.float32, name="x")]
+
+    compile_spec = {
+        "inputs": compile_inputs,
+        "ir": ir,
+        "min_block_size": 1,
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+
+    trt_module = torchtrt.compile(model, **compile_spec)
+
+    # Save - should NOT infer dynamic shapes (all inputs are static)
+    torchtrt.save(
+        trt_module,
+        trt_ep_path,
+        output_format="exported_program",
+        arg_inputs=compile_inputs,
+        retrace=True,
+    )
+
+    deser_trt_module = torchtrt.load(trt_ep_path).module()
+
+    # Should only work with the exact shape
+    input_tensor = torch.randn(4, 10).cuda()
+    outputs_pyt = model(input_tensor)
+    outputs_trt_deser = deser_trt_module(input_tensor)
+
+    cos_sim = cosine_similarity(outputs_pyt, outputs_trt_deser)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=f"test_save_static_inputs_no_dynamic_inference outputs don't match. Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}",
     )

--- a/uv.lock
+++ b/uv.lock
@@ -32,9 +32,6 @@ required-markers = [
     "python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32'",
 ]
 
-[options]
-prerelease-mode = "allow"
-
 [[package]]
 name = "accelerate"
 version = "1.12.0"


### PR DESCRIPTION
# Description

Adds functionality to store shape expressions for compiled subgraph in the metadata pickle. At re-searlization time, these objects will apply these shape expressions on the input FakeTensor to describe the output shape in terms of symbolic shape.

Fixes N/A

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
