### PR TITLE
feat: Allow pulling the venv's torch after uv sync so that people don…

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,6 +24,8 @@ git_override(
 
 new_local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 
+local_torch = use_repo_rule("//toolchains:local_torch.bzl", "local_torch")
+
 # External dependency for torch_tensorrt if you already have precompiled binaries.
 new_local_repository(
     name = "torch_tensorrt",
@@ -56,17 +58,45 @@ new_local_repository(
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+####################################################################################
+# Locally installed dependencies (use in cases of custom dependencies or aarch64)
+####################################################################################
+
+# Detect the locally installed PyTorch at build time so the headers always match
+# the runtime libtorch_cuda.so, avoiding ABI mismatches (e.g. CUDAGraph layout).
+# Works with uv (.venv/), virtualenv (VIRTUAL_ENV), and conda (CONDA_PREFIX).
+# Override with TORCH_PATH env var if auto-detection fails.
+local_torch(name = "libtorch")
+
+# NOTE: If you are using a local archive build of torch, just point the Libtorch dep to that path.
+
+#new_local_repository(
+#    name = "libtorch",
+# please modify this path according to your local python wheel path
+#    path = "/usr/local/lib/python3.11/dist-packages/torch",
+#    build_file = "third_party/libtorch/BUILD"
+#)
+
+#new_local_repository(
+#   name = "tensorrt",
+#   path = "/usr/",
+#   build_file = "@//third_party/tensorrt/local:BUILD"
+#)
+
 #############################################################################################################
 # Tarballs and fetched dependencies (default - use in cases when building from precompiled bin and tarballs)
 #############################################################################################################
 
-# this is used for linux x86_64
-http_archive(
-    name = "libtorch",
-    build_file = "@//third_party/libtorch:BUILD",
-    strip_prefix = "libtorch",
-    urls = ["https://download.pytorch.org/libtorch/nightly/cu130/libtorch-shared-with-deps-latest.zip"],
-)
+# Alternatively, pin to a specific nightly for reproducible/frozen builds.
+# Uncomment this block and comment out local_torch above.
+# NOTE: The pinned version must match the PyTorch installed in your Python
+# environment — a mismatch causes ABI breakage (see installation docs).
+#http_archive(
+#    name = "libtorch",
+#    build_file = "@//third_party/libtorch:BUILD",
+#    strip_prefix = "libtorch",
+#    urls = ["https://download.pytorch.org/libtorch/nightly/cu130/libtorch-shared-with-deps-latest.zip"],
+#)
 
 # in aarch64 platform you can get libtorch via either local or wheel file
 # It is possible to specify a wheel file to use as the libtorch source by providing the URL below and
@@ -151,21 +181,3 @@ http_archive(
         "https://developer.nvidia.com/downloads/trt/rtx_sdk/secure/1.3/tensorrt-rtx-1.3.0.35-win10-amd64-cuda-13.1-release-external.zip",
     ],
 )
-####################################################################################
-# Locally installed dependencies (use in cases of custom dependencies or aarch64)
-####################################################################################
-
-# NOTE: If you are using a local build of torch, just point the Libtorch dep to that path.
-
-#new_local_repository(
-#    name = "libtorch",
-# please modify this path according to your local python wheel path
-#    path = "/usr/local/lib/python3.11/dist-packages/torch",
-#    build_file = "third_party/libtorch/BUILD"
-#)
-
-#new_local_repository(
-#   name = "tensorrt",
-#   path = "/usr/",
-#   build_file = "@//third_party/tensorrt/local:BUILD"
-#)

--- a/core/runtime/TRTEngine.cpp
+++ b/core/runtime/TRTEngine.cpp
@@ -264,6 +264,7 @@ TRTEngine::TRTEngine(
 }
 
 TRTEngine::~TRTEngine() {
+  torch::cuda::synchronize(device_info.id);
   trt_engine_profiler.reset();
   exec_ctx.reset();
   cuda_engine.reset();

--- a/docsrc/getting_started/installation.rst
+++ b/docsrc/getting_started/installation.rst
@@ -92,10 +92,32 @@ Dependencies
     * Specify your CUDA version here if not the version used in the branch being built: https://github.com/pytorch/TensorRT/blob/4e5b0f6e860910eb510fa70a76ee3eb9825e7a4d/WORKSPACE#L46
 
 
-* The correct **LibTorch** and **TensorRT** versions will be pulled down for you by bazel.
+* **LibTorch** — by default Bazel automatically detects the PyTorch installation from your active environment and compiles against it. This ensures the C++ headers always match the runtime ``libtorch_cuda.so``, avoiding ABI mismatches.
 
-    NOTE: By default bazel will pull the latest nightly from pytorch.org. For building main, this is usually sufficient however if there is a specific PyTorch you are targeting,
-    edit these locations with updated URLs/paths:
+    Detection order:
+
+    1. ``TORCH_PATH`` environment variable — absolute path to the torch package directory.
+    2. ``VIRTUAL_ENV`` — used when a virtualenv or ``uv`` venv is activated (``source .venv/bin/activate``).
+    3. ``CONDA_PREFIX`` — used when a conda environment is activated (``conda activate myenv``).
+    4. ``.venv/bin/python3`` relative to the repository root
+    5. ``python3`` / ``python`` on ``PATH`` — system Python fallback.
+
+    If auto-detection fails, set ``TORCH_PATH`` explicitly:
+
+    .. code-block:: sh
+
+        TORCH_PATH=$(python3 -c "import torch, os; print(os.path.dirname(torch.__file__))") \
+            bazelisk build //:libtorchtrt -c opt
+
+    **Pinning to a specific nightly (frozen deps)**
+
+    If you prefer reproducible builds against a fixed PyTorch nightly, ``MODULE.bazel`` contains
+    a commented-out ``http_archive`` block for ``libtorch``. Comment out the ``local_torch`` line
+    and uncomment the ``http_archive`` block. The pinned version **must** match the PyTorch
+    installed in your Python environment — a mismatch between compiled headers and the runtime
+    ``libtorch_cuda.so`` can cause ABI breakage. To pin to a specific build rather than
+    ``latest``, replace the URL with a dated nightly, e.g.:
+    ``libtorch-shared-with-deps-2.6.0.dev20250101%2Bcu130.zip``
 
     * https://github.com/pytorch/TensorRT/blob/4e5b0f6e860910eb510fa70a76ee3eb9825e7a4d/WORKSPACE#L53C1-L53C1
 
@@ -208,9 +230,9 @@ A tarball with the include files and library can then be found in ``bazel-bin``
 Choosing the Right ABI
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-For the old versions, there were two ABI options to compile Torch-TensorRT which were incompatible with each other, 
-pre-cxx11-abi and cxx11-abi. The complexity came from the different distributions of PyTorch. Fortunately, PyTorch 
-has switched to cxx11-abi for all distributions. Below is a table with general pairings of PyTorch distribution 
+For the old versions, there were two ABI options to compile Torch-TensorRT which were incompatible with each other,
+pre-cxx11-abi and cxx11-abi. The complexity came from the different distributions of PyTorch. Fortunately, PyTorch
+has switched to cxx11-abi for all distributions. Below is a table with general pairings of PyTorch distribution
 sources and the recommended commands:
 
 +-------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------+

--- a/tests/py/dynamo/llm/test_llm_models.py
+++ b/tests/py/dynamo/llm/test_llm_models.py
@@ -6,7 +6,9 @@ import unittest
 import pytest
 import torch
 import torch_tensorrt
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+
+if importlib.util.find_spec("transformers"):
+    from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "../../../../tools/llm"))
 import argparse
@@ -17,6 +19,10 @@ import argparse
 @unittest.skipIf(
     not importlib.util.find_spec("modelopt"),
     "ModelOpt is required to run this test",
+)
+@unittest.skipIf(
+    not importlib.util.find_spec("transformers"),
+    "transformers is not installed",
 )
 def test_llm_decoder_layer(precision):
     from run_llm import compile_torchtrt

--- a/tests/py/dynamo/models/test_model_refit.py
+++ b/tests/py/dynamo/models/test_model_refit.py
@@ -3,7 +3,6 @@ import os
 import unittest
 
 import pytest
-import tensorrt as trt
 import torch
 import torch.nn.functional as F
 import torch_tensorrt as torchtrt
@@ -20,6 +19,8 @@ from torch_tensorrt.dynamo.lowering import (
     pre_export_lowering,
 )
 from torch_tensorrt.logging import TRT_LOGGER
+
+import tensorrt as trt
 
 assertions = unittest.TestCase()
 
@@ -529,6 +530,10 @@ def test_refit_one_engine_bert_with_weightmap():
     not torch_trt.ENABLED_FEATURES.refit,
     "Refit feature is not supported in Python 3.13 or higher",
 )
