### PR TITLE
Fix #4150: [Bug] TestWeightStrippedEngine OOM on RTX 3070 (8GB) with ...

### DIFF
--- a/tests/py/dynamo/models/test_weight_stripped_engine.py
+++ b/tests/py/dynamo/models/test_weight_stripped_engine.py
@@ -114,7 +114,7 @@ class TestWeightStrippedEngine(TestCase):
     )
     def test_weight_stripped_engine_sizes(self):
         pyt_model = models.resnet18(pretrained=True).eval().to("cuda")
-        example_inputs = (torch.randn((100, 3, 224, 224)).to("cuda"),)
+        example_inputs = (torch.randn((2, 3, 224, 224)).to("cuda"),)
         exp_program = torch.export.export(pyt_model, example_inputs)
         weight_included_engine = convert_exported_program_to_serialized_trt_engine(
             exp_program,
@@ -159,14 +159,14 @@ class TestWeightStrippedEngine(TestCase):
     )
     def test_weight_stripped_engine_results(self):
         pyt_model = models.resnet18(pretrained=True).eval().to("cuda")
-        example_inputs = (torch.randn((100, 3, 224, 224)).to("cuda"),)
+        example_inputs = (torch.randn((2, 3, 224, 224)).to("cuda"),)
         # Mark the dim0 of inputs as dynamic
         batch = torch.export.Dim("batch", min=1, max=200)
         exp_program = torch.export.export(
             pyt_model, args=example_inputs, dynamic_shapes={"x": {0: batch}}
         )
 
-        inputs = [torch.rand((128, 3, 224, 224)).to("cuda")]
+        inputs = [torch.rand((2, 3, 224, 224)).to("cuda")]
 
         trt_gm = torch_trt.dynamo.compile(
             exp_program,
@@ -551,12 +551,12 @@ class TestWeightStrippedEngine(TestCase):
     )
     def test_two_TRTRuntime_in_refitting(self):
         pyt_model = models.resnet18(pretrained=True).eval().to("cuda")
-        example_inputs = (torch.randn((100, 3, 224, 224)).to("cuda"),)
+        example_inputs = (torch.randn((2, 3, 224, 224)).to("cuda"),)
         batch = torch.export.Dim("batch", min=1, max=200)
         exp_program = torch.export.export(
             pyt_model, args=example_inputs, dynamic_shapes={"x": {0: batch}}
         )
-        inputs = [torch.rand((128, 3, 224, 224)).to("cuda")]
+        inputs = [torch.rand((2, 3, 224, 224)).to("cuda")]
 
         pyt_results = pyt_model(*inputs)
 


### PR DESCRIPTION
Closes #4150

# Description

Reduces batch sizes in three `TestWeightStrippedEngine` tests in `tests/py/dynamo/models/test_weight_stripped_engine.py` to prevent CUDA out-of-memory failures on GPUs with 8GB VRAM (e.g., RTX 3070).

The three affected tests were using batch size 100 or 128 for ResNet-18 inputs at shape `(N, 3, 224, 224)`, which exhausts available VRAM on 8GB cards under CUDA 12.x. The fix reduces all example and inference inputs to batch size 2:

- `test_weight_stripped_engine_sizes`: `example_inputs` reduced from `(100, 3, 224, 224)` to `(2, 3, 224, 224)`
- `test_weight_stripped_engine_results`: `example_inputs` reduced from `(100, 3, 224, 224)` to `(2, 3, 224, 224)`; inference `inputs` reduced from `(128, 3, 224, 224)` to `(2, 3, 224, 224)`
- `test_two_TRTRuntime_in_refitting`: same reductions as `test_weight_stripped_engine_results`

The dynamic shape bounds (`min=1, max=200`) are unchanged, so these tests continue to exercise dynamic batching. The correctness assertions in `test_weight_stripped_engine_results` and the engine size comparisons in `test_weight_stripped_engine_sizes` remain intact.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified