### PR TITLE
test: skip cumsum conversion tests on TensorRT-RTX

### DIFF
--- a/tests/py/dynamo/conversion/test_cumsum_aten.py
+++ b/tests/py/dynamo/conversion/test_cumsum_aten.py
@@ -9,6 +9,10 @@ from torch.testing._internal.common_utils import run_tests
 from .harness import DispatchTestCase
 
 
+@unittest.skipIf(
+    torch_tensorrt.ENABLED_FEATURES.tensorrt_rtx,
+    "cumsum errors out on TensorRT-RTX",
+)
 class TestCumsumConverter(DispatchTestCase):
     @parameterized.expand(
         [

--- a/tests/py/dynamo/conversion/test_cumsum_aten.py
+++ b/tests/py/dynamo/conversion/test_cumsum_aten.py
@@ -1,5 +1,7 @@
+import sys
 import unittest
 
+import pytest
 import torch
 import torch.nn as nn
 import torch_tensorrt
@@ -9,9 +11,9 @@ from torch.testing._internal.common_utils import run_tests
 from .harness import DispatchTestCase
 
 
-@unittest.skipIf(
-    torch_tensorrt.ENABLED_FEATURES.tensorrt_rtx,
-    "cumsum errors out on TensorRT-RTX",
+@pytest.mark.xfail(
+    condition=torch_tensorrt.ENABLED_FEATURES.tensorrt_rtx and sys.platform == "win32",
+    reason="cumsum errors out on TensorRT-RTX",
 )
 class TestCumsumConverter(DispatchTestCase):
     @parameterized.expand(


### PR DESCRIPTION
# Description

Skip the `TestCumsumConverter` test class when TensorRT-RTX is enabled, as cumsum errors out on TensorRT-RTX.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [n/a] I have made corresponding changes to the documentation
- [n/a] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified