### PR TITLE
Add support for SymInt start values in slice_scatter_decomposition

### DIFF
--- a/py/torch_tensorrt/dynamo/lowering/_decompositions.py
+++ b/py/torch_tensorrt/dynamo/lowering/_decompositions.py
@@ -197,8 +197,13 @@ def slice_scatter_decomposition(
     dim_size = input_tensor.shape[dim]
     device_input_tensor = input_tensor.device
 
-    start = 0 if start is None else start  # Ensure start is int
-    start = get_positive_dim(start, input_tensor.shape[dim])
+    if start is None:
+        start = 0
+    elif isinstance(start, int):
+        start = get_positive_dim(start, dim_size)
+    elif isinstance(start, torch.SymInt):
+        if start < 0:
+            start = start + dim_size
     if end is None:  # Ensure end is int
         end = dim_size
     end = (


### PR DESCRIPTION
# Description

Add support for SymInt start values in slice_scatter_decomposition.

This fixes a crash issue when I run with ZoomASR.

Fixes # (issue): None

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
