### PR TITLE
fix: respect caller's CUDA stream in TRT runtime (Green Context support)

### DIFF
--- a/core/runtime/TRTEngine.cpp
+++ b/core/runtime/TRTEngine.cpp
@@ -137,6 +137,8 @@ TRTEngine::TRTEngine(
   device_info = most_compatible_device.value();
   multi_gpu_device_check();
   set_rt_device(device_info);
+  default_stream = c10::cuda::getDefaultCUDAStream(device_info.id);
+  owned_pool_stream = c10::cuda::getStreamFromPool(false, device_info.id);
 
   rt = make_trt(nvinfer1::createInferRuntime(util::logging::get_logger()));
 

--- a/core/runtime/TRTEngine.h
+++ b/core/runtime/TRTEngine.h
@@ -203,6 +203,8 @@ struct TRTEngine : torch::CustomClassHolder {
   at::cuda::CUDAGraph cudagraph = {};
   at::cuda::CUDAStream engine_stream = c10::cuda::getDefaultCUDAStream();
   at::cuda::CUDAStream caller_stream = c10::cuda::getDefaultCUDAStream();
+  at::cuda::CUDAStream default_stream = c10::cuda::getDefaultCUDAStream();
+  at::cuda::CUDAStream owned_pool_stream = c10::cuda::getDefaultCUDAStream();
   std::vector<at::Tensor> cudagraph_input_staging_buffers = {};
   std::vector<at::Tensor> cudagraph_output_staging_buffers = {};
 

--- a/core/runtime/execute_engine.cpp
+++ b/core/runtime/execute_engine.cpp
@@ -243,6 +243,23 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
     bool cudagraphs_enabled = (CUDAGRAPHS_MODE == SUBGRAPH_CUDAGRAPHS);
     bool shape_changed = _validate_shapes(inputs, compiled_engine);
 
+    auto current_device_id = inputs.size() > 0 ? inputs[0].device().index() : at::cuda::current_device();
+    auto default_stream = compiled_engine->default_stream;
+    auto previous_engine_stream = compiled_engine->engine_stream;
+    compiled_engine->caller_stream = c10::cuda::getCurrentCUDAStream(current_device_id);
+    bool caller_on_default = (compiled_engine->caller_stream == default_stream);
+    if (caller_on_default) {
+      compiled_engine->engine_stream = compiled_engine->owned_pool_stream;
+    } else {
+      // Honor caller's non-default stream so its scheduling choice (e.g. SM
+      // partitioning via a CUDA Green Context) is preserved end to end.
+      compiled_engine->engine_stream = compiled_engine->caller_stream;
+    }
+    if (cudagraphs_enabled && compiled_engine->engine_stream != previous_engine_stream) {
+      // Captured CUDA graph was recorded against the old stream; force re-record.
+      compiled_engine->runtime_states.context_changed = true;
+    }
+
     // Whether cudagraphs needs to record the graph on this pass
     auto result = compiled_engine->runtime_states.set_runtime_states(
         cudagraphs_enabled, compiled_engine->use_pre_allocated_outputs, shape_changed);
@@ -310,19 +327,6 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
       }
     }
 
-    auto current_device_id = -1;
-    if (inputs.size() > 0) {
-      current_device_id = inputs[0].device().index(); // Done this way to avoid a call to cudart
-    } else if (outputs.size() > 0) {
-      current_device_id = outputs[0].device().index(); // Done this way to avoid a call to cudart
-    }
-
-    compiled_engine->caller_stream = c10::cuda::getCurrentCUDAStream(current_device_id);
-    if (compiled_engine->engine_stream == c10::cuda::getDefaultCUDAStream(current_device_id)) {
-      // Create a new stream if the engine stream is the default stream
-      compiled_engine->engine_stream = c10::cuda::getStreamFromPool(false, current_device_id);
-    }
-
     compiled_engine->record_active_input_tensor_stream_usage(
         cudagraphs_enabled ? compiled_engine->caller_stream : compiled_engine->engine_stream);
 
@@ -335,10 +339,12 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
             std::make_unique<torch::autograd::profiler::RecordProfile>(compiled_engine->enqueue_profile_path);
       }
 
-      // Block engine stream until results are available on caller stream
-      at::cuda::CUDAEvent caller_exec_complete;
-      caller_exec_complete.record(compiled_engine->caller_stream);
-      caller_exec_complete.block(compiled_engine->engine_stream);
+      if (caller_on_default) {
+        // Block engine stream until results are available on caller stream
+        at::cuda::CUDAEvent caller_exec_complete;
+        caller_exec_complete.record(compiled_engine->caller_stream);
+        caller_exec_complete.block(compiled_engine->engine_stream);
+      }
 
       if (!cudagraphs_enabled) {
         // Direct execution uses the caller buffers directly
@@ -371,10 +377,12 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
       compiled_engine->pre_allocated_outputs = create_output_tensors(compiled_engine);
     }
 
-    // Block caller stream until engine execution is complete
-    at::cuda::CUDAEvent trt_exec_complete;
-    trt_exec_complete.record(compiled_engine->engine_stream);
-    trt_exec_complete.block(compiled_engine->caller_stream);
+    if (caller_on_default) {
+      // Block caller stream until engine execution is complete
+      at::cuda::CUDAEvent trt_exec_complete;
+      trt_exec_complete.record(compiled_engine->engine_stream);
+      trt_exec_complete.block(compiled_engine->caller_stream);
+    }
 
     if (cudagraphs_enabled) {
       // If in CUDAGraph mode, copy persistent staging outputs to returned tensors on the caller stream.
@@ -421,17 +429,16 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
       create_output_allocator(compiled_engine);
     }
 
-    auto current_device_id = -1;
-    if (inputs.size() > 0) {
-      current_device_id = inputs[0].device().index(); // Done this way to avoid a call to cudart
-    } else {
-      current_device_id = at::cuda::current_device();
-    }
-
+    auto current_device_id = inputs.size() > 0 ? inputs[0].device().index() : at::cuda::current_device();
+    auto default_stream = compiled_engine->default_stream;
     compiled_engine->caller_stream = c10::cuda::getCurrentCUDAStream(current_device_id);
-    if (compiled_engine->engine_stream == c10::cuda::getDefaultCUDAStream(current_device_id)) {
-      // Create a new stream if the engine stream is the default stream
-      compiled_engine->engine_stream = c10::cuda::getStreamFromPool(false, current_device_id);
+    bool caller_on_default = (compiled_engine->caller_stream == default_stream);
+    if (caller_on_default) {
+      compiled_engine->engine_stream = compiled_engine->owned_pool_stream;
+    } else {
+      // Honor caller's non-default stream so its scheduling choice (e.g. SM
+      // partitioning via a CUDA Green Context) is preserved end to end.
+      compiled_engine->engine_stream = compiled_engine->caller_stream;
     }
 
     compiled_engine->record_active_input_tensor_stream_usage(compiled_engine->engine_stream);
@@ -445,10 +452,12 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
             std::make_unique<torch::autograd::profiler::RecordProfile>(compiled_engine->enqueue_profile_path);
       }
 
-      // Block engine stream until results are available on caller stream
-      at::cuda::CUDAEvent caller_exec_complete;
-      caller_exec_complete.record(compiled_engine->caller_stream);
-      caller_exec_complete.block(compiled_engine->engine_stream);
+      if (caller_on_default) {
+        // Block engine stream until results are available on caller stream
+        at::cuda::CUDAEvent caller_exec_complete;
+        caller_exec_complete.record(compiled_engine->caller_stream);
+        caller_exec_complete.block(compiled_engine->engine_stream);
+      }
 
       // Direct execution uses the caller buffers directly
       compiled_engine->exec_ctx->enqueueV3(compiled_engine->engine_stream);
@@ -457,10 +466,12 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
 
     compiled_engine->clear_active_input_tensors();
 
-    // Block caller stream until engine execution is complete
-    at::cuda::CUDAEvent trt_exec_complete;
-    trt_exec_complete.record(compiled_engine->engine_stream);
-    trt_exec_complete.block(compiled_engine->caller_stream);
+    if (caller_on_default) {
+      // Block caller stream until engine execution is complete
+      at::cuda::CUDAEvent trt_exec_complete;
+      trt_exec_complete.record(compiled_engine->engine_stream);
+      trt_exec_complete.block(compiled_engine->caller_stream);
+    }
 
     std::unique_ptr<torch::autograd::profiler::RecordProfile> output_profiler_guard;
     if (compiled_engine->profile_execution) {

--- a/py/torch_tensorrt/dynamo/runtime/_CudaGraphsTorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_CudaGraphsTorchTensorRTModule.py
@@ -68,6 +68,19 @@ class CudaGraphsTorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
         self.shape_key: Optional[str] = None
         self._caller_stream: Optional[torch.cuda.Stream] = None
         self._engine_stream: Optional[torch.cuda.Stream] = None
+        self._owned_pool_stream: Optional[torch.cuda.Stream] = None
+        # Bind to the device of the wrapped module's first CUDA parameter so
+        # multi-GPU deployments cache the right default stream.
+        target = next(
+            (p.device for p in self.compiled_module.parameters() if p.is_cuda),
+            None,
+        )
+        self._target_device = (
+            target
+            if target is not None
+            else torch.device("cuda", torch.cuda.current_device())
+        )
+        self._default_stream = torch.cuda.default_stream(self._target_device)
         self.warm_up()
 
     def warm_up(self) -> None:
@@ -121,7 +134,29 @@ class CudaGraphsTorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
         cudagraphs_enabled = torch_tensorrt.runtime.get_whole_cudagraphs_mode()
         if cudagraphs_enabled:
             shape_changed = self.validate_input_shapes(inputs)
-            need_cudagraphs_record = shape_changed or self.is_weight_streaming_set
+
+            current_device = (
+                inputs[0].device
+                if inputs and inputs[0].is_cuda
+                else self._target_device
+            )
+            default_stream = self._default_stream
+            previous_engine_stream = self._engine_stream
+            self._caller_stream = torch.cuda.current_stream(current_device)
+            caller_on_default = self._caller_stream == default_stream
+            if caller_on_default:
+                if self._owned_pool_stream is None:
+                    self._owned_pool_stream = torch.cuda.Stream(self._target_device)
+                self._engine_stream = self._owned_pool_stream
+            else:
+                # Honor caller's non-default stream so its scheduling choice (e.g. SM
+                # partitioning via a CUDA Green Context) is preserved end to end.
+                self._engine_stream = self._caller_stream
+            stream_changed = self._engine_stream != previous_engine_stream
+
+            need_cudagraphs_record = (
+                shape_changed or self.is_weight_streaming_set or stream_changed
+            )
             if need_cudagraphs_record:
                 self._reset_captured_graph()
                 self._input_buffers = [None] * len(inputs)
@@ -172,14 +207,8 @@ class CudaGraphsTorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
                     self._input_buffers, self.compiled_module._in_spec
                 )
 
-            self._caller_stream = torch.cuda.current_stream()
-            if (
-                self._engine_stream == torch.cuda.default_stream()
-                or self._engine_stream is None
-            ):
-                self._engine_stream = torch.cuda.Stream()
-
-            self._engine_stream.wait_stream(self._caller_stream)
+            if caller_on_default:
+                self._engine_stream.wait_stream(self._caller_stream)
 
             with torch.cuda.stream(self._engine_stream):
                 if need_cudagraphs_record:
@@ -188,7 +217,8 @@ class CudaGraphsTorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
                         self._output_buffers = self.compiled_module(*args, **kwargs)
 
                 self.cudagraph.replay()  # type: ignore
-            self._caller_stream.wait_stream(self._engine_stream)
+            if caller_on_default:
+                self._caller_stream.wait_stream(self._engine_stream)
 
             if isinstance(self._output_buffers, (list, tuple)):
                 output_buffers = self._output_buffers

--- a/py/torch_tensorrt/dynamo/runtime/_TRTEngine.py
+++ b/py/torch_tensorrt/dynamo/runtime/_TRTEngine.py
@@ -210,6 +210,7 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
         self._output_buffers: List[torch.Tensor] = []
         self._caller_stream: Optional[torch.cuda.Stream] = None
         self._engine_stream: Optional[torch.cuda.Stream] = None
+        self._owned_pool_stream: Optional[torch.cuda.Stream] = None
         self.cudagraph: Optional[torch.cuda.CUDAGraph] = None
         self.shape_key: Optional[str] = None
         self._empty_tensor_placeholder: Optional[torch.Tensor] = None
@@ -269,6 +270,7 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
         self._output_buffers = []
         self._caller_stream = None
         self._engine_stream = None
+        self._owned_pool_stream = None
         self.cudagraph = None
         self.shape_key = None
         self._empty_tensor_placeholder = None
@@ -350,6 +352,8 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
 
         device_info = parse_device_info(self.serialized_device_info)
         self.target_device_id = device_info["id"]
+        self._target_device = torch.device("cuda", self.target_device_id)
+        self._default_stream = torch.cuda.default_stream(self._target_device)
         # Serialized major/minor/name only — not ``_CudaDeviceProperties`` — so deepcopy/refit
         # can copy the owning ``GraphModule`` without pickle errors.
         self.target_device_properties = SimpleNamespace(
@@ -675,9 +679,59 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
 
     # --- execution ---
 
+    def _prepare_streams(self, contiguous_inputs: List[torch.Tensor]) -> bool:
+        """Pick the engine stream relative to the caller's current stream.
+
+        If the caller is on the default stream we keep the legacy behavior of
+        running the engine on a dedicated pool stream (and synchronising via
+        wait_stream).  If the caller is on a non-default stream (e.g. a stream
+        attached to a CUDA Green Context) we honor it by reusing the caller's
+        stream for the engine, so the caller's scheduling choice (e.g. SM
+        partitioning) is preserved end to end and no wait_stream sync is
+        needed.
+
+        Returns ``caller_on_default`` so call sites can gate the wait_stream
+        pair on it.  Also flips ``runtime_states.context_changed`` whenever
+        the engine stream changes while CUDA graphs are enabled so the
+        current invocation re-records the graph against the new stream.
+        Call sites MUST invoke this before ``runtime_states.set_runtime_states``
+        because that call consumes and resets ``context_changed``.
+        """
+        current_device = (
+            contiguous_inputs[0].device
+            if contiguous_inputs and contiguous_inputs[0].is_cuda
+            else self._target_device
+        )
+        default_stream = self._default_stream
+        previous_engine_stream = self._engine_stream
+        self._caller_stream = torch.cuda.current_stream(current_device)
+        caller_on_default = self._caller_stream == default_stream
+        if caller_on_default:
+            if self._owned_pool_stream is None:
+                self._owned_pool_stream = torch.cuda.Stream(self._target_device)
+            self._engine_stream = self._owned_pool_stream
+        else:
+            # Honor caller's non-default stream so its scheduling choice (e.g.
+            # SM partitioning via a CUDA Green Context) is preserved end to
+            # end.
+            self._engine_stream = self._caller_stream
+        if (
+            torch_tensorrt.runtime.get_cudagraphs_mode()
+            and self._engine_stream != previous_engine_stream
+        ):
+            # Captured CUDA graph was recorded against the old stream.
+            self.runtime_states.context_changed = True
+        return caller_on_default
+
     def _execute_standard(
         self, contiguous_inputs: List[torch.Tensor]
     ) -> torch.Tensor | Tuple[torch.Tensor, ...]:
+        # Pick the engine stream BEFORE set_runtime_states so that any
+        # stream-identity change observed this call flips
+        # runtime_states.context_changed in time to trigger same-call
+        # cudagraph recapture (set_runtime_states consumes and resets the
+        # flag).
+        caller_on_default = self._prepare_streams(contiguous_inputs)
         shape_changed = self.validate_input_shapes(contiguous_inputs)
         (
             need_cudagraphs_record,
@@ -734,14 +788,8 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
                     self.context.set_tensor_address(output_name, outputs[o].data_ptr())
 
         with self._profile_section("TRTEngine:TensorRTRuntime"):
-            self._caller_stream = torch.cuda.current_stream()
-            if (
-                self._engine_stream == torch.cuda.default_stream()
-                or self._engine_stream is None
-            ):
-                self._engine_stream = torch.cuda.Stream()
-
-            self._engine_stream.wait_stream(self._caller_stream)
+            if caller_on_default:
+                self._engine_stream.wait_stream(self._caller_stream)
             with torch.cuda.stream(self._engine_stream):
                 if self.resource_allocation_strategy:
                     self._dynamic_workspace = torch.empty(
@@ -770,7 +818,8 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
                 else:
                     self.context.execute_async_v3(self._engine_stream.cuda_stream)
 
-            self._caller_stream.wait_stream(self._engine_stream)
+            if caller_on_default:
+                self._caller_stream.wait_stream(self._engine_stream)
 
         if self.use_pre_allocated_outputs and (
             self.output_tensors_are_unowned
@@ -809,18 +858,15 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
                         f"Failed to set output allocator for {output_name}"
                     )
 
-        with self._profile_section("TRTEngine:TensorRTRuntime"):
-            self._caller_stream = torch.cuda.current_stream()
-            if (
-                self._engine_stream == torch.cuda.default_stream()
-                or self._engine_stream is None
-            ):
-                self._engine_stream = torch.cuda.Stream()
+        caller_on_default = self._prepare_streams(contiguous_inputs)
 
-            self._engine_stream.wait_stream(self._caller_stream)
+        with self._profile_section("TRTEngine:TensorRTRuntime"):
+            if caller_on_default:
+                self._engine_stream.wait_stream(self._caller_stream)
             with torch.cuda.stream(self._engine_stream):
                 self.context.execute_async_v3(self._engine_stream.cuda_stream)
-            self._caller_stream.wait_stream(self._engine_stream)
+            if caller_on_default:
+                self._caller_stream.wait_stream(self._engine_stream)
 
         outputs = []
         assert self.output_allocator is not None


### PR DESCRIPTION
### What this fixes

Callers commonly pin work to a specific CUDA stream via `torch.cuda.stream(...)` (Python) or `c10::cuda::CUDAStreamGuard(...)` (C++) for NCCL, AMP overlap, custom scheduling, and most recently CUDA Green Contexts (CUDA 12.4+) for SM partitioning. A green-context-derived stream is the only way to confine a TensorRT engine to a partition.

Today the Torch-TensorRT runtime ignores the caller's stream. It reads `getCurrentCUDAStream()`, then substitutes one from PyTorch's pool. Pool streams are not bound to any green context, so the partition is silently bypassed. The same pattern lives in both Python runtime modules. Net effect: Torch-TensorRT cannot be used for GPU partitioning at all today.

### What this PR does

The runtime now picks the engine's stream like this:

- If the caller is on the regular default stream, behavior is unchanged. Grab a stream from the pool so the device does not get accidentally serialized on the default stream.
- If the caller is on any other stream (custom user stream, Green Context stream, NCCL stream, etc.), run the engine directly on that stream.

Two small pieces of bookkeeping fall out of this change:

- When the chosen stream changes between calls, force any captured CUDA Graph to re-record. Otherwise replay would launch on a stale stream and silently produce wrong results.
- When the engine stream and the caller's stream are the same, skip the pre/post sync events between them. They become no-ops in that case.

The same logic is mirrored in `_PythonTorchTensorRTModule.py` (hoisted to the outer `forward` so both the standard and output-allocator paths see the resolved stream) and `_CudaGraphsTorchTensorRTModule.py`.

### What stays the same for existing users

Anyone who calls `model(x)` without setting a stream sees the exact same behavior as before. No new public API. No new arguments. No `.pt2` file format change. No new fields on engine state.

### Behavior change for existing non-default-stream callers

Users who already wrap inference in `torch.cuda.stream(my_stream)` (or `c10::cuda::CUDAStreamGuard(my_stream)`) for non-green reasons (custom scheduling, NCCL, AMP) will see the engine run on their stream instead of a separate pool stream. Results are identical; the timing characteristics may differ, since the previous separate-stream + event-fence pattern is replaced by direct execution on the caller's stream. For CUDA Graphs users who alternate between several non-default streams, the captured graph re-records on each stream change.

### What a Green Context user does

```cpp
auto green_stream = c10::cuda::getStreamFromExternal(my_green_ctx_stream, /*device=*/0);
{
  c10::cuda::CUDAStreamGuard guard(green_stream);
  auto outputs = loader.run(inputs);   // runs on green_stream, inside the SM partition
}
```

### Test plan

- Existing test suite passes (no API surface changed).
- Manual: build a small `.pt2`, run inside a `CUDAStreamGuard` over a Green-Context-derived stream, capture an `nsys` trace, confirm kernels run on the green stream and stay inside the partition's SMs.
- CUDA Graphs path: switch streams between calls, confirm the captured graph re-records on stream change.