+@unittest.skipIf(
+    not importlib.util.find_spec("torchvision"),
+    "torchvision is not installed",
+)
 @pytest.mark.unit
 def test_refit_one_engine_inline_runtime_with_weightmap(tmpdir):
 
@@ -580,6 +585,10 @@ def test_refit_one_engine_inline_runtime_with_weightmap(tmpdir):
 @unittest.skipIf(
     not torch_trt.ENABLED_FEATURES.refit,
     "Refit feature is not supported in Python 3.13 or higher",
+)
+@unittest.skipIf(
+    not importlib.util.find_spec("torchvision"),
+    "torchvision is not installed",
 )
 @pytest.mark.unit
 def test_refit_one_engine_python_runtime_with_weightmap():
@@ -772,6 +781,10 @@ def test_refit_multiple_engine_with_weightmap_cpu_offload():
     not torch_trt.ENABLED_FEATURES.refit,
     "Refit feature is not supported in Python 3.13 or higher",
 )
+@unittest.skipIf(
+    not importlib.util.find_spec("torchvision"),
+    "torchvision is not installed",
+)
 @pytest.mark.unit
 def test_refit_one_engine_without_weightmap():
     model = models.resnet18(pretrained=True).eval().to("cuda")
@@ -887,6 +900,10 @@ def test_refit_one_engine_bert_without_weightmap():
     not torch_trt.ENABLED_FEATURES.refit,
     "Refit feature is not supported in Python 3.13 or higher",
 )
