### PR TITLE
docs: Update nightly package install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install torch-tensorrt
 
 Nightly versions of Torch-TensorRT are published on the PyTorch package index
 ```bash
-pip install --pre torch-tensorrt --index-url https://download.pytorch.org/whl/nightly/cu130
+pip install --pre torch-tensorrt --index-url https://download.pytorch.org/whl/nightly/cu130 --extra-index-url https://pypi.org/simple
 ```
 
 Torch-TensorRT is also distributed in the ready-to-run [NVIDIA NGC PyTorch Container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch) which has all dependencies with the proper versions and example notebooks included.


### PR DESCRIPTION
# Description

The existing nightly install command uses --index-url, which makes the PyTorch nightly index the only package source. This can fail in clean environments when Torch-TensorRT dependencies must be resolved from PyPI. Adding --extra-index-url https://pypi.org/simple keeps the PyTorch nightly index available for Torch/PyTorch nightly wheels while allowing pip to resolve PyPI-hosted dependencies.


## Type of change

Please delete options that are not relevant and/or add your own.


# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
