### PR TITLE
build: upgrade cuda to 13.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -64,7 +64,7 @@ new_local_repository(
 new_local_repository(
     name = "cuda",
     build_file = "@//third_party/cuda:BUILD",
-    path = "/usr/local/cuda-13.0/",
+    path = "/usr/local/cuda-13.2/",
 )
 
 # for Jetson
@@ -79,7 +79,7 @@ new_local_repository(
 new_local_repository(
     name = "cuda_win",
     build_file = "@//third_party/cuda:BUILD",
-    path = "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v13.0/",
+    path = "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v13.2/",
 )
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Torch-TensorRT
 
 [![Documentation](https://img.shields.io/badge/docs-master-brightgreen)](https://nvidia.github.io/Torch-TensorRT/)
 [![pytorch](https://img.shields.io/badge/PyTorch-2.13-green)](https://download.pytorch.org/whl/nightly/cu130)
-[![cuda](https://img.shields.io/badge/CUDA-13.0-green)](https://developer.nvidia.com/cuda-downloads)
+[![cuda](https://img.shields.io/badge/CUDA-13.2-green)](https://developer.nvidia.com/cuda-downloads)
 [![trt](https://img.shields.io/badge/TensorRT-11.0.0-green)](https://github.com/nvidia/tensorrt)
 [![license](https://img.shields.io/badge/license-BSD--3--Clause-blue)](./LICENSE)
 [![Linux x86-64 Nightly Wheels](https://github.com/pytorch/TensorRT/actions/workflows/build-test-linux-x86_64.yml/badge.svg?branch=nightly)](https://github.com/pytorch/TensorRT/actions/workflows/build-test-linux-x86_64.yml)
@@ -122,7 +122,7 @@ These are the following dependencies used to verify the testcases. Torch-TensorR
 
 - Bazel 8.1.1
 - Libtorch 2.13.0.dev (latest nightly)
-- CUDA 13.0 (CUDA 12.6 on Jetson)
+- CUDA 13.2 (CUDA 12.6 on Jetson)
 - TensorRT 11.0.0.114 (TensorRT 10.3 on Jetson)
 
 ## Deprecation Policy

--- a/dev_dep_versions.yml
+++ b/dev_dep_versions.yml
@@ -1,4 +1,4 @@
-__cuda_version__: "13.0"
+__cuda_version__: "13.2"
 __tensorrt_version__: "11.0.0"
 __tensorrt_rtx_version__: "1.5.0"
 __tensorrt_llm_version__: "0.17.0.post1"


### PR DESCRIPTION
# Description

Upgrade build dependency for CUDA from 13.0 to 13.2 for Linux and Windows.