+@unittest.skipIf(
+    not importlib.util.find_spec("torchvision"),
+    "torchvision is not installed",
+)
 @pytest.mark.unit
 def test_refit_one_engine_inline_runtime_without_weightmap(tmpdir):
     trt_ep_path = os.path.join(tmpdir, "compiled.ep")
@@ -935,6 +952,10 @@ def test_refit_one_engine_inline_runtime_without_weightmap(tmpdir):
 @unittest.skipIf(
     not torch_trt.ENABLED_FEATURES.refit,
     "Refit feature is not supported in Python 3.13 or higher",
+)
+@unittest.skipIf(
+    not importlib.util.find_spec("torchvision"),
+    "torchvision is not installed",
 )
 @pytest.mark.unit
 def test_refit_one_engine_python_runtime_without_weightmap():

--- a/tests/py/dynamo/models/test_models.py
+++ b/tests/py/dynamo/models/test_models.py
@@ -20,6 +20,8 @@ if importlib.util.find_spec("torchvision"):
     import torchvision.models as models
 if importlib.util.find_spec("timm"):
     import timm
+if importlib.util.find_spec("transformers"):
+    import transformers
 
 
 @pytest.mark.unit
@@ -334,6 +336,9 @@ def test_bert_base_uncased(ir, dtype):
     torch._dynamo.reset()
 
 
+@unittest.skipIf(
+    not importlib.util.find_spec("transformers"), "torchvision not installed"
+)
 @pytest.mark.unit
 def test_bert_base_uncased_cpu_offload(ir):
     from transformers import BertModel

--- a/tests/py/dynamo/models/test_models_export.py
+++ b/tests/py/dynamo/models/test_models_export.py
@@ -55,6 +55,9 @@ def test_resnet18(ir):
     torch._dynamo.reset()
 
 
+@unittest.skipIf(
+    not importlib.util.find_spec("torchvision"), "torchvision not installed"
+)
 @pytest.mark.unit
 def test_mobilenet_v2(ir):
     model = models.mobilenet_v2(pretrained=True).eval().to("cuda")
@@ -178,6 +181,9 @@ def test_bert_base_uncased(ir):
     torch._dynamo.reset()
 
 
+@unittest.skipIf(
+    not importlib.util.find_spec("torchvision"), "torchvision not installed"
+)
 @pytest.mark.unit
 def test_resnet18_half(ir):
     model = models.resnet18(pretrained=True).eval().to("cuda").half()

