### PR TITLE
fix: detect incomplete fast refit on TRT-RTX via unset weights check

### DIFF
--- a/py/torch_tensorrt/dynamo/_refit.py
+++ b/py/torch_tensorrt/dynamo/_refit.py
@@ -187,9 +187,18 @@ def _refit_single_trt_engine_with_gm(
                     weight_dtype, weight.data_ptr(), torch.numel(weight)
                 )
                 refitter.set_named_weights(layer_name, trt_wt_tensor, trt_wt_location)
-            assert (
-                len(refitter.get_missing_weights()) == 0
-            ), "Fast refitting failed due to incomplete mapping"
+            # Check completeness via two methods:
+            # 1. get_missing_weights(): reports weights in connected engines
+            #    that were not set.
+            # 2. Compare weights actually set vs all engine weights: catches
+            #    weights in independent engines that get_missing_weights() may not report.
+            missing_weights = refitter.get_missing_weights()
+            unset_weights = {w for w in weight_list if w not in mapping}
+            assert len(missing_weights) == 0 and len(unset_weights) == 0, (
+                f"Fast refitting failed due to incomplete mapping"
+                f" ({len(missing_weights)} missing,"
+                f" {len(unset_weights)} unset)"
+            )
 
         else:
             mapping = construct_refit_mapping(new_gm, input_list, settings)

--- a/tests/py/dynamo/models/test_model_refit.py
+++ b/tests/py/dynamo/models/test_model_refit.py
@@ -21,7 +21,8 @@ from torch_tensorrt.dynamo.lowering import (
 )
 from torch_tensorrt.logging import TRT_LOGGER
 
-import tensorrt as trt
+# must import after torch_tensorrt to resolve tensorrt_rtx alias
+import tensorrt as trt  # isort: skip
 
 assertions = unittest.TestCase()
 
@@ -409,10 +410,6 @@ def test_refit_one_engine_no_map_with_weightmap():
 @unittest.skipIf(
     not importlib.util.find_spec("torchvision"),
     "torchvision is not installed",
-)
-@unittest.skipIf(
-    torch_trt.ENABLED_FEATURES.tensorrt_rtx,
-    "Refit with wrong weightmap is not supported on TensorRT-RTX",
 )
 @pytest.mark.unit
 def test_refit_one_engine_with_wrong_weightmap():


### PR DESCRIPTION
## Summary
- Add complementary completeness check in fast refit path that compares engine weights against the mapping to detect unset weights directly
- On TRT-RTX, `get_missing_weights()` may not report weights in independent wtsEngines (TRT-RTX native refit closures have no cross-engine dependencies), causing the fast refit to silently produce wrong results with stale weights
- The new `unset_weights` check catches this regardless of the wtsEngine dependency structure
- Unwaive `test_refit_one_engine_with_wrong_weightmap` on TRT-RTX

## Test plan
- [x] `test_refit_one_engine_with_wrong_weightmap` passes on standard TRT (torch 2.13.0.dev20260416, TRT 10.16.1.11)
- [x] `test_refit_one_engine_with_wrong_weightmap` passes on TRT-RTX (torch 2.13.0.dev20260416, TRT-RTX 1.4.0.76)
- [ ] CI L0/L1 refit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)