### PR TITLE
Move all Python test dependencies to pyproject

### DIFF
--- a/.github/scripts/install-torch-tensorrt.sh
+++ b/.github/scripts/install-torch-tensorrt.sh
@@ -12,8 +12,8 @@ if [[ $(uname -m) == "aarch64" ]]; then
 fi
 
 # Install all the dependencies required for Torch-TensorRT
-pip install --upgrade "pip>=25.1" "tomli>=1.1.0; python_version < '3.11'"
-pip install \
+python -m pip install --upgrade "pip>=25.1" "tomli>=1.1.0; python_version < '3.11'"
+python -m pip install \
     --pre \
     --extra-index-url https://pypi.nvidia.com \
     --extra-index-url https://download.pytorch.org/whl/nightly/cu130 \
@@ -40,9 +40,9 @@ PY
 # test dependencies might install a different version of torch or torchvision
 # eg. timm will install the latest torchvision, however we want to use the torchvision from nightly
 # reinstall torch torchvision to make sure we have the correct version
-pip uninstall -y torch torchvision
-pip install --force-reinstall --pre ${TORCHVISION} --index-url ${INDEX_URL} --extra-index-url https://pypi.org/simple
-pip install --force-reinstall --pre ${TORCH} --index-url ${INDEX_URL} --extra-index-url https://pypi.org/simple
+python -m pip uninstall -y torch torchvision
+python -m pip install --force-reinstall --pre ${TORCHVISION} --index-url ${INDEX_URL} --extra-index-url https://pypi.org/simple
+python -m pip install --force-reinstall --pre ${TORCH} --index-url ${INDEX_URL} --extra-index-url https://pypi.org/simple
 
 # If CUDA 13 (cu13), prepend venv's NVIDIA CUDA 13 libs to LD_LIBRARY_PATH
 if [[ "${CU_VERSION}" == cu13* ]]; then
@@ -52,9 +52,9 @@ fi
 
 # Install Torch-TensorRT
 if [[ ${PLATFORM} == win32 ]]; then
-    pip install ${RUNNER_ARTIFACT_DIR}/torch_tensorrt*.whl
+    python -m pip install ${RUNNER_ARTIFACT_DIR}/torch_tensorrt*.whl
 else
-    pip install /opt/torch-tensorrt-builds/torch_tensorrt*.whl --use-deprecated=legacy-resolver
+    python -m pip install /opt/torch-tensorrt-builds/torch_tensorrt*.whl --use-deprecated=legacy-resolver
 fi
 
 echo -e "Running test script";

--- a/.github/scripts/install-torch-tensorrt.sh
+++ b/.github/scripts/install-torch-tensorrt.sh
@@ -2,7 +2,6 @@
 set -x
 
 TORCH=$(grep "^torch>" ${PWD}/py/requirements.txt)
-TORCHVISION=$(grep "^torchvision>" ${PWD}/tests/py/requirements.txt)
 INDEX_URL=https://download.pytorch.org/whl/${CHANNEL}/${CU_VERSION}
 PLATFORM=$(python -c "import sys; print(sys.platform)")
 
@@ -13,10 +12,34 @@ if [[ $(uname -m) == "aarch64" ]]; then
 fi
 
 # Install all the dependencies required for Torch-TensorRT
-pip install --pre -r ${PWD}/tests/py/requirements.txt
-# dependencies in the tests/py/requirements.txt might install a different version of torch or torchvision
+pip install --upgrade "pip>=25.1" "tomli>=1.1.0; python_version < '3.11'"
+pip install \
+    --pre \
+    --extra-index-url https://pypi.nvidia.com \
+    --extra-index-url https://download.pytorch.org/whl/nightly/cu130 \
+    --group test \
+    --group test-ext \
+    --group quantization
+TORCHVISION=$(python - <<'PY'
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+with open("pyproject.toml", "rb") as f:
+    deps = tomllib.load(f)["dependency-groups"]["test-ext"]
+
+for dep in deps:
+    if dep.startswith("torchvision"):
+        print(dep)
+        break
+else:
+    raise SystemExit("torchvision was not found in dependency group test-ext")
+PY
+)
+# test dependencies might install a different version of torch or torchvision
 # eg. timm will install the latest torchvision, however we want to use the torchvision from nightly