--- a/toolchains/local_torch.bzl
+++ b/toolchains/local_torch.bzl
@@ -1,0 +1,90 @@
+"""Repository rule that locates the locally installed PyTorch.
+
+This avoids hardcoding torch's install path in MODULE.bazel, making the build
+portable across machines regardless of Python version or venv location.
+
+Discovery order:
+  1. TORCH_PATH env var  — absolute path to the torch package directory
+  2. VIRTUAL_ENV env var  — virtualenv / uv venv ($VIRTUAL_ENV/bin/python3)
+  3. CONDA_PREFIX env var — conda environment ($CONDA_PREFIX/bin/python3)
+  4. .venv/bin/python3 relative to the workspace root (uv / virtualenv default)
+  5. venv/bin/python3 relative to the workspace root
+  6. python3 / python on PATH
+"""
+
+def _find_python(ctx):
+    """Return a path-like object for a Python that has torch importable, or None."""
+    candidates = []
+
+    # virtualenv / uv venv
+    virtual_env = ctx.os.environ.get("VIRTUAL_ENV", "")
+    if virtual_env:
+        candidates.append(ctx.path(virtual_env + "/bin/python3"))
+        candidates.append(ctx.path(virtual_env + "/bin/python"))
+
+    # conda environment
+    conda_prefix = ctx.os.environ.get("CONDA_PREFIX", "")
+    if conda_prefix:
+        candidates.append(ctx.path(conda_prefix + "/bin/python3"))
+        candidates.append(ctx.path(conda_prefix + "/bin/python"))
+
+    # Common relative-to-workspace venv locations
+    # ctx.workspace_root is the real workspace root (not the synthetic repo root)
+    ws = ctx.workspace_root
+    for rel in [
+        ".venv/bin/python3",
+        ".venv/bin/python",
+        "venv/bin/python3",
+        "venv/bin/python",
+    ]:
+        candidates.append(ws.get_child(rel.replace("/", ws.sep if hasattr(ws, "sep") else "/")))
+
+    # System Python last
+    for name in ["python3", "python"]:
+        p = ctx.which(name)
+        if p:
+            candidates.append(p)
+
+    for candidate in candidates:
+        if candidate.exists:
+            result = ctx.execute([candidate, "-c", "import torch"])
+            if result.return_code == 0:
+                return candidate
+    return None
+
+def _local_torch_impl(ctx):
+    # 1. Env-var override (takes priority over auto-detection)
+    torch_dir = ctx.os.environ.get("TORCH_PATH", "").strip()
+
+    if not torch_dir:
+        python = _find_python(ctx)
+        if not python:
+            fail(
+                "Cannot locate a Python interpreter that has torch installed. " +
+                "Either activate the project venv, or set TORCH_PATH to the " +
+                "directory containing torch (e.g. /path/to/.venv/lib/pythonX.Y/site-packages/torch).",
+            )
+        result = ctx.execute(
+            [python, "-c", "import torch, os; print(os.path.dirname(torch.__file__))"],
+        )
+        if result.return_code != 0:
+            fail("Failed to get torch path from python: " + result.stderr)
+        torch_dir = result.stdout.strip()
+
+    if not torch_dir:
+        fail("Torch path is empty. Set TORCH_PATH or ensure torch is installed in the active Python.")
+
+    torch_path = ctx.path(torch_dir)
+
+    # Symlink the subdirectories the BUILD file references into the synthetic repo
+    for sub in ["include", "lib", "share"]:
+        child = torch_path.get_child(sub)
+        if child.exists:
+            ctx.symlink(child, sub)
+
+    ctx.file("BUILD", ctx.read(Label("@//third_party/libtorch:BUILD")))
+
+local_torch = repository_rule(
+    implementation = _local_torch_impl,
+    environ = ["TORCH_PATH", "VIRTUAL_ENV", "CONDA_PREFIX"],
+)


### PR DESCRIPTION
…t have the version mismatch anymore

# Description

Long standing developer ergonomics issue was this occasional mismatch between libtorch and torch. Bazel made this hard because we didnt have a rule to go find the right torch. Now we do. The docs have the new usage 

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
