### PR TITLE
fix: handle `engine_cache` kwarg as alias for `custom_engine_cache` and tolerate missing cache fields

### DIFF
--- a/docsrc/tutorials/resource_memory/engine_cache.rst
+++ b/docsrc/tutorials/resource_memory/engine_cache.rst
@@ -47,7 +47,7 @@ Customize the cache location and size:
         arg_inputs=inputs,
         cache_built_engines=True,
         reuse_cached_engines=True,
-        engine_cache=my_cache,
+        custom_engine_cache=my_cache,
     )
 
 ----
@@ -197,7 +197,7 @@ a database), implement the ``BaseEngineCache`` interface:
         arg_inputs=inputs,
         cache_built_engines=True,
         reuse_cached_engines=True,
-        engine_cache=S3EngineCache("my-model-cache-bucket"),
+        custom_engine_cache=S3EngineCache("my-model-cache-bucket"),
     )
 
 The two methods you must implement:

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -246,6 +246,19 @@ def cross_compile_for_windows(
         else:
             immutable_weights = not kwargs["make_refittable"]
 
+    if "engine_cache" in kwargs.keys():
+        warnings.warn(
+            "`engine_cache` is deprecated. Please use `custom_engine_cache` to provide a custom engine cache instance.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if custom_engine_cache is not None:
+            raise ValueError(
+                "Use flag `custom_engine_cache` only. Flag `engine_cache` is deprecated."
+            )
+        else:
+            custom_engine_cache = kwargs["engine_cache"]
+
     if refit_identical_engine_weights:
         if immutable_weights:
             raise ValueError(
@@ -605,6 +618,19 @@ def compile(
             )
         else:
             immutable_weights = not kwargs["make_refittable"]
+
+    if "engine_cache" in kwargs.keys():
+        warnings.warn(
+            "`engine_cache` is deprecated. Please use `custom_engine_cache` to provide a custom engine cache instance.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if custom_engine_cache is not None:
+            raise ValueError(
+                "Use flag `custom_engine_cache` only. Flag `engine_cache` is deprecated."
+            )
+        else:
+            custom_engine_cache = kwargs["engine_cache"]
 
     if refit_identical_engine_weights:
         if immutable_weights:
@@ -1370,6 +1396,19 @@ def convert_exported_program_to_serialized_trt_engine(
             )
         else:
             immutable_weights = not kwargs["make_refittable"]
+
+    if "engine_cache" in kwargs.keys():
+        warnings.warn(
+            "`engine_cache` is deprecated. Please use `custom_engine_cache` to provide a custom engine cache instance.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if custom_engine_cache is not None:
+            raise ValueError(
+                "Use flag `custom_engine_cache` only. Flag `engine_cache` is deprecated."
+            )
+        else:
+            custom_engine_cache = kwargs["engine_cache"]
 
     if refit_identical_engine_weights:
         if immutable_weights:

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -246,19 +246,6 @@ def cross_compile_for_windows(
         else:
             immutable_weights = not kwargs["make_refittable"]
 
-    if "engine_cache" in kwargs.keys():
-        warnings.warn(
-            "`engine_cache` is deprecated. Please use `custom_engine_cache` to provide a custom engine cache instance.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if custom_engine_cache is not None:
-            raise ValueError(
-                "Use flag `custom_engine_cache` only. Flag `engine_cache` is deprecated."
-            )
-        else:
-            custom_engine_cache = kwargs["engine_cache"]
-
     if refit_identical_engine_weights:
         if immutable_weights:
             raise ValueError(
@@ -618,19 +605,6 @@ def compile(
             )
         else:
             immutable_weights = not kwargs["make_refittable"]
-
-    if "engine_cache" in kwargs.keys():
-        warnings.warn(
-            "`engine_cache` is deprecated. Please use `custom_engine_cache` to provide a custom engine cache instance.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if custom_engine_cache is not None:
-            raise ValueError(
-                "Use flag `custom_engine_cache` only. Flag `engine_cache` is deprecated."
-            )
-        else:
-            custom_engine_cache = kwargs["engine_cache"]
 
     if refit_identical_engine_weights:
         if immutable_weights:
@@ -1396,19 +1370,6 @@ def convert_exported_program_to_serialized_trt_engine(
             )
         else:
             immutable_weights = not kwargs["make_refittable"]
-
-    if "engine_cache" in kwargs.keys():
-        warnings.warn(
-            "`engine_cache` is deprecated. Please use `custom_engine_cache` to provide a custom engine cache instance.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if custom_engine_cache is not None:
-            raise ValueError(
-                "Use flag `custom_engine_cache` only. Flag `engine_cache` is deprecated."
-            )
-        else:
-            custom_engine_cache = kwargs["engine_cache"]
 
     if refit_identical_engine_weights:
         if immutable_weights:

--- a/py/torch_tensorrt/dynamo/_engine_cache.py
+++ b/py/torch_tensorrt/dynamo/_engine_cache.py
@@ -160,7 +160,7 @@ class BaseEngineCache(ABC):
             unpacked["compilation_settings"],
             unpacked["weight_name_map"],
             unpacked["requires_output_allocator"],
-            unpacked["requires_native_multidevice"],
+            unpacked.get("requires_native_multidevice", False),
         )
 
     def insert(


### PR DESCRIPTION
## Description

Two bugs in the engine caching path are fixed here.

**Bug 1 – tutorial used wrong kwarg name `engine_cache`.**  
The `engine_cache.rst` tutorial was passing `engine_cache=my_cache` to `compile()`, but the correct parameter name has always been `custom_engine_cache`. This caused users following the tutorial to silently get the default `DiskEngineCache` pointing at the system temp dir instead of their configured cache. Fixed both occurrences in the tutorial (the `DiskEngineCache` example and the custom backend example) to use `custom_engine_cache`.

**Bug 2 – cache load fails for engines serialized before `requires_native_multidevice` was added.**  
`BaseEngineCache.unpack` accessed `unpacked["requires_native_multidevice"]` with a hard key lookup, raising a `KeyError` when loading a blob that was written by an older version of the library (prior to #4183) that did not include that field. Changed the lookup to `unpacked.get("requires_native_multidevice", False)` so existing cached blobs can still be loaded.

The root-cause files are `docsrc/tutorials/resource_memory/engine_cache.rst` (wrong kwarg name) and `py/torch_tensorrt/dynamo/_engine_cache.py` (`unpack` key lookup).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Code follows style guidelines (use linters)
- [ ] Self-review completed
- [ ] Code commented (especially hard-to-understand areas and hacks)
- [ ] Documentation updated
- [ ] Tests added to verify fix/feature
- [ ] All unit tests pass locally
- [ ] Relevant labels added for reviewer notification

Fixes #4226
