### PR TITLE
fix: Remove explicit casts from the torch.compile pre aten identity lowering pass

### DIFF
--- a/py/torch_tensorrt/dynamo/lowering/passes/fold_get_attr_item_calls.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/fold_get_attr_item_calls.py
@@ -7,7 +7,13 @@ logger = logging.getLogger(__name__)
 
 # Identity ops that produce an alias / copy of their single input.
 # Removing them before folding means .item() nodes will see placeholder/get_attr directly.
-_IDENTITY_METHODS = frozenset({"clone", "contiguous", "detach", "to"})
+#
+# NOTE: ``"to"`` is intentionally excluded here. ``Tensor.to(dtype=...)`` (or
+# ``device=...``) is not an identity — stripping it silently drops dtype casts
+# such as the ``softmax(..., dtype=fp32).to(bf16)`` pattern used in HuggingFace
+# attention, leaving fp32 softmax feeding a bf16 matmul and triggering a
+# ``Float vs BFloat16`` mismatch at AOT meta-bmm dispatch.
+_IDENTITY_METHODS = frozenset({"clone", "contiguous", "detach"})
 _IDENTITY_FUNCTIONS = frozenset(
     {
         torch.ops.aten.clone.default,


### PR DESCRIPTION
# Description

For torch.compile, the pre-aten lowering passes designed to add support for various huggingface models silently removed explicit casts. This should now remove that identity op from being removed 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
