### PR TITLE
fix: torch-TRT runtime cache attribute + standard-TRT fast refit regression

### DIFF
--- a/py/torch_tensorrt/dynamo/_refit.py
+++ b/py/torch_tensorrt/dynamo/_refit.py
@@ -41,7 +41,6 @@ from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import (
     TorchTensorRTModule,
 )
 from torch_tensorrt.dynamo.utils import (
-    CPU_DEVICE,
     check_module_output,
     check_output_equal,
     get_model_device,

--- a/py/torch_tensorrt/dynamo/_refit.py
+++ b/py/torch_tensorrt/dynamo/_refit.py
@@ -12,7 +12,7 @@ import torch
 from torch.export import ExportedProgram
 from torch.fx.experimental.proxy_tensor import unset_fake_temporarily
 from torch_tensorrt._enums import dtype
-from torch_tensorrt._features import needs_refit
+from torch_tensorrt._features import ENABLED_FEATURES, needs_refit
 from torch_tensorrt._Input import Input
 from torch_tensorrt.dynamo import partitioning
 from torch_tensorrt.dynamo._exporter import inline_torch_modules
@@ -198,18 +198,24 @@ def _refit_single_trt_engine_with_gm(
                     weight_dtype, weight.data_ptr(), torch.numel(weight)
                 )
                 refitter.set_named_weights(layer_name, trt_wt_tensor, trt_wt_location)
-            # Check completeness via two methods:
-            # 1. get_missing_weights(): reports weights in connected engines
-            #    that were not set.
-            # 2. Compare weights actually set vs all engine weights: catches
-            #    weights in independent engines that get_missing_weights() may not report.
+            # get_missing_weights(): reports weights in connected engines
+            # that were not set.
             missing_weights = refitter.get_missing_weights()
-            unset_weights = {w for w in weight_list if w not in mapping}
-            assert len(missing_weights) == 0 and len(unset_weights) == 0, (
-                f"Fast refitting failed due to incomplete mapping"
-                f" ({len(missing_weights)} missing,"
-                f" {len(unset_weights)} unset)"
+            assert len(missing_weights) == 0, (
+                f"Fast refit failed: refitter.get_missing_weights() reports "
+                f"{len(missing_weights)} of {len(weight_list)} engine weight(s) "
+                f"were never set."
             )
+            if ENABLED_FEATURES.tensorrt_rtx:
+                # Compare weights actually set vs all engine weights: catches
+                # weights in independent engines that get_missing_weights() may not report.
+                unset_weights = {w for w in weight_list if w not in mapping}
+                assert len(unset_weights) == 0, (
+                    f"Fast refit failed on TensorRT-RTX: {len(unset_weights)} of "
+                    f"{len(weight_list)} engine weight(s) had no entry in "
+                    f"weight_name_map. "
+                    f"Unset (showing up to 5): {sorted(unset_weights)[:5]}"
+                )
 
         else:
             mapping = construct_refit_mapping(new_gm, input_list, settings)

--- a/py/torch_tensorrt/dynamo/runtime/_PythonTorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_PythonTorchTensorRTModule.py
@@ -24,7 +24,8 @@ from torch_tensorrt.runtime._utils import (
     multi_gpu_device_check,
 )
 
-import tensorrt as trt
+# must import after torch_tensorrt to resolve tensorrt_rtx alias
+import tensorrt as trt  # isort: skip
 
 logger = logging.getLogger(__name__)
 
@@ -529,6 +530,12 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
         self.output_names = state_dict[prefix + "output_names"]
         self.target_platform = state_dict[prefix + "platform"]
 
+        # Same rationale as __setstate__: ensure these exist before
+        # setup_engine() so __del__ -> _save_runtime_cache() is safe even
+        # if a future caller invokes this without __init__ having run.
+        self.runtime_config = None
+        self.runtime_cache = None
+
         # Run multi-gpu device check to validate engine instantiation
         multi_gpu_device_check()
         self.setup_engine()
@@ -547,6 +554,12 @@ class PythonTorchTensorRTModule(Module):  # type: ignore[misc]
         self.__dict__.update(state)
         # reset after unpickling, apbose: is this required though?
         self._nccl_comm = None
+        # __getstate__ pops these; re-initialize before setup_engine() so
+        # __del__ -> _save_runtime_cache() can always read them, including
+        # on standard (non-RTX) TRT where setup_engine() does not call
+        # _setup_runtime_config().
+        self.runtime_config = None
+        self.runtime_cache = None
         self.setup_engine()
 
     def __deepcopy__(self, memo: Any) -> PythonTorchTensorRTModule:


### PR DESCRIPTION
## Summary

Two related fixes to issues introduced by recent torch-TensorRT runtime-cache and refit work, both surfaced by the L2 dynamo compile tests.

- **fix(runtime): preserve runtime_cache/runtime_config on rehydration paths** — `PythonTorchTensorRTModule.__getstate__` pops `runtime_config` and `runtime_cache` (they hold non-picklable native handles), but `__setstate__` never restored them. `setup_engine()` only re-creates them inside `_setup_runtime_config()`, which is gated by `ENABLED_FEATURES.tensorrt_rtx`. On standard TRT the gate is false, so on every unpickle / deepcopy the attributes simply do not exist — `__del__ -> _save_runtime_cache()` then reads `self.runtime_cache` and Python emits `PytestUnraisableExceptionWarning` across the refit and weight-stripped-engine test suites. Re-init both fields to `None` in `__setstate__` and `_load_from_state_dict` before `setup_engine()`. No behavior change on TRT-RTX.
- **fix(refit): scope unset-weights strict check to TRT-RTX only** — the strict cross-check `unset_weights = {w for w in weight_list if w not in mapping}` added previously broke fast refit on standard TRT for any engine with CONSTANT layers intentionally absent from the mapping (e.g. batch-norm `eps` constants baked at build time). The pre-existing warn-and-continue branch makes that absence the contract; the strict check made it an error. On a resnet18 disk-engine-cache hit, the path now asserts with "0 missing, 20 unset" and `_pretraced_backend` silently falls back to GraphModule (visible as XPASS on `test_dynamo_compile_with_default_disk_engine_cache` and `test_torch_compile_with_default_disk_engine_cache`). The strict check exists only to guard the TRT-RTX case where each weight lives in its own independent wtsEngine and `get_missing_weights()` can under-report; on standard TRT, `get_missing_weights()` is authoritative because connected weight engines surface any unset weight transitively. Gate the assertion behind `ENABLED_FEATURES.tensorrt_rtx`.
- **chore(refit): drop unused `CPU_DEVICE` import** — pre-existing F401 surfaced by ruff on the touched file.

## Test plan

Verified end-to-end on a fresh standard-TRT (non-RTX) install of nightly torch_tensorrt on Linux + CUDA 13.0:

- [x] Fix 1: `pytest tests/py/dynamo/models/test_model_refit.py::test_refit_one_engine_with_weightmap test_refit_one_engine_python_runtime_with_weightmap test_complex_buffer_with_real_param_refit` — baseline reproduces 2× `AttributeError: ...runtime_cache`; with patch, 0 occurrences.
- [x] Fix 2: `pytest tests/py/dynamo/models/test_engine_cache.py::TestEngineCache::test_dynamo_compile_with_default_disk_engine_cache test_torch_compile_with_default_disk_engine_cache` — baseline reproduces 1× `AssertionError: Fast refitting failed due to incomplete mapping (0 missing, 20 unset)` plus `Returning GraphModule forward instead` silent fallback; with patch, 0 of either, TRT compilation actually succeeds on the cache-hit path.
- [ ] CI sweep on Windows L2 dynamo compile job to confirm the original `PytestUnraisableExceptionWarning` groups disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)