### PR TITLE
feat: custom binding names for out of runtime deployment

### DIFF
--- a/docsrc/tutorials/deployment/index.rst
+++ b/docsrc/tutorials/deployment/index.rst
@@ -11,4 +11,5 @@ complex-valued model support.
    serving_torch_tensorrt_with_triton
    cross_compile_windows
    Example: Cross-runtime Compilation for Windows <../_rendered_examples/dynamo/cross_runtime_compilation_for_windows>
+   Example: Naming engine I/O bindings <../_rendered_examples/dynamo/engine_converter_binding_names>
    distributed_inference

--- a/examples/dynamo/README.rst
+++ b/examples/dynamo/README.rst
@@ -27,3 +27,4 @@ Model Zoo
 * :ref:`_torch_export_flux_dev`: Compiling FLUX.1-dev model using AOT workflow (`ir=dynamo`)
 * :ref:`debugger_example`: Debugging Torch-TensorRT Compilation
 * :ref:`torch_export_3d_rope`: Compiling a 3D RoPE video-transformer block with complex numerics support
+* :ref:`engine_converter_binding_names`: Naming input / output bindings when emitting a raw serialized TRT engine

--- a/examples/dynamo/engine_converter_binding_names.py
+++ b/examples/dynamo/engine_converter_binding_names.py
@@ -1,0 +1,334 @@
+"""
+.. _engine_converter_binding_names:
+
+Naming Engine Bindings with ``convert_exported_program_to_serialized_trt_engine``
+=================================================================================
+
+When you use ``torch_tensorrt.dynamo.convert_exported_program_to_serialized_trt_engine``
+to produce a raw serialized TensorRT engine, the engine's binding names are
+determined by Torch-TensorRT's default policy:
+
+* **Inputs** get the FX placeholder names from the exported program (typically
+  the names of your ``forward()`` arguments).
+* **Outputs** get auto-generated names ``output0``, ``output1``, etc.
+
+Many production runtimes (Triton Inference Server, custom C++ harnesses,
+ONNX-style integrations) bind tensors by name rather than position, and the
+auto-generated names often don't line up with what the rest of the serving
+stack expects.  The engine converter exposes three keyword arguments that
+let you supply binding names shaped like your model's inputs and return
+value:
+
+* ``arg_input_binding_names`` — pytree of strings matching ``arg_inputs``
+* ``kwarg_input_binding_names`` — pytree of strings matching ``kwarg_inputs``
+* ``output_binding_names`` — pytree of strings matching the model's return
+
+The shape of each kwarg directly mirrors how you already pass the values
+themselves: ``arg_input_binding_names`` lines up with ``arg_inputs``,
+``kwarg_input_binding_names`` lines up with ``kwarg_inputs``.
+
+A note on "the return shape"
+----------------------------
+
+A Python function always returns exactly one value.  ``return a, b`` is a
+single tuple-shaped return value; ``return {"x": a, "y": b}`` is a single
+dict-shaped return value.  Whatever that value is, the exported program
+captures it as a pytree.  Its *leaves* — the individual tensors at the
+bottom of the structure — become engine bindings, and you supply names in
+the same pytree shape.  Inputs work the same way: ``arg_inputs`` is itself
+a pytree (a tuple of positional values, each of which can be a tensor or
+a nested collection of tensors); ``kwarg_inputs`` is a dict-shaped pytree.
+
+How it works
+------------
+
+The exported program already carries pytree specs (``args_spec`` for
+``arg_inputs``, ``kwargs_spec`` for ``kwarg_inputs``, ``out_spec`` for the
+return value) that fully describe the structure of inputs and outputs.
+When you provide binding names as a pytree of strings, Torch-TensorRT
+runs ``pytree.tree_flatten`` and compares the resulting ``TreeSpec``
+against the exported program's spec.  When they match, the flat list of
+names maps 1:1 to FX's flattened placeholder / output order — no runtime
+queue, no in-band validation, just an up-front structural check.
+"""
+
+import torch
+import torch_tensorrt
+from torch_tensorrt.dynamo._compiler import BindingNameMismatchError
+
+# %%
+import tensorrt as trt
+
+DEVICE = torch.device("cuda", 0)
+
+
+# %%
+# Helpers
+# --------
+#
+# A pair of small helpers: one reads binding names off a deserialized
+# engine, the other actually runs the engine via the native TRT Python
+# API.  The "execute via native TRT" path is what production deployments
+# use — the whole point of this API is that the binding names you supply
+# are the names you'll bind by at execution time, not just metadata in
+# the engine file.
+
+
+def deserialize(engine_bytes: bytes) -> trt.ICudaEngine:
+    runtime = trt.Runtime(trt.Logger(trt.Logger.WARNING))
+    return runtime.deserialize_cuda_engine(engine_bytes)
+
+
+def binding_names(engine: trt.ICudaEngine, mode: trt.TensorIOMode) -> list[str]:
+    return [
+        engine.get_tensor_name(i)
+        for i in range(engine.num_io_tensors)
+        if engine.get_tensor_mode(engine.get_tensor_name(i)) == mode
+    ]
+
+
+_TRT_TO_TORCH_DTYPE = {
+    trt.DataType.FLOAT: torch.float32,
+    trt.DataType.HALF: torch.float16,
+    trt.DataType.INT32: torch.int32,
+    trt.DataType.INT64: torch.int64,
+    trt.DataType.BOOL: torch.bool,
+    trt.DataType.BF16: torch.bfloat16,
+}
+
+
+def run_engine(engine: trt.ICudaEngine, named_inputs: dict) -> dict:
+    """Execute an engine via the native TRT Python API.
+
+    ``named_inputs`` is a {binding_name: contiguous CUDA tensor} dict.
+    Returns {binding_name: output tensor}.  Demonstrates that the
+    user-supplied binding names are what production C++/Python TRT
+    runtime code will bind by.
+    """
+    context = engine.create_execution_context()
+    for name, tensor in named_inputs.items():
+        context.set_input_shape(name, tuple(tensor.shape))
+        context.set_tensor_address(name, tensor.data_ptr())
+
+    outputs = {}
+    for i in range(engine.num_io_tensors):
+        name = engine.get_tensor_name(i)
+        if engine.get_tensor_mode(name) != trt.TensorIOMode.OUTPUT:
+            continue
+        shape = tuple(context.get_tensor_shape(name))
+        dtype = _TRT_TO_TORCH_DTYPE[engine.get_tensor_dtype(name)]
+        out = torch.empty(shape, dtype=dtype, device=DEVICE)
+        context.set_tensor_address(name, out.data_ptr())
+        outputs[name] = out
+
+    stream = torch.cuda.Stream(device=DEVICE)
+    with torch.cuda.stream(stream):
+        context.execute_async_v3(stream.cuda_stream)
+    stream.synchronize()
+    return outputs
+
+
+# %%
+# Case 1 — positional args, tuple-shaped return
+# ----------------------------------------------
+#
+# Start with the most common shape: ``forward(x)`` returning a 2-tuple.
+# ``arg_input_binding_names`` mirrors ``arg_inputs`` (a 1-tuple here);
+# ``output_binding_names`` mirrors the return tuple.
+
+
+class TwoHeads(torch.nn.Module):
+    def forward(self, x: torch.Tensor):
+        return torch.relu(x), torch.tanh(x)
+
+
+two_heads = TwoHeads().eval().cuda().half()
+x = torch.randn(2, 3, device=DEVICE, dtype=torch.float16)
+exported = torch.export.export(two_heads, (x,))
+
+engine_bytes = torch_tensorrt.dynamo.convert_exported_program_to_serialized_trt_engine(
+    exported,
+    arg_inputs=(x,),
+    arg_input_binding_names=("input_image",),
+    output_binding_names=("relu_out", "tanh_out"),
+    require_full_compilation=True,
+    min_block_size=1,
+    use_python_runtime=False,
+    immutable_weights=True,
+)
+engine = deserialize(engine_bytes)
+print("Case 1 inputs:", binding_names(engine, trt.TensorIOMode.INPUT))
+print("Case 1 outputs:", binding_names(engine, trt.TensorIOMode.OUTPUT))
+# Case 1 inputs: ['input_image']
+# Case 1 outputs: ['relu_out', 'tanh_out']
+
+# Run the engine through the native TRT API using the names we requested.
+trt_outs = run_engine(engine, {"input_image": x.contiguous()})
+with torch.no_grad():
+    ref_relu, ref_tanh = two_heads(x)
+torch.testing.assert_close(trt_outs["relu_out"], ref_relu, rtol=1e-2, atol=1e-2)
+torch.testing.assert_close(trt_outs["tanh_out"], ref_tanh, rtol=1e-2, atol=1e-2)
+print("Case 1 native TRT run matches PyTorch.")
+
+
+# %%
+# Case 2 — keyword-only inputs
+# ------------------------------
+#
+# When the model takes keyword arguments, you pass ``kwarg_inputs`` and
+# match its shape with ``kwarg_input_binding_names``.  Note we leave
+# ``arg_input_binding_names`` unset because ``arg_inputs`` is empty.
+
+
+class KwargOnly(torch.nn.Module):
+    def forward(self, image: torch.Tensor, positions: torch.Tensor):
+        return image + positions
+
+
+kwarg_only = KwargOnly().eval().cuda().half()
+image = torch.randn(2, 3, device=DEVICE, dtype=torch.float16)
+positions = torch.randn(2, 3, device=DEVICE, dtype=torch.float16)
+kw_exported = torch.export.export(
+    kwarg_only,
+    args=(),
+    kwargs={"image": image, "positions": positions},
+)
+
+engine_bytes = torch_tensorrt.dynamo.convert_exported_program_to_serialized_trt_engine(
+    kw_exported,
+    arg_inputs=(),
+    kwarg_inputs={"image": image, "positions": positions},
+    kwarg_input_binding_names={"image": "rgb_in", "positions": "pos_in"},
+    output_binding_names="combined",
+    require_full_compilation=True,
+    min_block_size=1,
+    use_python_runtime=False,
+    immutable_weights=True,
+)
+engine = deserialize(engine_bytes)
+print("Case 2 inputs:", sorted(binding_names(engine, trt.TensorIOMode.INPUT)))
+print("Case 2 outputs:", binding_names(engine, trt.TensorIOMode.OUTPUT))
+# Case 2 inputs: ['pos_in', 'rgb_in']
+# Case 2 outputs: ['combined']
+
+trt_outs = run_engine(
+    engine,
+    {"rgb_in": image.contiguous(), "pos_in": positions.contiguous()},
+)
+with torch.no_grad():
+    ref = kwarg_only(image=image, positions=positions)
+torch.testing.assert_close(trt_outs["combined"], ref, rtol=1e-2, atol=1e-2)
+print("Case 2 native TRT run matches PyTorch.")
+
+
+# %%
+# Case 3 — nested collections as inputs and outputs
+# --------------------------------------------------
+#
+# Inputs and outputs can be arbitrary nested collections of tensors —
+# tuples of dicts of tensors, lists of tuples, anything ``pytree`` can
+# flatten.  The binding-name kwargs follow the same nesting.  Here the
+# model takes a tuple of two cameras (each a dict of two tensors) and
+# returns a dict of feature stacks.
+
+
+class CameraTower(torch.nn.Module):
+    def forward(self, cameras: tuple, bias: torch.Tensor):
+        feats = []
+        for cam in cameras:
+            feats.append(cam["rgb"] + cam["depth"] + bias)
+        return {"primary": feats[0], "secondary": feats[1]}
+
+
+def _cam():
+    return {
+        "rgb": torch.randn(2, 3, device=DEVICE, dtype=torch.float16),
+        "depth": torch.randn(2, 3, device=DEVICE, dtype=torch.float16),
+    }
+
+
+camera_tower = CameraTower().eval().cuda().half()
+cameras = (_cam(), _cam())
+bias = torch.randn(2, 3, device=DEVICE, dtype=torch.float16)
+nested_exported = torch.export.export(camera_tower, args=(cameras, bias))
+
+engine_bytes = torch_tensorrt.dynamo.convert_exported_program_to_serialized_trt_engine(
+    nested_exported,
+    arg_inputs=(cameras, bias),
+    arg_input_binding_names=(
+        (
+            {"rgb": "cam0_rgb", "depth": "cam0_depth"},
+            {"rgb": "cam1_rgb", "depth": "cam1_depth"},
+        ),
+        "global_bias",
+    ),
+    output_binding_names={"primary": "p_feats", "secondary": "s_feats"},
+    require_full_compilation=True,
+    min_block_size=1,
+    use_python_runtime=False,
+    immutable_weights=True,
+)
+engine = deserialize(engine_bytes)
+print("Case 3 inputs:", sorted(binding_names(engine, trt.TensorIOMode.INPUT)))
+print("Case 3 outputs:", sorted(binding_names(engine, trt.TensorIOMode.OUTPUT)))
+# Case 3 inputs: ['cam0_depth', 'cam0_rgb', 'cam1_depth', 'cam1_rgb', 'global_bias']
+# Case 3 outputs: ['p_feats', 's_feats']
+
+trt_outs = run_engine(
+    engine,
+    {
+        "cam0_rgb": cameras[0]["rgb"].contiguous(),
+        "cam0_depth": cameras[0]["depth"].contiguous(),
+        "cam1_rgb": cameras[1]["rgb"].contiguous(),
+        "cam1_depth": cameras[1]["depth"].contiguous(),
+        "global_bias": bias.contiguous(),
+    },
+)
+with torch.no_grad():
+    ref = camera_tower(cameras, bias)
+torch.testing.assert_close(trt_outs["p_feats"], ref["primary"], rtol=1e-2, atol=1e-2)
+torch.testing.assert_close(trt_outs["s_feats"], ref["secondary"], rtol=1e-2, atol=1e-2)
+print("Case 3 native TRT run matches PyTorch.")
+
+
+# %%
+# Case 4 — structural validation
+# -------------------------------
+#
+# If the shape of any of the binding-name kwargs doesn't match the
+# exported program's spec, the converter raises
+# ``BindingNameMismatchError`` before any TensorRT network construction.
+# The error message shows the expected structure plus a leaf-position
+# listing — you can read the correct shape off the error and re-run.
+
+try:
+    torch_tensorrt.dynamo.convert_exported_program_to_serialized_trt_engine(
+        exported,
+        arg_inputs=(x,),
+        output_binding_names=("only_one",),  # wrong arity for the 2-tuple return
+        require_full_compilation=True,
+        min_block_size=1,
+        use_python_runtime=False,
+        immutable_weights=True,
+    )
+except BindingNameMismatchError as err:
+    print("Caught BindingNameMismatchError as expected.")
+    print(str(err).splitlines()[0])
+
+
+# %%
+# Notes
+# -----
+#
+# * The binding-name kwargs are *parallel* to the input kwargs they refer
+#   to: ``arg_input_binding_names`` matches ``arg_inputs``,
+#   ``kwarg_input_binding_names`` matches ``kwarg_inputs``.  Skip either
+#   one if the corresponding input slot is empty.
+# * Duplicate names within any individual list, or across inputs and
+#   outputs, are rejected at the API boundary — TensorRT requires
+#   binding names to be globally unique.
+# * This API is **only** available on
+#   ``convert_exported_program_to_serialized_trt_engine``.  ``compile()``
+#   and ``dynamo.compile()`` produce ``TorchTensorRTModule`` artifacts
+#   whose runtime depends on the default naming policy, so they
+#   intentionally don't expose this knob.

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -5,6 +5,7 @@ import logging
 import os
 import platform
 import warnings
+
 from typing import Any, Collection, Dict, List, Optional, Sequence, Tuple, Union
 
 import sympy
@@ -1492,6 +1493,181 @@ def compile_module(
     return partitioned_module
 
 
+class BindingNameMismatchError(ValueError):
+    """Raised when user-supplied ``input_binding_names`` / ``output_binding_names``
+    don't match the exported program's pytree spec.
+
+    The user provides names shaped like their original ``forward()`` would
+    receive (for inputs) or return (for outputs).  We flatten via
+    ``pytree.tree_flatten`` and compare the resulting ``TreeSpec`` against
+    the spec the exported program already carries — they must be equal,
+    which guarantees a 1:1 mapping between the user's structured names and
+    FX's flattened placeholder / output order.  No runtime queue, no
+    in-band validator: spec equality up front, single flat list passed
+    through to the interpreter.
+
+    The error message shows both specs side-by-side plus a per-leaf path
+    listing of what each binding slot expects, so the user can read the
+    correct shape off the error and re-run.
+    """
+
+    def __init__(
+        self,
+        role: str,
+        expected_spec: Any,
+        provided: Any = None,
+        provided_spec: Any = None,
+        reason: str = "spec_mismatch",
+    ) -> None:
+        self.role = role
+        self.expected_spec = expected_spec
+        self.provided = provided
+        self.provided_spec = provided_spec
+        self.reason = reason
+        super().__init__(self._format_message())
+
+    def _expected_leaf_paths(self) -> List[str]:
+        import torch.utils._pytree as pytree
+
+        if self.expected_spec is None:
+            return []
+        # Reconstruct a dummy pytree from the spec so we can walk paths via
+        # tree_flatten_with_path.  Each leaf carries its position description.
+        try:
+            dummy = pytree.tree_unflatten(
+                [object()] * self.expected_spec.num_leaves, self.expected_spec
+            )
+            paths_leaves = pytree.tree_flatten_with_path(dummy)[0]
+            return [pytree.keystr(p) or "<root>" for p, _ in paths_leaves]
+        except Exception:
+            return []
+
+    def _format_message(self) -> str:
+        role_kw = f"{self.role}_binding_names"
+        paths = self._expected_leaf_paths()
+        expected_section = (
+            f"Expected structure (from exported program "
+            f"{self.role}_spec):\n  {self.expected_spec}"
+        )
+        if paths:
+            expected_section += (
+                "\n\nExpected leaf positions (in FX flattening order):\n"
+                + "\n".join(f"  [{i}] {p}" for i, p in enumerate(paths))
+            )
+
+        if self.reason == "duplicate":
+            return (
+                f"{role_kw} contains duplicate names. Each binding name "
+                f"must be unique.\n\nProvided structure:\n  {self.provided!r}"
+            )
+        if self.reason == "overlap":
+            return (
+                "Provided input_binding_names and output_binding_names "
+                "share one or more names. Engine binding names must be "
+                "globally unique.\n\n"
+                f"Overlap: {self.provided!r}"
+            )
+        if self.reason == "non_string_leaf":
+            return (
+                f"{role_kw} pytree leaves must all be strings.\n"
+                f"Provided structure:\n  {self.provided!r}"
+            )
+
+        # spec_mismatch
+        return (
+            f"{role_kw} structure does not match the exported program's "
+            f"{self.role}_spec.\n\n"
+            f"Provided structure:\n  {self.provided_spec}\n\n"
+            f"{expected_section}\n\n"
+            f"Hint: pass a pytree of strings whose structure matches the "
+            f"exported program's "
+            f"{'(args, kwargs)' if self.role == 'input' else 'forward() return value'}."
+        )
+
+
+def _binding_name_specs(
+    exported_program: ExportedProgram,
+) -> Tuple[Optional[Any], Optional[Any], Optional[Any]]:
+    """Extract (args_spec, kwargs_spec, out_spec) from an exported program.
+
+    ``in_spec`` on an exported program is a 2-tuple TreeSpec of
+    ``(args_spec, kwargs_spec)`` that mirrors how the program was traced.
+    We return them split so the API can validate ``arg_input_binding_names``
+    against args_spec and ``kwarg_input_binding_names`` against kwargs_spec
+    independently — matching the shape of the existing ``arg_inputs`` /
+    ``kwarg_inputs`` kwargs.  ``out_spec`` is the return spec.
+    """
+    args_spec = kwargs_spec = out_spec = None
+    if exported_program.module_call_graph:
+        sig = exported_program.module_call_graph[0].signature
+        in_spec = getattr(sig, "in_spec", None)
+        out_spec = getattr(sig, "out_spec", None)
+        if in_spec is not None:
+            try:
+                args_spec = in_spec.child(0)
+                kwargs_spec = in_spec.child(1)
+            except (AttributeError, IndexError):
+                pass
+    return args_spec, kwargs_spec, out_spec
+
+
+def _resolve_pytree_binding_names(
+    user: Any,
+    role: str,
+    expected_spec: Any,
+) -> Optional[List[str]]:
+    """Flatten the user's pytree of names and verify spec equality.
+
+    Returns the flat list of names in FX flattening order, or ``None`` when
+    no override was provided.  Raises :class:`BindingNameMismatchError` on
+    any structural / typing / duplicate problem.
+    """
+    if user is None:
+        return None
+
+    import torch.utils._pytree as pytree
+
+    if expected_spec is None:
+        # Exported program doesn't carry a spec for this slot — fall back
+        # to a plain pytree flatten with no structural validation.
+        leaves, _ = pytree.tree_flatten(user)
+        if not all(isinstance(x, str) for x in leaves):
+            raise BindingNameMismatchError(
+                role=role,
+                expected_spec=None,
+                provided=user,
+                reason="non_string_leaf",
+            )
+        return list(leaves)
+
+    leaves, user_spec = pytree.tree_flatten(user)
+    if not all(isinstance(x, str) for x in leaves):
+        raise BindingNameMismatchError(
+            role=role,
+            expected_spec=expected_spec,
+            provided=user,
+            reason="non_string_leaf",
+        )
+
+    if user_spec != expected_spec:
+        raise BindingNameMismatchError(
+            role=role,
+            expected_spec=expected_spec,
+            provided=user,
+            provided_spec=user_spec,
+            reason="spec_mismatch",
+        )
+
+    if len(set(leaves)) != len(leaves):
+        raise BindingNameMismatchError(
+            role=role,
+            expected_spec=expected_spec,
+            provided=user,
+            reason="duplicate",
+        )
+    return list(leaves)
+
+
 def convert_exported_program_to_serialized_trt_engine(
     exported_program: ExportedProgram,
     inputs: Optional[Sequence[Sequence[Any]]] = None,
@@ -1541,6 +1717,9 @@ def convert_exported_program_to_serialized_trt_engine(
     decompose_attention: bool = _defaults.DECOMPOSE_ATTENTION,
     attn_bias_is_causal: bool = _defaults.ATTN_BIAS_IS_CAUSAL,
     lift_mutable_buffers: bool = False,
+    arg_input_binding_names: Any = None,
+    kwarg_input_binding_names: Any = None,
+    output_binding_names: Any = None,
     **kwargs: Any,
 ) -> bytes:
     """Convert an ExportedProgram to a serialized TensorRT engine
@@ -1861,12 +2040,55 @@ def convert_exported_program_to_serialized_trt_engine(
         exported_program, list(trt_arg_inputs), trt_kwarg_inputs
     )[0]
 
+    # Validate user-provided pytree-shaped binding names against the
+    # exported program's args / kwargs / output specs.  The shape of these
+    # kwargs mirrors arg_inputs / kwarg_inputs: caller passes a pytree of
+    # strings in the same shape as the values it would pass at runtime.
+    # Spec / typing / duplicate errors fire here before any TRT work.
+    args_spec, kwargs_spec, out_spec = _binding_name_specs(exported_program)
+    arg_names = _resolve_pytree_binding_names(
+        arg_input_binding_names, role="arg_input", expected_spec=args_spec
+    )
+    kwarg_names = _resolve_pytree_binding_names(
+        kwarg_input_binding_names, role="kwarg_input", expected_spec=kwargs_spec
+    )
+    # FX flattens placeholders in (args, kwargs) order — concatenate the
+    # two resolved lists in the same order to get the positional input list.
+    if arg_names is None and kwarg_names is None:
+        flat_input_names: Optional[List[str]] = None
+    else:
+        flat_input_names = list(arg_names or []) + list(kwarg_names or [])
+
+    flat_output_names = _resolve_pytree_binding_names(
+        output_binding_names, role="output", expected_spec=out_spec
+    )
+
+    if flat_input_names is not None:
+        if len(set(flat_input_names)) != len(flat_input_names):
+            raise BindingNameMismatchError(
+                role="input",
+                expected_spec=None,
+                provided=flat_input_names,
+                reason="duplicate",
+            )
+    if flat_input_names is not None and flat_output_names is not None:
+        overlap = set(flat_input_names) & set(flat_output_names)
+        if overlap:
+            raise BindingNameMismatchError(
+                role="input",
+                expected_spec=None,
+                provided=sorted(overlap),
+                reason="overlap",
+            )
+
     try:
         interpreter_result = interpret_module_to_result(
             gm,
             inputs=flattened_input_list,
             settings=settings,
             engine_cache=engine_cache,
+            input_binding_names=flat_input_names,
+            output_binding_names=flat_output_names,
         )
     except UnsupportedOperatorException as e:
         logger.error(

--- a/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
+++ b/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
@@ -15,7 +15,6 @@ from typing import (
 )
 
 import numpy as np
-import tensorrt as trt
 import torch
 import torch.fx
 from torch.fx.experimental.proxy_tensor import unset_fake_temporarily
@@ -52,6 +51,8 @@ from torch_tensorrt.dynamo.utils import (
     validate_optimization_profiles,
 )
 from torch_tensorrt.logging import TRT_LOGGER
+
+import tensorrt as trt
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -95,6 +96,8 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
         compilation_settings: CompilationSettings = CompilationSettings(),
         engine_cache: Optional[BaseEngineCache] = None,
         *,
+        input_binding_names: Optional[Sequence[str]] = None,
+        output_binding_names: Optional[Sequence[str]] = None,
         _debugger_config: Optional[DebuggerConfig] = None,
     ):
         super().__init__(module)
@@ -164,6 +167,18 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
         # `kind_str` is "kv_cache_update" or "user". Populated by aliased
         # converters and reconciled with engine.get_aliased_input_tensor.
         self._aliased_io: Dict[str, Tuple[str, str]] = {}
+
+        # User-supplied binding-name overrides (engine-converter API only).
+        # The caller has already validated these against the exported
+        # program's in_spec / out_spec, so the lists are guaranteed to have
+        # one entry per placeholder / output in FX's flattened order.  The
+        # interpreter just indexes into them positionally.
+        self._user_input_binding_names: Optional[List[str]] = (
+            list(input_binding_names) if input_binding_names is not None else None
+        )
+        self._user_output_binding_names: Optional[List[str]] = (
+            list(output_binding_names) if output_binding_names is not None else None
+        )
         self._itensor_to_tensor_meta: Dict[trt.tensorrt.ITensor, TensorMetadata] = (
             dict()
         )
@@ -570,8 +585,18 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
         return result
 
     def placeholder(self, target: str, args: Any, kwargs: Any) -> trt.ITensor:
-        self._input_names.append(target)
-        current_input = self.input_specs[self.input_specs_iter]
+        # Determine the binding name.  Default policy is the FX target name;
+        # the engine-converter API may override via input_binding_names,
+        # already validated by the caller to have one entry per placeholder
+        # in FX flattening order.
+        idx = self.input_specs_iter
+        if self._user_input_binding_names is not None:
+            binding_name = self._user_input_binding_names[idx]
+        else:
+            binding_name = target
+
+        self._input_names.append(binding_name)
+        current_input = self.input_specs[idx]
         self.input_specs_iter += 1
         # Set optimization profile for dynamic input shape
         shape = None
@@ -592,9 +617,11 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
                 if current_input.is_shape_tensor:
                     # For shape_tensors, min/opt/max_shapes correspond to actual
                     # values of the shapes provided during runtime.
-                    opt_profile.set_shape_input(target, min_shape, opt_shape, max_shape)
+                    opt_profile.set_shape_input(
+                        binding_name, min_shape, opt_shape, max_shape
+                    )
                 else:
-                    opt_profile.set_shape(target, min_shape, opt_shape, max_shape)
+                    opt_profile.set_shape(binding_name, min_shape, opt_shape, max_shape)
 
             # The INetwork input shape uses the union envelope to mark which
             # dims are dynamic (-1). A dim is static only if it is identical
@@ -631,11 +658,12 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
 
         trt_input_dtype = current_input.dtype.to(trt.DataType, use_default=True)
         _LOGGER.debug(
-            f"Adding input to in-progress INetwork: {target} [shape={shape}, dtype={trt_input_dtype}]"
+            f"Adding input to in-progress INetwork: {binding_name} "
+            f"[shape={shape}, dtype={trt_input_dtype}]"
         )
 
         return self.ctx.net.add_input(
-            name=target,
+            name=binding_name,
             shape=tuple(shape),
             dtype=trt_input_dtype,
         )
@@ -779,7 +807,13 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
                 continue
             marked_outputs_ids.append(id(output))
 
-            name = f"output{i}"
+            # Default policy is "output{i}"; engine-converter API may override
+            # via output_binding_names, already validated by the caller to
+            # have one entry per output node in FX flattening order.
+            if self._user_output_binding_names is not None:
+                name = self._user_output_binding_names[i]
+            else:
+                name = f"output{i}"
 
             if self.output_dtypes is not None:
                 output_dtype = self.output_dtypes[i]

--- a/py/torch_tensorrt/dynamo/conversion/_conversion.py
+++ b/py/torch_tensorrt/dynamo/conversion/_conversion.py
@@ -4,7 +4,6 @@ import io
 import logging
 from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Tuple
 
-import tensorrt as trt
 import torch
 from torch_tensorrt._enums import dtype
 from torch_tensorrt._features import ENABLED_FEATURES
@@ -25,6 +24,8 @@ from torch_tensorrt.dynamo.utils import (
     release_host_and_device_memory,
 )
 from torch_tensorrt.logging import TRT_LOGGER
+
+import tensorrt as trt
 
 logger = logging.getLogger(__name__)
 
@@ -203,6 +204,9 @@ def interpret_module_to_result(
     inputs: Sequence[Input],
     settings: CompilationSettings = CompilationSettings(),
     engine_cache: Optional[BaseEngineCache] = None,
+    *,
+    input_binding_names: Optional[Sequence[str]] = None,
+    output_binding_names: Optional[Sequence[str]] = None,
 ) -> SerializedInterpreterResult:
     """Interpret an FX module to a TRTInterpreterResult
     Args:
@@ -276,6 +280,8 @@ def interpret_module_to_result(
         output_dtypes=output_dtypes,
         compilation_settings=settings,
         engine_cache=engine_cache,
+        input_binding_names=input_binding_names,
+        output_binding_names=output_binding_names,
     )
 
     interpreter_result = interpreter.run()

--- a/tests/py/dynamo/conversion/test_engine_converter_binding_names.py
+++ b/tests/py/dynamo/conversion/test_engine_converter_binding_names.py
@@ -1,0 +1,374 @@
+"""
+Tests for user-supplied I/O binding names on the engine-converter API.
+
+Architecture: the exported program carries split pytree specs — one for
+``args``, one for ``kwargs``, one for the return value.  The user
+provides binding names in the same shape via three parallel kwargs:
+
+  * ``arg_input_binding_names`` — pytree matching ``arg_inputs``
+  * ``kwarg_input_binding_names`` — pytree matching ``kwarg_inputs``
+  * ``output_binding_names`` — pytree matching the model's return value
+
+We ``tree_flatten`` each and verify spec equality against the exported
+program's specs.  On success the flat lists concatenate (args then
+kwargs) into FX's flattened placeholder order; the interpreter just
+indexes positionally.
+"""
+
+import unittest
+
+import torch
+import torch_tensorrt
+from torch.testing._internal.common_utils import TestCase, run_tests
+from torch_tensorrt.dynamo._compiler import (
+    BindingNameMismatchError,
+    _binding_name_specs,
+    _resolve_pytree_binding_names,
+    convert_exported_program_to_serialized_trt_engine,
+)
+
+import tensorrt as trt
+
+DEVICE = torch.device("cuda", 0)
+
+
+def _trace(model, args, kwargs=None):
+    return torch.export.export(model, args, kwargs or {})
+
+
+# ── Spec extraction + pytree flattening (no GPU required) ────────────────────
+
+
+class TestSpecResolution(TestCase):
+    def _positional_two_input_program(self):
+        class M(torch.nn.Module):
+            def forward(self, x, y):
+                return x + y
+
+        return _trace(M().eval(), (torch.randn(2, 3), torch.randn(2, 3)))
+
+    def _kwarg_program(self):
+        class M(torch.nn.Module):
+            def forward(self, image, positions):
+                return image + positions
+
+        return _trace(
+            M().eval(),
+            args=(),
+            kwargs={"image": torch.randn(2, 3), "positions": torch.randn(2, 3)},
+        )
+
+    def _dict_output_program(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return {"primary": torch.relu(x), "secondary": torch.tanh(x)}
+
+        return _trace(M().eval(), (torch.randn(2, 3),))
+
+    def test_specs_extracted_for_positional(self) -> None:
+        args_spec, kwargs_spec, out_spec = _binding_name_specs(
+            self._positional_two_input_program()
+        )
+        self.assertIsNotNone(args_spec)
+        self.assertEqual(args_spec.num_leaves, 2)
+        # kwargs spec is the empty-dict spec — 0 leaves.
+        self.assertIsNotNone(kwargs_spec)
+        self.assertEqual(kwargs_spec.num_leaves, 0)
+        self.assertIsNotNone(out_spec)
+
+    def test_specs_extracted_for_kwargs(self) -> None:
+        args_spec, kwargs_spec, _ = _binding_name_specs(self._kwarg_program())
+        self.assertEqual(args_spec.num_leaves, 0)
+        self.assertEqual(kwargs_spec.num_leaves, 2)
+
+    def test_positional_args_match(self) -> None:
+        args_spec, _, _ = _binding_name_specs(self._positional_two_input_program())
+        names = _resolve_pytree_binding_names(
+            ("name_x", "name_y"), role="arg_input", expected_spec=args_spec
+        )
+        self.assertEqual(names, ["name_x", "name_y"])
+
+    def test_kwargs_match(self) -> None:
+        _, kwargs_spec, _ = _binding_name_specs(self._kwarg_program())
+        names = _resolve_pytree_binding_names(
+            {"image": "img", "positions": "pos"},
+            role="kwarg_input",
+            expected_spec=kwargs_spec,
+        )
+        self.assertEqual(sorted(names), ["img", "pos"])
+
+    def test_dict_output_match(self) -> None:
+        _, _, out_spec = _binding_name_specs(self._dict_output_program())
+        names = _resolve_pytree_binding_names(
+            {"primary": "p_out", "secondary": "s_out"},
+            role="output",
+            expected_spec=out_spec,
+        )
+        self.assertEqual(sorted(names), ["p_out", "s_out"])
+
+    def test_spec_mismatch_raises(self) -> None:
+        """User provides a dict where positional args were expected."""
+        args_spec, _, _ = _binding_name_specs(self._positional_two_input_program())
+        with self.assertRaises(BindingNameMismatchError) as ctx:
+            _resolve_pytree_binding_names(
+                {"x": "a", "y": "b"},
+                role="arg_input",
+                expected_spec=args_spec,
+            )
+        self.assertIn("does not match the exported program", str(ctx.exception))
+
+    def test_arity_mismatch_raises(self) -> None:
+        args_spec, _, _ = _binding_name_specs(self._positional_two_input_program())
+        with self.assertRaises(BindingNameMismatchError):
+            _resolve_pytree_binding_names(
+                ("only_one",), role="arg_input", expected_spec=args_spec
+            )
+
+    def test_non_string_leaf_raises(self) -> None:
+        args_spec, _, _ = _binding_name_specs(self._positional_two_input_program())
+        with self.assertRaises(BindingNameMismatchError) as ctx:
+            _resolve_pytree_binding_names(
+                ("a", 2), role="arg_input", expected_spec=args_spec
+            )
+        self.assertIn("leaves must all be strings", str(ctx.exception))
+
+    def test_duplicate_within_pytree_raises(self) -> None:
+        args_spec, _, _ = _binding_name_specs(self._positional_two_input_program())
+        with self.assertRaises(BindingNameMismatchError) as ctx:
+            _resolve_pytree_binding_names(
+                ("same", "same"), role="arg_input", expected_spec=args_spec
+            )
+        self.assertIn("duplicate", str(ctx.exception))
+
+
+# ── End-to-end (requires CUDA + TRT) ─────────────────────────────────────────
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA required")
+class TestEngineConverterBindingNames(TestCase):
+    def _two_output_model(self):
+        class M(torch.nn.Module):
+            def forward(self, x: torch.Tensor):
+                return torch.relu(x), torch.tanh(x)
+
+        x = torch.randn(2, 3, device=DEVICE, dtype=torch.float16)
+        return M().eval().cuda().half(), (x,)
+
+    def _kwarg_model(self):
+        class M(torch.nn.Module):
+            def forward(self, image: torch.Tensor, positions: torch.Tensor):
+                return image + positions
+
+        image = torch.randn(2, 3, device=DEVICE, dtype=torch.float16)
+        positions = torch.randn(2, 3, device=DEVICE, dtype=torch.float16)
+        return M().eval().cuda().half(), {"image": image, "positions": positions}
+
+    def _deserialize(self, engine_bytes: bytes):
+        runtime = trt.Runtime(trt.Logger(trt.Logger.WARNING))
+        return runtime.deserialize_cuda_engine(engine_bytes)
+
+    def _binding_names(self, engine, mode: trt.TensorIOMode):
+        names = []
+        for i in range(engine.num_io_tensors):
+            n = engine.get_tensor_name(i)
+            if engine.get_tensor_mode(n) == mode:
+                names.append(n)
+        return names
+
+    def _run_engine(self, engine, named_inputs):
+        """Execute an engine through the native TRT Python API.
+
+        Confirms the requested binding names are actually addressable at
+        execution time, not just present in the engine metadata.
+        ``named_inputs`` is a dict {binding_name -> contiguous CUDA tensor};
+        returns a dict {binding_name -> output tensor}.
+        """
+        context = engine.create_execution_context()
+        for name, tensor in named_inputs.items():
+            context.set_input_shape(name, tuple(tensor.shape))
+            context.set_tensor_address(name, tensor.data_ptr())
+
+        outputs = {}
+        for i in range(engine.num_io_tensors):
+            name = engine.get_tensor_name(i)
+            if engine.get_tensor_mode(name) != trt.TensorIOMode.OUTPUT:
+                continue
+            shape = tuple(context.get_tensor_shape(name))
+            trt_dtype = engine.get_tensor_dtype(name)
+            torch_dtype = {
+                trt.DataType.FLOAT: torch.float32,
+                trt.DataType.HALF: torch.float16,
+                trt.DataType.INT32: torch.int32,
+                trt.DataType.INT64: torch.int64,
+                trt.DataType.BOOL: torch.bool,
+                trt.DataType.BF16: torch.bfloat16,
+            }[trt_dtype]
+            out = torch.empty(shape, dtype=torch_dtype, device=DEVICE)
+            context.set_tensor_address(name, out.data_ptr())
+            outputs[name] = out
+
+        stream = torch.cuda.Stream(device=DEVICE)
+        with torch.cuda.stream(stream):
+            ok = context.execute_async_v3(stream.cuda_stream)
+        stream.synchronize()
+        self.assertTrue(ok, "execute_async_v3 returned False")
+        return outputs
+
+    def test_default_names_unchanged(self) -> None:
+        model, inputs = self._two_output_model()
+        program = _trace(model, inputs)
+        engine_bytes = convert_exported_program_to_serialized_trt_engine(
+            program,
+            arg_inputs=inputs,
+            require_full_compilation=True,
+            min_block_size=1,
+            use_python_runtime=False,
+            immutable_weights=True,
+        )
+        engine = self._deserialize(engine_bytes)
+        outs = self._binding_names(engine, trt.TensorIOMode.OUTPUT)
+        self.assertEqual(outs, ["output0", "output1"])
+
+    def test_user_supplied_arg_and_output_names(self) -> None:
+        model, inputs = self._two_output_model()
+        program = _trace(model, inputs)
+        engine_bytes = convert_exported_program_to_serialized_trt_engine(
+            program,
+            arg_inputs=inputs,
+            arg_input_binding_names=("input_image",),
+            output_binding_names=("relu_out", "tanh_out"),
+            require_full_compilation=True,
+            min_block_size=1,
+            use_python_runtime=False,
+            immutable_weights=True,
+        )
+        engine = self._deserialize(engine_bytes)
+        self.assertEqual(
+            self._binding_names(engine, trt.TensorIOMode.INPUT), ["input_image"]
+        )
+        self.assertEqual(
+            self._binding_names(engine, trt.TensorIOMode.OUTPUT),
+            ["relu_out", "tanh_out"],
+        )
+
+        # Native-TRT execution: bind by the user-supplied names and verify
+        # numerical match against the PyTorch eager outputs.
+        (x,) = inputs
+        outs = self._run_engine(engine, {"input_image": x.contiguous()})
+        with torch.no_grad():
+            ref_relu, ref_tanh = model(x)
+        torch.testing.assert_close(outs["relu_out"], ref_relu, rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(outs["tanh_out"], ref_tanh, rtol=1e-2, atol=1e-2)
+
+    def test_kwarg_input_binding_names(self) -> None:
+        """Model takes kwargs; user names them via kwarg_input_binding_names."""
+        model, kwargs = self._kwarg_model()
+        program = _trace(model, (), kwargs)
+        engine_bytes = convert_exported_program_to_serialized_trt_engine(
+            program,
+            arg_inputs=(),
+            kwarg_inputs=kwargs,
+            kwarg_input_binding_names={"image": "img_in", "positions": "pos_in"},
+            require_full_compilation=True,
+            min_block_size=1,
+            use_python_runtime=False,
+            immutable_weights=True,
+        )
+        engine = self._deserialize(engine_bytes)
+        self.assertEqual(
+            sorted(self._binding_names(engine, trt.TensorIOMode.INPUT)),
+            ["img_in", "pos_in"],
+        )
+
+        outs = self._run_engine(
+            engine,
+            {
+                "img_in": kwargs["image"].contiguous(),
+                "pos_in": kwargs["positions"].contiguous(),
+            },
+        )
+        with torch.no_grad():
+            ref = model(**kwargs)
+        # Single-output model → exactly one output binding.
+        only_out = next(iter(outs.values()))
+        torch.testing.assert_close(only_out, ref, rtol=1e-2, atol=1e-2)
+
+    def test_arity_mismatch_raises_before_engine_build(self) -> None:
+        model, inputs = self._two_output_model()
+        program = _trace(model, inputs)
+        with self.assertRaises(BindingNameMismatchError):
+            convert_exported_program_to_serialized_trt_engine(
+                program,
+                arg_inputs=inputs,
+                output_binding_names=("only_one",),
+                require_full_compilation=True,
+                min_block_size=1,
+                use_python_runtime=False,
+                immutable_weights=True,
+            )
+
+    def test_duplicate_within_list_raises(self) -> None:
+        model, inputs = self._two_output_model()
+        program = _trace(model, inputs)
+        with self.assertRaises(BindingNameMismatchError):
+            convert_exported_program_to_serialized_trt_engine(
+                program,
+                arg_inputs=inputs,
+                output_binding_names=("same", "same"),
+                require_full_compilation=True,
+                min_block_size=1,
+                use_python_runtime=False,
+                immutable_weights=True,
+            )
+
+    def test_cross_input_output_overlap_raises(self) -> None:
+        model, inputs = self._two_output_model()
+        program = _trace(model, inputs)
+        with self.assertRaises(BindingNameMismatchError):
+            convert_exported_program_to_serialized_trt_engine(
+                program,
+                arg_inputs=inputs,
+                arg_input_binding_names=("shared_name",),
+                output_binding_names=("shared_name", "tanh_out"),
+                require_full_compilation=True,
+                min_block_size=1,
+                use_python_runtime=False,
+                immutable_weights=True,
+            )
+
+    def test_pytree_dict_output(self) -> None:
+        class M(torch.nn.Module):
+            def forward(self, x: torch.Tensor):
+                return {"primary": torch.relu(x), "secondary": torch.tanh(x)}
+
+        x = torch.randn(2, 3, device=DEVICE, dtype=torch.float16)
+        model = M().eval().cuda().half()
+        program = _trace(model, (x,))
+        engine_bytes = convert_exported_program_to_serialized_trt_engine(
+            program,
+            arg_inputs=(x,),
+            output_binding_names={"primary": "p_out", "secondary": "s_out"},
+            require_full_compilation=True,
+            min_block_size=1,
+            use_python_runtime=False,
+            immutable_weights=True,
+        )
+        engine = self._deserialize(engine_bytes)
+        self.assertEqual(
+            sorted(self._binding_names(engine, trt.TensorIOMode.OUTPUT)),
+            ["p_out", "s_out"],
+        )
+
+        # Bind by user-supplied names via native TRT and verify numerics.
+        (input_name,) = self._binding_names(engine, trt.TensorIOMode.INPUT)
+        outs = self._run_engine(engine, {input_name: x.contiguous()})
+        with torch.no_grad():
+            ref = model(x)
+        torch.testing.assert_close(outs["p_out"], ref["primary"], rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(
+            outs["s_out"], ref["secondary"], rtol=1e-2, atol=1e-2
+        )
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
# Description

Allows users of the `convert_exported_program_to_serialized_engine` API to specify binding names for **all** bindings utilizing the exported programs pytrees for i/o flattening to flatten the provided names and associate names to specific io positions. 

TODO: Add support for aliasing inputs and outputs through this method (see: #4251)

Fixes #4212

## Type of change

Please delete options that are not relevant and/or add your own.


- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
