### PR TITLE
fix: cap tensorrt_rtx requirement below 1.5.0 on release/2.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -839,7 +839,7 @@ def get_x86_64_requirements(base_requirements):
         ]
         if USE_TRT_RTX:
             return requirements + [
-                "tensorrt_rtx>=1.4.0.76",
+                "tensorrt_rtx>=1.4.0.76,<1.5.0",
             ]
         else:
             requirements = requirements + [


### PR DESCRIPTION
# Description

The `torch_tensorrt_rtx` wheel on the `release/2.12` line is built and tested against the TRT-RTX 1.4 series. The current `setup.py` requirement `"tensorrt_rtx>=1.4.0.76"` has no upper bound, so the latest `tensorrt_rtx` 1.5. release (with breaking API changes) produces a broken install.

Tighten the pin to `>=1.4.0.76,<1.5.0` so the 2.12 line stays on the 1.4 series. `main` is unaffected and continues to track the latest TRT-RTX.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified