### PR TITLE
executorch: log once when the TensorRT delegate stages host I/O; document the device-handling contract

### DIFF
--- a/cpp/include/torch_tensorrt/executorch/TensorRTBackend.h
+++ b/cpp/include/torch_tensorrt/executorch/TensorRTBackend.h
@@ -61,6 +61,9 @@ struct EngineHandle {
   size_t num_outputs = 0;
   int device_id = 0;
   bool unified_memory = false;
+  // Set the first time execute() stages an IO tensor through a host<->device
+  // copy; guards a one-shot Info log (read/written under mu).
+  bool staged_logged = false;
   std::mutex mu;
   // Makes the skip-sync fast path safe to reuse: TensorRT forbids reconfiguring or
   // destroying an execution context while one of its enqueues is in flight, so when

--- a/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
+++ b/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
@@ -317,6 +317,20 @@ Result<DelegateHandle*> TensorRTBackend::init(
 // Args layout (mirroring the Python exporter):
 //   args[0 .. num_inputs-1]             – input EValues
 //   args[num_inputs .. num_inputs+num_outputs-1] – output EValues
+//
+// Device-handling contract (intentional divergence from the CUDA/AOTI delegate;
+// do not "reconcile" without revisiting this):
+//   1. We ignore the per-tensor device metadata the partitioner emits (the AOT
+//      target_device CompileSpec, serialized into extra_tensor_info's
+//      device_type/device_index). Instead we sniff each pointer at runtime
+//      (is_cuda_accessible_ptr) so the backend stays correct for host- or
+//      device-resident inputs; asserting device_type would reject valid host
+//      inputs today.
+//   2. We stage host<->device ourselves via cudaMemcpyAsync into cached scratch
+//      buffers rather than ExecuTorch device-copy ops or a DeviceAllocator; the
+//      copy is conditional on the runtime pointer check and shares the stream.
+//   3. The engine-baked device_id (applied via cudaSetDevice) is the runtime
+//      source of truth for the GPU, not the AOT target_device.
 // ---------------------------------------------------------------------------
 Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle* handle, Span<EValue*> args) const {
   (void)context;
@@ -563,6 +577,17 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
       ET_LOG(Error, "TensorRTBackend::execute: setTensorAddress failed for output '%s'", name.c_str());
       return Error::InvalidState;
     }
+  }
+
+  // One-shot diagnostic: host-resident I/O was just staged through a device
+  // copy, so this engine is off the zero-copy fast path.
+  if ((input_staged_from_host || output_staged_to_host) && !engine->staged_logged) {
+    ET_LOG(
+        Info,
+        "TensorRTBackend::execute: an I/O tensor is host memory; staging it "
+        "through a device copy (zero-copy requires device-resident tensors). "
+        "Logged once per engine.");
+    engine->staged_logged = true;
   }
 
   // ------------------------------------------------------------------


### PR DESCRIPTION
## What

Two small, self-contained changes to the ExecuTorch TensorRT delegate runtime (`cpp/.../executorch/TensorRTBackend.{h,cpp}`):

1. **Observability for the zero-copy path.** `execute()` binds device-resident I/O straight into the execution context (zero-copy) and silently stages host-resident I/O through a per-call device allocation + `cudaMemcpyAsync`, with no signal. This adds a one-shot `ET_LOG(Info)` (guarded by a new `staged_warned` flag on `EngineHandle`, read/written under the existing `mu` lock) the first time an engine stages host I/O, so a caller intending device-resident, zero-copy I/O can tell when they have fallen off the fast path. Purely additive.

2. **Document the device-handling contract.** A WHY-only comment at `execute()`'s header records three intentional choices that diverge from the CUDA/AOTI delegate: (a) the runtime ignores the AOT `target_device` metadata and sniffs pointers at runtime (so asserting `device_type` would wrongly reject host inputs today), (b) it stages H2D/D2H itself rather than via ExecuTorch device-copy ops / a `DeviceAllocator`, and (c) the engine-baked `device_id` is the runtime source of truth for the GPU.

## Why now

ExecuTorch is moving on-device memory planning toward the default. Once that lands, device-aware planning is meant to keep delegate I/O on device; a regression that reinserts a host op between two GPU delegates would silently restore copies. The one-shot log makes that visible, and the contract comment keeps the intentional divergences from being "fixed" into breakage.

## Risk

Low. (1) is additive logging guarded by a flag under the existing lock; (2) is a comment. No fast-path or control-flow change.

## Test plan

- Device-resident I/O: the new Info line is NOT emitted (fast path unchanged).
- Host I/O: exactly one Info line per engine on the first `execute()`.
- Repeated calls / a second engine: one line per engine total.
- Existing TensorRT delegate tests pass; outputs unchanged.

Draft for review; part of a small device-support readiness series (a partitioner-side `target_device` fix + a readiness test follow).
