### PR TITLE
[ExecuTorch] Restore libtorch-free .pte runtime

### DIFF
--- a/core/runtime/executorch/BUILD
+++ b/core/runtime/executorch/BUILD
@@ -65,8 +65,6 @@ cc_library(
     # links this target together with the ExecuTorch runtime it was compiled
     # against, avoiding any runtime plugin/dlopen dependency.
     deps = [
-        "//core/runtime:runtime_base",
-        "//core/util:prelude",
         "@executorch//:executorch_headers",
     ] + select({
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],

--- a/core/runtime/executorch/TensorRTBackend.cpp
+++ b/core/runtime/executorch/TensorRTBackend.cpp
@@ -3,12 +3,33 @@
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * ExecuTorch backend delegate that runs TensorRT engines serialized by
+ * torch_tensorrt.  Fully self-contained: depends only on the TensorRT C++
+ * API, the CUDA runtime, ExecuTorch runtime headers, and the C++ standard
+ * library.  No libtorch / ATen / c10 dependencies.
+ *
+ * Wire format (vector-of-strings, produced by
+ *   py/torch_tensorrt/executorch/serialization.py::serialize_engine_info()):
+ *
+ *   [uint32_t count (LE)]
+ *   for each of `count` entries:
+ *     [uint32_t len (LE)] [uint8_t data[len]]
+ *
+ * The slots match the SerializedInfoIndex enum in core/runtime/runtime.h.
+ * This backend consumes only the four slots it needs:
+ *   DEVICE_IDX(2)               = "id%major%minor%type%name"
+ *   ENGINE_IDX(3)               = raw serialized TensorRT engine bytes
+ *   INPUT_BINDING_NAMES_IDX(4)  = '%'-separated input names
+ *   OUTPUT_BINDING_NAMES_IDX(5) = '%'-separated output names
  */
 
 #include "core/runtime/executorch/TensorRTBackend.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -17,15 +38,8 @@
 #include <cuda_runtime.h>
 
 #include <executorch/runtime/backend/interface.h>
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
 #include <executorch/runtime/platform/log.h>
-
-// RTDevice and Platform must be included before TRTEngine.h because TRTEngine.h
-// references them without including their headers directly (Bazel handles this
-// via transitive deps, but a standalone compile needs them explicit).
-#include "core/runtime/Platform.h"
-#include "core/runtime/RTDevice.h"
-#include "core/runtime/TRTEngine.h"
-#include "core/util/prelude.h"
 
 namespace torch_tensorrt {
 namespace executorch_backend {
@@ -42,31 +56,69 @@ using ::executorch::runtime::MemoryAllocator;
 using ::executorch::runtime::Result;
 using ::executorch::runtime::Span;
 
+// ============================================================================
+// Wire-format slot indices (mirror SerializedInfoIndex in
+// core/runtime/runtime.h; duplicated here to avoid pulling in libtorch headers)
+// ============================================================================
 namespace {
 
-// ---------------------------------------------------------------------------
-// Blob deserialization
-//
-// Wire format written by
-//   py/torch_tensorrt/executorch/serialization.py::serialize_engine_info()
-//
-//   [uint32_t count (LE)]
-//   for each of `count` entries:
-//     [uint32_t len (LE)] [uint8_t data[len]]
-//
-// The resulting vector<string> is passed directly to
-//   core::runtime::TRTEngine(std::vector<std::string> serialized_info)
-// which expects the 11-element list defined by SerializedInfoIndex in
-//   core/runtime/runtime.h
-// ---------------------------------------------------------------------------
-std::vector<std::string> deserialize_engine_info(const void* data, size_t size) {
+constexpr size_t kDeviceIdx = 2;
+constexpr size_t kEngineIdx = 3;
+constexpr size_t kInputBindingNamesIdx = 4;
+constexpr size_t kOutputBindingNamesIdx = 5;
+constexpr size_t kMinSerializedSlots = 6;
+
+constexpr char kBindingDelim = '%';
+constexpr char kDeviceInfoDelim = '%';
+
+} // namespace
+
+// ============================================================================
+// Minimal TensorRT logger forwarding to ExecuTorch logging
+// ============================================================================
+namespace {
+
+class ETTRTLogger : public nvinfer1::ILogger {
+ public:
+  void log(Severity severity, const char* msg) noexcept override {
+    switch (severity) {
+      case Severity::kINTERNAL_ERROR:
+      case Severity::kERROR:
+        ET_LOG(Error, "TensorRT: %s", msg);
+        break;
+      case Severity::kWARNING:
+        ET_LOG(Info, "TensorRT [WARN]: %s", msg);
+        break;
+      default:
+        // kINFO and kVERBOSE suppressed to avoid noise
+        break;
+    }
+  }
+};
+
+ETTRTLogger& get_trt_logger() {
+  static ETTRTLogger logger;
+  return logger;
+}
+
+} // namespace
+
+// ============================================================================
+// Wire-format helpers
+// ============================================================================
+namespace {
+
+// Decode the vector-of-strings wire format produced by
+// py/torch_tensorrt/executorch/serialization.py::serialize_engine_info().
+std::vector<std::string> deserialize_engine_info(
+    const void* data,
+    size_t size) {
   const uint8_t* ptr = static_cast<const uint8_t*>(data);
   const uint8_t* const end = ptr + size;
 
   if (ptr + sizeof(uint32_t) > end) {
     return {};
   }
-
   uint32_t count = 0;
   std::memcpy(&count, ptr, sizeof(uint32_t));
   ptr += sizeof(uint32_t);
@@ -88,15 +140,63 @@ std::vector<std::string> deserialize_engine_info(const void* data, size_t size) 
     result.emplace_back(reinterpret_cast<const char*>(ptr), len);
     ptr += len;
   }
-
   return result;
 }
 
-// ---------------------------------------------------------------------------
-// Build a nvinfer1::Dims from an ExecuTorch tensor's shape
-// ---------------------------------------------------------------------------
+// Split a delimiter-separated string into non-empty tokens.
+std::vector<std::string> split_delim(const std::string& s, char delim) {
+  std::vector<std::string> out;
+  size_t start = 0;
+  while (start <= s.size()) {
+    size_t end = s.find(delim, start);
+    if (end == std::string::npos) {
+      if (start < s.size()) {
+        out.emplace_back(s.substr(start));
+      }
+      break;
+    }
+    if (end > start) {
+      out.emplace_back(s.substr(start, end - start));
+    }
+    start = end + 1;
+  }
+  return out;
+}
+
+// Extract the device id (first '%'-separated token) from the DEVICE_IDX slot.
+int parse_device_id(const std::string& device_info, int fallback) {
+  if (device_info.empty()) {
+    return fallback;
+  }
+  size_t end = device_info.find(kDeviceInfoDelim);
+  std::string id_tok =
+      (end == std::string::npos) ? device_info : device_info.substr(0, end);
+  try {
+    return std::stoi(id_tok);
+  } catch (...) {
+    return fallback;
+  }
+}
+
+} // namespace
+
+// ============================================================================
+// Tensor / dtype helpers
+// ============================================================================
+namespace {
+
+// Build nvinfer1::Dims from an ExecuTorch tensor's shape.
 nvinfer1::Dims to_trt_dims(const exec_aten::Tensor& t) {
   nvinfer1::Dims dims{};
+  if (t.dim() > nvinfer1::Dims::MAX_DIMS) {
+    ET_LOG(
+        Error,
+        "TensorRTBackend: tensor has %d dims, exceeds MAX_DIMS=%d",
+        t.dim(),
+        nvinfer1::Dims::MAX_DIMS);
+    dims.nbDims = 0;
+    return dims;
+  }
   dims.nbDims = t.dim();
   for (int d = 0; d < t.dim(); ++d) {
     dims.d[d] = static_cast<int64_t>(t.size(d));
@@ -104,60 +204,207 @@ nvinfer1::Dims to_trt_dims(const exec_aten::Tensor& t) {
   return dims;
 }
 
+// Element size for a TRT DataType.
+size_t trt_dtype_size(nvinfer1::DataType dtype) {
+  switch (dtype) {
+    case nvinfer1::DataType::kFLOAT:
+      return 4;
+    case nvinfer1::DataType::kHALF:
+      return 2;
+    case nvinfer1::DataType::kINT8:
+      return 1;
+    case nvinfer1::DataType::kINT32:
+      return 4;
+    case nvinfer1::DataType::kBOOL:
+      return 1;
+    case nvinfer1::DataType::kINT64:
+      return 8;
+    case nvinfer1::DataType::kBF16:
+      return 2;
+    case nvinfer1::DataType::kFP8:
+      return 1;
+    case nvinfer1::DataType::kUINT8:
+      return 1;
+    default:
+      ET_LOG(
+          Error,
+          "TensorRTBackend: unknown dtype %d, assuming 4 bytes",
+          static_cast<int>(dtype));
+      return 4;
+  }
+}
+
+// Product of a dims object (returns -1 if any dim is negative/unresolved).
+int64_t dims_volume(const nvinfer1::Dims& dims) {
+  int64_t vol = 1;
+  for (int i = 0; i < dims.nbDims; ++i) {
+    if (dims.d[i] < 0) {
+      return -1;
+    }
+    vol *= dims.d[i];
+  }
+  return vol;
+}
+
 } // namespace
 
-// ---------------------------------------------------------------------------
+// ============================================================================
+// TRTDelegateState - fully self-contained, libtorch-free
+//
+// Owns all TensorRT objects and GPU staging buffers.  Members are declared so
+// that C++ destroys exec_ctx before cuda_engine before runtime, which is the
+// lifetime order required by TensorRT.
+// ============================================================================
+namespace {
+
+struct TrtDeleter {
+  template <class T>
+  void operator()(T* p) const {
+    delete p;
+  }
+};
+
+using UniqueRuntime = std::unique_ptr<nvinfer1::IRuntime, TrtDeleter>;
+using UniqueEngine = std::unique_ptr<nvinfer1::ICudaEngine, TrtDeleter>;
+using UniqueContext = std::unique_ptr<nvinfer1::IExecutionContext, TrtDeleter>;
+
+struct TRTDelegateState {
+  // --- Engine metadata ---
+  int device_id = 0;
+  std::vector<std::string> in_binding_names;
+  std::vector<std::string> out_binding_names;
+  std::mutex mu;
+
+  // --- Grow-only GPU staging buffers (per-binding) ---
+  std::vector<void*> input_gpu_bufs;
+  std::vector<void*> output_gpu_bufs;
+  std::vector<size_t> input_buf_sizes;
+  std::vector<size_t> output_buf_sizes;
+
+  // --- TensorRT objects ---
+  // Declaration order matters: C++ destroys members in reverse declaration
+  // order, so runtime is declared first (destroyed last) and exec_ctx is
+  // declared last (destroyed first).  TRT requires
+  //   exec_ctx -> cuda_engine -> runtime.
+  UniqueRuntime runtime;
+  UniqueEngine cuda_engine;
+  UniqueContext exec_ctx;
+};
+
+} // namespace
+
+// ============================================================================
 // is_available
-// ---------------------------------------------------------------------------
+// ============================================================================
 bool TensorRTBackend::is_available() const {
   return true;
 }
 
-// ---------------------------------------------------------------------------
+// ============================================================================
 // init
-//
-// Deserializes the processed blob into a TRTEngine and returns it as the
-// opaque DelegateHandle.  The engine is placement-new'd into memory
-// provided by the ExecuTorch MemoryAllocator so that ExecuTorch owns the
-// lifetime; destroy() calls the destructor explicitly.
-// ---------------------------------------------------------------------------
+// ============================================================================
 Result<DelegateHandle*> TensorRTBackend::init(
     BackendInitContext& context,
     FreeableBuffer* processed,
     ArrayRef<CompileSpec> compile_specs) const {
   (void)compile_specs;
-  ET_LOG(Info, "TensorRTBackend::init: enter");
-
-  if (!is_available()) {
-    ET_LOG(Error, "TensorRT backend is not available");
-    return Error::NotSupported;
-  }
 
   if (processed == nullptr || processed->data() == nullptr) {
     ET_LOG(Error, "TensorRTBackend::init: null processed buffer");
     return Error::InvalidArgument;
   }
 
-  auto serialized_info = deserialize_engine_info(processed->data(), processed->size());
+  auto serialized_info =
+      deserialize_engine_info(processed->data(), processed->size());
 
-  if (serialized_info.empty()) {
-    fprintf(stderr, "[TensorRTBackend::init] FAIL: deserialize_engine_info returned empty\n");
-    ET_LOG(Error, "TensorRTBackend::init: failed to deserialize engine blob");
+  if (serialized_info.size() < kMinSerializedSlots) {
+    ET_LOG(
+        Error,
+        "TensorRTBackend::init: serialized info has %zu slots, need >= %zu",
+        serialized_info.size(),
+        kMinSerializedSlots);
     return Error::InvalidArgument;
   }
-  ET_LOG(Info, "TensorRTBackend::init: deserialized %zu entries", serialized_info.size());
 
-  // Validate the vector length before handing to TRTEngine
-  // (verify_serialization_fmt throws on mismatch)
-  ET_LOG(Info, "TensorRTBackend::init: calling verify_serialization_fmt");
-  try {
-    core::runtime::TRTEngine::verify_serialization_fmt(serialized_info);
-  } catch (const std::exception& e) {
-    ET_LOG(Error, "TensorRTBackend::init: verify_serialization_fmt threw: %s", e.what());
+  const std::string& device_blob = serialized_info[kDeviceIdx];
+  const std::string& engine_blob = serialized_info[kEngineIdx];
+  const std::string& in_names_blob = serialized_info[kInputBindingNamesIdx];
+  const std::string& out_names_blob = serialized_info[kOutputBindingNamesIdx];
+
+  if (engine_blob.empty()) {
+    ET_LOG(Error, "TensorRTBackend::init: empty engine bytes");
     return Error::InvalidArgument;
-  } catch (...) {
-    ET_LOG(Error, "TensorRTBackend::init: verify_serialization_fmt threw unknown exception");
-    return Error::InvalidArgument;
+  }
+
+  std::vector<std::string> in_names = split_delim(in_names_blob, kBindingDelim);
+  std::vector<std::string> out_names =
+      split_delim(out_names_blob, kBindingDelim);
+
+  int device_id = parse_device_id(device_blob, /*fallback=*/0);
+
+  cudaError_t dev_err = cudaSetDevice(device_id);
+  if (dev_err != cudaSuccess) {
+    ET_LOG(
+        Error,
+        "TensorRTBackend::init: cudaSetDevice(%d) failed: %s",
+        device_id,
+        cudaGetErrorString(dev_err));
+    return Error::InvalidState;
+  }
+
+  UniqueRuntime runtime(nvinfer1::createInferRuntime(get_trt_logger()));
+  if (!runtime) {
+    ET_LOG(Error, "TensorRTBackend::init: createInferRuntime failed");
+    return Error::InvalidState;
+  }
+
+  UniqueEngine cuda_engine(runtime->deserializeCudaEngine(
+      engine_blob.data(), engine_blob.size()));
+  if (!cuda_engine) {
+    ET_LOG(Error, "TensorRTBackend::init: deserializeCudaEngine failed");
+    return Error::InvalidState;
+  }
+
+  // If the wire format didn't carry binding names, query them from the engine.
+  if (in_names.empty() && out_names.empty()) {
+    const int32_t num_io = cuda_engine->getNbIOTensors();
+    for (int32_t i = 0; i < num_io; ++i) {
+      const char* tname = cuda_engine->getIOTensorName(i);
+      auto mode = cuda_engine->getTensorIOMode(tname);
+      if (mode == nvinfer1::TensorIOMode::kINPUT) {
+        in_names.emplace_back(tname);
+      } else if (mode == nvinfer1::TensorIOMode::kOUTPUT) {
+        out_names.emplace_back(tname);
+      }
+    }
+  }
+
+  // Validate every named binding exists on the engine with the right IO mode.
+  for (const auto& n : in_names) {
+    if (cuda_engine->getTensorIOMode(n.c_str()) !=
+        nvinfer1::TensorIOMode::kINPUT) {
+      ET_LOG(
+          Error,
+          "TensorRTBackend::init: '%s' is not an input tensor in the engine",
+          n.c_str());
+      return Error::InvalidArgument;
+    }
+  }
+  for (const auto& n : out_names) {
+    if (cuda_engine->getTensorIOMode(n.c_str()) !=
+        nvinfer1::TensorIOMode::kOUTPUT) {
+      ET_LOG(
+          Error,
+          "TensorRTBackend::init: '%s' is not an output tensor in the engine",
+          n.c_str());
+      return Error::InvalidArgument;
+    }
+  }
+
+  UniqueContext exec_ctx(cuda_engine->createExecutionContext());
+  if (!exec_ctx) {
+    ET_LOG(Error, "TensorRTBackend::init: createExecutionContext failed");
+    return Error::InvalidState;
   }
 
   MemoryAllocator* allocator = context.get_runtime_allocator();
@@ -165,267 +412,420 @@ Result<DelegateHandle*> TensorRTBackend::init(
     ET_LOG(Error, "TensorRTBackend::init: null runtime allocator");
     return Error::InvalidState;
   }
-  ET_LOG(Info, "TensorRTBackend::init: got allocator");
 
-  // Allocate raw storage for TRTEngine from ExecuTorch's arena
-  core::runtime::TRTEngine* engine = allocator->allocateInstance<core::runtime::TRTEngine>();
-  if (engine == nullptr) {
+  TRTDelegateState* state = allocator->allocateInstance<TRTDelegateState>();
+  if (state == nullptr) {
     ET_LOG(Error, "TensorRTBackend::init: allocateInstance failed");
     return Error::MemoryAllocationFailed;
   }
-  ET_LOG(Info, "TensorRTBackend::init: allocated engine storage at %p", (void*)engine);
+  new (state) TRTDelegateState{};
 
-  // Construct in-place; TRTEngine(std::vector<std::string>) deserializes the
-  // engine bytes, builds the IRuntime/ICudaEngine/IExecutionContext, and
-  // populates in_binding_names / out_binding_names / num_io.
-  ET_LOG(Info, "TensorRTBackend::init: constructing TRTEngine in-place");
-  try {
-    new (engine) core::runtime::TRTEngine(std::move(serialized_info));
-  } catch (const std::exception& e) {
-    fprintf(stderr, "[TensorRTBackend::init] FAIL: TRTEngine constructor threw: %s\n", e.what());
-    ET_LOG(Error, "TensorRTBackend::init: TRTEngine constructor threw: %s", e.what());
-    return Error::InvalidArgument;
-  } catch (...) {
-    fprintf(stderr, "[TensorRTBackend::init] FAIL: TRTEngine constructor threw unknown exception\n");
-    ET_LOG(Error, "TensorRTBackend::init: TRTEngine constructor threw unknown exception");
-    return Error::InvalidArgument;
-  }
+  state->device_id = device_id;
+  state->in_binding_names = std::move(in_names);
+  state->out_binding_names = std::move(out_names);
+  state->runtime = std::move(runtime);
+  state->cuda_engine = std::move(cuda_engine);
+  state->exec_ctx = std::move(exec_ctx);
 
-  // Release the blob; we no longer need it
+  // The blob is no longer needed once the engine has been deserialized.
   processed->Free();
 
   ET_LOG(
       Info,
-      "TensorRTBackend::init: engine '%s' ready (%zu inputs, %zu outputs)",
-      engine->name.c_str(),
-      engine->num_io.first,
-      engine->num_io.second);
+      "TensorRTBackend::init: ready on device %d (%zu inputs, %zu outputs)",
+      state->device_id,
+      state->in_binding_names.size(),
+      state->out_binding_names.size());
 
-  return static_cast<DelegateHandle*>(engine);
+  return static_cast<DelegateHandle*>(state);
 }
 
-// ---------------------------------------------------------------------------
+// ============================================================================
 // execute
 //
-// Binds the ExecuTorch input/output tensor data pointers directly to the
-// TRT IExecutionContext and calls enqueueV3().  ExecuTorch pre-allocates
-// all output tensors before calling execute(), so we only need to register
-// their addresses; no separate output allocation is required.
-//
-// Args layout (mirroring the Python exporter):
-//   args[0 .. num_inputs-1]             – input EValues
-//   args[num_inputs .. num_inputs+num_outputs-1] – output EValues
-// ---------------------------------------------------------------------------
-Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle* handle, Span<EValue*> args) const {
+// Uses cudaStreamPerThread (CUDA's per-thread default stream).  That stream
+// honors whatever CUDA context the calling thread has current, so callers
+// remain free to manage device / context selection externally.
+// ============================================================================
+Error TensorRTBackend::execute(
+    BackendExecutionContext& context,
+    DelegateHandle* handle,
+    Span<EValue*> args) const {
   (void)context;
-  fprintf(stderr, "[TensorRTBackend::execute] enter: handle=%p args.size()=%zu\n", (void*)handle, args.size());
-  ET_LOG(Info, "TensorRTBackend::execute: enter");
 
   if (handle == nullptr) {
     ET_LOG(Error, "TensorRTBackend::execute: null delegate handle");
     return Error::InvalidArgument;
   }
-  ET_LOG(Info, "TensorRTBackend::execute: got delegate handle");
-  auto* engine = static_cast<core::runtime::TRTEngine*>(handle);
+  auto* state = static_cast<TRTDelegateState*>(handle);
 
-  const size_t num_inputs = engine->num_io.first;
-  const size_t num_outputs = engine->num_io.second;
-  ET_LOG(Info, "TensorRTBackend::execute: got num_inputs %zu and num_outputs %zu", num_inputs, num_outputs);
+  cudaError_t dev_err = cudaSetDevice(state->device_id);
+  if (dev_err != cudaSuccess) {
+    ET_LOG(
+        Error,
+        "TensorRTBackend::execute: cudaSetDevice(%d) failed: %s",
+        state->device_id,
+        cudaGetErrorString(dev_err));
+    return Error::InvalidState;
+  }
+
+  const size_t num_inputs = state->in_binding_names.size();
+  const size_t num_outputs = state->out_binding_names.size();
 
   if (args.size() < num_inputs + num_outputs) {
     ET_LOG(
-        Error, "TensorRTBackend::execute: expected at least %zu args, got %zu", num_inputs + num_outputs, args.size());
+        Error,
+        "TensorRTBackend::execute: expected at least %zu args, got %zu",
+        num_inputs + num_outputs,
+        args.size());
     return Error::InvalidArgument;
   }
-  ET_LOG(Info, "TensorRTBackend::execute: got engine");
-  // IExecutionContext::enqueueV3 is not thread-safe; use the engine mutex
-  std::unique_lock<std::mutex> lock(engine->mu);
 
-  nvinfer1::IExecutionContext* ctx = engine->exec_ctx.get();
+  // IExecutionContext is not thread-safe; serialize concurrent calls.
+  std::unique_lock<std::mutex> lock(state->mu);
 
-  cudaStream_t stream = c10::cuda::getCurrentCUDAStream(static_cast<c10::DeviceIndex>(engine->device_info.id));
+  cudaStream_t stream = cudaStreamPerThread;
+  nvinfer1::IExecutionContext* ctx = state->exec_ctx.get();
 
-  // ExecuTorch's portable runtime pre-allocates output tensors as CPU buffers.
-  // TRT requires CUDA device pointers for all bindings.  We use
-  // cudaPointerGetAttributes to detect CPU pointers and stage them through
-  // temporary CUDA allocations, copying back after inference.
-  auto is_cuda_ptr = [](const void* ptr) -> bool {
-    if (ptr == nullptr)
-      return false;
-    cudaPointerAttributes attrs{};
-    cudaError_t err = cudaPointerGetAttributes(&attrs, ptr);
-    return err == cudaSuccess && attrs.type == cudaMemoryTypeDevice;
-  };
-
-  std::vector<void*> temp_input_bufs(num_inputs, nullptr);
-  std::vector<void*> temp_output_bufs(num_outputs, nullptr);
-
-  // Cleanup helper – called on every return path.
-  auto free_temp = [&]() {
-    for (void* p : temp_input_bufs)
-      if (p)
-        cudaFree(p);
-    for (void* p : temp_output_bufs)
-      if (p)
-        cudaFree(p);
-  };
-
-  // ------------------------------------------------------------------
-  // 1. Bind input shapes and addresses
-  // ------------------------------------------------------------------
+  // --------------------------------------------------------------------
+  // 1. Bind input shapes and addresses (stage CPU buffers to GPU as needed)
+  // --------------------------------------------------------------------
   for (size_t i = 0; i < num_inputs; ++i) {
     EValue* arg = args[i];
     if (arg == nullptr || !arg->isTensor()) {
       ET_LOG(Error, "TensorRTBackend::execute: input %zu is not a tensor", i);
-      free_temp();
       return Error::InvalidArgument;
     }
 
     exec_aten::Tensor et_in = arg->toTensor();
-    const std::string& name = engine->in_binding_names[i];
+    const std::string& name = state->in_binding_names[i];
     nvinfer1::Dims dims = to_trt_dims(et_in);
 
     if (!ctx->setInputShape(name.c_str(), dims)) {
-      ET_LOG(Error, "TensorRTBackend::execute: setInputShape failed for '%s'", name.c_str());
-      free_temp();
+      ET_LOG(
+          Error,
+          "TensorRTBackend::execute: setInputShape failed for '%s'",
+          name.c_str());
       return Error::InvalidState;
     }
 
-    void* src_ptr = et_in.mutable_data_ptr();
-    void* trt_ptr = src_ptr;
+    void* host_ptr = et_in.mutable_data_ptr();
+    size_t nbytes = et_in.nbytes();
 
-    static char placeholder[16] = {};
-    if (src_ptr == nullptr || et_in.numel() == 0) {
-      trt_ptr = placeholder;
-    } else if (!is_cuda_ptr(src_ptr)) {
-      // CPU input: stage to a temporary CUDA buffer
-      size_t nbytes = et_in.nbytes();
-      if (cudaMalloc(&temp_input_bufs[i], nbytes) != cudaSuccess) {
-        ET_LOG(Error, "TensorRTBackend::execute: cudaMalloc failed for input %zu", i);
-        free_temp();
-        return Error::MemoryAllocationFailed;
+    // TensorRT requires a non-null address even for 0-element tensors.
+    // Thread-local placeholder avoids sharing across concurrent delegates.
+    static thread_local char placeholder[16] = {};
+    if (host_ptr == nullptr || et_in.numel() == 0) {
+      host_ptr = placeholder;
+      nbytes = 0;
+    }
+
+    void* gpu_ptr = nullptr;
+    cudaPointerAttributes attrs;
+    cudaError_t attr_err = cudaPointerGetAttributes(&attrs, host_ptr);
+    if (attr_err == cudaSuccess &&
+        (attrs.type == cudaMemoryTypeDevice ||
+         attrs.type == cudaMemoryTypeManaged)) {
+      gpu_ptr = host_ptr;
+    } else {
+      // Clear any spurious error from probing a host pointer.
+      cudaGetLastError();
+
+      if (i >= state->input_gpu_bufs.size()) {
+        state->input_gpu_bufs.resize(i + 1, nullptr);
+        state->input_buf_sizes.resize(i + 1, 0);
       }
-      cudaMemcpyAsync(temp_input_bufs[i], src_ptr, nbytes, cudaMemcpyHostToDevice, stream);
-      trt_ptr = temp_input_bufs[i];
+
+      if (nbytes == 0) {
+        gpu_ptr = placeholder;
+      } else {
+        // Grow-only reallocation of the per-binding staging buffer.
+        if (state->input_buf_sizes[i] < nbytes) {
+          if (state->input_gpu_bufs[i]) {
+            cudaFree(state->input_gpu_bufs[i]);
+            state->input_gpu_bufs[i] = nullptr;
+          }
+          cudaError_t alloc_err =
+              cudaMalloc(&state->input_gpu_bufs[i], nbytes);
+          if (alloc_err != cudaSuccess) {
+            ET_LOG(
+                Error,
+                "TensorRTBackend::execute: cudaMalloc(%zu) failed for input "
+                "'%s': %s",
+                nbytes,
+                name.c_str(),
+                cudaGetErrorString(alloc_err));
+            return Error::MemoryAllocationFailed;
+          }
+          state->input_buf_sizes[i] = nbytes;
+        }
+        gpu_ptr = state->input_gpu_bufs[i];
+        cudaError_t cpy_err = cudaMemcpyAsync(
+            gpu_ptr, host_ptr, nbytes, cudaMemcpyHostToDevice, stream);
+        if (cpy_err != cudaSuccess) {
+          ET_LOG(
+              Error,
+              "TensorRTBackend::execute: H2D copy failed for input '%s': %s",
+              name.c_str(),
+              cudaGetErrorString(cpy_err));
+          return Error::InvalidState;
+        }
+      }
     }
 
-    if (!ctx->setTensorAddress(name.c_str(), trt_ptr)) {
-      ET_LOG(Error, "TensorRTBackend::execute: setTensorAddress failed for input '%s'", name.c_str());
-      free_temp();
+    if (!ctx->setTensorAddress(name.c_str(), gpu_ptr)) {
+      ET_LOG(
+          Error,
+          "TensorRTBackend::execute: setTensorAddress failed for input '%s'",
+          name.c_str());
       return Error::InvalidState;
     }
   }
 
-  // ------------------------------------------------------------------
-  // 2. Infer output shapes (requires all input shapes to be set first)
-  // ------------------------------------------------------------------
+  // --------------------------------------------------------------------
+  // 2. Infer output shapes (all input shapes must be set first)
+  // --------------------------------------------------------------------
   {
-    const int32_t io_size = engine->cuda_engine->getNbIOTensors();
+    const int32_t io_size = state->cuda_engine->getNbIOTensors();
     std::vector<const char*> unresolved(static_cast<size_t>(io_size), nullptr);
-    const int32_t n_unresolved = ctx->inferShapes(io_size, unresolved.data());
+    const int32_t n_unresolved =
+        ctx->inferShapes(io_size, unresolved.data());
     if (n_unresolved != 0) {
-      ET_LOG(Error, "TensorRTBackend::execute: inferShapes could not resolve %d tensor(s)", n_unresolved);
-      free_temp();
+      ET_LOG(
+          Error,
+          "TensorRTBackend::execute: inferShapes could not resolve %d "
+          "tensor(s)",
+          n_unresolved);
       return Error::InvalidState;
     }
   }
 
-  // ------------------------------------------------------------------
-  // 3. Bind output addresses
-  // ExecuTorch pre-allocates output tensors at the maximum shape for
-  // dynamic models.  After inferShapes() TRT knows the actual output
-  // dims, so update the ExecuTorch TensorImpl's sizes before computing
-  // nbytes() and before the Python binding reads back the shape.
-  // If the buffer is CPU, stage through a temporary CUDA allocation.
-  // ------------------------------------------------------------------
+  // --------------------------------------------------------------------
+  // 3. Bind output addresses (size GPU buffers from TRT's inferred shape,
+  //    not from the pre-allocated ExecuTorch tensor, to avoid overrun on
+  //    dynamic-shape outputs)
+  // --------------------------------------------------------------------
+  struct OutputCopyInfo {
+    void* gpu_ptr = nullptr;
+    size_t actual_bytes = 0;
+    bool needs_copy = false;
+  };
+  std::vector<OutputCopyInfo> output_copies(num_outputs);
+
   for (size_t o = 0; o < num_outputs; ++o) {
     EValue* arg = args[num_inputs + o];
     if (arg == nullptr || !arg->isTensor()) {
       ET_LOG(Error, "TensorRTBackend::execute: output %zu is not a tensor", o);
-      free_temp();
       return Error::InvalidArgument;
     }
 
     exec_aten::Tensor et_out = arg->toTensor();
-    const std::string& name = engine->out_binding_names[o];
+    const std::string& name = state->out_binding_names[o];
+    void* host_ptr = et_out.mutable_data_ptr();
 
-    // Update the ExecuTorch tensor shape to the actual TRT output shape.
-    // getTensorShape() is valid after inferShapes() has been called.
     nvinfer1::Dims actual_dims = ctx->getTensorShape(name.c_str());
-    if (actual_dims.nbDims > 0) {
-      exec_aten::SizesType new_sizes[nvinfer1::Dims::MAX_DIMS];
-      for (int d = 0; d < actual_dims.nbDims; ++d) {
-        new_sizes[d] = static_cast<exec_aten::SizesType>(actual_dims.d[d]);
+    nvinfer1::DataType out_dtype =
+        state->cuda_engine->getTensorDataType(name.c_str());
+    int64_t vol = dims_volume(actual_dims);
+    if (vol < 0) {
+      ET_LOG(
+          Error,
+          "TensorRTBackend::execute: unresolved output shape for '%s'",
+          name.c_str());
+      return Error::InvalidState;
+    }
+    size_t actual_bytes =
+        static_cast<size_t>(vol) * trt_dtype_size(out_dtype);
+    output_copies[o].actual_bytes = actual_bytes;
+
+    void* gpu_ptr = nullptr;
+    if (host_ptr != nullptr && et_out.numel() != 0) {
+      cudaPointerAttributes attrs;
+      cudaError_t attr_err = cudaPointerGetAttributes(&attrs, host_ptr);
+      if (attr_err == cudaSuccess &&
+          (attrs.type == cudaMemoryTypeDevice ||
+           attrs.type == cudaMemoryTypeManaged)) {
+        gpu_ptr = host_ptr;
+      } else {
+        cudaGetLastError();
       }
-      et_out.unsafeGetTensorImpl()->set_sizes_contiguous({new_sizes, static_cast<size_t>(actual_dims.nbDims)});
     }
 
-    void* dst_ptr = et_out.mutable_data_ptr();
-    void* trt_ptr = dst_ptr;
-
-    if (!is_cuda_ptr(dst_ptr)) {
-      // CPU output buffer: allocate temporary CUDA memory for TRT to write into
-      size_t nbytes = et_out.nbytes(); // uses updated shape
-      if (cudaMalloc(&temp_output_bufs[o], nbytes) != cudaSuccess) {
-        ET_LOG(Error, "TensorRTBackend::execute: cudaMalloc failed for output %zu", o);
-        free_temp();
-        return Error::MemoryAllocationFailed;
+    if (gpu_ptr == nullptr) {
+      if (o >= state->output_gpu_bufs.size()) {
+        state->output_gpu_bufs.resize(o + 1, nullptr);
+        state->output_buf_sizes.resize(o + 1, 0);
       }
-      trt_ptr = temp_output_bufs[o];
+      // TRT requires a valid 16-byte-aligned device address even for
+      // zero-element bindings; round up to 16 bytes.
+      size_t required = actual_bytes > 0 ? actual_bytes : 16;
+      if (state->output_buf_sizes[o] < required) {
+        if (state->output_gpu_bufs[o]) {
+          cudaFree(state->output_gpu_bufs[o]);
+          state->output_gpu_bufs[o] = nullptr;
+        }
+        cudaError_t alloc_err =
+            cudaMalloc(&state->output_gpu_bufs[o], required);
+        if (alloc_err != cudaSuccess) {
+          ET_LOG(
+              Error,
+              "TensorRTBackend::execute: cudaMalloc(%zu) failed for output "
+              "'%s': %s",
+              required,
+              name.c_str(),
+              cudaGetErrorString(alloc_err));
+          return Error::MemoryAllocationFailed;
+        }
+        state->output_buf_sizes[o] = required;
+      }
+      gpu_ptr = state->output_gpu_bufs[o];
+      output_copies[o].needs_copy = (host_ptr != nullptr && actual_bytes > 0);
     }
 
-    if (!ctx->setTensorAddress(name.c_str(), trt_ptr)) {
-      ET_LOG(Error, "TensorRTBackend::execute: setTensorAddress failed for output '%s'", name.c_str());
-      free_temp();
+    output_copies[o].gpu_ptr = gpu_ptr;
+
+    if (!ctx->setTensorAddress(name.c_str(), gpu_ptr)) {
+      ET_LOG(
+          Error,
+          "TensorRTBackend::execute: setTensorAddress failed for output '%s'",
+          name.c_str());
       return Error::InvalidState;
     }
   }
 
-  // ------------------------------------------------------------------
-  // 4. Enqueue inference on the current CUDA stream
-  // ------------------------------------------------------------------
+  // --------------------------------------------------------------------
+  // 4. Enqueue inference
+  // --------------------------------------------------------------------
   if (!ctx->enqueueV3(stream)) {
     ET_LOG(Error, "TensorRTBackend::execute: enqueueV3 failed");
-    free_temp();
     return Error::InvalidState;
   }
 
-  // ------------------------------------------------------------------
-  // 5. Copy temporary CUDA outputs back to the ExecuTorch CPU buffers
-  // ------------------------------------------------------------------
+  // --------------------------------------------------------------------
+  // 5. Resize output tensors to TRT's inferred shape, then queue any
+  //    device-to-host copies asynchronously so multiple small outputs
+  //    don't pay one host sync each.
+  // --------------------------------------------------------------------
+  bool any_d2h_copy = false;
   for (size_t o = 0; o < num_outputs; ++o) {
-    if (temp_output_bufs[o] != nullptr) {
-      exec_aten::Tensor et_out = args[num_inputs + o]->toTensor();
-      cudaMemcpyAsync(et_out.mutable_data_ptr(), temp_output_bufs[o], et_out.nbytes(), cudaMemcpyDeviceToHost, stream);
+    const std::string& out_name = state->out_binding_names[o];
+    nvinfer1::Dims actual_dims = ctx->getTensorShape(out_name.c_str());
+    exec_aten::Tensor et_out = args[num_inputs + o]->toTensor();
+
+    if (et_out.dim() != actual_dims.nbDims) {
+      ET_LOG(
+          Error,
+          "TensorRTBackend::execute: rank mismatch for output '%s': "
+          "tensor has %d dims, TRT produced %d dims",
+          out_name.c_str(),
+          et_out.dim(),
+          actual_dims.nbDims);
+      return Error::InvalidState;
+    }
+
+    bool shape_changed = false;
+    for (int d = 0; d < actual_dims.nbDims; ++d) {
+      if (et_out.size(d) != actual_dims.d[d]) {
+        shape_changed = true;
+        break;
+      }
+    }
+    if (shape_changed) {
+      std::vector<exec_aten::SizesType> new_sizes(actual_dims.nbDims);
+      for (int d = 0; d < actual_dims.nbDims; ++d) {
+        new_sizes[d] = static_cast<exec_aten::SizesType>(actual_dims.d[d]);
+      }
+      Error resize_err = ::executorch::runtime::resize_tensor(
+          et_out, {new_sizes.data(), new_sizes.size()});
+      if (resize_err != Error::Ok) {
+        ET_LOG(
+            Error,
+            "TensorRTBackend::execute: resize_tensor failed for output '%s'",
+            out_name.c_str());
+        return resize_err;
+      }
+    }
+
+    if (output_copies[o].needs_copy) {
+      // Re-fetch pointer/size after potential resize.
+      void* host_ptr = et_out.mutable_data_ptr();
+      size_t host_bytes = et_out.nbytes();
+      size_t copy_bytes =
+          std::min(output_copies[o].actual_bytes, host_bytes);
+      if (copy_bytes > 0 && host_ptr != nullptr) {
+        cudaError_t cpy_err = cudaMemcpyAsync(
+            host_ptr,
+            output_copies[o].gpu_ptr,
+            copy_bytes,
+            cudaMemcpyDeviceToHost,
+            stream);
+        if (cpy_err != cudaSuccess) {
+          ET_LOG(
+              Error,
+              "TensorRTBackend::execute: D2H copy failed for output '%s': %s",
+              out_name.c_str(),
+              cudaGetErrorString(cpy_err));
+          return Error::InvalidState;
+        }
+        any_d2h_copy = true;
+      }
     }
   }
 
-  // Synchronize so outputs are visible to downstream ExecuTorch ops
-  cudaStreamSynchronize(stream);
+  // Single trailing sync: covers enqueueV3 + all D2H copies.  If there were
+  // no D2H copies but the outputs live on the GPU, callers must sync the
+  // per-thread stream themselves before reading on the host - matches normal
+  // CUDA semantics.
+  if (any_d2h_copy) {
+    cudaError_t sync_err = cudaStreamSynchronize(stream);
+    if (sync_err != cudaSuccess) {
+      ET_LOG(
+          Error,
+          "TensorRTBackend::execute: cudaStreamSynchronize failed: %s",
+          cudaGetErrorString(sync_err));
+      return Error::InvalidState;
+    }
+  }
 
-  free_temp();
   return Error::Ok;
 }
 
-// ---------------------------------------------------------------------------
+// ============================================================================
 // destroy
-//
-// Explicitly destructs the TRTEngine.  The underlying memory was allocated
-// by ExecuTorch's MemoryAllocator and will be reclaimed by the arena.
-// ---------------------------------------------------------------------------
+// ============================================================================
 void TensorRTBackend::destroy(DelegateHandle* handle) const {
-  if (handle != nullptr) {
-    static_cast<core::runtime::TRTEngine*>(handle)->~TRTEngine();
+  if (handle == nullptr) {
+    return;
   }
+  auto* state = static_cast<TRTDelegateState*>(handle);
+
+  // Make sure all in-flight GPU work on this thread's stream is done before
+  // freeing buffers / destroying TRT objects.
+  cudaStreamSynchronize(cudaStreamPerThread);
+
+  for (void* buf : state->input_gpu_bufs) {
+    if (buf) {
+      cudaFree(buf);
+    }
+  }
+  for (void* buf : state->output_gpu_bufs) {
+    if (buf) {
+      cudaFree(buf);
+    }
+  }
+
+  // Member declaration order ensures exec_ctx -> cuda_engine -> runtime.
+  state->~TRTDelegateState();
+  // The underlying arena reclaims the storage.
 }
 
 } // namespace executorch_backend
 } // namespace torch_tensorrt
 
-// ---------------------------------------------------------------------------
-// Static registration – links the name "TensorRTBackend" used in the .pte
+// ============================================================================
+// Static registration - binds the name "TensorRTBackend" used in the .pte
 // file to this implementation at program startup.
-// ---------------------------------------------------------------------------
+// ============================================================================
 namespace {
 
 torch_tensorrt::executorch_backend::TensorRTBackend& get_backend() {
@@ -433,7 +833,9 @@ torch_tensorrt::executorch_backend::TensorRTBackend& get_backend() {
   return backend;
 }
 
-const ::executorch::runtime::Backend kBackendId{"TensorRTBackend", &get_backend()};
+const ::executorch::runtime::Backend kBackendId{
+    "TensorRTBackend",
+    &get_backend()};
 const auto kRegistered = ::executorch::runtime::register_backend(kBackendId);
 
 } // namespace

--- a/libtorchtrt_executorch/CMakeLists.txt
+++ b/libtorchtrt_executorch/CMakeLists.txt
@@ -7,66 +7,22 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-get_filename_component(_torchtrt_packaged_root "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
-if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/core/runtime/runtime.cpp" AND EXISTS "${_torchtrt_packaged_root}/include/torch_tensorrt/core/runtime/runtime.h")
-    set(_torchtrt_source_root "${CMAKE_CURRENT_LIST_DIR}")
-    set(_torchtrt_include_root "${_torchtrt_packaged_root}/include/torch_tensorrt")
-else()
-    get_filename_component(_torchtrt_source_root "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
-    set(_torchtrt_include_root "${_torchtrt_source_root}")
-endif()
-
-set(_torchtrt_executorch_backend_source "${_torchtrt_source_root}/core/runtime/executorch/TensorRTBackend.cpp")
-set(_torchtrt_executorch_backend_include_dir "${_torchtrt_source_root}/core/runtime/executorch")
+# Locate the in-tree TensorRTBackend.cpp source.  This file lives under
+# core/runtime/executorch/ in the source tree and is the only source we
+# need to build for the libtorch-free ExecuTorch backend.
+get_filename_component(_torchtrt_source_root "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
+set(_torchtrt_executorch_backend_source
+    "${_torchtrt_source_root}/core/runtime/executorch/TensorRTBackend.cpp")
+set(_torchtrt_executorch_backend_include_dir
+    "${_torchtrt_source_root}/core/runtime/executorch")
 
 list(APPEND CMAKE_MODULE_PATH "${_torchtrt_source_root}/cmake/Modules")
 
 find_package(TensorRT REQUIRED)
 find_package(CUDAToolkit REQUIRED)
-
-if(NOT Torch_DIR)
-    set(_torchtrt_python_executable "")
-    if(DEFINED PYTHON_EXECUTABLE AND EXISTS "${PYTHON_EXECUTABLE}")
-        set(_torchtrt_python_executable "${PYTHON_EXECUTABLE}")
-    else()
-        find_package(Python3 COMPONENTS Interpreter QUIET)
-        if(Python3_Interpreter_FOUND)
-            set(_torchtrt_python_executable "${Python3_EXECUTABLE}")
-        endif()
-    endif()
-
-    if(_torchtrt_python_executable)
-        execute_process(
-            COMMAND "${_torchtrt_python_executable}" -c "import torch; print(torch.utils.cmake_prefix_path)"
-            RESULT_VARIABLE _torchtrt_torch_prefix_result
-            OUTPUT_VARIABLE _torchtrt_torch_prefix
-            ERROR_QUIET
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-        if(_torchtrt_torch_prefix_result EQUAL 0 AND _torchtrt_torch_prefix)
-            list(APPEND CMAKE_PREFIX_PATH "${_torchtrt_torch_prefix}")
-        endif()
-    endif()
-endif()
-
-find_package(Torch REQUIRED)
 find_package(Threads REQUIRED)
 
-set(_torchtrt_executorch_sources
-    "${_torchtrt_executorch_backend_source}"
-    "${_torchtrt_source_root}/core/runtime/DeviceList.cpp"
-    "${_torchtrt_source_root}/core/runtime/Platform.cpp"
-    "${_torchtrt_source_root}/core/runtime/RTDevice.cpp"
-    "${_torchtrt_source_root}/core/runtime/TRTEngine.cpp"
-    "${_torchtrt_source_root}/core/runtime/TRTEngineProfiler.cpp"
-    "${_torchtrt_source_root}/core/runtime/runtime.cpp"
-    "${_torchtrt_source_root}/core/runtime/runtime_utils.cpp"
-    "${_torchtrt_source_root}/core/util/Exception.cpp"
-    "${_torchtrt_source_root}/core/util/trt_util.cpp"
-    "${_torchtrt_source_root}/core/util/logging/TorchTRTLogger.cpp"
-)
-
-add_library(executorch_trt_backend STATIC ${_torchtrt_executorch_sources})
+add_library(executorch_trt_backend STATIC "${_torchtrt_executorch_backend_source}")
 set_target_properties(executorch_trt_backend
     PROPERTIES
         OUTPUT_NAME "executorch_trt_backend"
@@ -75,16 +31,14 @@ set_target_properties(executorch_trt_backend
 
 target_include_directories(executorch_trt_backend
     PUBLIC
-        "${_torchtrt_include_root}"
-    PRIVATE
         "${_torchtrt_source_root}"
+    PRIVATE
         "${_torchtrt_executorch_backend_include_dir}"
 )
 
 set(_torchtrt_executorch_link_libraries
     CUDA::cudart
     TensorRT::nvinfer
-    torch
     Threads::Threads
 )
 
@@ -112,10 +66,6 @@ elseif(DEFINED EXECUTORCH_ROOT AND EXISTS "${EXECUTORCH_ROOT}/runtime")
     list(APPEND _torchtrt_executorch_link_libraries "${EXECUTORCH_CORE_LIBRARY}")
 else()
     message(FATAL_ERROR "Add ExecuTorch before the Torch-TensorRT ExecuTorch backend or set EXECUTORCH_ROOT to an ExecuTorch source tree")
-endif()
-
-if(NOT WIN32)
-    list(APPEND _torchtrt_executorch_link_libraries stdc++fs)
 endif()
 
 target_link_libraries(executorch_trt_backend


### PR DESCRIPTION
## Problem

The ExecuTorch backend (`core/runtime/executorch/`) exists so users can ship `.pte` models that run on ExecuTorch's standalone runtime with **no libtorch dependency**. That is the entire reason to choose the ExecuTorch path over the JIT/AOTI path.

A recent change to `release/2.12` (cherry-pick of #4238) rewrote `TensorRTBackend.cpp` to use `core::runtime::TRTEngine` — a class that extends `torch::CustomClassHolder` and holds `at::Tensor` and `at::cuda::CUDAStream` members. It also added a direct `c10::cuda::getCurrentCUDAStream(...)` call.

As a result, any binary linking `tensorrt_executorch_backend` now requires `libc10.so`, `libc10_cuda.so`, `libtorch.so`, `libtorch_cpu.so`, and `libtorch_cuda.so` at both link time and runtime — defeating the purpose of the backend.

## Fix

Restore the self-contained design that was in place earlier in the release cycle (and which previously shipped working binaries with `ldd` showing zero libtorch deps).

The runtime no longer references `TRTEngine` or any `at::` / `c10::` / `torch::` symbol. A local `TRTDelegateState` struct holds:

- The three TensorRT objects (`IRuntime`, `ICudaEngine`, `IExecutionContext`), declared so that C++ destroys them in TRT's required order (`exec_ctx → cuda_engine → runtime`).
- Input/output binding names parsed from the serialized blob.
- Grow-only GPU staging buffers cached per binding (so steady-state calls do not allocate).
- A mutex (since `IExecutionContext` is not thread-safe).

The runtime uses `cudaStreamPerThread`, CUDA's per-thread default stream. It honors whatever CUDA context the calling thread has current — including any user-created context — with no extra API surface.

Post-#4238 quality improvements are preserved:

- Dynamic shape handling via `setInputShape` + `inferShapes` + `resize_tensor` on outputs.
- Output size computed from the TRT-inferred volume × dtype size (not from the pre-allocated tensor) to avoid overrun on dynamic shapes.
- Async D2H copies with a single trailing `cudaStreamSynchronize` (avoids one host sync per output).
- Thread-local 16-byte placeholder for empty tensors.

## What is NOT changed

- **Wire format**: vector-of-strings (`SerializedInfoIndex`) is preserved end-to-end. No `.pte` file breakage.
- **Python API**: `torch_tensorrt.save(... output_format='executorch')` produces identical files.
- **Tests**: existing `tests/py/dynamo/executorch/test_*.py` apply as-is.
- **JIT / AOTI runtime**: untouched. `core::runtime::TRTEngine` and the `c10::cuda` call remain there — those paths legitimately depend on libtorch.

## Files changed

- `core/runtime/executorch/TensorRTBackend.cpp` — rewritten on top of the slim `TRTDelegateState`; raw CUDA + nvinfer1 only.
- `core/runtime/executorch/BUILD` — drop `//core/runtime:runtime_base` and `//core/util:prelude` deps; keep nvinfer + executorch headers only.
- `libtorchtrt_executorch/CMakeLists.txt` — drop `find_package(Torch)` and the libtorch-laden sources; build only `TensorRTBackend.cpp` and link only `nvinfer`, `cudart`, and the ExecuTorch headers.

## Verification

```bash
# The regression test:
ldd libtorchtrt_executorch.so | grep -E "libtorch|libc10|libcaffe"
# Expected: empty

nm -D libtorchtrt_executorch.so | grep -E "at::|c10::|torch::"
# Expected: empty

# Functional tests (no changes needed — wire format and API are stable):
pytest tests/py/dynamo/executorch/test_*.py
```

Compile-only symbol audit performed locally on `TensorRTBackend.cpp` shows zero undefined references in the `at::` / `c10::` / `torch::` / `caffe2::` namespaces; all external references are limited to `cudart`, `nvinfer`, the ExecuTorch runtime, and the C++ standard library.

## Migration

- Users producing `.pte` files: no change.
- Users linking `tensorrt_executorch_backend`: no source change required; their link line no longer needs libtorch.
