### PR TITLE
fix(test): skip cumsum tests on TensorRT-RTX Windows instead of xfail

### DIFF
--- a/tests/py/dynamo/conversion/test_cumsum_aten.py
+++ b/tests/py/dynamo/conversion/test_cumsum_aten.py
@@ -1,7 +1,6 @@
 import sys
 import unittest
 
-import pytest
 import torch
 import torch.nn as nn
 import torch_tensorrt
@@ -11,9 +10,9 @@ from torch.testing._internal.common_utils import run_tests
 from .harness import DispatchTestCase
 
 
-@pytest.mark.xfail(
-    condition=torch_tensorrt.ENABLED_FEATURES.tensorrt_rtx and sys.platform == "win32",
-    reason="cumsum errors out on TensorRT-RTX",
+@unittest.skipIf(
+    torch_tensorrt.ENABLED_FEATURES.tensorrt_rtx and sys.platform == "win32",
+    "cumsum errors out on TensorRT-RTX on Windows",
 )
 class TestCumsumConverter(DispatchTestCase):
     @parameterized.expand(


### PR DESCRIPTION
## Description

Change `TestCumsumConverter` from `@pytest.mark.xfail` to `@unittest.skipIf` to match the repo convention for TensorRT-RTX conditional test skips.

With `xfail`, the cumsum test still executes and the resulting error corrupts CUDA state, causing subsequent tests in the CI pipeline to fail. Using `skipIf` avoids running the test entirely and prevents these cascading failures.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified