### PR TITLE
fix(lowering): use factored sqrt form for complex acosh rewrite

### DIFF
--- a/py/torch_tensorrt/dynamo/lowering/passes/complex_graph_rewrite.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/complex_graph_rewrite.py
@@ -7,7 +7,6 @@ import torch
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx import GraphModule, Node
 from torch.fx.experimental.proxy_tensor import unset_fake_temporarily
-
 from torch_tensorrt.dynamo._settings import CompilationSettings
 from torch_tensorrt.dynamo.lowering._SubgraphBuilder import SubgraphBuilder
 from torch_tensorrt.dynamo.lowering.passes.pass_utils import (
@@ -1142,19 +1141,20 @@ class ComplexGraphRewriter:
 
     @_complex_unpacker(torch.ops.aten.acosh.default)
     def _rewrite_acosh(self, node: Node) -> bool:
-        # acosh(z) = log(z + sqrt(z² - 1))
+        # acosh(z) = log(z + sqrt(z+1) * sqrt(z-1))
+        # The factored sqrt form matches torch.acosh's principal branch
+        # (C99 cacosh convention). The simpler log(z + sqrt(z² - 1)) would
+        # pick the opposite Riemann sheet whenever Re(z) < 0.
         inp = node.args[0]
         with SubgraphBuilder(self.gm.graph, node) as b:
             re, im = self._inline_select_re_im(b, inp)
-            re2 = b(torch.ops.aten.mul.Tensor, re, re)
-            im2 = b(torch.ops.aten.mul.Tensor, im, im)
-            z2_re = b(torch.ops.aten.sub.Tensor, re2, im2)
-            re_im = b(torch.ops.aten.mul.Tensor, re, im)
-            z2_im = b(torch.ops.aten.mul.Tensor, re_im, 2.0)
-            w_re = b(torch.ops.aten.sub.Scalar, z2_re, 1.0)  # w = z²-1
-            sq_re, sq_im = self._inline_complex_sqrt(b, w_re, z2_im)
-            sum_re = b(torch.ops.aten.add.Tensor, re, sq_re)
-            sum_im = b(torch.ops.aten.add.Tensor, im, sq_im)
+            zp1_re = b(torch.ops.aten.add.Scalar, re, 1.0)
+            zm1_re = b(torch.ops.aten.sub.Scalar, re, 1.0)
+            sp_re, sp_im = self._inline_complex_sqrt(b, zp1_re, im)
+            sm_re, sm_im = self._inline_complex_sqrt(b, zm1_re, im)
+            prod_re, prod_im = self._inline_complex_mul(b, sp_re, sp_im, sm_re, sm_im)
+            sum_re = b(torch.ops.aten.add.Tensor, re, prod_re)
+            sum_im = b(torch.ops.aten.add.Tensor, im, prod_im)
             log_re, log_im = self._inline_complex_log(b, sum_re, sum_im)
             out = self._inline_cat_re_im(b, log_re, log_im)
             node.replace_all_uses_with(out)


### PR DESCRIPTION
# Description

`torch.acosh` for complex inputs follows the C99 `cacosh` convention, `acosh(z) = log(z + sqrt(z+1) * sqrt(z-1))`. The lowering pass for `torch.ops.aten.acosh.default` was using the algebraically equivalent `log(z + sqrt(z^2 - 1))`, but those two forms pick **opposite Riemann sheets** whenever `Re(z) < 0` — the lowered output ends up as the additive inverse of the eager `torch.acosh(z)` for those inputs.

`tests/py/dynamo/lowering/test_complex_rewrite.py::test_acosh` uses `torch.randn(3, 4, dtype=torch.complex64) + 2.0` as input. Since `randn(complex64)` draws Re from `N(0, 0.5)`, the `+2.0` shift only keeps `Re(z) > 0` about 97% of the time — a single element drops below zero in roughly 2.6% of runs, flipping the sign of one of the twelve lowered outputs and tripping the test's `1e-4` numerical tolerance, producing the intermittent `Mismatched elements: 1 / 12 (8.3%) ... greatest absolute difference 1.46` failure.

Rewrite `_rewrite_acosh` to compute the factored form `log(z + sqrt(z+1) * sqrt(z-1))` using the existing `_inline_complex_sqrt` and `_inline_complex_mul` helpers. Verified across 2000 random seeds drawn without any real-part shift (so `Re(z)` is freely negative) — 0 failures, max abs error ~1e-7. Full `tests/py/dynamo/lowering/test_complex_rewrite.py` (105 tests) passes.

Companion to #4300 (same fix on `release/2.12`).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
