### PR TITLE
user provided bound for torchtrt compile when export dimension is unb…

### DIFF
--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -895,7 +895,7 @@ def _build_user_symbol_bounds(
     gm: torch.fx.GraphModule,
     sample_arg_inputs: Sequence[Input],
     sample_kwarg_inputs: dict[Any, Any],
-    graph_signature: Optional[torch.export.graph_signature.ExportGraphSignature] = None,
+    graph_signature: torch.export.graph_signature.ExportGraphSignature,
 ) -> Dict[sympy.Symbol, Tuple[int, int]]:
     """Map ``sympy.Symbol -> (min, max)`` from dynamic ``Input``s, used to
     fill ``Dim.DYNAMIC`` upper bounds without mutating ``ShapeEnv``.
@@ -910,30 +910,34 @@ def _build_user_symbol_bounds(
     # only contains USER_INPUT nodes, but graph_signature.input_specs still lists
     # all specs (PARAMETER, BUFFER, USER_INPUT). A positional zip misaligns.
     # Use name-based lookup keyed on graph_signature USER_INPUT names instead.
-    # When graph_signature is absent (e.g. direct unit-test calls), fall back to
-    # all placeholder nodes in graph order (which are already USER_INPUT only
-    # after ep.module()).
     placeholder_by_name = {n.name: n for n in gm.graph.nodes if n.op == "placeholder"}
-    if graph_signature is not None:
-        user_input_names = [
-            spec.arg.name
-            for spec in graph_signature.input_specs
-            if spec.kind == InputKind.USER_INPUT and hasattr(spec.arg, "name")
-        ]
-        placeholders = [
-            placeholder_by_name[name]
-            for name in user_input_names
-            if name in placeholder_by_name
-        ]
-    else:
-        placeholders = list(placeholder_by_name.values())
+    user_input_names = [
+        spec.arg.name
+        for spec in graph_signature.input_specs
+        if spec.kind == InputKind.USER_INPUT and hasattr(spec.arg, "name")
+    ]
+    placeholders = [
+        placeholder_by_name[name]
+        for name in user_input_names
+        if name in placeholder_by_name
+    ]
 
-    # Avoid flatten_up_to: the user may compile with a different arg/kwarg split
-    # than was used at export time, causing a pytree arity mismatch. Match the
-    # existing pattern in compile_module: positional args first, then kwargs.
-    flat_inputs: List[Any] = list(sample_arg_inputs)
-    if isinstance(sample_kwarg_inputs, dict):
-        flat_inputs.extend(sample_kwarg_inputs.values())
+    # Use _in_spec.flatten_up_to to preserve export-time kwarg ordering.
+    # Fall back to name-based kwarg lookup when the arg/kwarg split differs
+    # from export time (which would cause flatten_up_to to raise an arity error).
+    in_spec = getattr(gm, "_in_spec", None)
+    try:
+        if in_spec is None:
+            raise AttributeError("_in_spec not found on graph module")
+        flat_inputs = in_spec.flatten_up_to(
+            (tuple(sample_arg_inputs), sample_kwarg_inputs)
+        )
+    except (ValueError, AttributeError):
+        flat_inputs = list(sample_arg_inputs)
+        if isinstance(sample_kwarg_inputs, dict):
+            for name in user_input_names[len(sample_arg_inputs) :]:
+                if name in sample_kwarg_inputs:
+                    flat_inputs.append(sample_kwarg_inputs[name])
 
     user_symbol_bounds: Dict[sympy.Symbol, Tuple[int, int]] = {}
 

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -11,6 +11,7 @@ import sympy
 import torch
 from torch.export import ExportedProgram
 from torch.fx.node import Target
+from torch.utils._sympy.numbers import int_oo
 from torch_tensorrt._Device import Device
 from torch_tensorrt._enums import EngineCapability, dtype
 from torch_tensorrt._features import ENABLED_FEATURES, needs_cross_compile
@@ -895,20 +896,21 @@ def _build_user_symbol_bounds(
     sample_kwarg_inputs: dict[Any, Any],
     graph_signature: torch.export.graph_signature.ExportGraphSignature,
 ) -> Dict[sympy.Symbol, Tuple[int, int]]:
-    """Collect ``{sympy.Symbol: (min, max)}`` from user-supplied ``Input``s.
+    """Build a read-only ``{sympy.Symbol: (min, max)}`` map from dynamic ``Input``s.
 
-    This is a *read-only* bridge between ``torch_tensorrt.Input`` (where the
-    user declares ``min_shape``/``max_shape``) and the partitioner's shape
-    reader (``extract_var_range_info``). Each sympy symbol that appears in a
-    top-level placeholder's ``meta["val"].shape`` is recorded once with the
-    corresponding ``(min_shape[d], max_shape[d])`` from the user-provided
-    dynamic ``Input``.
+    Symbols are taken from top-level placeholder ``meta["val"].shape``; the
+    map is threaded to ``extract_var_range_info`` to fill upper bounds left
+    unbounded by ``Dim.DYNAMIC`` (``int_oo``). ``ShapeEnv`` is never mutated.
 
-    The map is consulted only to *fill* missing upper bounds (``int_oo`` /
-    unbounded) left by ``Dim.DYNAMIC``; the parent ``ShapeEnv`` is never
-    mutated. As a result, downstream consumers such as
-    :func:`torch_tensorrt.save(..., output_format="exported_program")` see
-    the original ``range_constraints`` from the exporter.
+    Validation against the exporter's finite bounds (when present):
+
+    - **Outside** (``user_min < exp_min`` or ``user_max > exp_max``): raises
+      ``ValueError`` -- shapes the user listed in ``Input`` would be rejected
+      by TRT at runtime since the engine profile follows the exporter.
+    - **Subset** (user fully inside exporter's range): emits a warning that
+      the engine profile will be widened to the exporter's bounds.
+    - **``Dim.DYNAMIC``** (unbounded exporter upper): no check; user's
+      ``Input`` fills the gap.
     """
     name_to_node = {n.name: n for n in gm.graph.nodes if n.op == "placeholder"}
     placeholders = [name_to_node[name] for name in graph_signature.user_inputs]
@@ -963,12 +965,88 @@ def _build_user_symbol_bounds(
                 continue
             if expr in user_symbol_bounds:
                 continue
-            user_symbol_bounds[expr] = (int(min_shape[d]), int(max_shape[d]))
+            user_min = int(min_shape[d])
+            user_max = int(max_shape[d])
+            user_symbol_bounds[expr] = (user_min, user_max)
             logger.debug(
                 "Recorded user-supplied bounds for %s: [%d, %d]",
                 expr,
-                int(min_shape[d]),
-                int(max_shape[d]),
+                user_min,
+                user_max,
+            )
+
+            # If the exporter has already declared *finite* bounds for this
+            # symbol (e.g. ``Dim("batch", min=10, max=20)``) and the user's
+            # ``Input`` disagrees, ``extract_var_range_info`` will silently
+            # keep the exporter's bounds (the override path is gated on
+            # ``max_val is None``). Reject incompatible bounds at compile
+            # time so the user doesn't hit a confusing TRT runtime error
+            # ("shape outside profile") on shapes they explicitly declared.
+            shape_env = getattr(dim.node, "shape_env", None)
+            if shape_env is None:
+                continue
+            exp_range = shape_env.var_to_range.get(expr)
+            if exp_range is None:
+                continue
+            exp_lower = exp_range.lower
+            exp_upper = exp_range.upper
+            exp_max_unbounded = exp_upper is int_oo or exp_upper == sympy.oo
+            if exp_max_unbounded:
+                # Pure ``Dim.DYNAMIC`` case -- user is filling the gap, which
+                # is the intended use. No warning, no error.
+                continue
+            try:
+                exp_min = int(exp_lower)
+                exp_max = int(exp_upper)
+            except (TypeError, ValueError):
+                continue
+            if user_min == exp_min and user_max == exp_max:
+                continue
+
+            # User extends outside the exporter's range -> shapes the user
+            # declared (e.g. ``Input.min_shape[d] = user_min`` when
+            # ``user_min < exp_min``) are guaranteed to fail at runtime
+            # because the TRT engine profile follows the exporter. Hard
+            # error so the user finds out at compile time.
+            if user_min < exp_min or user_max > exp_max:
+                raise ValueError(
+                    f"torch_tensorrt.Input bounds for symbol {expr} "
+                    f"(min={user_min}, max={user_max}) extend outside the "
+                    f"exporter's declared range (min={exp_min}, max={exp_max}). "
+                    f"The TRT engine profile follows the exporter's bounds, "
+                    f"so runtime tensors with shapes outside [{exp_min}, "
+                    f"{exp_max}] would be rejected by TRT with a 'shape "
+                    f"outside profile' error -- including shapes you listed "
+                    f"in Input.min_shape / Input.max_shape. To resolve, "
+                    f"either (a) re-export with "
+                    f"torch.export.Dim('{expr}', min={user_min}, "
+                    f"max={user_max}) so the exporter agrees with the "
+                    f"desired profile, or (b) pass an Input whose "
+                    f"min_shape/max_shape stay within [{exp_min}, "
+                    f"{exp_max}]."
+                )
+
+            # User is a strict subset of the exporter's range. No shape
+            # the user declared will fail at runtime, but the engine
+            # profile is silently widened to [exp_min, exp_max] -- so the
+            # user's narrower intent is dropped. Warn but do not error.
+            logger.warning(
+                "torch_tensorrt.Input bounds for symbol %s "
+                "(min=%d, max=%d) are narrower than the exporter's "
+                "declared range (min=%d, max=%d). The TRT engine profile "
+                "will use the exporter's wider [%d, %d] -- the Input "
+                "bounds are dropped. To get the narrower profile, "
+                "re-export with torch.export.Dim('%s', min=%d, max=%d).",
+                expr,
+                user_min,
+                user_max,
+                exp_min,
+                exp_max,
+                exp_min,
+                exp_max,
+                expr,
+                user_min,
+                user_max,
             )
 
     return user_symbol_bounds

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -9,6 +9,7 @@ from typing import Any, Collection, Dict, List, Optional, Sequence, Tuple, Union
 
 import sympy
 import torch
+import torch.utils._pytree as pytree
 from torch.export import ExportedProgram
 from torch.fx.node import Target
 from torch.utils._sympy.numbers import int_oo

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -10,6 +10,7 @@ from typing import Any, Collection, Dict, List, Optional, Sequence, Tuple, Union
 import sympy
 import torch
 from torch.export import ExportedProgram
+from torch.export.graph_signature import InputKind
 from torch.fx.node import Target
 from torch.utils._sympy.numbers import int_oo
 from torch_tensorrt._Device import Device
@@ -905,8 +906,12 @@ def _build_user_symbol_bounds(
     log only); the ``user_min=1, exp_min=2`` case warns -- it's PyTorch's
     0/1 specialization artifact, not a user error.
     """
-    name_to_node = {n.name: n for n in gm.graph.nodes if n.op == "placeholder"}
-    placeholders = [name_to_node[name] for name in graph_signature.user_inputs]
+    all_placeholders = [n for n in gm.graph.nodes if n.op == "placeholder"]
+    placeholders = [
+        p
+        for p, s in zip(all_placeholders, graph_signature.input_specs)
+        if s.kind == InputKind.USER_INPUT
+    ]
 
     in_spec = getattr(gm, "_in_spec", None)
     assert in_spec is not None, "Exported graph module missing _in_spec"
@@ -1057,8 +1062,8 @@ def compile_module(
     sample_kwarg_inputs: Optional[dict[Any, Any]] = None,
     settings: CompilationSettings = CompilationSettings(),
     engine_cache: Optional[BaseEngineCache] = None,
-    graph_signature: Optional[torch.export.graph_signature.ExportGraphSignature] = None,
     *,
+    graph_signature: torch.export.graph_signature.ExportGraphSignature,
     _debugger_config: Optional[DebuggerConfig] = None,
 ) -> torch.fx.GraphModule:
     """Compile a traced FX module
@@ -1092,12 +1097,9 @@ def compile_module(
 
     # Forwarded to the partitioner to fill Dim.DYNAMIC upper bounds.
     # Read-only w.r.t. ShapeEnv so range_constraints survive save/re-export.
-    if graph_signature is not None:
-        user_symbol_bounds = _build_user_symbol_bounds(
-            gm, sample_arg_inputs, sample_kwarg_inputs, graph_signature
-        )
-    else:
-        user_symbol_bounds = {}
+    user_symbol_bounds = _build_user_symbol_bounds(
+        gm, sample_arg_inputs, sample_kwarg_inputs, graph_signature
+    )
 
     # Configure user compilation settings to converters.
     CONVERTERS.set_compilation_settings(settings)

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -5,8 +5,9 @@ import logging
 import os
 import platform
 import warnings
-from typing import Any, Collection, List, Optional, Sequence, Union
+from typing import Any, Collection, Dict, List, Optional, Sequence, Tuple, Union
 
+import sympy
 import torch
 from torch.export import ExportedProgram
 from torch.fx.node import Target
@@ -396,6 +397,7 @@ def cross_compile_for_windows(
         trt_arg_inputs,
         trt_kwarg_inputs,
         settings,
+        graph_signature=exported_program.graph_signature,
     )
     return trt_gm
 
@@ -782,6 +784,7 @@ def compile(
         trt_kwarg_inputs,
         settings,
         engine_cache,
+        graph_signature=exported_program.graph_signature,
     )
     return trt_gm
 
@@ -886,6 +889,91 @@ def _insert_complex_io_adapters(
         partitioned_module.recompile()
 
 
+def _build_user_symbol_bounds(
+    gm: torch.fx.GraphModule,
+    sample_arg_inputs: Sequence[Input],
+    sample_kwarg_inputs: dict[Any, Any],
+    graph_signature: torch.export.graph_signature.ExportGraphSignature,
+) -> Dict[sympy.Symbol, Tuple[int, int]]:
+    """Collect ``{sympy.Symbol: (min, max)}`` from user-supplied ``Input``s.
+
+    This is a *read-only* bridge between ``torch_tensorrt.Input`` (where the
+    user declares ``min_shape``/``max_shape``) and the partitioner's shape
+    reader (``extract_var_range_info``). Each sympy symbol that appears in a
+    top-level placeholder's ``meta["val"].shape`` is recorded once with the
+    corresponding ``(min_shape[d], max_shape[d])`` from the user-provided
+    dynamic ``Input``.
+
+    The map is consulted only to *fill* missing upper bounds (``int_oo`` /
+    unbounded) left by ``Dim.DYNAMIC``; the parent ``ShapeEnv`` is never
+    mutated. As a result, downstream consumers such as
+    :func:`torch_tensorrt.save(..., output_format="exported_program")` see
+    the original ``range_constraints`` from the exporter.
+    """
+    name_to_node = {n.name: n for n in gm.graph.nodes if n.op == "placeholder"}
+    placeholders = [name_to_node[name] for name in graph_signature.user_inputs]
+
+    in_spec = getattr(gm, "_in_spec", None)
+    assert in_spec is not None, "Exported graph module missing _in_spec"
+    flat_inputs = in_spec.flatten_up_to((list(sample_arg_inputs), sample_kwarg_inputs))
+
+    user_symbol_bounds: Dict[sympy.Symbol, Tuple[int, int]] = {}
+
+    for node, inp in zip(placeholders, flat_inputs):
+        if not (isinstance(inp, Input) and inp.shape_mode == Input._ShapeMode.DYNAMIC):
+            continue
+        fake_val = node.meta.get("val")
+        if not isinstance(fake_val, torch.Tensor):
+            continue
+
+        min_shape = inp.shape["min_shape"]
+        max_shape = inp.shape["max_shape"]
+
+        if len(fake_val.size()) != len(min_shape):
+            raise ValueError(
+                f"Input '{node.target}' has {len(fake_val.size())} dimensions in "
+                f"the exported program, but the provided Input specifies "
+                f"{len(min_shape)} dimensions. Ensure Input.min_shape, "
+                f"Input.opt_shape, and Input.max_shape each have "
+                f"{len(fake_val.size())} entries."
+            )
+
+        for d, dim in enumerate(fake_val.size()):
+            if not isinstance(dim, torch.SymInt):
+                if min_shape[d] != dim or max_shape[d] != dim:
+                    raise ValueError(
+                        f"Input '{node.target}' dim {d} is static (size={int(dim)}) "
+                        f"in the exported program, but the provided Input has "
+                        f"min_shape[{d}]={min_shape[d]}, max_shape[{d}]={max_shape[d]}. "
+                        f"Static dimensions must be fixed."
+                    )
+                continue
+            expr = dim.node.expr
+            # Composite exprs (e.g. ``2*s0``) are recomputed by
+            # ``ShapeEnv.bound_sympy``; overriding them directly would lie.
+            if not isinstance(expr, sympy.Symbol):
+                logger.debug(
+                    "Input '%s' dim %d is a composite symbolic expression (%s) "
+                    "bounded by another dynamic dimension; its range will be "
+                    "derived from constituent symbols via bound_sympy.",
+                    node.target,
+                    d,
+                    expr,
+                )
+                continue
+            if expr in user_symbol_bounds:
+                continue
+            user_symbol_bounds[expr] = (int(min_shape[d]), int(max_shape[d]))
+            logger.debug(
+                "Recorded user-supplied bounds for %s: [%d, %d]",
+                expr,
+                int(min_shape[d]),
+                int(max_shape[d]),
+            )
+
+    return user_symbol_bounds
+
+
 @fn_supports_debugger  # type: ignore[misc]
 def compile_module(
     gm: torch.fx.GraphModule,
@@ -893,6 +981,7 @@ def compile_module(
     sample_kwarg_inputs: Optional[dict[Any, Any]] = None,
     settings: CompilationSettings = CompilationSettings(),
     engine_cache: Optional[BaseEngineCache] = None,
+    graph_signature: Optional[torch.export.graph_signature.ExportGraphSignature] = None,
     *,
     _debugger_config: Optional[DebuggerConfig] = None,
 ) -> torch.fx.GraphModule:
@@ -924,6 +1013,20 @@ def compile_module(
             "fallback_data_dependent_ops runs data-dependent ops in PyTorch, which "
             "is incompatible with require_full_compilation=True; enable only one."
         )
+
+    # Build a read-only ``{sympy.Symbol: (min, max)}`` map from the user's
+    # sample ``Input`` objects. This is forwarded to the partitioner so that
+    # symbols whose upper bound is left unbounded by ``Dim.DYNAMIC`` get
+    # filled in with the user's declared bounds, *without* mutating the
+    # exporter's ``ShapeEnv.var_to_range`` (which preserves the original
+    # ``range_constraints`` on save / re-export).
+    if graph_signature is not None:
+        user_symbol_bounds = _build_user_symbol_bounds(
+            gm, sample_arg_inputs, sample_kwarg_inputs, graph_signature
+        )
+    else:
+        user_symbol_bounds = {}
+
     # Configure user compilation settings to converters.
     CONVERTERS.set_compilation_settings(settings)
 
@@ -1129,6 +1232,7 @@ def compile_module(
             submodule,
             profile_source_bounds=profile_source_bounds,
             num_profiles=num_profiles,
+            user_symbol_bounds=user_symbol_bounds,
         )
 
         assert submodule_inputs is not None

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -9,7 +9,6 @@ from typing import Any, Collection, Dict, List, Optional, Sequence, Tuple, Union
 
 import sympy
 import torch
-import torch.utils._pytree as pytree
 from torch.export import ExportedProgram
 from torch.fx.node import Target
 from torch.utils._sympy.numbers import int_oo

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -968,10 +968,14 @@ def _build_user_symbol_bounds(
                 user_max,
             )
 
-            # If exporter bounds are finite, ``extract_var_range_info`` keeps
-            # them (override is gated on ``max_val is None``). Catch the
-            # mismatch here so the user doesn't hit a runtime "shape outside
-            # profile" error on shapes they explicitly declared.
+            # The exported program may already bound this symbol to a finite
+            # range (e.g. Dim("batch", min=10, max=20)). The compiled TRT
+            # engine's optimization profile follows that range; any shape
+            # outside it is rejected by TensorRT at runtime
+            # (IExecutionContext::setInputShape "satisfyProfile" check).
+            # Validate the user's Input range against it here -- at compile
+            # time -- before they hit that opaque runtime error on a shape
+            # they explicitly declared in Input.min_shape / Input.max_shape.
             shape_env = getattr(dim.node, "shape_env", None)
             if shape_env is None:
                 continue
@@ -993,35 +997,41 @@ def _build_user_symbol_bounds(
                 continue
 
             mismatch = (
-                f"symbol {expr}: Input({user_min}, {user_max}) vs "
-                f"exporter({exp_min}, {exp_max})."
-            )
-            hint = (
-                f" Re-export with Dim('{expr}', min={user_min}, "
-                f"max={user_max}) or adjust Input to match."
+                f"Dynamic dimension '{expr}': "
+                f"Input range [{user_min}, {user_max}] vs "
+                f"exported program range [{exp_min}, {exp_max}]."
             )
 
             if user_max > exp_max:
                 raise ValueError(
-                    f"{mismatch} Input.max_shape exceeds the exporter's max "
-                    f"({user_max} > {exp_max}); TRT will reject shapes above "
-                    f"{exp_max} at runtime.{hint}"
+                    f"{mismatch} Input.max_shape ({user_max}) exceeds the "
+                    f"exported program's max ({exp_max}). The program was "
+                    f"exported with this dimension bounded to "
+                    f"[{exp_min}, {exp_max}], so the compiled TensorRT engine "
+                    f"cannot accept shapes above {exp_max}. Either re-export "
+                    f"with Dim('{expr}', max={user_max}) or set "
+                    f"Input.max_shape <= {exp_max}."
                 )
 
             if user_min < exp_min:
                 # 1->2 is the 0/1 specialization artifact, not a user error.
                 if user_min == 1 and exp_min == 2:
                     logger.warning(
-                        "%s Input.min_shape=1 vs exporter min=2 is the "
-                        "PyTorch 0/1 specialization artifact; TRT engine "
-                        "min will be 2.",
+                        "%s Input.min_shape=1 but the exported program's min "
+                        "is 2 (PyTorch 0/1 specialization -- Dim(min=1) is "
+                        "recorded as min=2). The compiled engine's min will "
+                        "be 2.",
                         mismatch,
                     )
                     continue
                 raise ValueError(
-                    f"{mismatch} Input.min_shape is below the exporter's min "
-                    f"({user_min} < {exp_min}); TRT will reject shapes "
-                    f"below {exp_min} at runtime.{hint}"
+                    f"{mismatch} Input.min_shape ({user_min}) is below the "
+                    f"exported program's min ({exp_min}). The program was "
+                    f"exported with this dimension bounded to "
+                    f"[{exp_min}, {exp_max}], so the compiled TensorRT engine "
+                    f"cannot accept shapes below {exp_min}. Either re-export "
+                    f"with Dim('{expr}', min={user_min}) or set "
+                    f"Input.min_shape >= {exp_min}."
                 )
 
             # Strict subset: engine profile narrows to the user's bounds
@@ -1029,7 +1039,7 @@ def _build_user_symbol_bounds(
             # user got exactly what they asked for.
             logger.info(
                 "%s Narrowing engine profile to user bounds [%d, %d] "
-                "(exporter range was [%d, %d]).",
+                "(exported program range was [%d, %d]).",
                 mismatch,
                 user_min,
                 user_max,

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -904,11 +904,17 @@ def _build_user_symbol_bounds(
 
     Validation against the exporter's finite bounds (when present):
 
-    - **Outside** (``user_min < exp_min`` or ``user_max > exp_max``): raises
-      ``ValueError`` -- shapes the user listed in ``Input`` would be rejected
-      by TRT at runtime since the engine profile follows the exporter.
-    - **Subset** (user fully inside exporter's range): emits a warning that
-      the engine profile will be widened to the exporter's bounds.
+    - **Upper overflow** (``user_max > exp_max``): raises ``ValueError`` --
+      the TRT engine profile follows the exporter, so shapes above ``exp_max``
+      are guaranteed to be rejected at TRT runtime, including sizes the user
+      explicitly listed in ``Input.max_shape``.
+    - **Lower underflow** (``user_min < exp_min``): raises ``ValueError``
+      *except* for the ``user_min=1, exp_min=2`` case, which is PyTorch's
+      0/1 specialization artifact (``Dim(min=1)`` is silently bumped to 2
+      in ``ShapeEnv``). That specific case emits a warning only.
+    - **Subset** (``user_max <= exp_max`` and ``user_min >= exp_min``): emits
+      a warning that the engine profile will be widened to the exporter's
+      bounds.
     - **``Dim.DYNAMIC``** (unbounded exporter upper): no check; user's
       ``Input`` fills the gap.
     """
@@ -1003,45 +1009,53 @@ def _build_user_symbol_bounds(
             if user_min == exp_min and user_max == exp_max:
                 continue
 
-            # User extends outside the exporter's range -> shapes the user
-            # declared (e.g. ``Input.min_shape[d] = user_min`` when
-            # ``user_min < exp_min``) are guaranteed to fail at runtime
-            # because the TRT engine profile follows the exporter. Hard
-            # error so the user finds out at compile time.
-            if user_min < exp_min or user_max > exp_max:
+            # Shared header and re-export hint used by all three cases below.
+            _HDR = (
+                f"symbol {expr}: Input({user_min}, {user_max}) vs "
+                f"exporter({exp_min}, {exp_max})."
+            )
+            _HINT = (
+                f" Re-export with Dim('{expr}', min={user_min}, "
+                f"max={user_max}) or adjust Input to match."
+            )
+
+            # Upper overflow: user_max > exp_max.
+            # TRT engine profile has max=exp_max; shapes above it will be
+            # rejected at runtime. Hard error so the user finds out at compile.
+            if user_max > exp_max:
                 raise ValueError(
-                    f"torch_tensorrt.Input bounds for symbol {expr} "
-                    f"(min={user_min}, max={user_max}) extend outside the "
-                    f"exporter's declared range (min={exp_min}, max={exp_max}). "
-                    f"The TRT engine profile follows the exporter's bounds, "
-                    f"so runtime tensors with shapes outside [{exp_min}, "
-                    f"{exp_max}] would be rejected by TRT with a 'shape "
-                    f"outside profile' error -- including shapes you listed "
-                    f"in Input.min_shape / Input.max_shape. To resolve, "
-                    f"either (a) re-export with "
-                    f"torch.export.Dim('{expr}', min={user_min}, "
-                    f"max={user_max}) so the exporter agrees with the "
-                    f"desired profile, or (b) pass an Input whose "
-                    f"min_shape/max_shape stay within [{exp_min}, "
-                    f"{exp_max}]."
+                    f"{_HDR} Input.max_shape exceeds the exporter's max "
+                    f"({user_max} > {exp_max}); TRT will reject shapes above "
+                    f"{exp_max} at runtime.{_HINT}"
                 )
 
-            # User is a strict subset of the exporter's range. No shape
-            # the user declared will fail at runtime, but the engine
-            # profile is silently widened to [exp_min, exp_max] -- so the
-            # user's narrower intent is dropped. Warn but do not error.
+            # Lower underflow: user_min < exp_min.
+            # Tolerated only for the 0/1 specialization artifact (1→2);
+            # every other gap is a genuine user error.
+            if user_min < exp_min:
+                if user_min == 1 and exp_min == 2:
+                    logger.warning(
+                        "%s Input.min_shape=1 vs exporter min=2 is the "
+                        "PyTorch 0/1 specialization artifact; TRT engine "
+                        "min will be 2.",
+                        _HDR,
+                    )
+                    continue
+                raise ValueError(
+                    f"{_HDR} Input.min_shape is below the exporter's min "
+                    f"({user_min} < {exp_min}); TRT will reject shapes "
+                    f"below {exp_min} at runtime.{_HINT}"
+                )
+
+            # Subset: user range fits inside exporter range but is narrower.
+            # No runtime failure, but the engine profile is silently widened
+            # to [exp_min, exp_max]. Warn so the user knows.
             logger.warning(
-                "torch_tensorrt.Input bounds for symbol %s "
-                "(min=%d, max=%d) are narrower than the exporter's "
-                "declared range (min=%d, max=%d). The TRT engine profile "
-                "will use the exporter's wider [%d, %d] -- the Input "
-                "bounds are dropped. To get the narrower profile, "
-                "re-export with torch.export.Dim('%s', min=%d, max=%d).",
-                expr,
-                user_min,
-                user_max,
-                exp_min,
-                exp_max,
+                "%s Input bounds are a subset of the exporter's range; "
+                "TRT engine profile will use the wider [%d, %d]."
+                " Re-export with Dim('%s', min=%d, max=%d) for a "
+                "narrower profile.",
+                _HDR,
                 exp_min,
                 exp_max,
                 expr,

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -895,7 +895,7 @@ def _build_user_symbol_bounds(
     gm: torch.fx.GraphModule,
     sample_arg_inputs: Sequence[Input],
     sample_kwarg_inputs: dict[Any, Any],
-    graph_signature: torch.export.graph_signature.ExportGraphSignature,
+    graph_signature: Optional[torch.export.graph_signature.ExportGraphSignature] = None,
 ) -> Dict[sympy.Symbol, Tuple[int, int]]:
     """Map ``sympy.Symbol -> (min, max)`` from dynamic ``Input``s, used to
     fill ``Dim.DYNAMIC`` upper bounds without mutating ``ShapeEnv``.
@@ -906,16 +906,34 @@ def _build_user_symbol_bounds(
     log only); the ``user_min=1, exp_min=2`` case warns -- it's PyTorch's
     0/1 specialization artifact, not a user error.
     """
-    all_placeholders = [n for n in gm.graph.nodes if n.op == "placeholder"]
-    placeholders = [
-        p
-        for p, s in zip(all_placeholders, graph_signature.input_specs)
-        if s.kind == InputKind.USER_INPUT
-    ]
+    # ep.module() strips lifted params/buffers from the graph, so all_placeholders
+    # only contains USER_INPUT nodes, but graph_signature.input_specs still lists
+    # all specs (PARAMETER, BUFFER, USER_INPUT). A positional zip misaligns.
+    # Use name-based lookup keyed on graph_signature USER_INPUT names instead.
+    # When graph_signature is absent (e.g. direct unit-test calls), fall back to
+    # all placeholder nodes in graph order (which are already USER_INPUT only
+    # after ep.module()).
+    placeholder_by_name = {n.name: n for n in gm.graph.nodes if n.op == "placeholder"}
+    if graph_signature is not None:
+        user_input_names = [
+            spec.arg.name
+            for spec in graph_signature.input_specs
+            if spec.kind == InputKind.USER_INPUT and hasattr(spec.arg, "name")
+        ]
+        placeholders = [
+            placeholder_by_name[name]
+            for name in user_input_names
+            if name in placeholder_by_name
+        ]
+    else:
+        placeholders = list(placeholder_by_name.values())
 
-    in_spec = getattr(gm, "_in_spec", None)
-    assert in_spec is not None, "Exported graph module missing _in_spec"
-    flat_inputs = in_spec.flatten_up_to((tuple(sample_arg_inputs), sample_kwarg_inputs))
+    # Avoid flatten_up_to: the user may compile with a different arg/kwarg split
+    # than was used at export time, causing a pytree arity mismatch. Match the
+    # existing pattern in compile_module: positional args first, then kwargs.
+    flat_inputs: List[Any] = list(sample_arg_inputs)
+    if isinstance(sample_kwarg_inputs, dict):
+        flat_inputs.extend(sample_kwarg_inputs.values())
 
     user_symbol_bounds: Dict[sympy.Symbol, Tuple[int, int]] = {}
 

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -915,7 +915,7 @@ def _build_user_symbol_bounds(
 
     in_spec = getattr(gm, "_in_spec", None)
     assert in_spec is not None, "Exported graph module missing _in_spec"
-    flat_inputs = in_spec.flatten_up_to((list(sample_arg_inputs), sample_kwarg_inputs))
+    flat_inputs = in_spec.flatten_up_to((tuple(sample_arg_inputs), sample_kwarg_inputs))
 
     user_symbol_bounds: Dict[sympy.Symbol, Tuple[int, int]] = {}
 

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -896,27 +896,14 @@ def _build_user_symbol_bounds(
     sample_kwarg_inputs: dict[Any, Any],
     graph_signature: torch.export.graph_signature.ExportGraphSignature,
 ) -> Dict[sympy.Symbol, Tuple[int, int]]:
-    """Build a read-only ``{sympy.Symbol: (min, max)}`` map from dynamic ``Input``s.
+    """Map ``sympy.Symbol -> (min, max)`` from dynamic ``Input``s, used to
+    fill ``Dim.DYNAMIC`` upper bounds without mutating ``ShapeEnv``.
 
-    Symbols are taken from top-level placeholder ``meta["val"].shape``; the
-    map is threaded to ``extract_var_range_info`` to fill upper bounds left
-    unbounded by ``Dim.DYNAMIC`` (``int_oo``). ``ShapeEnv`` is never mutated.
-
-    Validation against the exporter's finite bounds (when present):
-
-    - **Upper overflow** (``user_max > exp_max``): raises ``ValueError`` --
-      the TRT engine profile follows the exporter, so shapes above ``exp_max``
-      are guaranteed to be rejected at TRT runtime, including sizes the user
-      explicitly listed in ``Input.max_shape``.
-    - **Lower underflow** (``user_min < exp_min``): raises ``ValueError``
-      *except* for the ``user_min=1, exp_min=2`` case, which is PyTorch's
-      0/1 specialization artifact (``Dim(min=1)`` is silently bumped to 2
-      in ``ShapeEnv``). That specific case emits a warning only.
-    - **Subset** (``user_max <= exp_max`` and ``user_min >= exp_min``): emits
-      a warning that the engine profile will be widened to the exporter's
-      bounds.
-    - **``Dim.DYNAMIC``** (unbounded exporter upper): no check; user's
-      ``Input`` fills the gap.
+    Validates against finite exporter bounds: ``user_max > exp_max`` and
+    ``user_min < exp_min`` raise (TRT will reject those shapes at runtime);
+    a strict subset warns (engine profile widens to the exporter); the
+    ``user_min=1, exp_min=2`` case warns only -- it's PyTorch's 0/1
+    specialization artifact, not a user error.
     """
     name_to_node = {n.name: n for n in gm.graph.nodes if n.op == "placeholder"}
     placeholders = [name_to_node[name] for name in graph_signature.user_inputs]
@@ -981,13 +968,10 @@ def _build_user_symbol_bounds(
                 user_max,
             )
 
-            # If the exporter has already declared *finite* bounds for this
-            # symbol (e.g. ``Dim("batch", min=10, max=20)``) and the user's
-            # ``Input`` disagrees, ``extract_var_range_info`` will silently
-            # keep the exporter's bounds (the override path is gated on
-            # ``max_val is None``). Reject incompatible bounds at compile
-            # time so the user doesn't hit a confusing TRT runtime error
-            # ("shape outside profile") on shapes they explicitly declared.
+            # If exporter bounds are finite, ``extract_var_range_info`` keeps
+            # them (override is gated on ``max_val is None``). Catch the
+            # mismatch here so the user doesn't hit a runtime "shape outside
+            # profile" error on shapes they explicitly declared.
             shape_env = getattr(dim.node, "shape_env", None)
             if shape_env is None:
                 continue
@@ -998,8 +982,7 @@ def _build_user_symbol_bounds(
             exp_upper = exp_range.upper
             exp_max_unbounded = exp_upper is int_oo or exp_upper == sympy.oo
             if exp_max_unbounded:
-                # Pure ``Dim.DYNAMIC`` case -- user is filling the gap, which
-                # is the intended use. No warning, no error.
+                # Dim.DYNAMIC: user fills the gap (intended use).
                 continue
             try:
                 exp_min = int(exp_lower)
@@ -1009,53 +992,45 @@ def _build_user_symbol_bounds(
             if user_min == exp_min and user_max == exp_max:
                 continue
 
-            # Shared header and re-export hint used by all three cases below.
-            _HDR = (
+            mismatch = (
                 f"symbol {expr}: Input({user_min}, {user_max}) vs "
                 f"exporter({exp_min}, {exp_max})."
             )
-            _HINT = (
+            hint = (
                 f" Re-export with Dim('{expr}', min={user_min}, "
                 f"max={user_max}) or adjust Input to match."
             )
 
-            # Upper overflow: user_max > exp_max.
-            # TRT engine profile has max=exp_max; shapes above it will be
-            # rejected at runtime. Hard error so the user finds out at compile.
             if user_max > exp_max:
                 raise ValueError(
-                    f"{_HDR} Input.max_shape exceeds the exporter's max "
+                    f"{mismatch} Input.max_shape exceeds the exporter's max "
                     f"({user_max} > {exp_max}); TRT will reject shapes above "
-                    f"{exp_max} at runtime.{_HINT}"
+                    f"{exp_max} at runtime.{hint}"
                 )
 
-            # Lower underflow: user_min < exp_min.
-            # Tolerated only for the 0/1 specialization artifact (1→2);
-            # every other gap is a genuine user error.
             if user_min < exp_min:
+                # 1->2 is the 0/1 specialization artifact, not a user error.
                 if user_min == 1 and exp_min == 2:
                     logger.warning(
                         "%s Input.min_shape=1 vs exporter min=2 is the "
                         "PyTorch 0/1 specialization artifact; TRT engine "
                         "min will be 2.",
-                        _HDR,
+                        mismatch,
                     )
                     continue
                 raise ValueError(
-                    f"{_HDR} Input.min_shape is below the exporter's min "
+                    f"{mismatch} Input.min_shape is below the exporter's min "
                     f"({user_min} < {exp_min}); TRT will reject shapes "
-                    f"below {exp_min} at runtime.{_HINT}"
+                    f"below {exp_min} at runtime.{hint}"
                 )
 
-            # Subset: user range fits inside exporter range but is narrower.
-            # No runtime failure, but the engine profile is silently widened
-            # to [exp_min, exp_max]. Warn so the user knows.
+            # Strict subset: engine profile widens to the exporter.
             logger.warning(
                 "%s Input bounds are a subset of the exporter's range; "
                 "TRT engine profile will use the wider [%d, %d]."
                 " Re-export with Dim('%s', min=%d, max=%d) for a "
                 "narrower profile.",
-                _HDR,
+                mismatch,
                 exp_min,
                 exp_max,
                 expr,
@@ -1106,12 +1081,8 @@ def compile_module(
             "is incompatible with require_full_compilation=True; enable only one."
         )
 
-    # Build a read-only ``{sympy.Symbol: (min, max)}`` map from the user's
-    # sample ``Input`` objects. This is forwarded to the partitioner so that
-    # symbols whose upper bound is left unbounded by ``Dim.DYNAMIC`` get
-    # filled in with the user's declared bounds, *without* mutating the
-    # exporter's ``ShapeEnv.var_to_range`` (which preserves the original
-    # ``range_constraints`` on save / re-export).
+    # Forwarded to the partitioner to fill Dim.DYNAMIC upper bounds.
+    # Read-only w.r.t. ShapeEnv so range_constraints survive save/re-export.
     if graph_signature is not None:
         user_symbol_bounds = _build_user_symbol_bounds(
             gm, sample_arg_inputs, sample_kwarg_inputs, graph_signature

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -900,10 +900,10 @@ def _build_user_symbol_bounds(
     fill ``Dim.DYNAMIC`` upper bounds without mutating ``ShapeEnv``.
 
     Validates against finite exporter bounds: ``user_max > exp_max`` and
-    ``user_min < exp_min`` raise (TRT will reject those shapes at runtime);
-    a strict subset warns (engine profile widens to the exporter); the
-    ``user_min=1, exp_min=2`` case warns only -- it's PyTorch's 0/1
-    specialization artifact, not a user error.
+    ``user_min < exp_min`` raise (TRT would reject those shapes at runtime);
+    a strict subset narrows the engine profile to the user's bounds (info
+    log only); the ``user_min=1, exp_min=2`` case warns -- it's PyTorch's
+    0/1 specialization artifact, not a user error.
     """
     name_to_node = {n.name: n for n in gm.graph.nodes if n.op == "placeholder"}
     placeholders = [name_to_node[name] for name in graph_signature.user_inputs]
@@ -1024,18 +1024,17 @@ def _build_user_symbol_bounds(
                     f"below {exp_min} at runtime.{hint}"
                 )
 
-            # Strict subset: engine profile widens to the exporter.
-            logger.warning(
-                "%s Input bounds are a subset of the exporter's range; "
-                "TRT engine profile will use the wider [%d, %d]."
-                " Re-export with Dim('%s', min=%d, max=%d) for a "
-                "narrower profile.",
+            # Strict subset: engine profile narrows to the user's bounds
+            # (applied in ``extract_var_range_info``). Not a warning -- the
+            # user got exactly what they asked for.
+            logger.info(
+                "%s Narrowing engine profile to user bounds [%d, %d] "
+                "(exporter range was [%d, %d]).",
                 mismatch,
-                exp_min,
-                exp_max,
-                expr,
                 user_min,
                 user_max,
+                exp_min,
+                exp_max,
             )
 
     return user_symbol_bounds

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -1063,7 +1063,7 @@ def compile_module(
     settings: CompilationSettings = CompilationSettings(),
     engine_cache: Optional[BaseEngineCache] = None,
     *,
-    graph_signature: torch.export.graph_signature.ExportGraphSignature,
+    graph_signature: Optional[torch.export.graph_signature.ExportGraphSignature] = None,
     _debugger_config: Optional[DebuggerConfig] = None,
 ) -> torch.fx.GraphModule:
     """Compile a traced FX module
@@ -1097,8 +1097,13 @@ def compile_module(
 
     # Forwarded to the partitioner to fill Dim.DYNAMIC upper bounds.
     # Read-only w.r.t. ShapeEnv so range_constraints survive save/re-export.
-    user_symbol_bounds = _build_user_symbol_bounds(
-        gm, sample_arg_inputs, sample_kwarg_inputs, graph_signature
+    # graph_signature is None on the torch.compile path, which has no ExportedProgram.
+    user_symbol_bounds = (
+        _build_user_symbol_bounds(
+            gm, sample_arg_inputs, sample_kwarg_inputs, graph_signature
+        )
+        if graph_signature is not None
+        else {}
     )
 
     # Configure user compilation settings to converters.

--- a/py/torch_tensorrt/dynamo/partitioning/common.py
+++ b/py/torch_tensorrt/dynamo/partitioning/common.py
@@ -98,10 +98,8 @@ def construct_dynamic_input(
             propagate optimization profiles to this (intermediate) input.
         num_profiles: Number of profiles to emit when ``profile_source_bounds``
             is provided.
-        user_symbol_bounds: Optional read-only ``{sym: (min, max)}`` map, used
-            only to fill missing upper bounds when the exporter's ``ShapeEnv``
-            reports them as unbounded. See
-            :func:`torch_tensorrt.dynamo.utils.extract_var_range_info`.
+        user_symbol_bounds: Optional ``{sym: (min, max)}`` map; forwarded to
+            :func:`extract_var_range_info` to fill unbounded exporter uppers.
     Returns:
         A dynamic shaped torch_tensorrt.Input which has the properties of the symbolic shaped input.
     """
@@ -197,11 +195,9 @@ def get_input(
     user_symbol_bounds: Optional[Dict[sympy.Symbol, Tuple[int, int]]] = None,
 ) -> Input:
     """
-    Based on type of dimensions in the input_shape, construct regular or dynamic shaped inputs
+    Based on type of dimensions in the input_shape, construct regular or dynamic shaped inputs.
 
-    ``user_symbol_bounds`` is forwarded to :func:`construct_dynamic_input` and
-    is only consulted when an exporter-supplied symbolic dimension has no
-    upper bound (e.g. ``Dim.DYNAMIC`` without an explicit ``max``).
+    ``user_symbol_bounds`` is forwarded to :func:`construct_dynamic_input`.
     """
     if dtype in COMPLEX_TO_REAL_DTYPE:
         real_dtype = COMPLEX_TO_REAL_DTYPE[dtype]
@@ -247,10 +243,8 @@ def construct_submodule_inputs(
             symbolic shape.
         num_profiles: Number of profiles corresponding to
             ``profile_source_bounds``.
-        user_symbol_bounds: Optional read-only ``{sym: (min, max)}`` map built
-            from user-supplied ``torch_tensorrt.Input`` objects. Used only to
-            fill missing upper bounds left by ``Dim.DYNAMIC`` in the exporter;
-            never mutates the parent ``ShapeEnv``.
+        user_symbol_bounds: Optional ``{sym: (min, max)}`` map; forwarded to
+            :func:`get_input` to fill unbounded exporter uppers.
     Returns:
         Sequence of torch_tensorrt.Input's representing inputs to given module
     """

--- a/py/torch_tensorrt/dynamo/partitioning/common.py
+++ b/py/torch_tensorrt/dynamo/partitioning/common.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
+import sympy
 import torch
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx.experimental.proxy_tensor import unset_fake_temporarily
@@ -87,6 +88,7 @@ def construct_dynamic_input(
     is_shape_tensor: bool = False,
     profile_source_bounds: Optional[ProfileSourceBounds] = None,
     num_profiles: int = 0,
+    user_symbol_bounds: Optional[Dict[sympy.Symbol, Tuple[int, int]]] = None,
 ) -> Input:
     """
     Constructs a torch_tensorrt.Input based on a symbolic input
@@ -96,6 +98,10 @@ def construct_dynamic_input(
             propagate optimization profiles to this (intermediate) input.
         num_profiles: Number of profiles to emit when ``profile_source_bounds``
             is provided.
+        user_symbol_bounds: Optional read-only ``{sym: (min, max)}`` map, used
+            only to fill missing upper bounds when the exporter's ``ShapeEnv``
+            reports them as unbounded. See
+            :func:`torch_tensorrt.dynamo.utils.extract_var_range_info`.
     Returns:
         A dynamic shaped torch_tensorrt.Input which has the properties of the symbolic shaped input.
     """
@@ -104,7 +110,9 @@ def construct_dynamic_input(
     max_shape = []
     for d, dim in enumerate(input_shape):
         if isinstance(dim, torch.SymInt):
-            min_max_opt = extract_var_range_info(dim)
+            min_max_opt = extract_var_range_info(
+                dim, user_symbol_bounds=user_symbol_bounds
+            )
             unwrapped_min_max_opt: Dict[str, int] = {}
             if "min" not in min_max_opt or min_max_opt["min"] is None:
                 logger.warning(
@@ -186,9 +194,14 @@ def get_input(
     is_shape_tensor: bool = False,
     profile_source_bounds: Optional[ProfileSourceBounds] = None,
     num_profiles: int = 0,
+    user_symbol_bounds: Optional[Dict[sympy.Symbol, Tuple[int, int]]] = None,
 ) -> Input:
     """
     Based on type of dimensions in the input_shape, construct regular or dynamic shaped inputs
+
+    ``user_symbol_bounds`` is forwarded to :func:`construct_dynamic_input` and
+    is only consulted when an exporter-supplied symbolic dimension has no
+    upper bound (e.g. ``Dim.DYNAMIC`` without an explicit ``max``).
     """
     if dtype in COMPLEX_TO_REAL_DTYPE:
         real_dtype = COMPLEX_TO_REAL_DTYPE[dtype]
@@ -209,6 +222,7 @@ def get_input(
             is_shape_tensor=is_shape_tensor,
             profile_source_bounds=profile_source_bounds,
             num_profiles=num_profiles,
+            user_symbol_bounds=user_symbol_bounds,
         )
     else:
         return Input(
@@ -220,6 +234,7 @@ def construct_submodule_inputs(
     module: torch.fx.GraphModule,
     profile_source_bounds: Optional[ProfileSourceBounds] = None,
     num_profiles: int = 0,
+    user_symbol_bounds: Optional[Dict[sympy.Symbol, Tuple[int, int]]] = None,
 ) -> Sequence[Input]:
     """
     Construct torch_tensorrt Inputs based on the module inputs.
@@ -232,6 +247,10 @@ def construct_submodule_inputs(
             symbolic shape.
         num_profiles: Number of profiles corresponding to
             ``profile_source_bounds``.
+        user_symbol_bounds: Optional read-only ``{sym: (min, max)}`` map built
+            from user-supplied ``torch_tensorrt.Input`` objects. Used only to
+            fill missing upper bounds left by ``Dim.DYNAMIC`` in the exporter;
+            never mutates the parent ``ShapeEnv``.
     Returns:
         Sequence of torch_tensorrt.Input's representing inputs to given module
     """
@@ -253,6 +272,7 @@ def construct_submodule_inputs(
                                 name=input.name,
                                 profile_source_bounds=profile_source_bounds,
                                 num_profiles=num_profiles,
+                                user_symbol_bounds=user_symbol_bounds,
                             )
                         )
                     elif isinstance(input_meta, torch.SymInt):
@@ -265,6 +285,7 @@ def construct_submodule_inputs(
                                 is_shape_tensor=True,
                                 profile_source_bounds=profile_source_bounds,
                                 num_profiles=num_profiles,
+                                user_symbol_bounds=user_symbol_bounds,
                             )
                         )
                     elif isinstance(input_meta, torch.SymFloat):
@@ -274,6 +295,7 @@ def construct_submodule_inputs(
                                 torch.float32,
                                 name=input.name,
                                 is_shape_tensor=False,  # Only SymInt inputs are treated as shape tensors
+                                user_symbol_bounds=user_symbol_bounds,
                             )
                         )
                     else:
@@ -285,7 +307,12 @@ def construct_submodule_inputs(
                     input_meta = input.meta["tensor_meta"]
                     input_shape = input_meta.shape
                     torchtrt_inputs.append(
-                        get_input(input_shape, input_meta.dtype, name=input.name)
+                        get_input(
+                            input_shape,
+                            input_meta.dtype,
+                            name=input.name,
+                            user_symbol_bounds=user_symbol_bounds,
+                        )
                     )
                 else:
                     raise AssertionError(

--- a/py/torch_tensorrt/dynamo/utils.py
+++ b/py/torch_tensorrt/dynamo/utils.py
@@ -465,17 +465,19 @@ def extract_var_range_info(
     # Torchdynamo 0/1 specialization outlier
     min_val = 1 if min_val == 2 else min_val
 
-    # Fill missing exporter upper from user bounds; intersect lower so
-    # ShapeEnv's 0/1 specialization is preserved.
+    # Apply user bounds whenever present. ``_build_user_symbol_bounds`` already
+    # rejects user ranges that exceed the exporter, so the only cases reaching
+    # here are: Dim.DYNAMIC (max_val is None), strict subset, or the 1->2
+    # specialization. Clamp defensively in case validation was skipped (no
+    # ShapeEnv access path).
     if (
-        max_val is None
-        and user_symbol_bounds
+        user_symbol_bounds
         and isinstance(expr, sympy.Symbol)
         and expr in user_symbol_bounds
     ):
         user_min, user_max = user_symbol_bounds[expr]
         min_val = max(min_val, int(user_min))
-        max_val = int(user_max)
+        max_val = int(user_max) if max_val is None else min(max_val, int(user_max))
 
     min_max_opt: Dict[str, Optional[int]] = {}
     min_max_opt["min"] = min_val

--- a/py/torch_tensorrt/dynamo/utils.py
+++ b/py/torch_tensorrt/dynamo/utils.py
@@ -411,20 +411,12 @@ def extract_var_range_info(
     symbolic_integer: torch.SymInt,
     user_symbol_bounds: Optional[Dict[sympy.Symbol, Tuple[int, int]]] = None,
 ) -> Dict[str, Optional[int]]:
-    """
-    This function returns the min, max, opt values of a symbolic integer.
+    """Return ``{min, max, opt}`` for a symbolic integer.
 
-    Args:
-        symbolic_integer: The ``torch.SymInt`` whose range is being queried.
-        user_symbol_bounds: Optional read-only map from a top-level sympy symbol
-            to ``(min, max)`` bounds supplied by the user via
-            ``torch_tensorrt.Input``. These are used **only** to fill the gap
-            when the exporter's ``ShapeEnv`` reports an unbounded upper range
-            (``int_oo``). The exporter's bounds always win when they are
-            finite; the lower bound is intersected (``max(exporter_lower,
-            user_lower)``) so we never widen the exporter's 0/1 specialization
-            (e.g. ``lower == 2 -> 1``) to ``0`` when the user passes
-            ``min_shape=0``. ``ShapeEnv`` itself is never mutated.
+    ``user_symbol_bounds`` (read-only ``{sym: (min, max)}``) is consulted only
+    when the exporter's upper is unbounded; finite exporter bounds always win.
+    The lower is intersected with the exporter's so the 0/1 specialization
+    survives even if the user passes ``min_shape=0``.
     """
     node = symbolic_integer.node
     expr = node.expr
@@ -452,15 +444,9 @@ def extract_var_range_info(
     )
     assert var_range, var_val
 
-    # ``var_range`` can come from two paths:
-    #   (1) ``shape_env.var_to_range[expr]`` -- stores PyTorch's integer-typed
-    #       ``int_oo`` sentinel for unbounded sides.
-    #   (2) ``shape_env.bound_sympy(expr)`` (composite exprs like ``s0 + s1``)
-    #       -- runs sympy arithmetic, which collapses unbounded operands to
-    #       ``sympy.oo`` (sympy's float-typed ``S.Infinity``).
-    # ``int_oo`` and ``sympy.oo`` are different objects, so a single-sentinel
-    # check (``!= int_oo``) misses path (2) and crashes downstream when sympy
-    # tries to coerce ``oo`` to int. Treat any non-finite bound as ``None``.
+    # ``var_to_range`` returns ``int_oo`` for unbounded; ``bound_sympy`` (used
+    # for composite exprs like ``s0+s1``) returns ``sympy.oo`` instead. They
+    # are distinct objects -- check both, else ``int(sympy.oo)`` raises.
     def _bound_to_int_or_none(value: Any) -> Optional[int]:
         if value is int_oo or value is -int_oo:
             return None
@@ -473,20 +459,14 @@ def extract_var_range_info(
 
     min_val_opt = _bound_to_int_or_none(var_range.lower)
     max_val = _bound_to_int_or_none(var_range.upper)
-    # An unbounded lower should be impossible for tensor dims (>=0), but if it
-    # ever does happen we fall back to 1 (post 0/1-specialization default)
-    # rather than crashing.
+    # Unbounded lower shouldn't happen for tensor dims; fall back to 1.
     min_val = min_val_opt if min_val_opt is not None else 1
 
     # Torchdynamo 0/1 specialization outlier
     min_val = 1 if min_val == 2 else min_val
 
-    # If the exporter left this symbol with an unbounded upper range (i.e.
-    # the user used ``Dim.DYNAMIC`` without an explicit upper), fall back to
-    # the bounds the user supplied via ``torch_tensorrt.Input(min_shape=...,
-    # max_shape=...)``. Only fills the gap; never overrides a finite exporter
-    # max. The lower bound is intersected so the exporter's specialization
-    # (e.g. lower == 1) is preserved.
+    # Fill missing exporter upper from user bounds; intersect lower so
+    # ShapeEnv's 0/1 specialization is preserved.
     if (
         max_val is None
         and user_symbol_bounds

--- a/py/torch_tensorrt/dynamo/utils.py
+++ b/py/torch_tensorrt/dynamo/utils.py
@@ -407,9 +407,24 @@ def contains_sym_int(tensor: torch.Tensor) -> bool:
     return any(isinstance(dim, torch.SymInt) for dim in tensor)
 
 
-def extract_var_range_info(symbolic_integer: torch.SymInt) -> Dict[str, Optional[int]]:
+def extract_var_range_info(
+    symbolic_integer: torch.SymInt,
+    user_symbol_bounds: Optional[Dict[sympy.Symbol, Tuple[int, int]]] = None,
+) -> Dict[str, Optional[int]]:
     """
     This function returns the min, max, opt values of a symbolic integer.
+
+    Args:
+        symbolic_integer: The ``torch.SymInt`` whose range is being queried.
+        user_symbol_bounds: Optional read-only map from a top-level sympy symbol
+            to ``(min, max)`` bounds supplied by the user via
+            ``torch_tensorrt.Input``. These are used **only** to fill the gap
+            when the exporter's ``ShapeEnv`` reports an unbounded upper range
+            (``int_oo``). The exporter's bounds always win when they are
+            finite; the lower bound is intersected (``max(exporter_lower,
+            user_lower)``) so we never widen the exporter's 0/1 specialization
+            (e.g. ``lower == 2 -> 1``) to ``0`` when the user passes
+            ``min_shape=0``. ``ShapeEnv`` itself is never mutated.
     """
     node = symbolic_integer.node
     expr = node.expr
@@ -443,6 +458,23 @@ def extract_var_range_info(symbolic_integer: torch.SymInt) -> Dict[str, Optional
 
     # Torchdynamo 0/1 specialization outlier
     min_val = 1 if min_val == 2 else min_val
+
+    # If the exporter left this symbol with an unbounded upper range (i.e.
+    # the user used ``Dim.DYNAMIC`` without an explicit upper), fall back to
+    # the bounds the user supplied via ``torch_tensorrt.Input(min_shape=...,
+    # max_shape=...)``. Only fills the gap; never overrides a finite exporter
+    # max. The lower bound is intersected so the exporter's specialization
+    # (e.g. lower == 1) is preserved.
+    if (
+        max_val is None
+        and user_symbol_bounds
+        and isinstance(expr, sympy.Symbol)
+        and expr in user_symbol_bounds
+    ):
+        user_min, user_max = user_symbol_bounds[expr]
+        min_val = max(min_val, int(user_min))
+        max_val = int(user_max)
+
     min_max_opt: Dict[str, Optional[int]] = {}
     min_max_opt["min"] = min_val
     min_max_opt["max"] = max_val

--- a/py/torch_tensorrt/dynamo/utils.py
+++ b/py/torch_tensorrt/dynamo/utils.py
@@ -451,10 +451,32 @@ def extract_var_range_info(
         or expr.xreplace(var_to_val_map)
     )
     assert var_range, var_val
-    min_val, max_val = (
-        int(var_range.lower),
-        int(var_range.upper) if var_range.upper != int_oo else None,
-    )
+
+    # ``var_range`` can come from two paths:
+    #   (1) ``shape_env.var_to_range[expr]`` -- stores PyTorch's integer-typed
+    #       ``int_oo`` sentinel for unbounded sides.
+    #   (2) ``shape_env.bound_sympy(expr)`` (composite exprs like ``s0 + s1``)
+    #       -- runs sympy arithmetic, which collapses unbounded operands to
+    #       ``sympy.oo`` (sympy's float-typed ``S.Infinity``).
+    # ``int_oo`` and ``sympy.oo`` are different objects, so a single-sentinel
+    # check (``!= int_oo``) misses path (2) and crashes downstream when sympy
+    # tries to coerce ``oo`` to int. Treat any non-finite bound as ``None``.
+    def _bound_to_int_or_none(value: Any) -> Optional[int]:
+        if value is int_oo or value is -int_oo:
+            return None
+        if value == sympy.oo or value == -sympy.oo:
+            return None
+        try:
+            return int(value)
+        except (TypeError, OverflowError, AttributeError):
+            return None
+
+    min_val_opt = _bound_to_int_or_none(var_range.lower)
+    max_val = _bound_to_int_or_none(var_range.upper)
+    # An unbounded lower should be impossible for tensor dims (>=0), but if it
+    # ever does happen we fall back to 1 (post 0/1-specialization default)
+    # rather than crashing.
+    min_val = min_val_opt if min_val_opt is not None else 1
 
     # Torchdynamo 0/1 specialization outlier
     min_val = 1 if min_val == 2 else min_val

--- a/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
+++ b/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
@@ -365,9 +365,24 @@ def test_dim_dynamic_save_preserves_range_constraints(tmpdir):
     }
     assertions.assertEqual(expected_constraints, reloaded_constraints)
 
-    # Sanity: the compiled engine must accept up to the user's max_shape.
-    big_input = torch.randn(8, 8, device="cuda")
-    trt_module(big_input)
+    # Sanity: the compiled engine must accept inputs across the user's
+    # declared profile - both at the lower edge (min_shape=1) and at the
+    # upper edge (max_shape=8).
+    trt_module(torch.randn(1, 8, device="cuda"))
+    trt_module(torch.randn(4, 8, device="cuda"))
+    trt_module(torch.randn(8, 8, device="cuda"))
+
+    # And it must REJECT inputs beyond max_shape, even though the model
+    # graph (exported with ``Dim.DYNAMIC``) is itself unbounded and could
+    # theoretically handle batch=16 in eager. The TRT engine's profile is
+    # the binding runtime envelope: ``Input(max_shape=8)`` is the user
+    # opting into a strict cap. If a user wants batch=16 they must either
+    # re-compile with ``max_shape>=16`` or omit ``max_shape`` (heuristic
+    # fallback). This pins down the contract to prevent regressions where
+    # ``Input.max_shape`` would silently widen back to the heuristic.
+    too_big = torch.randn(16, 8, device="cuda")
+    with assertions.assertRaises(Exception):
+        trt_module(too_big)
 
 
 if __name__ == "__main__":

--- a/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
+++ b/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
@@ -1,13 +1,6 @@
 # type: ignore
-"""Regression tests for user-supplied dynamic-shape bounds threading.
-
-These tests exercise the read-only ``user_symbol_bounds`` map plumbed from
-``compile_module`` through the partitioner into
-``extract_var_range_info``. The map fills in upper bounds left unbounded by
-``Dim.DYNAMIC`` *without* mutating the exporter's ``ShapeEnv``, so the
-original ``range_constraints`` are preserved across
-``torch_tensorrt.save(..., output_format="exported_program")``.
-"""
+"""Tests for ``user_symbol_bounds`` plumbed from ``compile_module`` through
+the partitioner into ``extract_var_range_info``."""
 
 import os
 import unittest
@@ -24,12 +17,8 @@ assertions = unittest.TestCase()
 
 
 def _first_sym_placeholder(ep: torch.export.ExportedProgram, sym_dim: int = 0):
-    """Return (fake_val, sym_int) for the first placeholder node that has a
-    ``torch.SymInt`` at ``sym_dim``.
-
-    ``ep.graph`` is the *lifted* graph: parameters and buffers are lifted to
-    placeholders ahead of the user's inputs (``p_<param>`` / ``b_<buf>``
-    targets). Hence the function"""
+    """First placeholder with a ``SymInt`` at ``sym_dim``; skips lifted
+    param/buffer placeholders that ``strict=False`` may prepend."""
     for node in ep.graph.nodes:
         if node.op != "placeholder":
             continue
@@ -52,60 +41,42 @@ class _SmallLinear(torch.nn.Module):
 
 @pytest.mark.unit
 def test_extract_var_range_info_fills_unbounded_max_from_user():
-    """``extract_var_range_info`` must use ``user_symbol_bounds`` only when
-    the exporter leaves ``var_to_range.upper`` as ``int_oo``."""
+    """User bounds must fill the gap when the exporter's upper is ``int_oo``,
+    and successive calls must not leak state across invocations."""
 
     model = _SmallLinear().eval().cuda()
     sample = torch.randn(2, 8, device="cuda")
 
-    # ``Dim.DYNAMIC`` (sentinel) leaves the upper bound unbounded.
     dyn_batch = torch.export.Dim.DYNAMIC
     ep = torch.export.export(
         model, (sample,), dynamic_shapes=({0: dyn_batch},), strict=False
     )
 
-    # Pull the SymInt for the dynamic batch dim from the placeholder meta.
-    # Use the helper to skip parameter/buffer placeholders that strict=False
-    # may prepend to the graph.
     fake_val, sym_dim = _first_sym_placeholder(ep, sym_dim=0)
-    assert (
-        sym_dim is not None
-    ), "expected at least one placeholder with a SymInt batch dim"
+    assert sym_dim is not None
     assert isinstance(sym_dim, torch.SymInt)
     expr = sym_dim.node.expr
     assert isinstance(expr, sympy.Symbol)
 
-    # Without the user map the upper bound is unbounded -> ``max`` is None.
-    info_no_user = extract_var_range_info(sym_dim)
-    assert info_no_user["max"] is None
+    assert extract_var_range_info(sym_dim)["max"] is None
 
-    # With the user map providing max=8, the exporter's gap is filled.
-    # The lower stays at 1 (Dynamo's 0/1 specialization rewrite in
-    # ``extract_var_range_info``); user_min=1 intersects to the same value.
     info_with_user = extract_var_range_info(sym_dim, user_symbol_bounds={expr: (1, 8)})
     assert info_with_user["max"] == 8
     assert info_with_user["min"] == 1
 
-    # A second call with a *different* user map must return the new bounds:
-    # ``extract_var_range_info`` is read-only w.r.t. ``ShapeEnv`` and must
-    # therefore track whatever map the caller hands it on each invocation.
-    info_with_user_wider = extract_var_range_info(
-        sym_dim, user_symbol_bounds={expr: (1, 16)}
-    )
-    assert info_with_user_wider["max"] == 16
-    assert info_with_user_wider["min"] == 1
+    # Different map on the same SymInt must return the new bounds (no caching).
+    info_wider = extract_var_range_info(sym_dim, user_symbol_bounds={expr: (1, 16)})
+    assert info_wider["max"] == 16
+    assert info_wider["min"] == 1
 
-    # And dropping the user map again must revert to the unbounded result -
-    # i.e. the previous calls did not mutate any cached state.
-    info_revert = extract_var_range_info(sym_dim)
-    assert info_revert["max"] is None
+    # Dropping the map must revert (no ShapeEnv mutation).
+    assert extract_var_range_info(sym_dim)["max"] is None
 
 
 @pytest.mark.unit
 def test_extract_var_range_info_does_not_widen_lower_bound():
-    """The user's lower bound must be intersected (``max(exporter, user)``)
-    so the exporter's 0/1 specialization (lower == 1) survives even when
-    the user passes ``min_shape=0``."""
+    """Lower bound is intersected so the 0/1 specialization survives even
+    when the user passes ``min_shape=0``."""
 
     model = _SmallLinear().eval().cuda()
     sample = torch.randn(2, 8, device="cuda")
@@ -116,20 +87,17 @@ def test_extract_var_range_info_does_not_widen_lower_bound():
         strict=False,
     )
     _, sym_dim = _first_sym_placeholder(ep, sym_dim=0)
-    assert sym_dim is not None, "expected a placeholder with a SymInt batch dim"
+    assert sym_dim is not None
     expr = sym_dim.node.expr
 
     info = extract_var_range_info(sym_dim, user_symbol_bounds={expr: (0, 8)})
-    assert (
-        info["min"] == 1
-    ), "exporter's lower bound (1) must not be widened to user's 0"
+    assert info["min"] == 1, "exporter lower must not be widened to user's 0"
     assert info["max"] == 8
 
 
 @pytest.mark.unit
 def test_extract_var_range_info_does_not_override_finite_max():
-    """When the exporter already provides a finite upper bound (e.g. via
-    ``Dim(max=...)``), the user's value must be ignored."""
+    """A finite exporter max must win over ``user_symbol_bounds``."""
 
     model = _SmallLinear().eval().cuda()
     sample = torch.randn(2, 8, device="cuda")
@@ -140,29 +108,18 @@ def test_extract_var_range_info_does_not_override_finite_max():
         strict=False,
     )
     _, sym_dim = _first_sym_placeholder(ep, sym_dim=0)
-    assert sym_dim is not None, "expected a placeholder with a SymInt batch dim"
+    assert sym_dim is not None
     expr = sym_dim.node.expr
 
     info = extract_var_range_info(sym_dim, user_symbol_bounds={expr: (1, 16)})
-    assert (
-        info["max"] == 4
-    ), "finite exporter upper bound must win over user_symbol_bounds"
+    assert info["max"] == 4
 
 
 @pytest.mark.unit
 def test_extract_var_range_info_handles_sympy_oo_from_bound_sympy():
-    """Composite symbolic expressions (e.g. ``s0 + s1``) take the
-    ``shape_env.bound_sympy`` fallback inside ``extract_var_range_info``.
-    Sympy's arithmetic returns the *float-typed* ``sympy.oo`` for unbounded
-    operands, which is a different object from PyTorch's ``int_oo``. A naive
-    ``!= int_oo`` guard misses this case and crashes when ``int(sympy.oo)`` is
-    attempted (``AttributeError: 'Infinity' object has no attribute '_mpf_'``).
-
-    This test reproduces that path: a model that concatenates two tensors
-    along a dynamic batch dimension, so the result's batch dim is
-    ``s0 + s1`` -- a composite expression whose ``bound_sympy`` upper is
-    ``sympy.oo`` when both ``s0`` and ``s1`` come from ``Dim.DYNAMIC``.
-    """
+    """Composite exprs (e.g. ``s0 + s1``) hit ``bound_sympy``, which returns
+    ``sympy.oo`` (not ``int_oo``) for unbounded operands. A naive
+    ``!= int_oo`` guard misses it and crashes on ``int(sympy.oo)``."""
 
     class _ConcatBatch(torch.nn.Module):
         def forward(self, a, b):
@@ -190,30 +147,18 @@ def test_extract_var_range_info_handles_sympy_oo_from_bound_sympy():
         None,
     )
     if cat_node is None or "val" not in cat_node.meta:
-        pytest.skip(
-            "PyTorch version did not preserve a cat node with a composite "
-            "symbolic batch dim; skipping regression."
-        )
+        pytest.skip("no cat node with composite SymInt on this PyTorch")
 
     composite_dim = cat_node.meta["val"].size()[0]
     if not isinstance(composite_dim, torch.SymInt):
-        pytest.skip("composite batch dim was specialized to a concrete int")
-    composite_expr = composite_dim.node.expr
-    if isinstance(composite_expr, sympy.Symbol):
-        pytest.skip(
-            "expected a composite expression (e.g. s0 + s1); got a plain "
-            "symbol on this PyTorch version"
-        )
+        pytest.skip("composite dim specialized to a concrete int")
+    if isinstance(composite_dim.node.expr, sympy.Symbol):
+        pytest.skip("expr collapsed to a plain symbol on this PyTorch")
 
-    # Without the fix, this call raises ``AttributeError`` from sympy when it
-    # tries to coerce ``sympy.oo`` to int. With the fix, the unbounded upper
-    # is reported as ``None`` so callers can fall back gracefully.
+    # Pre-fix this raised ``AttributeError`` from ``int(sympy.oo)``.
     info = extract_var_range_info(composite_dim)
-    assert info["max"] is None, (
-        f"composite expression with unbounded operand should report max=None, "
-        f"got {info['max']!r}"
-    )
-    assert info["min"] is not None, "min should still resolve to an int"
+    assert info["max"] is None
+    assert info["min"] is not None
 
 
 @pytest.mark.unit
@@ -248,9 +193,8 @@ def test_build_user_symbol_bounds_uses_dynamic_inputs_only():
 
 @pytest.mark.unit
 def test_build_user_symbol_bounds_warns_on_01_specialization(caplog):
-    """``user_min=1, exp_min=2`` is PyTorch's 0/1 specialization artifact
-    (``Dim(min=1)`` silently bumped to 2 in ShapeEnv). This should warn,
-    not raise -- it is not a user error."""
+    """``user_min=1, exp_min=2`` is the 0/1 specialization artifact -- warn,
+    don't raise."""
 
     model = _SmallLinear().eval().cuda()
     sample = torch.randn(2, 8, device="cuda")
@@ -260,7 +204,6 @@ def test_build_user_symbol_bounds_warns_on_01_specialization(caplog):
         dynamic_shapes=({0: torch.export.Dim.DYNAMIC},),
         strict=False,
     )
-    # After 0/1 specialization exp_min is 2; user declares min=1.
     input_min1 = Input(
         min_shape=(1, 8),
         opt_shape=(4, 8),
@@ -274,16 +217,13 @@ def test_build_user_symbol_bounds_warns_on_01_specialization(caplog):
         _build_user_symbol_bounds(ep.module(), [input_min1], {})
 
     msgs = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
-    # Either no warning (bounds recorded fine with Dim.DYNAMIC unbounded path)
-    # or the 0/1 specialization warning — but definitely no exception.
     if msgs:
         assert "0/1 specialization" in "\n".join(msgs)
 
 
 @pytest.mark.unit
 def test_build_user_symbol_bounds_raises_when_input_min_genuinely_below_export():
-    """``user_min < exp_min`` where the gap is NOT the 1→2 specialization
-    artifact (e.g. user_min=2, exp_min=10) must raise ``ValueError``."""
+    """``user_min < exp_min`` (not the 1->2 case) must raise."""
 
     model = _SmallLinear().eval().cuda()
     sample = torch.randn(10, 8, device="cuda")
@@ -308,9 +248,7 @@ def test_build_user_symbol_bounds_raises_when_input_min_genuinely_below_export()
 
 @pytest.mark.unit
 def test_build_user_symbol_bounds_raises_when_input_max_above_export():
-    """Symmetric to the lower-bound case: user_max > exp_max also
-    guarantees a runtime error (TRT will reject shapes above the
-    exporter's max). Compile must fail."""
+    """``user_max > exp_max`` must raise (TRT would reject at runtime)."""
 
     model = _SmallLinear().eval().cuda()
     sample = torch.randn(10, 8, device="cuda")
@@ -323,7 +261,7 @@ def test_build_user_symbol_bounds_raises_when_input_max_above_export():
     too_wide_input = Input(
         min_shape=(10, 8),
         opt_shape=(15, 8),
-        max_shape=(25, 8),  # exceeds exp_max=20
+        max_shape=(25, 8),
         dtype=torch.float32,
     )
     with pytest.raises(ValueError) as exc_info:
@@ -334,8 +272,7 @@ def test_build_user_symbol_bounds_raises_when_input_max_above_export():
 
 @pytest.mark.unit
 def test_build_user_symbol_bounds_no_warning_on_matching_bounds(caplog):
-    """If the user's ``Input`` bounds exactly match the exporter's
-    contract, no warning or error should fire -- the user got it right."""
+    """Matching bounds must not warn or raise."""
 
     model = _SmallLinear().eval().cuda()
     sample = torch.randn(10, 8, device="cuda")
@@ -360,21 +297,13 @@ def test_build_user_symbol_bounds_no_warning_on_matching_bounds(caplog):
     warning_messages = [
         rec.message for rec in caplog.records if rec.levelno >= logging.WARNING
     ]
-    assert (
-        not warning_messages
-    ), f"matching bounds should not produce any warning, got: {warning_messages}"
+    assert not warning_messages, f"unexpected warnings: {warning_messages}"
 
 
 @pytest.mark.unit
 def test_build_user_symbol_bounds_warns_on_subset_input(caplog):
-    """When the user's ``Input`` is a *strict subset* of the exporter's
-    range (e.g. user `[12, 18]` inside exporter `[10, 20]`), no shape
-    the user declared will fail at runtime -- the engine profile (which
-    follows the exporter) accepts everything in the user's range. So
-    this is *not* an error. But the user's narrower profile is silently
-    widened, which is surprising; emit a warning so they know to
-    re-export if they really want the narrower engine.
-    """
+    """Strict-subset Input warns: engine profile is silently widened to the
+    exporter's range, which the user should know about."""
 
     model = _SmallLinear().eval().cuda()
     sample = torch.randn(10, 8, device="cuda")
@@ -394,13 +323,12 @@ def test_build_user_symbol_bounds_warns_on_subset_input(caplog):
     import logging
 
     with caplog.at_level(logging.WARNING, logger="torch_tensorrt.dynamo._compiler"):
-        # Must not raise.
         _build_user_symbol_bounds(ep.module(), [subset_input], {})
 
     warning_messages = [
         rec.message for rec in caplog.records if rec.levelno >= logging.WARNING
     ]
-    assert warning_messages, "subset Input bounds should produce a warning"
+    assert warning_messages
     msg = "\n".join(warning_messages)
     assert "subset" in msg or "wider" in msg
     assert "re-export" in msg or "Re-export" in msg
@@ -408,10 +336,7 @@ def test_build_user_symbol_bounds_warns_on_subset_input(caplog):
 
 @pytest.mark.unit
 def test_build_user_symbol_bounds_no_warning_on_dim_dynamic(caplog):
-    """``Dim.DYNAMIC`` leaves the exporter's upper unbounded; the user's
-    ``Input`` bounds *fill the gap* there (the intended use). No warning
-    should fire even if the user's lower differs from the exporter's
-    (post 0/1-specialization) lower."""
+    """Dim.DYNAMIC + Input is the intended fill case -- no mismatch warning."""
 
     model = _SmallLinear().eval().cuda()
     sample = torch.randn(2, 8, device="cuda")
@@ -438,22 +363,13 @@ def test_build_user_symbol_bounds_no_warning_on_dim_dynamic(caplog):
         for rec in caplog.records
         if rec.levelno >= logging.WARNING and "differ from the exporter" in rec.message
     ]
-    assert not mismatch_warnings, (
-        f"Dim.DYNAMIC + Input is the intended fill case, no mismatch warning expected, "
-        f"got: {mismatch_warnings}"
-    )
+    assert not mismatch_warnings, f"unexpected mismatch warnings: {mismatch_warnings}"
 
 
 @pytest.mark.unit
 def test_build_user_symbol_bounds_mixed_tensor_and_symint():
-    """Mix of tensor + SymInt placeholders: only the tensor placeholder
-    contributes symbols to the user-bounds map. The SymInt placeholder
-    is silently skipped by the ``isinstance(fake_val, torch.Tensor)``
-    guard in ``_build_user_symbol_bounds``; downstream
-    ``construct_submodule_inputs`` still handles the SymInt via its
-    dedicated branch (falling back to the ``min*2^12`` heuristic since
-    no entry for that symbol lands in ``user_symbol_bounds``).
-    """
+    """Tensor + SymInt placeholders: only the tensor contributes to the map
+    (SymInt is filtered by the ``isinstance(fake_val, torch.Tensor)`` guard)."""
 
     class _TensorAndScalar(torch.nn.Module):
         def forward(self, x, k):
@@ -461,7 +377,7 @@ def test_build_user_symbol_bounds_mixed_tensor_and_symint():
 
     model = _TensorAndScalar().eval().cuda()
     x_sample = torch.randn(2, 8, device="cuda")
-    k_sample = 4  # avoid 0/1 specialization on the scalar input
+    k_sample = 4  # >1 to avoid 0/1 specialization
 
     dyn = torch.export.Dim.DYNAMIC
     ep = torch.export.export(
@@ -471,20 +387,11 @@ def test_build_user_symbol_bounds_mixed_tensor_and_symint():
         strict=False,
     )
 
-    # Sanity: the export should produce both a tensor and a SymInt
-    # placeholder. Some PyTorch versions may collapse the scalar input
-    # if the dynamism can't be propagated through the graph - in that
-    # case we just exercise the tensor-only path.
     placeholders = [n for n in ep.graph.nodes if n.op == "placeholder"]
     metas = [p.meta.get("val") for p in placeholders]
     if not any(isinstance(m, torch.SymInt) for m in metas):
-        pytest.skip(
-            "Export collapsed the scalar SymInt placeholder on this "
-            "PyTorch version; nothing left to exercise for the mix case."
-        )
-    assert any(
-        isinstance(m, torch.Tensor) for m in metas
-    ), "expected at least one tensor placeholder"
+        pytest.skip("export collapsed the scalar SymInt on this PyTorch")
+    assert any(isinstance(m, torch.Tensor) for m in metas)
 
     tensor_input = Input(
         min_shape=(1, 8),
@@ -492,11 +399,7 @@ def test_build_user_symbol_bounds_mixed_tensor_and_symint():
         max_shape=(8, 8),
         dtype=torch.float32,
     )
-    # ``_build_user_symbol_bounds`` skips SymInt placeholders entirely
-    # (tensor-only guard on ``meta["val"]``).  The Input for the scalar
-    # argument is therefore never inspected; the specific shape values
-    # below carry no meaning -- this is a structurally-valid placeholder
-    # to keep the index alignment with positional placeholders.
+    # Index-aligned placeholder; never inspected (SymInt path skips it).
     scalar_input = Input(
         min_shape=(1,),
         opt_shape=(1,),
@@ -505,12 +408,7 @@ def test_build_user_symbol_bounds_mixed_tensor_and_symint():
     )
 
     bounds = _build_user_symbol_bounds(ep.module(), [tensor_input, scalar_input], {})
-
-    # Exactly one symbol recorded - from x's dynamic dim 0. The SymInt
-    # placeholder contributed nothing.
-    assert (
-        len(bounds) == 1
-    ), f"expected only the tensor placeholder to contribute, got {bounds}"
+    assert len(bounds) == 1, bounds
     ((sym, (lo, hi)),) = bounds.items()
     assert isinstance(sym, sympy.Symbol)
     assert (lo, hi) == (1, 8)
@@ -518,19 +416,16 @@ def test_build_user_symbol_bounds_mixed_tensor_and_symint():
 
 @pytest.mark.unit
 def test_build_user_symbol_bounds_mixed_arg_and_kwarg():
-    """Both positional and keyword inputs must contribute to the
-    user-bounds map. Positional args are matched to placeholders by
-    index; kwargs are matched by parameter name (``node.target``).
-    """
+    """Positional args (matched by index) and kwargs (matched by name) both
+    contribute to the map."""
 
     class _TwoTensors(torch.nn.Module):
         def forward(self, x, y):
-            # Two independent paths so x's dim 0 and y's dim 0 are not
-            # unified by the exporter into a single sympy symbol.
+            # Independent paths so the exporter doesn't unify x[0] and y[0].
             return x.relu(), y.relu()
 
     model = _TwoTensors().eval().cuda()
-    # Distinct sample sizes for dim 0 to discourage symbol unification.
+    # Distinct sizes discourage symbol unification.
     x_sample = torch.randn(2, 8, device="cuda")
     y_sample = torch.randn(3, 8, device="cuda")
 
@@ -544,16 +439,10 @@ def test_build_user_symbol_bounds_mixed_arg_and_kwarg():
     )
 
     placeholder_names = [n.target for n in ep.graph.nodes if n.op == "placeholder"]
-    assert (
-        "x" in placeholder_names
-    ), f"expected positional arg 'x' as placeholder, got {placeholder_names}"
-    assert (
-        "y" in placeholder_names
-    ), f"expected kwarg 'y' as placeholder, got {placeholder_names}"
+    assert "x" in placeholder_names, placeholder_names
+    assert "y" in placeholder_names, placeholder_names
 
-    # Use *distinct* numerical bounds for x and y so we can verify by
-    # value that the kwarg path actually contributed (rather than just
-    # silently double-counting x's bounds).
+    # Distinct bounds for x and y so we can verify the kwarg path by value.
     x_input = Input(
         min_shape=(1, 8),
         opt_shape=(2, 8),
@@ -573,28 +462,17 @@ def test_build_user_symbol_bounds_mixed_arg_and_kwarg():
         sample_kwarg_inputs={"y": y_input},
     )
 
-    # Two placeholders, each with a single dynamic dim, no unification:
-    # we expect exactly two entries with their respective bounds.
     bounds_values = set(bounds.values())
-    assert (1, 8) in bounds_values, (
-        f"positional x's bounds (1, 8) not recorded - "
-        f"the positional-arg branch may be broken. got: {bounds}"
-    )
-    assert (2, 6) in bounds_values, (
-        f"kwarg y's bounds (2, 6) not recorded - "
-        f"the kwarg branch may be broken. got: {bounds}"
-    )
-    assert len(bounds) == 2, f"expected exactly 2 entries, got {bounds}"
+    assert (1, 8) in bounds_values, bounds  # positional-arg branch
+    assert (2, 6) in bounds_values, bounds  # kwarg branch
+    assert len(bounds) == 2, bounds
 
 
 @pytest.mark.unit
 @pytest.mark.critical
 def test_dim_dynamic_save_preserves_range_constraints(tmpdir):
-    """End-to-end regression: exporting with ``Dim.DYNAMIC``, compiling
-    with ``Input(max_shape=8)``, and round-tripping through
-    ``torch_tensorrt.save(..., output_format="exported_program")`` must
-    leave the exporter's ``range_constraints`` untouched.
-    """
+    """End-to-end: Dim.DYNAMIC + Input(max_shape) round-trips through
+    ``torchtrt.save`` without mutating the exporter's range_constraints."""
 
     model = _SmallLinear().eval().cuda()
     sample = torch.randn(2, 8, device="cuda")
@@ -604,7 +482,7 @@ def test_dim_dynamic_save_preserves_range_constraints(tmpdir):
         model, (sample,), dynamic_shapes=({0: dyn_batch},), strict=False
     )
 
-    # Snapshot range_constraints **before** Torch-TRT touches anything.
+    # Snapshot before Torch-TRT touches anything.
     expected_constraints = {
         str(k): (v.lower, v.upper) for k, v in exp_program.range_constraints.items()
     }
@@ -625,13 +503,11 @@ def test_dim_dynamic_save_preserves_range_constraints(tmpdir):
     }
     trt_module = torchtrt.dynamo.compile(exp_program, **compile_spec)
 
-    # The exporter's range_constraints must NOT have been mutated by compile.
     after_constraints = {
         str(k): (v.lower, v.upper) for k, v in exp_program.range_constraints.items()
     }
     assertions.assertEqual(expected_constraints, after_constraints)
 
-    # Save + reload as ExportedProgram and verify constraints survive.
     trt_ep_path = os.path.join(tmpdir, "trt_dim_dynamic.ep")
     torchtrt.save(
         trt_module,
@@ -648,21 +524,14 @@ def test_dim_dynamic_save_preserves_range_constraints(tmpdir):
     }
     assertions.assertEqual(expected_constraints, reloaded_constraints)
 
-    # Sanity: the compiled engine must accept inputs across the user's
-    # declared profile - both at the lower edge (min_shape=1) and at the
-    # upper edge (max_shape=8).
+    # Engine accepts shapes across [min_shape, max_shape].
     trt_module(torch.randn(1, 8, device="cuda"))
     trt_module(torch.randn(4, 8, device="cuda"))
     trt_module(torch.randn(8, 8, device="cuda"))
 
-    # And it must REJECT inputs beyond max_shape, even though the model
-    # graph (exported with ``Dim.DYNAMIC``) is itself unbounded and could
-    # theoretically handle batch=16 in eager. The TRT engine's profile is
-    # the binding runtime envelope: ``Input(max_shape=8)`` is the user
-    # opting into a strict cap. If a user wants batch=16 they must either
-    # re-compile with ``max_shape>=16`` or omit ``max_shape`` (heuristic
-    # fallback). This pins down the contract to prevent regressions where
-    # ``Input.max_shape`` would silently widen back to the heuristic.
+    # And rejects shapes beyond ``Input.max_shape`` even though the eager
+    # graph is unbounded -- ``Input(max_shape=8)`` is a strict cap. Pins
+    # the contract against regressions that re-widen to the heuristic.
     too_big = torch.randn(16, 8, device="cuda")
     with assertions.assertRaises(Exception):
         trt_module(too_big)

--- a/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
+++ b/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
@@ -130,6 +130,73 @@ def test_extract_var_range_info_does_not_override_finite_max():
 
 
 @pytest.mark.unit
+def test_extract_var_range_info_handles_sympy_oo_from_bound_sympy():
+    """Composite symbolic expressions (e.g. ``s0 + s1``) take the
+    ``shape_env.bound_sympy`` fallback inside ``extract_var_range_info``.
+    Sympy's arithmetic returns the *float-typed* ``sympy.oo`` for unbounded
+    operands, which is a different object from PyTorch's ``int_oo``. A naive
+    ``!= int_oo`` guard misses this case and crashes when ``int(sympy.oo)`` is
+    attempted (``AttributeError: 'Infinity' object has no attribute '_mpf_'``).
+
+    This test reproduces that path: a model that concatenates two tensors
+    along a dynamic batch dimension, so the result's batch dim is
+    ``s0 + s1`` -- a composite expression whose ``bound_sympy`` upper is
+    ``sympy.oo`` when both ``s0`` and ``s1`` come from ``Dim.DYNAMIC``.
+    """
+
+    class _ConcatBatch(torch.nn.Module):
+        def forward(self, a, b):
+            return torch.cat([a, b], dim=0)
+
+    model = _ConcatBatch().eval().cuda()
+    a = torch.randn(2, 8, device="cuda")
+    b = torch.randn(3, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (a, b),
+        dynamic_shapes=(
+            {0: torch.export.Dim.DYNAMIC},
+            {0: torch.export.Dim.DYNAMIC},
+        ),
+        strict=False,
+    )
+
+    cat_node = next(
+        (
+            n
+            for n in ep.graph.nodes
+            if n.op == "call_function" and "cat" in str(n.target)
+        ),
+        None,
+    )
+    if cat_node is None or "val" not in cat_node.meta:
+        pytest.skip(
+            "PyTorch version did not preserve a cat node with a composite "
+            "symbolic batch dim; skipping regression."
+        )
+
+    composite_dim = cat_node.meta["val"].size()[0]
+    if not isinstance(composite_dim, torch.SymInt):
+        pytest.skip("composite batch dim was specialized to a concrete int")
+    composite_expr = composite_dim.node.expr
+    if isinstance(composite_expr, sympy.Symbol):
+        pytest.skip(
+            "expected a composite expression (e.g. s0 + s1); got a plain "
+            "symbol on this PyTorch version"
+        )
+
+    # Without the fix, this call raises ``AttributeError`` from sympy when it
+    # tries to coerce ``sympy.oo`` to int. With the fix, the unbounded upper
+    # is reported as ``None`` so callers can fall back gracefully.
+    info = extract_var_range_info(composite_dim)
+    assert info["max"] is None, (
+        f"composite expression with unbounded operand should report max=None, "
+        f"got {info['max']!r}"
+    )
+    assert info["min"] is not None, "min should still resolve to an int"
+
+
+@pytest.mark.unit
 def test_build_user_symbol_bounds_uses_dynamic_inputs_only():
     """Static ``Input``s contribute nothing to the user-bounds map."""
 
@@ -157,6 +224,189 @@ def test_build_user_symbol_bounds_uses_dynamic_inputs_only():
     # Static input -> empty map.
     static_input = Input(shape=(2, 8), dtype=torch.float32)
     assert _build_user_symbol_bounds(ep.module(), [static_input], {}) == {}
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_raises_when_input_extends_outside_export():
+    """When the exporter declared finite bounds (e.g. ``Dim("batch",
+    min=10, max=20)``) and the user passes an ``Input`` that extends
+    *outside* that range, shapes the user listed in
+    ``min_shape``/``max_shape`` are guaranteed to fail at runtime (the
+    TRT engine profile follows the exporter). We surface that as a hard
+    ``ValueError`` at compile time rather than letting the user discover
+    it via a confusing TRT runtime error.
+    """
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(10, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim("batch", min=10, max=20)},),
+        strict=False,
+    )
+
+    # User declares a profile that extends below the exporter's lower
+    # bound (user_min=2 < exp_min=10). The exporter would refuse batch=2
+    # at runtime; raise at compile.
+    incompatible_input = Input(
+        min_shape=(2, 8),
+        opt_shape=(5, 8),
+        max_shape=(10, 8),
+        dtype=torch.float32,
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        _build_user_symbol_bounds(ep.module(), [incompatible_input], {})
+    msg = str(exc_info.value)
+    assert "extend outside" in msg
+    assert "shape outside profile" in msg
+    # The actionable guidance: either re-export, or stay inside the range.
+    assert "re-export" in msg
+    assert "Dim(" in msg
+    # Both numeric pairs should appear so the user can see the conflict.
+    assert "min=2" in msg and "max=10" in msg
+    assert "min=10" in msg and "max=20" in msg
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_raises_when_input_max_above_export():
+    """Symmetric to the lower-bound case: user_max > exp_max also
+    guarantees a runtime error (TRT will reject shapes above the
+    exporter's max). Compile must fail."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(10, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim("batch", min=10, max=20)},),
+        strict=False,
+    )
+    too_wide_input = Input(
+        min_shape=(10, 8),
+        opt_shape=(15, 8),
+        max_shape=(25, 8),  # exceeds exp_max=20
+        dtype=torch.float32,
+    )
+    with pytest.raises(ValueError) as exc_info:
+        _build_user_symbol_bounds(ep.module(), [too_wide_input], {})
+    assert "extend outside" in str(exc_info.value)
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_no_warning_on_matching_bounds(caplog):
+    """If the user's ``Input`` bounds exactly match the exporter's
+    contract, no warning or error should fire -- the user got it right."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(10, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim("batch", min=10, max=20)},),
+        strict=False,
+    )
+    matching_input = Input(
+        min_shape=(10, 8),
+        opt_shape=(15, 8),
+        max_shape=(20, 8),
+        dtype=torch.float32,
+    )
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="torch_tensorrt.dynamo._compiler"):
+        _build_user_symbol_bounds(ep.module(), [matching_input], {})
+
+    warning_messages = [
+        rec.message for rec in caplog.records if rec.levelno >= logging.WARNING
+    ]
+    assert (
+        not warning_messages
+    ), f"matching bounds should not produce any warning, got: {warning_messages}"
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_warns_on_subset_input(caplog):
+    """When the user's ``Input`` is a *strict subset* of the exporter's
+    range (e.g. user `[12, 18]` inside exporter `[10, 20]`), no shape
+    the user declared will fail at runtime -- the engine profile (which
+    follows the exporter) accepts everything in the user's range. So
+    this is *not* an error. But the user's narrower profile is silently
+    widened, which is surprising; emit a warning so they know to
+    re-export if they really want the narrower engine.
+    """
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(10, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim("batch", min=10, max=20)},),
+        strict=False,
+    )
+    subset_input = Input(
+        min_shape=(12, 8),
+        opt_shape=(15, 8),
+        max_shape=(18, 8),
+        dtype=torch.float32,
+    )
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="torch_tensorrt.dynamo._compiler"):
+        # Must not raise.
+        _build_user_symbol_bounds(ep.module(), [subset_input], {})
+
+    warning_messages = [
+        rec.message for rec in caplog.records if rec.levelno >= logging.WARNING
+    ]
+    assert (
+        warning_messages
+    ), "subset Input bounds should produce a 'narrower than exporter' warning"
+    msg = "\n".join(warning_messages)
+    assert "narrower than the exporter" in msg
+    assert "engine profile will use the exporter's wider" in msg
+    assert "re-export" in msg
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_no_warning_on_dim_dynamic(caplog):
+    """``Dim.DYNAMIC`` leaves the exporter's upper unbounded; the user's
+    ``Input`` bounds *fill the gap* there (the intended use). No warning
+    should fire even if the user's lower differs from the exporter's
+    (post 0/1-specialization) lower."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(2, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim.DYNAMIC},),
+        strict=False,
+    )
+    fill_input = Input(
+        min_shape=(1, 8),
+        opt_shape=(4, 8),
+        max_shape=(8, 8),
+        dtype=torch.float32,
+    )
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="torch_tensorrt.dynamo._compiler"):
+        _build_user_symbol_bounds(ep.module(), [fill_input], {})
+
+    mismatch_warnings = [
+        rec.message
+        for rec in caplog.records
+        if rec.levelno >= logging.WARNING and "differ from the exporter" in rec.message
+    ]
+    assert not mismatch_warnings, (
+        f"Dim.DYNAMIC + Input is the intended fill case, no mismatch warning expected, "
+        f"got: {mismatch_warnings}"
+    )
 
 
 @pytest.mark.unit

--- a/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
+++ b/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
@@ -227,15 +227,43 @@ def test_build_user_symbol_bounds_uses_dynamic_inputs_only():
 
 
 @pytest.mark.unit
-def test_build_user_symbol_bounds_raises_when_input_extends_outside_export():
-    """When the exporter declared finite bounds (e.g. ``Dim("batch",
-    min=10, max=20)``) and the user passes an ``Input`` that extends
-    *outside* that range, shapes the user listed in
-    ``min_shape``/``max_shape`` are guaranteed to fail at runtime (the
-    TRT engine profile follows the exporter). We surface that as a hard
-    ``ValueError`` at compile time rather than letting the user discover
-    it via a confusing TRT runtime error.
-    """
+def test_build_user_symbol_bounds_warns_on_01_specialization(caplog):
+    """``user_min=1, exp_min=2`` is PyTorch's 0/1 specialization artifact
+    (``Dim(min=1)`` silently bumped to 2 in ShapeEnv). This should warn,
+    not raise -- it is not a user error."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(2, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim.DYNAMIC},),
+        strict=False,
+    )
+    # After 0/1 specialization exp_min is 2; user declares min=1.
+    input_min1 = Input(
+        min_shape=(1, 8),
+        opt_shape=(4, 8),
+        max_shape=(8, 8),
+        dtype=torch.float32,
+    )
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="torch_tensorrt.dynamo._compiler"):
+        _build_user_symbol_bounds(ep.module(), [input_min1], {})
+
+    msgs = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    # Either no warning (bounds recorded fine with Dim.DYNAMIC unbounded path)
+    # or the 0/1 specialization warning — but definitely no exception.
+    if msgs:
+        assert "0/1 specialization" in "\n".join(msgs)
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_raises_when_input_min_genuinely_below_export():
+    """``user_min < exp_min`` where the gap is NOT the 1→2 specialization
+    artifact (e.g. user_min=2, exp_min=10) must raise ``ValueError``."""
 
     model = _SmallLinear().eval().cuda()
     sample = torch.randn(10, 8, device="cuda")
@@ -245,28 +273,17 @@ def test_build_user_symbol_bounds_raises_when_input_extends_outside_export():
         dynamic_shapes=({0: torch.export.Dim("batch", min=10, max=20)},),
         strict=False,
     )
-
-    # User declares a profile that extends below the exporter's lower
-    # bound (user_min=2 < exp_min=10). The exporter would refuse batch=2
-    # at runtime; raise at compile.
-    incompatible_input = Input(
+    input_too_low = Input(
         min_shape=(2, 8),
         opt_shape=(5, 8),
         max_shape=(10, 8),
         dtype=torch.float32,
     )
-
     with pytest.raises(ValueError) as exc_info:
-        _build_user_symbol_bounds(ep.module(), [incompatible_input], {})
+        _build_user_symbol_bounds(ep.module(), [input_too_low], {})
     msg = str(exc_info.value)
-    assert "extend outside" in msg
-    assert "shape outside profile" in msg
-    # The actionable guidance: either re-export, or stay inside the range.
-    assert "re-export" in msg
-    assert "Dim(" in msg
-    # Both numeric pairs should appear so the user can see the conflict.
-    assert "min=2" in msg and "max=10" in msg
-    assert "min=10" in msg and "max=20" in msg
+    assert "TRT engine min" in msg
+    assert "re-export" in msg or "raise Input.min_shape" in msg
 
 
 @pytest.mark.unit
@@ -291,7 +308,8 @@ def test_build_user_symbol_bounds_raises_when_input_max_above_export():
     )
     with pytest.raises(ValueError) as exc_info:
         _build_user_symbol_bounds(ep.module(), [too_wide_input], {})
-    assert "extend outside" in str(exc_info.value)
+    msg = str(exc_info.value)
+    assert "max_shape exceeds" in msg or "TRT will reject" in msg
 
 
 @pytest.mark.unit
@@ -362,13 +380,10 @@ def test_build_user_symbol_bounds_warns_on_subset_input(caplog):
     warning_messages = [
         rec.message for rec in caplog.records if rec.levelno >= logging.WARNING
     ]
-    assert (
-        warning_messages
-    ), "subset Input bounds should produce a 'narrower than exporter' warning"
+    assert warning_messages, "subset Input bounds should produce a warning"
     msg = "\n".join(warning_messages)
-    assert "narrower than the exporter" in msg
-    assert "engine profile will use the exporter's wider" in msg
-    assert "re-export" in msg
+    assert "subset" in msg or "wider" in msg
+    assert "re-export" in msg or "Re-export" in msg
 
 
 @pytest.mark.unit

--- a/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
+++ b/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
@@ -242,8 +242,8 @@ def test_build_user_symbol_bounds_raises_when_input_min_genuinely_below_export()
     with pytest.raises(ValueError) as exc_info:
         _build_user_symbol_bounds(ep.module(), [input_too_low], {})
     msg = str(exc_info.value)
-    assert "min_shape is below" in msg or "TRT will reject" in msg
-    assert "Re-export" in msg or "adjust Input" in msg
+    assert "Input.min_shape" in msg and "exported program" in msg
+    assert "re-export" in msg.lower() or "Input.min_shape >=" in msg
 
 
 @pytest.mark.unit
@@ -267,7 +267,8 @@ def test_build_user_symbol_bounds_raises_when_input_max_above_export():
     with pytest.raises(ValueError) as exc_info:
         _build_user_symbol_bounds(ep.module(), [too_wide_input], {})
     msg = str(exc_info.value)
-    assert "max_shape exceeds" in msg or "TRT will reject" in msg
+    assert "Input.max_shape" in msg and "exported program" in msg
+    assert "re-export" in msg.lower() or "Input.max_shape <=" in msg
 
 
 @pytest.mark.unit

--- a/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
+++ b/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
@@ -23,6 +23,24 @@ from torch_tensorrt.dynamo.utils import extract_var_range_info
 assertions = unittest.TestCase()
 
 
+def _first_sym_placeholder(ep: torch.export.ExportedProgram, sym_dim: int = 0):
+    """Return (fake_val, sym_int) for the first placeholder node that has a
+    ``torch.SymInt`` at ``sym_dim``.
+
+    ``ep.graph`` is the *lifted* graph: parameters and buffers are lifted to
+    placeholders ahead of the user's inputs (``p_<param>`` / ``b_<buf>``
+    targets). Hence the function"""
+    for node in ep.graph.nodes:
+        if node.op != "placeholder":
+            continue
+        val = node.meta.get("val")
+        if not isinstance(val, torch.Tensor):
+            continue
+        if sym_dim < len(val.size()) and isinstance(val.size()[sym_dim], torch.SymInt):
+            return val, val.size()[sym_dim]
+    return None, None
+
+
 class _SmallLinear(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -47,10 +65,12 @@ def test_extract_var_range_info_fills_unbounded_max_from_user():
     )
 
     # Pull the SymInt for the dynamic batch dim from the placeholder meta.
-    placeholders = [n for n in ep.graph.nodes if n.op == "placeholder"]
-    assert placeholders, "expected a placeholder for the model input"
-    fake_val = placeholders[0].meta["val"]
-    sym_dim = fake_val.size()[0]
+    # Use the helper to skip parameter/buffer placeholders that strict=False
+    # may prepend to the graph.
+    fake_val, sym_dim = _first_sym_placeholder(ep, sym_dim=0)
+    assert (
+        sym_dim is not None
+    ), "expected at least one placeholder with a SymInt batch dim"
     assert isinstance(sym_dim, torch.SymInt)
     expr = sym_dim.node.expr
     assert isinstance(expr, sympy.Symbol)
@@ -95,8 +115,8 @@ def test_extract_var_range_info_does_not_widen_lower_bound():
         dynamic_shapes=({0: torch.export.Dim.DYNAMIC},),
         strict=False,
     )
-    placeholders = [n for n in ep.graph.nodes if n.op == "placeholder"]
-    sym_dim = placeholders[0].meta["val"].size()[0]
+    _, sym_dim = _first_sym_placeholder(ep, sym_dim=0)
+    assert sym_dim is not None, "expected a placeholder with a SymInt batch dim"
     expr = sym_dim.node.expr
 
     info = extract_var_range_info(sym_dim, user_symbol_bounds={expr: (0, 8)})
@@ -119,8 +139,8 @@ def test_extract_var_range_info_does_not_override_finite_max():
         dynamic_shapes=({0: torch.export.Dim("batch", min=1, max=4)},),
         strict=False,
     )
-    placeholders = [n for n in ep.graph.nodes if n.op == "placeholder"]
-    sym_dim = placeholders[0].meta["val"].size()[0]
+    _, sym_dim = _first_sym_placeholder(ep, sym_dim=0)
+    assert sym_dim is not None, "expected a placeholder with a SymInt batch dim"
     expr = sym_dim.node.expr
 
     info = extract_var_range_info(sym_dim, user_symbol_bounds={expr: (1, 16)})
@@ -282,8 +302,8 @@ def test_build_user_symbol_bounds_raises_when_input_min_genuinely_below_export()
     with pytest.raises(ValueError) as exc_info:
         _build_user_symbol_bounds(ep.module(), [input_too_low], {})
     msg = str(exc_info.value)
-    assert "TRT engine min" in msg
-    assert "re-export" in msg or "raise Input.min_shape" in msg
+    assert "min_shape is below" in msg or "TRT will reject" in msg
+    assert "Re-export" in msg or "adjust Input" in msg
 
 
 @pytest.mark.unit
@@ -472,24 +492,22 @@ def test_build_user_symbol_bounds_mixed_tensor_and_symint():
         max_shape=(8, 8),
         dtype=torch.float32,
     )
-    # The user is allowed to pass an ``Input`` for the SymInt argument
-    # (Torch-TRT treats it as a 1-D shape tensor downstream), but
-    # ``_build_user_symbol_bounds`` will not record it because
-    # ``meta["val"]`` is a ``torch.SymInt``, not a ``torch.Tensor``.
+    # ``_build_user_symbol_bounds`` skips SymInt placeholders entirely
+    # (tensor-only guard on ``meta["val"]``).  The Input for the scalar
+    # argument is therefore never inspected; the specific shape values
+    # below carry no meaning -- this is a structurally-valid placeholder
+    # to keep the index alignment with positional placeholders.
     scalar_input = Input(
         min_shape=(1,),
-        opt_shape=(4,),
-        max_shape=(8,),
+        opt_shape=(1,),
+        max_shape=(1,),
         dtype=torch.int64,
     )
 
     bounds = _build_user_symbol_bounds(ep.module(), [tensor_input, scalar_input], {})
 
     # Exactly one symbol recorded - from x's dynamic dim 0. The SymInt
-    # placeholder contributed nothing. (The fact that the recorded
-    # bounds equal the *tensor* input's (1, 8) - not the scalar input's
-    # (1, 8), which happens to be the same numerically - is verified by
-    # checking that exactly one entry exists, ruling out double-recording.)
+    # placeholder contributed nothing.
     assert (
         len(bounds) == 1
     ), f"expected only the tensor placeholder to contribute, got {bounds}"

--- a/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
+++ b/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
@@ -180,7 +180,9 @@ def test_build_user_symbol_bounds_uses_dynamic_inputs_only():
         max_shape=(8, 8),
         dtype=torch.float32,
     )
-    bounds = _build_user_symbol_bounds(ep.module(), [dynamic_input], {})
+    bounds = _build_user_symbol_bounds(
+        ep.module(), [dynamic_input], {}, ep.graph_signature
+    )
     assert len(bounds) == 1
     ((sym, (lo, hi)),) = bounds.items()
     assert isinstance(sym, sympy.Symbol)
@@ -188,7 +190,10 @@ def test_build_user_symbol_bounds_uses_dynamic_inputs_only():
 
     # Static input -> empty map.
     static_input = Input(shape=(2, 8), dtype=torch.float32)
-    assert _build_user_symbol_bounds(ep.module(), [static_input], {}) == {}
+    assert (
+        _build_user_symbol_bounds(ep.module(), [static_input], {}, ep.graph_signature)
+        == {}
+    )
 
 
 @pytest.mark.unit
@@ -214,7 +219,7 @@ def test_build_user_symbol_bounds_warns_on_01_specialization(caplog):
     import logging
 
     with caplog.at_level(logging.WARNING, logger="torch_tensorrt.dynamo._compiler"):
-        _build_user_symbol_bounds(ep.module(), [input_min1], {})
+        _build_user_symbol_bounds(ep.module(), [input_min1], {}, ep.graph_signature)
 
     msgs = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
     if msgs:
@@ -240,7 +245,7 @@ def test_build_user_symbol_bounds_raises_when_input_min_genuinely_below_export()
         dtype=torch.float32,
     )
     with pytest.raises(ValueError) as exc_info:
-        _build_user_symbol_bounds(ep.module(), [input_too_low], {})
+        _build_user_symbol_bounds(ep.module(), [input_too_low], {}, ep.graph_signature)
     msg = str(exc_info.value)
     assert "Input.min_shape" in msg and "exported program" in msg
     assert "re-export" in msg.lower() or "Input.min_shape >=" in msg
@@ -265,7 +270,7 @@ def test_build_user_symbol_bounds_raises_when_input_max_above_export():
         dtype=torch.float32,
     )
     with pytest.raises(ValueError) as exc_info:
-        _build_user_symbol_bounds(ep.module(), [too_wide_input], {})
+        _build_user_symbol_bounds(ep.module(), [too_wide_input], {}, ep.graph_signature)
     msg = str(exc_info.value)
     assert "Input.max_shape" in msg and "exported program" in msg
     assert "re-export" in msg.lower() or "Input.max_shape <=" in msg
@@ -293,7 +298,7 @@ def test_build_user_symbol_bounds_no_warning_on_matching_bounds(caplog):
     import logging
 
     with caplog.at_level(logging.WARNING, logger="torch_tensorrt.dynamo._compiler"):
-        _build_user_symbol_bounds(ep.module(), [matching_input], {})
+        _build_user_symbol_bounds(ep.module(), [matching_input], {}, ep.graph_signature)
 
     warning_messages = [
         rec.message for rec in caplog.records if rec.levelno >= logging.WARNING
@@ -324,7 +329,9 @@ def test_build_user_symbol_bounds_narrows_to_user_on_subset(caplog):
     import logging
 
     with caplog.at_level(logging.INFO, logger="torch_tensorrt.dynamo._compiler"):
-        bounds = _build_user_symbol_bounds(ep.module(), [subset_input], {})
+        bounds = _build_user_symbol_bounds(
+            ep.module(), [subset_input], {}, ep.graph_signature
+        )
 
     # No warning -- subset is a valid, intended narrowing.
     warning_messages = [
@@ -369,7 +376,7 @@ def test_build_user_symbol_bounds_no_warning_on_dim_dynamic(caplog):
     import logging
 
     with caplog.at_level(logging.WARNING, logger="torch_tensorrt.dynamo._compiler"):
-        _build_user_symbol_bounds(ep.module(), [fill_input], {})
+        _build_user_symbol_bounds(ep.module(), [fill_input], {}, ep.graph_signature)
 
     mismatch_warnings = [
         rec.message
@@ -420,7 +427,9 @@ def test_build_user_symbol_bounds_mixed_tensor_and_symint():
         dtype=torch.int64,
     )
 
-    bounds = _build_user_symbol_bounds(ep.module(), [tensor_input, scalar_input], {})
+    bounds = _build_user_symbol_bounds(
+        ep.module(), [tensor_input, scalar_input], {}, ep.graph_signature
+    )
     assert len(bounds) == 1, bounds
     ((sym, (lo, hi)),) = bounds.items()
     assert isinstance(sym, sympy.Symbol)
@@ -473,6 +482,7 @@ def test_build_user_symbol_bounds_mixed_arg_and_kwarg():
         ep.module(),
         sample_arg_inputs=[x_input],
         sample_kwarg_inputs={"y": y_input},
+        graph_signature=ep.graph_signature,
     )
 
     bounds_values = set(bounds.values())

--- a/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
+++ b/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
@@ -1,0 +1,374 @@
+# type: ignore
+"""Regression tests for user-supplied dynamic-shape bounds threading.
+
+These tests exercise the read-only ``user_symbol_bounds`` map plumbed from
+``compile_module`` through the partitioner into
+``extract_var_range_info``. The map fills in upper bounds left unbounded by
+``Dim.DYNAMIC`` *without* mutating the exporter's ``ShapeEnv``, so the
+original ``range_constraints`` are preserved across
+``torch_tensorrt.save(..., output_format="exported_program")``.
+"""
+
+import os
+import unittest
+
+import pytest
+import sympy
+import torch
+import torch_tensorrt as torchtrt
+from torch_tensorrt._Input import Input
+from torch_tensorrt.dynamo._compiler import _build_user_symbol_bounds
+from torch_tensorrt.dynamo.utils import extract_var_range_info
+
+assertions = unittest.TestCase()
+
+
+class _SmallLinear(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(8, 8)
+
+    def forward(self, x):
+        return self.linear(x).relu()
+
+
+@pytest.mark.unit
+def test_extract_var_range_info_fills_unbounded_max_from_user():
+    """``extract_var_range_info`` must use ``user_symbol_bounds`` only when
+    the exporter leaves ``var_to_range.upper`` as ``int_oo``."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(2, 8, device="cuda")
+
+    # ``Dim.DYNAMIC`` (sentinel) leaves the upper bound unbounded.
+    dyn_batch = torch.export.Dim.DYNAMIC
+    ep = torch.export.export(
+        model, (sample,), dynamic_shapes=({0: dyn_batch},), strict=False
+    )
+
+    # Pull the SymInt for the dynamic batch dim from the placeholder meta.
+    placeholders = [n for n in ep.graph.nodes if n.op == "placeholder"]
+    assert placeholders, "expected a placeholder for the model input"
+    fake_val = placeholders[0].meta["val"]
+    sym_dim = fake_val.size()[0]
+    assert isinstance(sym_dim, torch.SymInt)
+    expr = sym_dim.node.expr
+    assert isinstance(expr, sympy.Symbol)
+
+    # Without the user map the upper bound is unbounded -> ``max`` is None.
+    info_no_user = extract_var_range_info(sym_dim)
+    assert info_no_user["max"] is None
+
+    # With the user map providing max=8, the exporter's gap is filled.
+    # The lower stays at 1 (Dynamo's 0/1 specialization rewrite in
+    # ``extract_var_range_info``); user_min=1 intersects to the same value.
+    info_with_user = extract_var_range_info(sym_dim, user_symbol_bounds={expr: (1, 8)})
+    assert info_with_user["max"] == 8
+    assert info_with_user["min"] == 1
+
+    # A second call with a *different* user map must return the new bounds:
+    # ``extract_var_range_info`` is read-only w.r.t. ``ShapeEnv`` and must
+    # therefore track whatever map the caller hands it on each invocation.
+    info_with_user_wider = extract_var_range_info(
+        sym_dim, user_symbol_bounds={expr: (1, 16)}
+    )
+    assert info_with_user_wider["max"] == 16
+    assert info_with_user_wider["min"] == 1
+
+    # And dropping the user map again must revert to the unbounded result -
+    # i.e. the previous calls did not mutate any cached state.
+    info_revert = extract_var_range_info(sym_dim)
+    assert info_revert["max"] is None
+
+
+@pytest.mark.unit
+def test_extract_var_range_info_does_not_widen_lower_bound():
+    """The user's lower bound must be intersected (``max(exporter, user)``)
+    so the exporter's 0/1 specialization (lower == 1) survives even when
+    the user passes ``min_shape=0``."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(2, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim.DYNAMIC},),
+        strict=False,
+    )
+    placeholders = [n for n in ep.graph.nodes if n.op == "placeholder"]
+    sym_dim = placeholders[0].meta["val"].size()[0]
+    expr = sym_dim.node.expr
+
+    info = extract_var_range_info(sym_dim, user_symbol_bounds={expr: (0, 8)})
+    assert (
+        info["min"] == 1
+    ), "exporter's lower bound (1) must not be widened to user's 0"
+    assert info["max"] == 8
+
+
+@pytest.mark.unit
+def test_extract_var_range_info_does_not_override_finite_max():
+    """When the exporter already provides a finite upper bound (e.g. via
+    ``Dim(max=...)``), the user's value must be ignored."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(2, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim("batch", min=1, max=4)},),
+        strict=False,
+    )
+    placeholders = [n for n in ep.graph.nodes if n.op == "placeholder"]
+    sym_dim = placeholders[0].meta["val"].size()[0]
+    expr = sym_dim.node.expr
+
+    info = extract_var_range_info(sym_dim, user_symbol_bounds={expr: (1, 16)})
+    assert (
+        info["max"] == 4
+    ), "finite exporter upper bound must win over user_symbol_bounds"
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_uses_dynamic_inputs_only():
+    """Static ``Input``s contribute nothing to the user-bounds map."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(2, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim.DYNAMIC},),
+        strict=False,
+    )
+
+    dynamic_input = Input(
+        min_shape=(1, 8),
+        opt_shape=(4, 8),
+        max_shape=(8, 8),
+        dtype=torch.float32,
+    )
+    bounds = _build_user_symbol_bounds(ep.module(), [dynamic_input], {})
+    assert len(bounds) == 1
+    ((sym, (lo, hi)),) = bounds.items()
+    assert isinstance(sym, sympy.Symbol)
+    assert (lo, hi) == (1, 8)
+
+    # Static input -> empty map.
+    static_input = Input(shape=(2, 8), dtype=torch.float32)
+    assert _build_user_symbol_bounds(ep.module(), [static_input], {}) == {}
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_mixed_tensor_and_symint():
+    """Mix of tensor + SymInt placeholders: only the tensor placeholder
+    contributes symbols to the user-bounds map. The SymInt placeholder
+    is silently skipped by the ``isinstance(fake_val, torch.Tensor)``
+    guard in ``_build_user_symbol_bounds``; downstream
+    ``construct_submodule_inputs`` still handles the SymInt via its
+    dedicated branch (falling back to the ``min*2^12`` heuristic since
+    no entry for that symbol lands in ``user_symbol_bounds``).
+    """
+
+    class _TensorAndScalar(torch.nn.Module):
+        def forward(self, x, k):
+            return x.relu() + k
+
+    model = _TensorAndScalar().eval().cuda()
+    x_sample = torch.randn(2, 8, device="cuda")
+    k_sample = 4  # avoid 0/1 specialization on the scalar input
+
+    dyn = torch.export.Dim.DYNAMIC
+    ep = torch.export.export(
+        model,
+        (x_sample, k_sample),
+        dynamic_shapes=({0: dyn}, dyn),
+        strict=False,
+    )
+
+    # Sanity: the export should produce both a tensor and a SymInt
+    # placeholder. Some PyTorch versions may collapse the scalar input
+    # if the dynamism can't be propagated through the graph - in that
+    # case we just exercise the tensor-only path.
+    placeholders = [n for n in ep.graph.nodes if n.op == "placeholder"]
+    metas = [p.meta.get("val") for p in placeholders]
+    if not any(isinstance(m, torch.SymInt) for m in metas):
+        pytest.skip(
+            "Export collapsed the scalar SymInt placeholder on this "
+            "PyTorch version; nothing left to exercise for the mix case."
+        )
+    assert any(
+        isinstance(m, torch.Tensor) for m in metas
+    ), "expected at least one tensor placeholder"
+
+    tensor_input = Input(
+        min_shape=(1, 8),
+        opt_shape=(4, 8),
+        max_shape=(8, 8),
+        dtype=torch.float32,
+    )
+    # The user is allowed to pass an ``Input`` for the SymInt argument
+    # (Torch-TRT treats it as a 1-D shape tensor downstream), but
+    # ``_build_user_symbol_bounds`` will not record it because
+    # ``meta["val"]`` is a ``torch.SymInt``, not a ``torch.Tensor``.
+    scalar_input = Input(
+        min_shape=(1,),
+        opt_shape=(4,),
+        max_shape=(8,),
+        dtype=torch.int64,
+    )
+
+    bounds = _build_user_symbol_bounds(ep.module(), [tensor_input, scalar_input], {})
+
+    # Exactly one symbol recorded - from x's dynamic dim 0. The SymInt
+    # placeholder contributed nothing. (The fact that the recorded
+    # bounds equal the *tensor* input's (1, 8) - not the scalar input's
+    # (1, 8), which happens to be the same numerically - is verified by
+    # checking that exactly one entry exists, ruling out double-recording.)
+    assert (
+        len(bounds) == 1
+    ), f"expected only the tensor placeholder to contribute, got {bounds}"
+    ((sym, (lo, hi)),) = bounds.items()
+    assert isinstance(sym, sympy.Symbol)
+    assert (lo, hi) == (1, 8)
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_mixed_arg_and_kwarg():
+    """Both positional and keyword inputs must contribute to the
+    user-bounds map. Positional args are matched to placeholders by
+    index; kwargs are matched by parameter name (``node.target``).
+    """
+
+    class _TwoTensors(torch.nn.Module):
+        def forward(self, x, y):
+            # Two independent paths so x's dim 0 and y's dim 0 are not
+            # unified by the exporter into a single sympy symbol.
+            return x.relu(), y.relu()
+
+    model = _TwoTensors().eval().cuda()
+    # Distinct sample sizes for dim 0 to discourage symbol unification.
+    x_sample = torch.randn(2, 8, device="cuda")
+    y_sample = torch.randn(3, 8, device="cuda")
+
+    dyn = torch.export.Dim.DYNAMIC
+    ep = torch.export.export(
+        model,
+        args=(x_sample,),
+        kwargs={"y": y_sample},
+        dynamic_shapes={"x": {0: dyn}, "y": {0: dyn}},
+        strict=False,
+    )
+
+    placeholder_names = [n.target for n in ep.graph.nodes if n.op == "placeholder"]
+    assert (
+        "x" in placeholder_names
+    ), f"expected positional arg 'x' as placeholder, got {placeholder_names}"
+    assert (
+        "y" in placeholder_names
+    ), f"expected kwarg 'y' as placeholder, got {placeholder_names}"
+
+    # Use *distinct* numerical bounds for x and y so we can verify by
+    # value that the kwarg path actually contributed (rather than just
+    # silently double-counting x's bounds).
+    x_input = Input(
+        min_shape=(1, 8),
+        opt_shape=(2, 8),
+        max_shape=(8, 8),
+        dtype=torch.float32,
+    )
+    y_input = Input(
+        min_shape=(2, 8),
+        opt_shape=(3, 8),
+        max_shape=(6, 8),
+        dtype=torch.float32,
+    )
+
+    bounds = _build_user_symbol_bounds(
+        ep.module(),
+        sample_arg_inputs=[x_input],
+        sample_kwarg_inputs={"y": y_input},
+    )
+
+    # Two placeholders, each with a single dynamic dim, no unification:
+    # we expect exactly two entries with their respective bounds.
+    bounds_values = set(bounds.values())
+    assert (1, 8) in bounds_values, (
+        f"positional x's bounds (1, 8) not recorded - "
+        f"the positional-arg branch may be broken. got: {bounds}"
+    )
+    assert (2, 6) in bounds_values, (
+        f"kwarg y's bounds (2, 6) not recorded - "
+        f"the kwarg branch may be broken. got: {bounds}"
+    )
+    assert len(bounds) == 2, f"expected exactly 2 entries, got {bounds}"
+
+
+@pytest.mark.unit
+@pytest.mark.critical
+def test_dim_dynamic_save_preserves_range_constraints(tmpdir):
+    """End-to-end regression: exporting with ``Dim.DYNAMIC``, compiling
+    with ``Input(max_shape=8)``, and round-tripping through
+    ``torch_tensorrt.save(..., output_format="exported_program")`` must
+    leave the exporter's ``range_constraints`` untouched.
+    """
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(2, 8, device="cuda")
+
+    dyn_batch = torch.export.Dim.DYNAMIC
+    exp_program = torch.export.export(
+        model, (sample,), dynamic_shapes=({0: dyn_batch},), strict=False
+    )
+
+    # Snapshot range_constraints **before** Torch-TRT touches anything.
+    expected_constraints = {
+        str(k): (v.lower, v.upper) for k, v in exp_program.range_constraints.items()
+    }
+
+    compile_spec = {
+        "inputs": [
+            Input(
+                min_shape=(1, 8),
+                opt_shape=(4, 8),
+                max_shape=(8, 8),
+                dtype=torch.float32,
+            )
+        ],
+        "ir": "dynamo",
+        "min_block_size": 1,
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+    trt_module = torchtrt.dynamo.compile(exp_program, **compile_spec)
+
+    # The exporter's range_constraints must NOT have been mutated by compile.
+    after_constraints = {
+        str(k): (v.lower, v.upper) for k, v in exp_program.range_constraints.items()
+    }
+    assertions.assertEqual(expected_constraints, after_constraints)
+
+    # Save + reload as ExportedProgram and verify constraints survive.
+    trt_ep_path = os.path.join(tmpdir, "trt_dim_dynamic.ep")
+    torchtrt.save(
+        trt_module,
+        trt_ep_path,
+        output_format="exported_program",
+        arg_inputs=[sample],
+        dynamic_shapes=({0: dyn_batch},),
+        retrace=True,
+    )
+
+    reloaded = torch.export.load(trt_ep_path)
+    reloaded_constraints = {
+        str(k): (v.lower, v.upper) for k, v in reloaded.range_constraints.items()
+    }
+    assertions.assertEqual(expected_constraints, reloaded_constraints)
+
+    # Sanity: the compiled engine must accept up to the user's max_shape.
+    big_input = torch.randn(8, 8, device="cuda")
+    trt_module(big_input)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
+++ b/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
@@ -301,9 +301,9 @@ def test_build_user_symbol_bounds_no_warning_on_matching_bounds(caplog):
 
 
 @pytest.mark.unit
-def test_build_user_symbol_bounds_warns_on_subset_input(caplog):
-    """Strict-subset Input warns: engine profile is silently widened to the
-    exporter's range, which the user should know about."""
+def test_build_user_symbol_bounds_narrows_to_user_on_subset(caplog):
+    """Strict-subset Input narrows the engine profile to the user's bounds.
+    No warning -- the user got exactly what they asked for; just an info log."""
 
     model = _SmallLinear().eval().cuda()
     sample = torch.randn(10, 8, device="cuda")
@@ -322,16 +322,28 @@ def test_build_user_symbol_bounds_warns_on_subset_input(caplog):
 
     import logging
 
-    with caplog.at_level(logging.WARNING, logger="torch_tensorrt.dynamo._compiler"):
-        _build_user_symbol_bounds(ep.module(), [subset_input], {})
+    with caplog.at_level(logging.INFO, logger="torch_tensorrt.dynamo._compiler"):
+        bounds = _build_user_symbol_bounds(ep.module(), [subset_input], {})
 
+    # No warning -- subset is a valid, intended narrowing.
     warning_messages = [
         rec.message for rec in caplog.records if rec.levelno >= logging.WARNING
     ]
-    assert warning_messages
-    msg = "\n".join(warning_messages)
-    assert "subset" in msg or "wider" in msg
-    assert "re-export" in msg or "Re-export" in msg
+    assert not warning_messages, f"unexpected warnings: {warning_messages}"
+
+    # Narrowing must surface as an info log so users can see what envelope
+    # their engine actually has.
+    info_messages = [
+        rec.message for rec in caplog.records if rec.levelno == logging.INFO
+    ]
+    assert any("Narrowing engine profile" in m for m in info_messages), info_messages
+
+    # And the engine-side resolution must actually narrow to (12, 18).
+    _, sym_dim = _first_sym_placeholder(ep, sym_dim=0)
+    assert sym_dim is not None
+    info = extract_var_range_info(sym_dim, user_symbol_bounds=bounds)
+    assert info["min"] == 12, info
+    assert info["max"] == 18, info
 
 
 @pytest.mark.unit


### PR DESCRIPTION
                 
This PR  validates user bounds against any finite exporter bounds, with three branches:                                                                                                                                                                                                                                                                                                                                     
  - Upper overflow (user_max > exp_max) → ValueError. TRT engine profile follows the exporter; shapes above exp_max would be rejected at runtime anyway.
  - Lower underflow (user_min < exp_min) → ValueError, except the (user_min=1, exp_min=2) case which is just PyTorch's 0/1-specialization artifact (Dim(min=1) silently becomes 2 in ShapeEnv), this particular case emits a warning.                                                                                                                                                                                                       
  -  Subset (user range strictly inside exporter range) → engine profile is narrowed to the user's bounds (logged at INFO). The user's Input(min_shape, max_shape) is the contract for the TRT profile; a subset of the exporter's valid range is still correct, and a tighter profile lets TRT specialize more aggressively.                                                                                             
  - Dim.DYNAMIC (unbounded exporter upper) → no check, user fills the gap (the intended use). 