-# reinstall torch torchvisionto make sure we have the correct version
+# reinstall torch torchvision to make sure we have the correct version
 pip uninstall -y torch torchvision
 pip install --force-reinstall --pre ${TORCHVISION} --index-url ${INDEX_URL} --extra-index-url https://pypi.org/simple
 pip install --force-reinstall --pre ${TORCH} --index-url ${INDEX_URL} --extra-index-url https://pypi.org/simple

--- a/docsrc/RELEASE_CHECKLIST.md
+++ b/docsrc/RELEASE_CHECKLIST.md
@@ -24,7 +24,7 @@ will result in a minor version bump and significant bug fixes will result in a p
 4. Version bump PR
     - There should be a PR which will be the PR that bumps the actual version of the library, this PR should contain the following
         - Bump version in `py/setup.py`
-        - Make sure dependency versions are updated in `py/requirements.txt`, `tests/py/requirements.txt` and `py/setup.py`
+        - Make sure dependency versions are updated in `py/requirements.txt`, `pyproject.toml` dependency groups, and `py/setup.py`
         - Bump version in `cpp/include/macros.h`
         - Add new link to doc versions in `docsrc/conf.py`
         - Generate frozen docs for new version

--- a/noxfile.py
+++ b/noxfile.py
@@ -39,7 +39,23 @@ nox.options.sessions = [
 def install_deps(session):
     print("Installing deps")
     session.install("-r", os.path.join(TOP_DIR, "py", "requirements.txt"))
-    session.install("-r", os.path.join(TOP_DIR, "tests", "py", "requirements.txt"))
+    session.install(
+        "--upgrade",
+        "pip>=25.1",
+    )
+    session.install(
+        "--pre",
+        "--extra-index-url",
+        "https://pypi.nvidia.com",
+        "--extra-index-url",
+        "https://download.pytorch.org/whl/nightly/cu130",
+        "--group",
+        "test",
+        "--group",
+        "test-ext",
+        "--group",
+        "quantization",
+    )
 
 
 def download_models(session):

--- a/noxfile.py
+++ b/noxfile.py
@@ -39,23 +39,7 @@ nox.options.sessions = [
 def install_deps(session):
     print("Installing deps")
     session.install("-r", os.path.join(TOP_DIR, "py", "requirements.txt"))
-    session.install(
-        "--upgrade",
-        "pip>=25.1",
-    )
-    session.install(
-        "--pre",
-        "--extra-index-url",
-        "https://pypi.nvidia.com",
-        "--extra-index-url",
-        "https://download.pytorch.org/whl/nightly/cu130",
-        "--group",
-        "test",
-        "--group",
-        "test-ext",
-        "--group",
-        "quantization",
-    )
+    session.install("-r", os.path.join(TOP_DIR, "tests", "py", "requirements.txt"))
 
 
 def download_models(session):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,11 +76,15 @@ debug = [
 ]
 
 test = [
-    "pytest",
-    "pytest-xdist",
-    "pytest-forked>=1.6.0",
-    "parameterized>=0.2.0",
     "expecttest==0.1.6",
+    "networkx",
+    "numpy",
+    "parameterized>=0.2.0",
+    "pytest>=8.2.1",
+    "pytest-forked>=1.6.0",
+    "pytest-xdist>=3.6.1",
+    "pyyaml",
+    "setuptools",
 ]
 
 test-ext = [
@@ -88,7 +92,6 @@ test-ext = [
     "transformers>=5.0.0",
     "torchvision>=0.27.0.dev,<0.28.0",
     "flashinfer-python; python_version >'3.9' and python_version <'3.13'",
-    #"nvidia-modelopt[hf]@git+https://github.com/NVIDIA/Model-Optimizer.git; python_version >'3.10' and python_version <'3.14'"
 ]
 
 docs = [
@@ -102,7 +105,9 @@ docs = [
     "pillow",
 ]
 
-quantization = ["nvidia-modelopt[hf]>=0.43.0"]
+quantization = [
+    "nvidia-modelopt[hf]>=0.43.0; python_version > '3.9' and python_version < '3.13'",
+]
 
 [project.urls]
 Homepage = "https://pytorch.org/tensorrt"

--- a/tests/py/requirements.txt
+++ b/tests/py/requirements.txt
@@ -1,19 +1,2 @@
-# This file is specifically to install correct version of libraries during CI testing.
-# networkx library issue: https://discuss.pytorch.org/t/installing-pytorch-under-python-3-8-question-about-networkx-version/196740
-expecttest
-networkx
-numpy
-setuptools
-parameterized>=0.2.0
-pytest>=8.2.1
-pytest-xdist>=3.6.1
-pyyaml
-transformers==4.53.1
-nvidia-modelopt[all]; python_version >'3.9' and python_version <'3.13'
---extra-index-url https://pypi.nvidia.com
-# flashinfer-python is not supported for python version 3.13 or higher
-# flashinfer-python is broken on python 3.9 at the moment, so skip it for now
-flashinfer-python; python_version >'3.9' and python_version <'3.13'
---extra-index-url https://download.pytorch.org/whl/nightly/cu130
-torchvision>=0.27.0.dev,<0.28.0
-timm>=1.0.3
+# Compatibility stub for tooling that still expects this file to exist.
+# Shared test dependencies live in pyproject.toml dependency groups.


### PR DESCRIPTION
Install Python test dependencies from pyproject dependency groups in CI to avoid duplicated requirements.

# Description

### Summary

This PR ports Python test dependency installation in CI from `tests/py/requirements.txt` to `pyproject.toml` dependency groups, so local development and CI use the same dependency source of truth.

### Problem

The test dependencies were defined in more than one place and had drifted. In particular, `tests/py/requirements.txt` pinned `transformers==4.53.1`, while `pyproject.toml` specified `transformers>=5.0.0`.

That was risky because GitHub CI was installing from `tests/py/requirements.txt`, while local development with `uv` uses the dependency groups in `pyproject.toml`. As a result, CI and local dev could resolve meaningfully different test environments.

### What Changed

- Moved the shared Python test dependencies into the `test`, `test-ext`, and `quantization` dependency groups in `pyproject.toml`.
- Updated `.github/scripts/install-torch-tensorrt.sh` to install test dependencies with:

  ```bash
  pip install --group test --group test-ext --group quantization

- Updated noxfile.py to install the same dependency groups instead of tests/py/requirements.txt.
- Reduced tests/py/requirements.txt to a compatibility stub for tooling that still expects the file to exist.
- Updated the release checklist to point maintainers at pyproject.toml dependency groups instead of the old test requirements file.

### Design Decisions

The main design choice was to make pyproject.toml the source of truth for shared test dependencies. This matches the local uv workflow and avoids maintaining duplicate package constraints in both dependency groups and a requirements file.

CI now uses native pip dependency group support instead of a custom parser or generated requirements file. This keeps the CI path simple and close to the intended interface for PEP 735 dependency groups.

install-torch-tensorrt.sh upgrades to pip>=25.1 before installing groups because pip --group support requires a recent pip. The script also installs tomli only for Python versions before 3.11 because it parses pyproject.toml to recover the torchvision requirement used later in the script.

The old tests/py/requirements.txt file is intentionally left in place as an empty compatibility stub because there is still non-CI tooling that references it by path. It no longer contains dependency constraints, so it cannot drift from pyproject.toml.

## Type of change

- CI Refactor

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
