### PR TITLE
Replace FakeTensorUpdater copy with Torch import

### DIFF
--- a/py/torch_tensorrt/dynamo/lowering/passes/_FakeTensorUpdater.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/_FakeTensorUpdater.py
@@ -1,207 +1,24 @@
-import contextlib
-import operator
-from collections import defaultdict
-from typing import Any, Optional
+from inspect import signature
+from typing import TYPE_CHECKING
 
-import sympy
-import torch
-import torch.fx
-from torch._dispatch.python import enable_python_dispatcher
-import torch._inductor.fx_passes.reinplace  # ensure submodule is loaded as attribute
-from torch._inductor.fx_utils import get_fake_args_kwargs, get_node_storage, get_storage
-from torch._subclasses.fake_tensor import FakeTensorMode
-from torch.fx.experimental.symbolic_shapes import (
-    compute_unbacked_bindings,
-    rebind_unbacked,
-    statically_known_true,
-    sym_eq,
-)
-from torch.utils._ordered_set import OrderedSet
+from torch._inductor.fx_utils import FakeTensorUpdater as _torch_FakeTensorUpdater
+from torch._inductor.virtualized import V
+
+if TYPE_CHECKING:
+    from torch._subclasses import FakeTensorMode
+    from torch.fx import GraphModule
 
 
-# Adapted from torch._inductor.fx_utils.FakeTensorUpdater
-class FakeTensorUpdater:
-    """
-    The main idea here is that it's difficult to maintain accurate fake
-    tensors (our primary form of metadata) for each node in our graph as we
-    transform it.
+class FakeTensorUpdater(_torch_FakeTensorUpdater):
+    def __init__(self, gm: "GraphModule") -> None:
+        # TODO: remove this method entirely in favor of the parent class after
+        # https://github.com/pytorch/pytorch/pull/159523 is in a PyTorch release.
+        if "gm" in signature(_torch_FakeTensorUpdater).parameters:
+            super().__init__(gm)
+        else:
+            super().__init__(gm.graph)
 
-    The most reliable way to obtain this information is by rerunning
-    faketensor propagation. However, in general, faketensor propagation is
-    fairly expensive. So, instead we'd like to only rerun faketensor
-    propagation on nodes that have changed.
-
-    In order to detect which nodes have changed, we first hash its node,
-    target, and argument lists (which are immutable in FX).
-
-    Then, whenever we call incremental_update, we check which FX nodes have a
-    new hash, and recompute the faketensor metadata for that node. Then, we
-    continue to recursively compute the faketensors for all users until the
-    fake tensors stop changing.
-    """
-
-    def __init__(self, graph: torch.fx.Graph) -> None:
-        self.processed_hashes = OrderedSet[Any]()
-        self.graph = graph
-
-        for node in self.graph.nodes:
-            self.processed_hashes.add(self.hash_node(node))
-
-    def hash_node(self, node: torch.fx.Node) -> tuple[torch.fx.Node, Any, Any, Any]:
-        return (node, node.target, id(node.args), id(node.kwargs))
-
-    def incremental_update(self, fake_mode: FakeTensorMode) -> None:
-        """Update FakeTensors on self.graph. We will try to do the minimum amount of work."""
-        existing_storages: defaultdict[Optional[int], int] = defaultdict(int)
-        for node in self.graph.nodes:
-            existing_storages[get_node_storage(node)] += 1
-
-        def is_intlist_same(new: Any, old: Any) -> Any:
-            return statically_known_true(sym_eq(new, old))
-
-        def is_fake_tensor_same(new: Any, old: Any, *, node: torch.fx.Node) -> Any:
-            if type(new) is not type(old):
-                return False
-            if isinstance(new, (list, tuple)):
-                if len(new) != len(old):
-                    return False
-                return all(
-                    is_fake_tensor_same(new_i, old_i, node=node)
-                    for new_i, old_i in zip(new, old)
-                )
-            if new is None:
-                return old is None
-            if not isinstance(new, torch.Tensor):
-                assert isinstance(
-                    new, (torch.SymInt, torch.SymBool, torch.SymFloat)
-                ), f"Unknown type {type(new)} in {self.graph}"
-                return (
-                    new.node.shape_env._maybe_evaluate_static(
-                        sympy.Eq(new.node.expr, old.node.expr)
-                    )
-                    == sympy.true
-                )
-            if not is_intlist_same(new.shape, old.shape) or new.layout != old.layout:
-                return False
-            if new.layout == torch.strided and (
-                not is_intlist_same(new.stride(), old.stride())
-                or not statically_known_true(
-                    new.storage_offset() == old.storage_offset()
-                )
-            ):
-                return False
-
-            if new.device != old.device:
-                return False
-
-            if get_storage(new) == get_storage(old):
-                return True
-
-            def any_user_may_alias(node: torch.fx.Node) -> bool:
-                if not isinstance(node.meta["val"], torch.Tensor):
-                    # analysis too complicated on lists, can support in the future
-                    return True
-                for user in node.users:
-                    if not (
-                        isinstance(
-                            user.target,
-                            (torch._ops.OpOverload, torch._ops.HigherOrderOperator),
-                        )
-                    ):
-                        return True
-                    if isinstance(user.target, torch._ops.HigherOrderOperator):
-                        # HOPs that survive until inductor are all non-aliasing HOPs.
-                        # We will likely never support HOPs that are aliasing.
-                        continue
-                    # Strategy: do a FakeTensor prop, see if the storage aliases.
-                    # If Inductor ever gets tighter invariants on OpOverloads
-                    # (that is, we ban things like torch.ops.aten.reshape calls in the graph),
-                    # Then this could just be a fast schema lookup.
-                    is_valid, args, kwargs = get_fake_args_kwargs(user)
-                    if not is_valid:
-                        return True
-                    with (
-                        fake_mode,
-                        enable_python_dispatcher(),
-                        contextlib.ExitStack() as stack,
-                    ):
-                        # Ignore unbacked symbols (if they exist): we're making
-                        # this FakeTensor and then throwing it away.
-                        if fake_mode.shape_env is not None:
-                            stack.enter_context(
-                                fake_mode.shape_env.ignore_fresh_unbacked_symbols()
-                            )
-                        new_fake_tensor = user.target(*args, **kwargs)
-                    if not isinstance(new_fake_tensor, torch.Tensor):
-                        # analysis too complicated on lists, can support in the future
-                        return True
-                    if get_storage(new_fake_tensor) == get_storage(node.meta["val"]):
-                        return True
-                return False
-
-            # This is the case where it returns a completely fresh storage that's used nowhere else.
-            # If the FakeTensor's storage is fresh and none of the node's users can alias it, then
-            # we don't need to update this node.
-            if (
-                existing_storages[get_storage(old)] == 1
-                and get_storage(new) not in existing_storages
-                and not any_user_may_alias(node)
-            ):
-                return True
-
-            return False
-
-        def should_process_node(node: torch.fx.Node) -> bool:
-            # node.target for nodes returning true from this function
-            # are called under fake mode and does not work for inductor
-            # lowerings. We check if the node.target is an aten operator
-            # or operator.getitem which is used when returning multiple
-            # tensors from an op.
-            return node.op == "call_function" and (
-                isinstance(node.target, torch._ops.OpOverload)
-                or node.target is operator.getitem
-                or node.target
-                is torch._inductor.fx_passes.reinplace._generalized_scatter
-            )
-
-        to_process = OrderedSet[int]()
-        for node in self.graph.nodes:
-            # NB: Be very careful about skipping nodes (via continues) here
-            # and ask for a careful review when changing this code. The
-            # consequence for incorrect FakeTensor metadata is difficult-to-debug
-            # silent incorrectness.
-            if (
-                self.hash_node(node) in self.processed_hashes
-                and id(node) not in to_process
-            ):
-                continue
-
-            if not should_process_node(node):
-                continue
-
-            is_valid, args, kwargs = get_fake_args_kwargs(node)
-            if not is_valid:
-                continue
-            with fake_mode, enable_python_dispatcher():
-                new_fake_tensor = node.target(*args, **kwargs)
-
-            if "val" in node.meta and is_fake_tensor_same(
-                new_fake_tensor, node.meta["val"], node=node
-            ):
-                continue
-
-            rebind_unbacked(fake_mode.shape_env, node, new_fake_tensor)
-
-            node.meta["val"] = new_fake_tensor
-            if (shape_env := fake_mode.shape_env) and (
-                symbol_to_path := compute_unbacked_bindings(shape_env, new_fake_tensor)
-            ):
-                # Refresh the bindings to the new symbols
-
-                node.meta["unbacked_bindings"] = symbol_to_path
-
-            existing_storages[get_node_storage(node)] += 1
-
-            to_process.update([id(user) for user in node.users])
-
-            self.processed_hashes.add(self.hash_node(node))
+    def incremental_update(self, fake_mode: "FakeTensorMode") -> int:
+        """Wrap incremental_update to accept fake_mode as an argument."""
+        with V.set_fake_mode(fake_mode):
+            return super().incremental_update()

--- a/py/torch_tensorrt/dynamo/lowering/passes/_aten_lowering_pass.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/_aten_lowering_pass.py
@@ -135,7 +135,7 @@ def post_lowering(
         f"Invoking DynamoPassManager and applying lowering passes: {ATEN_POST_LOWERING_PASSES}"
     )
     fake_mode = torch._export.utils._detect_fake_mode_from_gm(gm)
-    fake_tensor_updater = FakeTensorUpdater(gm.graph)
+    fake_tensor_updater = FakeTensorUpdater(gm)
     gm = ATEN_POST_LOWERING_PASSES(gm, settings)
     if fake_mode is not None:
         fake_tensor_updater.incremental_update(fake_mode)


### PR DESCRIPTION
# Description

#4017 added a copy of `torch._inductor.fx_utils.FakeTensorUpdater` to the repo, with some minor changes.  The original class is being updated to handle subgraphs and HOPs, and fix corner cases, in https://github.com/pytorch/pytorch/pull/159523. Rather than once again copying all the new code over, I've changed to subclassing from `FakeTensorUpdater` and only implementing the interface changes.

## Type of change

- Port of PyTorch feature updates

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
