### PR TITLE
fix: cudnn and efficient attention

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -4232,31 +4232,11 @@ def aten_ops_scaled_dot_product_efficient_attention(
 def scaled_dot_product_cudnn_attention_validator(
     node: Node, settings: Optional[CompilationSettings] = None
 ) -> bool:
-    if args_bounds_check(node.args, 4, False):
-        _LOGGER.debug("compute_log_sumexp is not yet supported.")
-        return False
-
     if args_bounds_check(node.args, 7, False):
         _LOGGER.debug("return_debug_mask is not yet supported.")
         return False
 
-    query_shape, key_shape, value_shape = None, None, None
-    if "val" in node.args[0].meta:
-        query_shape = node.args[0].meta["val"].size()
-    if "val" in node.args[1].meta:
-        key_shape = node.args[1].meta["val"].size()
-    if "val" in node.args[2].meta:
-        value_shape = node.args[2].meta["val"].size()
-    if (
-        query_shape != key_shape
-        or query_shape != value_shape
-        or key_shape != value_shape
-    ):
-        _LOGGER.debug(
-            "query, key, and value have different shapes. Please try setting decompose_attention=True in the compilation settings."
-        )
-        return False
-    return True
+    return scaled_dot_product_efficient_attention_validator(node, settings)
 
 
 @dynamo_tensorrt_converter(

--- a/py/torch_tensorrt/dynamo/conversion/impl/attention.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/attention.py
@@ -436,11 +436,10 @@ def scaled_dot_product_efficient_attention(
         and isinstance(key.shape[1], int)
         and key.shape[1] > 0
     ):
-        shape_layer = ctx.net.add_shape(key)
-        shape_layer.name = name + "_key_shape"
         shuffle = ctx.net.add_shuffle(scaled_query)
-        shuffle.set_input(1, shape_layer.get_output(0))
-        shuffle.name = name + "_fix_head_dim"
+        shuffle.name = name + "_fix_query_num_heads"
+        shuffle.zero_is_placeholder = True
+        shuffle.reshape_dims = (0, key.shape[1], 0, 0)
         scaled_query = shuffle.get_output(0)
 
     mask_tensor = None


### PR DESCRIPTION
# Description

Since `scaled_dot_product_cudnn_attention` reuses `scaled_dot_product_efficient_attention`, the validator should be changed accordingly. For efficient SDPA, the num of heads should be the same as described in the inline comment but `seq_q` and `seq_k` could be different. 

This PR fixes the graph break issue in Alpamayo. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
