### PR TITLE
Add TensorRT weight streaming support to the ExecuTorch delegate

### DIFF
--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -97,6 +97,17 @@ cc_library(
 )
 
 cc_library(
+    name = "tensorrt_executorch_weight_streaming_budget",
+    srcs = [
+        "src/torch_tensorrt/executorch/WeightStreamingBudget.cpp",
+    ],
+    hdrs = [
+        "include/torch_tensorrt/executorch/WeightStreamingBudget.h",
+    ],
+    strip_include_prefix = "include",
+)
+
+cc_library(
     name = "tensorrt_executorch_binding_names",
     hdrs = [
         "include/torch_tensorrt/executorch/TensorRTBindingNames.h",
@@ -127,6 +138,7 @@ cc_library(
     deps = [
         ":tensorrt_executorch_binding_names",
         ":tensorrt_executorch_blob_header",
+        ":tensorrt_executorch_weight_streaming_budget",
     ] + select({
         ":linux_x86_64": [
             "@executorch//:executorch_headers",
@@ -150,6 +162,7 @@ filegroup(
         "src/torch_tensorrt/executorch/README.md",
         "src/torch_tensorrt/executorch/TensorRTBackend.cpp",
         "src/torch_tensorrt/executorch/TensorRTBlobHeader.cpp",
+        "src/torch_tensorrt/executorch/WeightStreamingBudget.cpp",
     ],
 )
 
@@ -169,5 +182,6 @@ filegroup(
         "include/torch_tensorrt/executorch/TensorRTBackend.h",
         "include/torch_tensorrt/executorch/TensorRTBindingNames.h",
         "include/torch_tensorrt/executorch/TensorRTBlobHeader.h",
+        "include/torch_tensorrt/executorch/WeightStreamingBudget.h",
     ],
 )

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -120,6 +120,17 @@ cc_library(
 )
 
 cc_library(
+    name = "tensorrt_executorch_weight_streaming_budget",
+    srcs = [
+        "src/torch_tensorrt/executorch/WeightStreamingBudget.cpp",
+    ],
+    hdrs = [
+        "include/torch_tensorrt/executorch/WeightStreamingBudget.h",
+    ],
+    strip_include_prefix = "include",
+)
+
+cc_library(
     name = "tensorrt_executorch_binding_names",
     hdrs = [
         "include/torch_tensorrt/executorch/TensorRTBindingNames.h",
@@ -150,6 +161,7 @@ cc_library(
     deps = [
         ":tensorrt_executorch_binding_names",
         ":tensorrt_executorch_blob_header",
+        ":tensorrt_executorch_weight_streaming_budget",
     ] + select({
         ":linux_x86_64": [
             "@cuda//:cudart",
@@ -173,6 +185,7 @@ filegroup(
         "src/torch_tensorrt/executorch/README.md",
         "src/torch_tensorrt/executorch/TensorRTBackend.cpp",
         "src/torch_tensorrt/executorch/TensorRTBlobHeader.cpp",
+        "src/torch_tensorrt/executorch/WeightStreamingBudget.cpp",
     ],
 )
 
@@ -192,5 +205,6 @@ filegroup(
         "include/torch_tensorrt/executorch/TensorRTBackend.h",
         "include/torch_tensorrt/executorch/TensorRTBindingNames.h",
         "include/torch_tensorrt/executorch/TensorRTBlobHeader.h",
+        "include/torch_tensorrt/executorch/WeightStreamingBudget.h",
     ],
 )

--- a/cpp/include/torch_tensorrt/executorch/WeightStreamingBudget.h
+++ b/cpp/include/torch_tensorrt/executorch/WeightStreamingBudget.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace torch_tensorrt {
+namespace executorch_backend {
+
+// Compile spec key that carries the weight streaming budget from export into the
+// delegate. Must match WEIGHT_STREAMING_BUDGET_COMPILE_SPEC_KEY on the Python
+// side (py/torch_tensorrt/executorch/partitioner.py).
+inline constexpr char kWeightStreamingBudgetKey[] = "weight_streaming_budget";
+
+// Result of parsing a weight streaming budget compile spec value.
+//
+// The value is a non-negative decimal integer: an explicit GPU budget in bytes.
+// The automatic budget is intentionally not encoded here: when no budget spec is
+// present, the delegate applies TensorRT's automatic budget itself, mirroring the
+// PyTorch runtimes.
+//
+//   valid == false -> a value was present but could not be parsed (or was
+//                     negative); the caller should reject the program.
+//   valid == true  -> bytes holds the parsed non-negative byte budget.
+struct WsBudget {
+  bool valid = false;
+  int64_t bytes = 0;
+};
+
+// Parses a budget from a raw byte range. The value is NOT assumed to be NUL
+// terminated; only the first nbytes bytes are read.
+WsBudget parse_weight_streaming_budget(const void* value, std::size_t nbytes);
+
+} // namespace executorch_backend
+} // namespace torch_tensorrt

--- a/cpp/src/torch_tensorrt/executorch/CMakeLists.txt
+++ b/cpp/src/torch_tensorrt/executorch/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(Threads REQUIRED)
 set(_torchtrt_executorch_sources
     "${CMAKE_CURRENT_LIST_DIR}/TensorRTBackend.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/TensorRTBlobHeader.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/WeightStreamingBudget.cpp"
 )
 
 add_library(executorch_trt_backend STATIC ${_torchtrt_executorch_sources})

--- a/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
+++ b/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
@@ -8,6 +8,7 @@
 #include "torch_tensorrt/executorch/TensorRTBackend.h"
 #include "torch_tensorrt/executorch/TensorRTBindingNames.h"
 #include "torch_tensorrt/executorch/TensorRTBlobHeader.h"
+#include "torch_tensorrt/executorch/WeightStreamingBudget.h"
 
 #include <cstdint>
 #include <cstring>
@@ -225,8 +226,6 @@ Result<DelegateHandle*> TensorRTBackend::init(
     BackendInitContext& context,
     FreeableBuffer* processed,
     ArrayRef<CompileSpec> compile_specs) const {
-  (void)compile_specs;
-
   TORCHTRT_ET_CHECK_NOT_NULL(processed, Error::InvalidArgument, "TensorRTBackend::init: null processed buffer");
   TORCHTRT_ET_CHECK_NOT_NULL(processed->data(), Error::InvalidArgument, "TensorRTBackend::init: null processed buffer");
 
@@ -283,6 +282,130 @@ Result<DelegateHandle*> TensorRTBackend::init(
   handle->engine.reset(handle->runtime->deserializeCudaEngine(engine_data, header.engine_size));
   TORCHTRT_ET_CHECK_NOT_NULL(
       handle->engine, Error::InvalidProgram, "TensorRTBackend::init: failed to deserialize TensorRT engine");
+
+  // Apply the weight streaming budget before the execution context is created
+  // below: TensorRT forbids changing the budget while a context is active. The
+  // budget is a non-negative decimal byte count and may come from two places, in
+  // order of precedence:
+  //   1. A load-time backend option ("weight_streaming_budget" runtime spec) that
+  //      the caller passes to Module::load(LoadBackendOptionsMap). This lets a
+  //      deployment size the budget for its own GPU without re-exporting.
+  //   2. The same key baked into the .pte as a compile spec at export, used as a
+  //      default when no load-time option is given (and the only channel for
+  //      loaders that cannot pass backend options yet, e.g. Python/Android).
+  // When neither is present and the engine supports streaming, we apply
+  // TensorRT's automatic budget, mirroring what the PyTorch runtimes do on
+  // deserialize. Negative or malformed values are rejected as InvalidProgram.
+  WsBudget ws_request;
+  bool is_explicit = false;
+
+  // (1) A load-time runtime spec takes precedence over the baked compile spec.
+  // The value is a decimal byte string; a non-negative int is also accepted for
+  // small budgets. A present-but-wrong-type or empty option is handled explicitly
+  // so a runtime option is never silently dropped. The const char* returned by
+  // get_runtime_spec points into the caller's LoadBackendOptionsMap storage, which
+  // outlives init(); we parse it immediately and keep only the int64 result.
+  const auto ws_runtime = context.get_runtime_spec<const char*>(kWeightStreamingBudgetKey);
+  if (ws_runtime.ok()) {
+    const char* const value = ws_runtime.get();
+    // The option array need not be NUL terminated (the struct is public), so
+    // bound the scan. An empty value means "unset", so fall through to (2).
+    constexpr std::size_t kRuntimeBudgetMaxScan = 256;
+    std::size_t len = 0;
+    if (value != nullptr) {
+      while (len < kRuntimeBudgetMaxScan && value[len] != '\0') {
+        ++len;
+      }
+    }
+    if (len > 0) {
+      ws_request = parse_weight_streaming_budget(value, len);
+      if (!ws_request.valid) {
+        ET_LOG(Error, "TensorRTBackend::init: malformed weight_streaming_budget runtime option");
+        return Error::InvalidProgram;
+      }
+      is_explicit = true;
+    }
+  } else if (ws_runtime.error() != Error::NotFound) {
+    // The key is present but stored as a non-string type. Accept a non-negative
+    // int for convenience (its 32-bit range only covers budgets under 2 GB);
+    // otherwise reject it so a wrong-typed option is never silently ignored.
+    const auto ws_runtime_int = context.get_runtime_spec<int>(kWeightStreamingBudgetKey);
+    if (ws_runtime_int.ok() && ws_runtime_int.get() >= 0) {
+      ws_request.valid = true;
+      ws_request.bytes = ws_runtime_int.get();
+      is_explicit = true;
+    } else {
+      ET_LOG(
+          Error,
+          "TensorRTBackend::init: weight_streaming_budget runtime option must be a "
+          "non-negative int or a decimal byte string");
+      return Error::InvalidProgram;
+    }
+  }
+
+  // (2) Otherwise fall back to the compile spec baked into the .pte at export.
+  if (!is_explicit) {
+    const CompileSpec* ws_spec = nullptr;
+    for (const auto& spec : compile_specs) {
+      if (spec.key != nullptr && std::strcmp(spec.key, kWeightStreamingBudgetKey) == 0) {
+        if (ws_spec != nullptr) {
+          // The budget must appear at most once; a second match means the spec
+          // list is inconsistent, so reject the program instead of guessing.
+          ET_LOG(Error, "TensorRTBackend::init: duplicate weight_streaming_budget compile spec");
+          return Error::InvalidProgram;
+        }
+        ws_spec = &spec;
+      }
+    }
+    if (ws_spec != nullptr) {
+      ws_request = parse_weight_streaming_budget(ws_spec->value.buffer, ws_spec->value.nbytes);
+      if (!ws_request.valid) {
+        ET_LOG(Error, "TensorRTBackend::init: malformed weight_streaming_budget compile spec");
+        return Error::InvalidProgram;
+      }
+      is_explicit = true;
+    }
+  }
+
+  const int64_t streamable = handle->engine->getStreamableWeightsSize();
+  if (streamable > 0) {
+    // getStreamableWeightsSize is > 0 only when the engine was built with
+    // BuilderFlag::kWEIGHT_STREAMING.
+    int64_t budget;
+    if (is_explicit) {
+      // An explicit budget is a non-negative byte count, clamped to the
+      // streamable size (TensorRT also caps it, but clamp for a clear log).
+      budget = ws_request.bytes > streamable ? streamable : ws_request.bytes;
+    } else {
+      budget = handle->engine->getWeightStreamingAutomaticBudget();
+    }
+    if (!handle->engine->setWeightStreamingBudgetV2(budget)) {
+      if (!is_explicit && handle->engine->setWeightStreamingBudgetV2(0)) {
+        // The automatic budget could not be applied; fall back to budget 0, which
+        // streams all weights (minimum resident memory) and always fits.
+        ET_LOG(Info, "TensorRTBackend::init: automatic weight streaming budget failed; falling back to budget 0 (stream all weights)");
+      } else {
+        ET_LOG(
+            Error,
+            "TensorRTBackend::init: setWeightStreamingBudgetV2 failed (requested=%lld%s)",
+            (long long)budget,
+            is_explicit ? "" : ", and fallback to 0 also failed");
+        return Error::InvalidProgram;
+      }
+    }
+    ET_LOG(
+        Info,
+        "TensorRTBackend::init: weight streaming budget=%lld streamable=%lld scratch=%lld",
+        (long long)handle->engine->getWeightStreamingBudgetV2(),
+        (long long)streamable,
+        (long long)handle->engine->getWeightStreamingScratchMemorySize());
+  } else if (is_explicit) {
+    // A budget was requested but the engine has no streamable weights (it was not
+    // built with enable_weight_streaming=True, or nothing is streamable). The
+    // engine is still valid and runs fully resident, so log and continue rather
+    // than fail; failing here would break mixed multi-engine programs.
+    ET_LOG(Info, "TensorRTBackend::init: weight_streaming_budget ignored; engine does not support weight streaming (build with enable_weight_streaming=True)");
+  }
 
   Error err = initialize_engine_io(*handle);
   if (err != Error::Ok) {

--- a/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
+++ b/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
@@ -8,6 +8,7 @@
 #include "torch_tensorrt/executorch/TensorRTBackend.h"
 #include "torch_tensorrt/executorch/TensorRTBindingNames.h"
 #include "torch_tensorrt/executorch/TensorRTBlobHeader.h"
+#include "torch_tensorrt/executorch/WeightStreamingBudget.h"
 
 #include <cstdint>
 #include <cstring>
@@ -301,6 +302,144 @@ Result<DelegateHandle*> TensorRTBackend::init(
   handle->engine.reset(handle->runtime->deserializeCudaEngine(engine_data, header.engine_size));
   TORCHTRT_ET_CHECK_NOT_NULL(
       handle->engine, Error::InvalidProgram, "TensorRTBackend::init: failed to deserialize TensorRT engine");
+
+  // Apply the weight streaming budget before the execution context is created
+  // below: TensorRT forbids changing the budget while a context is active. The
+  // budget is a non-negative decimal byte count and may come from two places, in
+  // order of precedence:
+  //   1. A load-time backend option ("weight_streaming_budget" runtime spec) that
+  //      the caller passes to Module::load(LoadBackendOptionsMap). This lets a
+  //      deployment size the budget for its own GPU without re-exporting.
+  //   2. The same key baked into the .pte as a compile spec at export, used as a
+  //      default when no load-time option is given (and the only channel for
+  //      loaders that cannot pass backend options yet, e.g. Python/Android).
+  // When neither is present and the engine supports streaming, we apply
+  // TensorRT's automatic budget, mirroring what the PyTorch runtimes do on
+  // deserialize. Negative or malformed values are rejected as InvalidProgram.
+  WsBudget ws_request;
+  bool is_explicit = false;
+
+  // (1) A load-time runtime spec takes precedence over the baked compile spec.
+  // The value is a decimal byte string; a non-negative int is also accepted for
+  // small budgets. A present-but-wrong-type or empty option is handled explicitly
+  // so a runtime option is never silently dropped. The const char* returned by
+  // get_runtime_spec points into the caller's LoadBackendOptionsMap storage, which
+  // outlives init(); we parse it immediately and keep only the int64 result.
+  const auto ws_runtime = context.get_runtime_spec<const char*>(kWeightStreamingBudgetKey);
+  if (ws_runtime.ok()) {
+    const char* const value = ws_runtime.get();
+    // The option array need not be NUL terminated (the struct is public), so
+    // bound the scan. An empty value means "unset", so fall through to (2).
+    constexpr std::size_t kRuntimeBudgetMaxScan = 256;
+    std::size_t len = 0;
+    if (value != nullptr) {
+      while (len < kRuntimeBudgetMaxScan && value[len] != '\0') {
+        ++len;
+      }
+    }
+    if (len > 0) {
+      ws_request = parse_weight_streaming_budget(value, len);
+      if (!ws_request.valid) {
+        ET_LOG(Error, "TensorRTBackend::init: malformed weight_streaming_budget runtime option");
+        return Error::InvalidProgram;
+      }
+      is_explicit = true;
+    } else {
+      // The option was supplied but carries no characters, so nothing was set. Say so
+      // rather than falling through silently, since a caller who passed the option
+      // expects it to take effect. The actual fallback is resolved below: either a
+      // budget compile spec if the program carries one, or TensorRT's automatic
+      // budget, so do not name one here.
+      ET_LOG(Error, "TensorRTBackend::init: weight_streaming_budget runtime option is empty and was ignored");
+    }
+  } else if (ws_runtime.error() != Error::NotFound) {
+    // The key is present but stored as a non-string type. Accept a non-negative
+    // int for convenience (its 32-bit range only covers budgets under 2 GB);
+    // otherwise reject it so a wrong-typed option is never silently ignored.
+    const auto ws_runtime_int = context.get_runtime_spec<int>(kWeightStreamingBudgetKey);
+    if (ws_runtime_int.ok() && ws_runtime_int.get() >= 0) {
+      ws_request.valid = true;
+      ws_request.bytes = ws_runtime_int.get();
+      is_explicit = true;
+    } else {
+      ET_LOG(
+          Error,
+          "TensorRTBackend::init: weight_streaming_budget runtime option must be a "
+          "non-negative int or a decimal byte string");
+      return Error::InvalidProgram;
+    }
+  }
+
+  // (2) Otherwise fall back to the compile spec baked into the .pte at export.
+  if (!is_explicit) {
+    const CompileSpec* ws_spec = nullptr;
+    for (const auto& spec : compile_specs) {
+      if (spec.key != nullptr && std::strcmp(spec.key, kWeightStreamingBudgetKey) == 0) {
+        if (ws_spec != nullptr) {
+          // The budget must appear at most once; a second match means the spec
+          // list is inconsistent, so reject the program instead of guessing.
+          ET_LOG(Error, "TensorRTBackend::init: duplicate weight_streaming_budget compile spec");
+          return Error::InvalidProgram;
+        }
+        ws_spec = &spec;
+      }
+    }
+    if (ws_spec != nullptr) {
+      ws_request = parse_weight_streaming_budget(ws_spec->value.buffer, ws_spec->value.nbytes);
+      if (!ws_request.valid) {
+        ET_LOG(Error, "TensorRTBackend::init: malformed weight_streaming_budget compile spec");
+        return Error::InvalidProgram;
+      }
+      is_explicit = true;
+    }
+  }
+
+  const int64_t streamable = handle->engine->getStreamableWeightsSize();
+  if (streamable > 0) {
+    // getStreamableWeightsSize is > 0 only when the engine was built with
+    // BuilderFlag::kWEIGHT_STREAMING.
+    int64_t budget;
+    if (is_explicit) {
+      // An explicit budget is a non-negative byte count, clamped to the
+      // streamable size (TensorRT also caps it, but clamp for a clear log).
+      budget = ws_request.bytes > streamable ? streamable : ws_request.bytes;
+    } else {
+      budget = handle->engine->getWeightStreamingAutomaticBudget();
+    }
+    if (!handle->engine->setWeightStreamingBudgetV2(budget)) {
+      if (!is_explicit && handle->engine->setWeightStreamingBudgetV2(0)) {
+        // The automatic budget could not be applied; fall back to budget 0, which
+        // streams all weights (minimum resident memory) and always fits.
+        ET_LOG(
+            Info,
+            "TensorRTBackend::init: automatic weight streaming budget failed; falling back to budget 0 (stream all weights)");
+      } else {
+        ET_LOG(
+            Error,
+            "TensorRTBackend::init: setWeightStreamingBudgetV2 failed (requested=%lld%s)",
+            (long long)budget,
+            is_explicit ? "" : ", and fallback to 0 also failed");
+        return Error::InvalidProgram;
+      }
+    }
+    ET_LOG(
+        Info,
+        "TensorRTBackend::init: weight streaming budget=%lld streamable=%lld scratch=%lld",
+        (long long)handle->engine->getWeightStreamingBudgetV2(),
+        (long long)streamable,
+        (long long)handle->engine->getWeightStreamingScratchMemorySize());
+  } else if (is_explicit) {
+    // A budget was requested but the engine has no streamable weights (it was not
+    // built with enable_weight_streaming=True, or nothing is streamable). The
+    // engine is still valid and runs fully resident, so log and continue rather
+    // than fail; failing here would break mixed multi-engine programs where only
+    // some engines were built for streaming. Logged at Error because the caller
+    // asked for a memory setting that will not take effect, and ExecuTorch has no
+    // Warning level.
+    ET_LOG(
+        Error,
+        "TensorRTBackend::init: weight_streaming_budget ignored; engine has no streamable weights (it was not built with enable_weight_streaming=True, or none of its weights are streamable). The engine runs with all weights resident.");
+  }
 
   Error err = initialize_engine_io(*handle);
   if (err != Error::Ok) {

--- a/cpp/src/torch_tensorrt/executorch/WeightStreamingBudget.cpp
+++ b/cpp/src/torch_tensorrt/executorch/WeightStreamingBudget.cpp
@@ -1,0 +1,35 @@
+#include "torch_tensorrt/executorch/WeightStreamingBudget.h"
+
+#include <charconv>
+#include <cstddef>
+#include <cstdint>
+#include <system_error>
+
+namespace torch_tensorrt {
+namespace executorch_backend {
+
+WsBudget parse_weight_streaming_budget(const void* value, std::size_t nbytes) {
+  WsBudget result; // valid == false until the value is fully parsed
+
+  if (value == nullptr || nbytes == 0) {
+    return result;
+  }
+  // The value is a non-negative decimal byte budget and is not NUL terminated.
+  // std::from_chars consumes only ASCII digits (no leading whitespace, sign, or
+  // base prefix), so a leftover byte (trailing garbage or an embedded NUL), an
+  // out-of-range value, or a negative leaves the result invalid.
+  const char* const first = static_cast<const char*>(value);
+  const char* const last = first + nbytes;
+  int64_t parsed = 0;
+  const std::from_chars_result fc = std::from_chars(first, last, parsed);
+  if (fc.ec != std::errc() || fc.ptr != last || parsed < 0) {
+    return result;
+  }
+
+  result.valid = true;
+  result.bytes = parsed;
+  return result;
+}
+
+} // namespace executorch_backend
+} // namespace torch_tensorrt

--- a/py/torch-tensorrt-executorch-runtime/native/CMakeLists.txt
+++ b/py/torch-tensorrt-executorch-runtime/native/CMakeLists.txt
@@ -179,7 +179,8 @@ add_subdirectory("${EXECUTORCH_SOURCE_DIR}" executorch)
 
 add_library(torch_tensorrt_executorch_backend STATIC
   "${TORCH_TENSORRT_SOURCE_DIR}/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp"
-  "${TORCH_TENSORRT_SOURCE_DIR}/cpp/src/torch_tensorrt/executorch/TensorRTBlobHeader.cpp")
+  "${TORCH_TENSORRT_SOURCE_DIR}/cpp/src/torch_tensorrt/executorch/TensorRTBlobHeader.cpp"
+  "${TORCH_TENSORRT_SOURCE_DIR}/cpp/src/torch_tensorrt/executorch/WeightStreamingBudget.cpp")
 target_compile_features(torch_tensorrt_executorch_backend PUBLIC cxx_std_17)
 target_compile_definitions(torch_tensorrt_executorch_backend
   PRIVATE C10_USING_CUSTOM_GENERATED_MACROS)

--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -30,32 +30,26 @@ else:
 
 if ENABLED_FEATURES.torchscript_frontend:
     import torch_tensorrt.ts
-    from torch_tensorrt.ts._compiler import compile as torchscript_compile
     from torch_tensorrt.ts._compiler import (
+        compile as torchscript_compile,
         convert_method_to_trt_engine as ts_convert_method_to_trt_engine,
     )
 
 if ENABLED_FEATURES.dynamo_frontend:
     from torch.export import ExportedProgram
-    from torch_tensorrt.dynamo._compiler import compile as dynamo_compile
     from torch_tensorrt.dynamo._compiler import (
+        compile as dynamo_compile,
         convert_exported_program_to_serialized_trt_engine as dynamo_convert_exported_program_to_serialized_trt_engine,
-    )
-    from torch_tensorrt.dynamo._compiler import (
         cross_compile_for_windows as dynamo_cross_compile_for_windows,
-    )
-    from torch_tensorrt.dynamo._compiler import (
         load_cross_compiled_exported_program as dynamo_load_cross_compiled_exported_program,
-    )
-    from torch_tensorrt.dynamo._compiler import (
         save_cross_compiled_exported_program as dynamo_save_cross_compiled_exported_program,
     )
     from torch_tensorrt.dynamo._defaults import default_device
     from torch_tensorrt.dynamo._tracer import (
         get_dynamic_shapes_args,
         get_dynamic_shapes_kwargs,
+        trace as dynamo_trace,
     )
-    from torch_tensorrt.dynamo._tracer import trace as dynamo_trace
     from torch_tensorrt.dynamo.utils import get_torch_inputs
 
 logger = logging.getLogger(__name__)
@@ -728,11 +722,26 @@ def save(
 
                 - If both dynamic_shapes and Input objects are provided, the explicit dynamic_shapes
                   parameter takes precedence.
-        kwargs: Additional format-specific kwargs. ``partitioners=`` and
-                ``compile_specs=`` are only used with ``output_format="executorch"``;
-                otherwise they are ignored with a warning. Pass
+        kwargs: Additional format-specific kwargs. ``partitioners=``,
+                ``compile_specs=``, and ``weight_streaming_budget=`` are only used
+                with ``output_format="executorch"``; otherwise they are ignored
+                with a warning. Pass
                 ``compile_specs=[CompileSpec("target_device", b"cuda:<i>")]`` to
                 override the default target device (``cuda:0``).
+                ``weight_streaming_budget`` controls the TensorRT weight streaming
+                budget for the delegate: ``None`` (the default) lets the delegate
+                pick an automatic budget at load, and a non-negative integer sets
+                an explicit GPU budget in bytes. For a program with multiple
+                TensorRT engines an explicit byte budget applies to each engine
+                independently, so prefer ``None`` there. Only an engine built with
+                ``enable_weight_streaming=True`` honors the budget at runtime. This
+                value is an export-time default; it can be overridden at load with a
+                ``weight_streaming_budget`` backend option so the same ``.pte`` can
+                be sized for different GPUs without re-exporting. That load-time
+                override currently works only from runtimes that pass ExecuTorch
+                backend options (the C++ ``Module`` API and iOS); the ExecuTorch
+                Python and Android loaders do not expose it yet and use this
+                export-time value.
     """
     if isinstance(module, CudaGraphsTorchTensorRTModule):
         module = module.compiled_module
@@ -759,6 +768,7 @@ def save(
 
     executorch_partitioners = kwargs.pop("partitioners", None)
     executorch_compile_specs = kwargs.pop("compile_specs", None)
+    executorch_weight_streaming_budget = kwargs.pop("weight_streaming_budget", None)
 
     if output_format not in accepted_formats:
         raise ValueError(
@@ -769,6 +779,16 @@ def save(
             "Saving in ExecuTorch format requires the executorch package "
             "with executorch.exir. Install with: pip install "
             "\"executorch\" to use output_format='executorch'."
+        )
+    # Recognized executorch options are popped above; any other leftover kwarg
+    # for output_format='executorch' is a typo (the executorch path forwards no
+    # other kwargs), so fail loudly instead of silently ignoring it.
+    if output_format == "executorch" and kwargs:
+        raise TypeError(
+            "save() received unexpected keyword argument(s) for "
+            f"output_format='executorch': {sorted(kwargs)}. Supported executorch "
+            "options are 'partitioners', 'compile_specs', and "
+            "'weight_streaming_budget'."
         )
 
     def _all_are_input_objects(obj: Any) -> bool:
@@ -880,6 +900,16 @@ def save(
             "compile_specs= is only used with output_format='executorch' and will "
             f"be ignored for output_format='{output_format}'."
         )
+    if executorch_weight_streaming_budget is not None and output_format != "executorch":
+        logger.warning(
+            "weight_streaming_budget= is only used with output_format='executorch' "
+            f"and will be ignored for output_format='{output_format}'."
+        )
+    if executorch_weight_streaming_budget is not None and output_format == "executorch":
+        # Validate eagerly so an invalid budget (non-int or out-of-range) fails
+        # fast, before any expensive export. It is normalized again later when
+        # building the compile_specs.
+        _normalize_weight_streaming_budget(executorch_weight_streaming_budget)
     if output_format == "aot_inductor" and platform.system() != "Linux":
         raise ValueError(
             f"The AOT Inductor format is only supported on Linux, {platform.system()} is not a supported platform for this format"
@@ -948,6 +978,7 @@ def save(
                     file_path,
                     partitioners=executorch_partitioners,
                     compile_specs=executorch_compile_specs,
+                    weight_streaming_budget=executorch_weight_streaming_budget,
                 )
             else:
                 raise RuntimeError(
@@ -1013,6 +1044,7 @@ def save(
                         file_path,
                         partitioners=executorch_partitioners,
                         compile_specs=executorch_compile_specs,
+                        weight_streaming_budget=executorch_weight_streaming_budget,
                     )
                 else:
                     raise RuntimeError(
@@ -1099,6 +1131,7 @@ def save(
                         file_path,
                         partitioners=executorch_partitioners,
                         compile_specs=executorch_compile_specs,
+                        weight_streaming_budget=executorch_weight_streaming_budget,
                     )
                 else:
                     raise RuntimeError(
@@ -1233,9 +1266,7 @@ def _replace_execute_engine_for_executorch(exp_program: Any) -> Any:
         # Use FX's unique-attr-name helper so re-export passes (which may
         # invoke this rewriter multiple times on the same `gm`) don't
         # silently overwrite earlier engine buffers.
-        from torch.fx.experimental.const_fold import (
-            get_unique_attr_name_in_module,
-        )
+        from torch.fx.experimental.const_fold import get_unique_attr_name_in_module
 
         buffer_name = get_unique_attr_name_in_module(gm, "_trt_engine_0")
         gm.register_buffer(buffer_name, engine_tensor, persistent=True)
@@ -1296,6 +1327,80 @@ def _replace_execute_engine_for_executorch(exp_program: Any) -> Any:
     return exp_program
 
 
+WEIGHT_STREAMING_BUDGET_MAX_BYTES = 2**63
+
+
+def _normalize_weight_streaming_budget(
+    weight_streaming_budget: Any,
+) -> Optional[bytes]:
+    """Validate the budget and encode it as a compile-spec value.
+
+    ``None`` (the default) means automatic: the delegate picks the budget at load.
+    A non-negative integer is an explicit GPU budget in bytes. Returns the ASCII
+    bytes to store in the CompileSpec, or ``None`` when no budget was supplied.
+    """
+    if weight_streaming_budget is None:
+        return None
+    # bool is an int subclass, so reject it explicitly along with non-ints.
+    if isinstance(weight_streaming_budget, bool) or not isinstance(
+        weight_streaming_budget, int
+    ):
+        raise TypeError(
+            "weight_streaming_budget must be a non-negative int (number of bytes) "
+            f"or None for automatic, got {type(weight_streaming_budget).__name__}."
+        )
+    if (
+        weight_streaming_budget < 0
+        or weight_streaming_budget >= WEIGHT_STREAMING_BUDGET_MAX_BYTES
+    ):
+        raise ValueError(
+            "weight_streaming_budget must be in [0, 2**63), got "
+            f"{weight_streaming_budget}."
+        )
+    return str(weight_streaming_budget).encode("ascii")
+
+
+def _resolve_executorch_compile_specs(
+    exp_program: Any,
+    caller_compile_specs: Sequence[Any],
+    weight_streaming_budget: Any,
+) -> List[Any]:
+    """Resolve the compile_specs passed to TensorRTPartitioner.
+
+    Appends the explicit weight streaming budget (from the save() kwarg) as a
+    CompileSpec. When no budget is given nothing is added and the delegate applies
+    TensorRT's automatic budget itself for engines built with weight streaming.
+    Caller-provided compile_specs are forwarded unchanged.
+    """
+    from executorch.exir.backend.compile_spec_schema import CompileSpec
+    from torch_tensorrt.executorch.partitioner import (
+        WEIGHT_STREAMING_BUDGET_COMPILE_SPEC_KEY,
+    )
+
+    specs = list(caller_compile_specs)
+    if any(
+        getattr(spec, "key", None) == WEIGHT_STREAMING_BUDGET_COMPILE_SPEC_KEY
+        for spec in specs
+    ):
+        raise ValueError(
+            f"Do not pass a CompileSpec('{WEIGHT_STREAMING_BUDGET_COMPILE_SPEC_KEY}', "
+            "...) in compile_specs; use the weight_streaming_budget argument of "
+            "save() instead."
+        )
+    spec_value = _normalize_weight_streaming_budget(weight_streaming_budget)
+    if spec_value is None:
+        return specs
+
+    if _count_executorch_engine_nodes(exp_program) > 1:
+        logger.warning(
+            "weight_streaming_budget is an explicit byte budget but the program "
+            "contains multiple TensorRT engines; it is applied to each engine "
+            "independently. Pass None to size each engine's budget automatically."
+        )
+    specs.append(CompileSpec(WEIGHT_STREAMING_BUDGET_COMPILE_SPEC_KEY, spec_value))
+    return specs
+
+
 def _save_as_executorch(exp_program: Any, file_path: str, **kwargs: Any) -> None:
     """Save an ExportedProgram (with TensorRT execute_engine nodes) as an ExecuTorch .pte file.
 
@@ -1318,16 +1423,12 @@ def _save_as_executorch(exp_program: Any, file_path: str, **kwargs: Any) -> None
             "\"executorch\" to use output_format='executorch'."
         )
     import torch_tensorrt.dynamo.runtime.meta_ops.register_meta_ops  # noqa: F401
-    from torch_tensorrt.executorch import (
-        TensorRTPartitioner,
-        get_edge_compile_config,
-    )
+    from torch_tensorrt.executorch import get_edge_compile_config, TensorRTPartitioner
 
     extra_partitioners = kwargs.get("partitioners") or []
     if not isinstance(extra_partitioners, (list, tuple)):
         raise TypeError(
-            "partitioners must be a list or tuple when using "
-            "output_format='executorch'"
+            "partitioners must be a list or tuple when using output_format='executorch'"
         )
     # Forward any caller-provided compile_specs to TensorRTPartitioner so users
     # can override the default target_device ("cuda:0") by passing e.g.
@@ -1339,9 +1440,17 @@ def _save_as_executorch(exp_program: Any, file_path: str, **kwargs: Any) -> None
             "compile_specs must be a list or tuple when using "
             "output_format='executorch'"
         )
-    partitioners = [
-        TensorRTPartitioner(compile_specs=list(executorch_compile_specs))
-    ] + list(extra_partitioners)
+    # Resolve the weight streaming budget into the compile_specs from the save()
+    # kwarg. If none is given nothing is added and the delegate applies TensorRT's
+    # automatic budget itself for engines built with weight streaming.
+    resolved_compile_specs = _resolve_executorch_compile_specs(
+        exp_program,
+        list(executorch_compile_specs),
+        kwargs.get("weight_streaming_budget"),
+    )
+    partitioners = [TensorRTPartitioner(compile_specs=resolved_compile_specs)] + list(
+        extra_partitioners
+    )
 
     engine_count = _count_executorch_engine_nodes(exp_program)
     if engine_count > 1:
@@ -1377,14 +1486,10 @@ def _normalize_engine_constants_to_python(exp_program: "ExportedProgram") -> Non
     import base64
 
     from torch_tensorrt.dynamo.runtime._serialized_engine_layout import ENGINE_IDX
-    from torch_tensorrt.dynamo.runtime._TRTEngine import (
-        EngineSerializer,
-        TRTEngine,
-    )
+    from torch_tensorrt.dynamo.runtime._TRTEngine import EngineSerializer, TRTEngine
 
     for fqn, constant in list(exp_program.constants.items()):
         if isinstance(constant, (torch._C.ScriptObject, TRTEngine)):
-
             state = constant.__getstate__()
             if len(state) == 2 and (
                 state[1] == "TRTEngine"

--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -781,8 +781,8 @@ def save(
                   parameter takes precedence.
         kwargs: Additional format-specific kwargs. ``partitioners=``,
                 ``compile_specs=``, ``backend_config=``, ``constant_methods=``,
-                ``transform_passes=``, ``compile_config=`` and
-                ``generate_etrecord=`` are only used with
+                ``transform_passes=``, ``compile_config=``, ``generate_etrecord=``
+                and ``weight_streaming_budget_per_engine=`` are only used with
                 ``output_format="executorch"``; otherwise they are ignored with a
                 warning. Pass ``compile_specs=[CompileSpec("target_device",
                 b"cuda:<i>")]`` to override the default target device (``cuda:0``).
@@ -807,6 +807,14 @@ def save(
                 ``generate_etrecord=True`` writes an ETRecord to
                 ``<model>_etrecord.bin`` next to the ``.pte`` for use with the
                 ExecuTorch Inspector.
+                ``weight_streaming_budget_per_engine=`` takes an ``Optional[int]``
+                number of bytes of engine weights that may stay resident in GPU
+                memory, with the rest streamed from host memory. It applies to
+                **each** TensorRT engine separately, not as a total for the program,
+                so a program with N engines can hold up to N times this value
+                resident. Requires the engine to have been compiled with
+                ``enable_weight_streaming=True``. See
+                :func:`torch_tensorrt.executorch.export` for the full description.
     """
     if isinstance(module, CudaGraphsTorchTensorRTModule):
         module = module.compiled_module
@@ -838,6 +846,9 @@ def save(
     executorch_transform_passes = kwargs.pop("transform_passes", None)
     executorch_compile_config = kwargs.pop("compile_config", None)
     executorch_generate_etrecord = kwargs.pop("generate_etrecord", False)
+    executorch_weight_streaming_budget_per_engine = kwargs.pop(
+        "weight_streaming_budget_per_engine", None
+    )
 
     if output_format not in accepted_formats:
         raise ValueError(
@@ -848,6 +859,25 @@ def save(
             "Saving in ExecuTorch format requires the executorch package "
             "with executorch.exir. Install with: pip install "
             "\"torch_tensorrt[executorch]\" to use output_format='executorch'."
+        )
+    if output_format == "executorch":
+        # Every executorch option is popped above, so a leftover kwarg is a typo. Fail
+        # here rather than silently ignoring it, since nothing downstream reads kwargs.
+        if kwargs:
+            raise TypeError(
+                "save() received unexpected keyword argument(s) for "
+                f"output_format='executorch': {sorted(kwargs)}. Supported executorch "
+                "options are 'partitioners', 'compile_specs', 'backend_config', and "
+                "'weight_streaming_budget_per_engine'."
+            )
+        # Validate the budget before the input and model-shape checks below, so a wrong
+        # type is not reported as an unrelated failure.
+        from torch_tensorrt.executorch.partitioner import (
+            normalize_weight_streaming_budget_per_engine,
+        )
+
+        normalize_weight_streaming_budget_per_engine(
+            executorch_weight_streaming_budget_per_engine
         )
 
     def _all_are_input_objects(obj: Any) -> bool:
@@ -989,6 +1019,15 @@ def save(
             "generate_etrecord= is only used with output_format='executorch' and will "
             f"be ignored for output_format='{output_format}'."
         )
+    if (
+        executorch_weight_streaming_budget_per_engine is not None
+        and output_format != "executorch"
+    ):
+        logger.warning(
+            "weight_streaming_budget_per_engine= is only used with "
+            "output_format='executorch' and will be ignored for "
+            f"output_format='{output_format}'."
+        )
     if output_format == "aot_inductor" and platform.system() != "Linux":
         raise ValueError(
             f"The AOT Inductor format is only supported on Linux, {platform.system()} is not a supported platform for this format"
@@ -1062,6 +1101,7 @@ def save(
                     transform_passes=executorch_transform_passes,
                     compile_config=executorch_compile_config,
                     generate_etrecord=executorch_generate_etrecord,
+                    weight_streaming_budget_per_engine=executorch_weight_streaming_budget_per_engine,
                 )
             else:
                 raise RuntimeError(
@@ -1132,6 +1172,7 @@ def save(
                         transform_passes=executorch_transform_passes,
                         compile_config=executorch_compile_config,
                         generate_etrecord=executorch_generate_etrecord,
+                        weight_streaming_budget_per_engine=executorch_weight_streaming_budget_per_engine,
                     )
                 else:
                     raise RuntimeError(
@@ -1223,6 +1264,7 @@ def save(
                         transform_passes=executorch_transform_passes,
                         compile_config=executorch_compile_config,
                         generate_etrecord=executorch_generate_etrecord,
+                        weight_streaming_budget_per_engine=executorch_weight_streaming_budget_per_engine,
                     )
                 else:
                     raise RuntimeError(
@@ -1292,6 +1334,9 @@ def _save_as_executorch(exp_program: Any, file_path: str, **kwargs: Any) -> None
         compile_config=kwargs.get("compile_config"),
         constant_methods=kwargs.get("constant_methods"),
         generate_etrecord=generate_etrecord,
+        weight_streaming_budget_per_engine=kwargs.get(
+            "weight_streaming_budget_per_engine"
+        ),
     )
     executorch_program = edge_program.to_executorch(config=kwargs.get("backend_config"))
     with open(file_path, "wb") as f:

--- a/py/torch_tensorrt/executorch/_export.py
+++ b/py/torch_tensorrt/executorch/_export.py
@@ -238,6 +238,41 @@ def _declared_method_name(partitioner: Any) -> str | None:
     return None
 
 
+def _apply_weight_streaming_budget(
+    method_compile_specs: dict[str, list[Any]],
+    weight_streaming_budget_per_engine: Any,
+) -> None:
+    """Bake the per-engine weight streaming budget into every method's compile specs.
+
+    The raw compile spec is rejected even when no budget is given, because writing it
+    by hand skips the validation here and silently disagrees with a budget passed the
+    supported way.
+    """
+    from executorch.exir.backend.compile_spec_schema import CompileSpec
+    from torch_tensorrt.executorch.partitioner import (
+        normalize_weight_streaming_budget_per_engine,
+        WEIGHT_STREAMING_BUDGET_COMPILE_SPEC_KEY,
+    )
+
+    for name, specs in method_compile_specs.items():
+        if any(
+            getattr(spec, "key", None) == WEIGHT_STREAMING_BUDGET_COMPILE_SPEC_KEY
+            for spec in specs
+        ):
+            raise ValueError(
+                f"compile_specs for {name!r} carries a "
+                f"CompileSpec({WEIGHT_STREAMING_BUDGET_COMPILE_SPEC_KEY!r}, ...). Pass "
+                "weight_streaming_budget_per_engine instead."
+            )
+    spec_value = normalize_weight_streaming_budget_per_engine(
+        weight_streaming_budget_per_engine
+    )
+    if spec_value is None:
+        return
+    for specs in method_compile_specs.values():
+        specs.append(CompileSpec(WEIGHT_STREAMING_BUDGET_COMPILE_SPEC_KEY, spec_value))
+
+
 def _per_method_values(
     value: Sequence[Any] | Mapping[str, Sequence[Any] | None] | None,
     method_names: tuple[str, ...],
@@ -288,6 +323,7 @@ def export(
     compile_config: "EdgeCompileConfig | None" = None,
     constant_methods: Mapping[str, Any] | None = None,
     generate_etrecord: bool = False,
+    weight_streaming_budget_per_engine: int | None = None,
 ) -> "EdgeProgramManager":
     """Prepare TensorRT-compiled programs for composable ExecuTorch lowering.
 
@@ -362,6 +398,18 @@ def export(
             ``source``.
         generate_etrecord (bool): Ask ExecuTorch for an ETRecord for later debugging.
             This copies the whole program, engines included.
+        weight_streaming_budget_per_engine (Optional[int]): Bytes of engine weights that
+            may stay resident in GPU memory, with the rest streamed from host memory.
+            It applies to **each** TensorRT engine separately, not as a total for the
+            program, so a program with N engines can hold up to N times this value
+            resident: every delegate is initialized when its method loads and they stay
+            resident together. Requires the engine to have been compiled with
+            ``enable_weight_streaming=True``; it is ignored, with a log message, on an
+            engine that cannot stream. Leave it unset, the default, so each engine gets
+            TensorRT's own automatic budget, sized against free memory on the device it
+            actually loads on. This is a different unit from
+            ``torch_tensorrt.runtime.weight_streaming(...).device_budget``, which is a
+            program total split proportionally across engines.
 
     Returns:
         executorch.exir.EdgeProgramManager: The Edge program, ready for inspection,
@@ -404,6 +452,9 @@ def export(
     _reject_misnamed_partitioners(extra_partitioners)
     method_compile_specs = _per_method_values(
         compile_specs, method_names, "compile_specs"
+    )
+    _apply_weight_streaming_budget(
+        method_compile_specs, weight_streaming_budget_per_engine
     )
 
     if constant_methods is not None:
@@ -462,6 +513,15 @@ def export(
                 name,
                 engine_call_counts[name],
             )
+            if weight_streaming_budget_per_engine is not None:
+                logger.warning(
+                    "weight_streaming_budget_per_engine applies to each of those %d "
+                    "engines separately, not as a total, so resident weights for %s "
+                    "can reach %d times the value given.",
+                    engine_call_counts[name],
+                    name,
+                    engine_call_counts[name],
+                )
         # Drop this method's engine payloads as soon as they are in the graph.
         rewritten[name] = replace_execute_engine(program, resolved_engines.pop(name))
         method_partitioners[name] = [

--- a/py/torch_tensorrt/executorch/partitioner.py
+++ b/py/torch_tensorrt/executorch/partitioner.py
@@ -15,9 +15,9 @@ from torch.export import ExportedProgram
 from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
 from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import DEVICE_IDX
 from torch_tensorrt.executorch.backend import (
-    TensorRTBackend,
     _get_engine_info_from_edge_program,
     _parse_device_id,
+    TensorRTBackend,
 )
 from torch_tensorrt.executorch.operator_support import TensorRTOperatorSupport
 
@@ -34,6 +34,15 @@ try:
     )
 except ImportError:
     _TARGET_DEVICE_COMPILE_SPEC_KEY = "target_device"
+
+# Compile spec key that carries the TensorRT weight streaming budget into the
+# delegate. Must match kWeightStreamingBudgetKey on the C++ side
+# (cpp/include/torch_tensorrt/executorch/WeightStreamingBudget.h). The value is a
+# non-negative decimal integer of bytes (ASCII). The key is absent for the
+# automatic budget, which the delegate applies itself for streamable engines.
+# The delegate also reads this same key as a load-time backend option (runtime
+# spec), which takes precedence over this baked value when provided at load.
+WEIGHT_STREAMING_BUDGET_COMPILE_SPEC_KEY = "weight_streaming_budget"
 
 logger = logging.getLogger(__name__)
 

--- a/py/torch_tensorrt/executorch/partitioner.py
+++ b/py/torch_tensorrt/executorch/partitioner.py
@@ -36,7 +36,48 @@ try:
 except ImportError:
     _TARGET_DEVICE_COMPILE_SPEC_KEY = "target_device"
 
+# Compile spec key that carries the TensorRT weight streaming budget into the
+# delegate. Must match kWeightStreamingBudgetKey on the C++ side
+# (cpp/include/torch_tensorrt/executorch/WeightStreamingBudget.h). The value is a
+# non-negative decimal integer of bytes (ASCII). The key is absent for the
+# automatic budget, which the delegate applies itself for streamable engines.
+# The delegate also reads this same key as a load-time backend option (runtime
+# spec), which takes precedence over this baked value when provided at load.
+WEIGHT_STREAMING_BUDGET_COMPILE_SPEC_KEY = "weight_streaming_budget"
+
+# The C++ side parses the value into an int64_t, so anything at or above 2**63 has no
+# representation there.
+WEIGHT_STREAMING_BUDGET_MAX_BYTES = 2**63
+
 logger = logging.getLogger(__name__)
+
+
+def normalize_weight_streaming_budget_per_engine(
+    weight_streaming_budget_per_engine: Optional[int],
+) -> Optional[bytes]:
+    """Validate a per-engine weight streaming budget and encode it for a CompileSpec.
+
+    ``None``, the default, means automatic: the delegate picks the budget at load time.
+    A non-negative integer is an explicit GPU budget in bytes. Returns the ASCII bytes
+    to store in the CompileSpec, or ``None`` when no budget was supplied.
+    """
+    if weight_streaming_budget_per_engine is None:
+        return None
+    # bool is an int subclass, so reject it explicitly along with non-ints.
+    if isinstance(weight_streaming_budget_per_engine, bool) or not isinstance(
+        weight_streaming_budget_per_engine, int
+    ):
+        raise TypeError(
+            "weight_streaming_budget_per_engine must be a non-negative int (number of "
+            "bytes) or None for automatic, got "
+            f"{type(weight_streaming_budget_per_engine).__name__}."
+        )
+    if not 0 <= weight_streaming_budget_per_engine < WEIGHT_STREAMING_BUDGET_MAX_BYTES:
+        raise ValueError(
+            "weight_streaming_budget_per_engine must be in [0, 2**63), got "
+            f"{weight_streaming_budget_per_engine}."
+        )
+    return str(weight_streaming_budget_per_engine).encode("ascii")
 
 
 class TensorRTPartitioner(Partitioner):  # type: ignore[misc]

--- a/tests/cpp/BUILD
+++ b/tests/cpp/BUILD
@@ -66,6 +66,7 @@ test_suite(
     tests = [
         "//tests/cpp/executorch:test_executorch_binding_names",
         "//tests/cpp/executorch:test_executorch_blob_header",
+        "//tests/cpp/executorch:test_executorch_weight_streaming_budget",
     ],
 )
 

--- a/tests/cpp/BUILD
+++ b/tests/cpp/BUILD
@@ -67,6 +67,7 @@ test_suite(
     tests = [
         "//tests/cpp/executorch:test_executorch_binding_names",
         "//tests/cpp/executorch:test_executorch_blob_header",
+        "//tests/cpp/executorch:test_executorch_weight_streaming_budget",
     ],
 )
 

--- a/tests/cpp/executorch/BUILD
+++ b/tests/cpp/executorch/BUILD
@@ -7,6 +7,7 @@ test_suite(
     tests = [
         ":test_executorch_binding_names",
         ":test_executorch_blob_header",
+        ":test_executorch_weight_streaming_budget",
     ],
 )
 
@@ -24,6 +25,15 @@ cc_test(
     srcs = ["test_executorch_blob_header.cpp"],
     deps = [
         "//cpp:tensorrt_executorch_blob_header",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "test_executorch_weight_streaming_budget",
+    srcs = ["test_executorch_weight_streaming_budget.cpp"],
+    deps = [
+        "//cpp:tensorrt_executorch_weight_streaming_budget",
         "@googletest//:gtest_main",
     ],
 )

--- a/tests/cpp/executorch/test_executorch_weight_streaming_budget.cpp
+++ b/tests/cpp/executorch/test_executorch_weight_streaming_budget.cpp
@@ -1,0 +1,109 @@
+#include "torch_tensorrt/executorch/WeightStreamingBudget.h"
+
+#include "gtest/gtest.h"
+
+#include <cstddef>
+#include <cstring>
+#include <limits>
+
+namespace torch_tensorrt {
+namespace executorch_backend {
+namespace {
+
+// The compile spec value is a raw byte range; parse a C string literal by length.
+WsBudget parse(const char* s) {
+  return parse_weight_streaming_budget(s, std::strlen(s));
+}
+
+TEST(ExecuTorchWeightStreamingBudget, ParsesZeroBytes) {
+  const WsBudget budget = parse("0");
+  EXPECT_TRUE(budget.valid);
+  EXPECT_EQ(budget.bytes, 0);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, ParsesLargeByteCount) {
+  const WsBudget budget = parse("8589934592");
+  EXPECT_TRUE(budget.valid);
+  EXPECT_EQ(budget.bytes, 8589934592LL);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsNegative) {
+  // The budget is a non-negative byte count; negatives are rejected.
+  EXPECT_FALSE(parse("-1").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, ParsesInt64Max) {
+  const WsBudget budget = parse("9223372036854775807");
+  EXPECT_TRUE(budget.valid);
+  EXPECT_EQ(budget.bytes, std::numeric_limits<int64_t>::max());
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsLargeNegative) {
+  EXPECT_FALSE(parse("-9223372036854775808").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsOverflow) {
+  // One past the int64_t maximum, so from_chars reports result_out_of_range.
+  EXPECT_FALSE(parse("9223372036854775808").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsEmpty) {
+  EXPECT_FALSE(parse("").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsGarbage) {
+  EXPECT_FALSE(parse("garbage").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsTrailingNonNumeric) {
+  EXPECT_FALSE(parse("12x").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsInternalWhitespace) {
+  EXPECT_FALSE(parse("12 34").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsTrailingWhitespace) {
+  EXPECT_FALSE(parse("42 ").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, ParsesNonNulTerminatedBuffer) {
+  // The compile spec value is a raw byte range, not a C string. Place the value
+  // inside a larger buffer with no terminator after it and parse only its bytes.
+  const char raw[] = {'1', '2', '8', 'X', 'Y', 'Z'};
+  const WsBudget budget = parse_weight_streaming_budget(raw, 3);
+  EXPECT_TRUE(budget.valid);
+  EXPECT_EQ(budget.bytes, 128);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, ZeroLengthBufferIsMalformed) {
+  EXPECT_FALSE(parse_weight_streaming_budget("0", 0).valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, ParsesLeadingZeros) {
+  // Leading zeros are accepted as long as the value fits in int64.
+  const WsBudget budget = parse("0000000001");
+  EXPECT_TRUE(budget.valid);
+  EXPECT_EQ(budget.bytes, 1);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsEmbeddedNul) {
+  // The compile spec value is a raw byte range, so an interior NUL must not let
+  // the value parse as just the bytes before it.
+  const char raw[] = {'1', '2', '3', '\0', 'x'};
+  EXPECT_FALSE(parse_weight_streaming_budget(raw, sizeof(raw)).valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsLeadingWhitespace) {
+  // from_chars does not skip leading whitespace, so " 42" is rejected.
+  EXPECT_FALSE(parse(" 42").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsLeadingPlus) {
+  // from_chars does not accept a leading plus sign.
+  EXPECT_FALSE(parse("+42").valid);
+}
+
+} // namespace
+} // namespace executorch_backend
+} // namespace torch_tensorrt

--- a/tests/cpp/executorch/test_executorch_weight_streaming_budget.cpp
+++ b/tests/cpp/executorch/test_executorch_weight_streaming_budget.cpp
@@ -1,0 +1,123 @@
+#include "torch_tensorrt/executorch/WeightStreamingBudget.h"
+
+#include "gtest/gtest.h"
+
+#include <cstddef>
+#include <cstring>
+#include <limits>
+
+namespace torch_tensorrt {
+namespace executorch_backend {
+namespace {
+
+// The compile spec value is a raw byte range; parse a C string literal by length.
+WsBudget parse(const char* s) {
+  return parse_weight_streaming_budget(s, std::strlen(s));
+}
+
+TEST(ExecuTorchWeightStreamingBudget, ParsesZeroBytes) {
+  const WsBudget budget = parse("0");
+  EXPECT_TRUE(budget.valid);
+  EXPECT_EQ(budget.bytes, 0);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, ParsesLargeByteCount) {
+  const WsBudget budget = parse("8589934592");
+  EXPECT_TRUE(budget.valid);
+  EXPECT_EQ(budget.bytes, 8589934592LL);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsNegative) {
+  // The budget is a non-negative byte count; negatives are rejected.
+  EXPECT_FALSE(parse("-1").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, ParsesInt64Max) {
+  const WsBudget budget = parse("9223372036854775807");
+  EXPECT_TRUE(budget.valid);
+  EXPECT_EQ(budget.bytes, std::numeric_limits<int64_t>::max());
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsLargeNegative) {
+  EXPECT_FALSE(parse("-9223372036854775808").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsOverflow) {
+  // One past the int64_t maximum, so from_chars reports result_out_of_range.
+  EXPECT_FALSE(parse("9223372036854775808").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsEmpty) {
+  EXPECT_FALSE(parse("").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsGarbage) {
+  EXPECT_FALSE(parse("garbage").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsTrailingNonNumeric) {
+  EXPECT_FALSE(parse("12x").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsInternalWhitespace) {
+  EXPECT_FALSE(parse("12 34").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsTrailingWhitespace) {
+  EXPECT_FALSE(parse("42 ").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, ParsesNonNulTerminatedBuffer) {
+  // The compile spec value is a raw byte range, not a C string. Place the value inside a
+  // larger buffer and parse only its bytes. The bytes that follow are DIGITS, then a NUL,
+  // so a parser that ignored nbytes and scanned to the terminator would return 128999 and
+  // this assertion would fail. That makes the counterexample deterministic rather than
+  // undefined behaviour. Note this checks that bytes past nbytes do not affect the RESULT;
+  // it cannot prove they were never read. Proving that needs a guard page or ASan.
+  const char raw[] = {'1', '2', '8', '9', '9', '9', '\0'};
+  const WsBudget budget = parse_weight_streaming_budget(raw, 3);
+  EXPECT_TRUE(budget.valid);
+  EXPECT_EQ(budget.bytes, 128);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, NonNulTerminatedBufferIgnoresTrailingBytes) {
+  // Same shape with non-numeric trailing bytes. This case alone cannot detect an unbounded
+  // parser (it would stop at 'X' and also return 128), so it is kept only as a regression
+  // guard for the accept path; the digits case above is the discriminating one.
+  const char raw[] = {'1', '2', '8', 'X', 'Y', 'Z'};
+  const WsBudget budget = parse_weight_streaming_budget(raw, 3);
+  EXPECT_TRUE(budget.valid);
+  EXPECT_EQ(budget.bytes, 128);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, ZeroLengthBufferIsMalformed) {
+  EXPECT_FALSE(parse_weight_streaming_budget("0", 0).valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, ParsesLeadingZeros) {
+  // Leading zeros are accepted as long as the value fits in int64.
+  const WsBudget budget = parse("0000000001");
+  EXPECT_TRUE(budget.valid);
+  EXPECT_EQ(budget.bytes, 1);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsEmbeddedNul) {
+  // The compile spec value is a raw byte range, so an interior NUL must not let
+  // the value parse as just the bytes before it.
+  const char raw[] = {'1', '2', '3', '\0', 'x'};
+  EXPECT_FALSE(parse_weight_streaming_budget(raw, sizeof(raw)).valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsLeadingWhitespace) {
+  // from_chars does not skip leading whitespace, so " 42" is rejected.
+  EXPECT_FALSE(parse(" 42").valid);
+}
+
+TEST(ExecuTorchWeightStreamingBudget, RejectsLeadingPlus) {
+  // from_chars does not accept a leading plus sign.
+  EXPECT_FALSE(parse("+42").valid);
+}
+
+} // namespace
+} // namespace executorch_backend
+} // namespace torch_tensorrt

--- a/tests/py/dynamo/executorch/test_weight_streaming_budget.py
+++ b/tests/py/dynamo/executorch/test_weight_streaming_budget.py
@@ -1,0 +1,206 @@
+"""CPU-only tests for the ExecuTorch weight streaming budget option.
+
+These exercise the export-time plumbing: budget validation and the compile spec
+carried into the delegate. The automatic default is applied by the C++ delegate
+at load time, so it is not covered here.
+"""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+executorch = pytest.importorskip("executorch.exir")
+
+import torch  # noqa: E402
+from torch_tensorrt._compile import (  # noqa: E402
+    _normalize_weight_streaming_budget,
+    _resolve_executorch_compile_specs,
+    save,
+)
+from torch_tensorrt.executorch.partitioner import (  # noqa: E402
+    WEIGHT_STREAMING_BUDGET_COMPILE_SPEC_KEY,
+)
+
+_KEY = WEIGHT_STREAMING_BUDGET_COMPILE_SPEC_KEY
+
+
+def _budget_spec(specs):
+    for spec in specs:
+        if spec.key == _KEY:
+            return spec
+    return None
+
+
+@pytest.fixture
+def patch_engine_count(monkeypatch):
+    """Patch the engine-node count so the resolver runs without a real program."""
+
+    def _apply(count=1):
+        monkeypatch.setattr(
+            "torch_tensorrt._compile._count_executorch_engine_nodes",
+            lambda exp_program: count,
+        )
+
+    return _apply
+
+
+# ---------------------------------------------------------------------------
+# _normalize_weight_streaming_budget
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, None),
+        (0, b"0"),
+        (8589934592, b"8589934592"),
+    ],
+)
+def test_normalize_valid(value, expected):
+    assert _normalize_weight_streaming_budget(value) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", [-1, -(2**63), 2**63, 2**63 + 5])
+def test_normalize_out_of_range_raises(value):
+    with pytest.raises(ValueError):
+        _normalize_weight_streaming_budget(value)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", ["auto", "disabled", "1024"])
+def test_normalize_string_raises(value):
+    # Strings are not accepted; the budget is a non-negative int (or None).
+    with pytest.raises(TypeError):
+        _normalize_weight_streaming_budget(value)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", [True, False])
+def test_normalize_bool_raises(value):
+    with pytest.raises(TypeError):
+        _normalize_weight_streaming_budget(value)
+
+
+@pytest.mark.unit
+def test_normalize_float_raises():
+    with pytest.raises(TypeError):
+        _normalize_weight_streaming_budget(1.5)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_executorch_compile_specs
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.parametrize("budget,expected", [(0, b"0"), (8589934592, b"8589934592")])
+def test_kwarg_injects_compile_spec(patch_engine_count, budget, expected):
+    patch_engine_count(1)
+    specs = _resolve_executorch_compile_specs(SimpleNamespace(), [], budget)
+    spec = _budget_spec(specs)
+    assert spec is not None
+    assert spec.value == expected
+
+
+@pytest.mark.unit
+def test_kwarg_spec_lands_on_delegation_spec(patch_engine_count):
+    from torch_tensorrt.executorch.partitioner import TensorRTPartitioner
+
+    patch_engine_count(1)
+    specs = _resolve_executorch_compile_specs(SimpleNamespace(), [], 8589934592)
+    partitioner = TensorRTPartitioner(compile_specs=specs)
+    spec = _budget_spec(partitioner.delegation_spec.compile_specs)
+    assert spec is not None
+    assert spec.value == b"8589934592"
+
+
+@pytest.mark.unit
+def test_no_spec_injected_without_budget():
+    # No budget: nothing is injected. The delegate applies the automatic budget
+    # itself for streaming-built engines.
+    specs = _resolve_executorch_compile_specs(SimpleNamespace(), [], None)
+    assert _budget_spec(specs) is None
+
+
+@pytest.mark.unit
+def test_caller_compile_specs_passed_through():
+    # Non-budget caller compile_specs are forwarded unchanged.
+    sentinel = SimpleNamespace(key="target_device", value=b"cuda:1")
+    specs = _resolve_executorch_compile_specs(SimpleNamespace(), [sentinel], None)
+    assert sentinel in specs
+    assert _budget_spec(specs) is None
+
+
+@pytest.mark.unit
+def test_caller_budget_spec_in_compile_specs_raises():
+    # The budget must come from the kwarg, not a manually-pinned compile spec.
+    spec = SimpleNamespace(key=_KEY, value=b"4096")
+    with pytest.raises(ValueError):
+        _resolve_executorch_compile_specs(SimpleNamespace(), [spec], None)
+
+
+# ---------------------------------------------------------------------------
+# Multi-engine warning
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_multi_engine_explicit_warns(patch_engine_count, caplog):
+    patch_engine_count(2)
+    with caplog.at_level(logging.WARNING, logger="torch_tensorrt._compile"):
+        _resolve_executorch_compile_specs(SimpleNamespace(), [], 4096)
+    assert "multiple TensorRT engines" in caplog.text
+
+
+@pytest.mark.unit
+def test_multi_engine_none_does_not_warn(patch_engine_count, caplog):
+    patch_engine_count(2)
+    with caplog.at_level(logging.WARNING, logger="torch_tensorrt._compile"):
+        specs = _resolve_executorch_compile_specs(SimpleNamespace(), [], None)
+    assert _budget_spec(specs) is None
+    assert "multiple TensorRT engines" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# save() entry-point guards
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_save_rejects_bool_budget(tmp_path):
+    with pytest.raises(TypeError):
+        save(
+            torch.nn.Linear(1, 1),
+            str(tmp_path / "model.pte"),
+            output_format="executorch",
+            weight_streaming_budget=True,
+        )
+
+
+@pytest.mark.unit
+def test_save_rejects_string_budget(tmp_path):
+    with pytest.raises(TypeError):
+        save(
+            torch.nn.Linear(1, 1),
+            str(tmp_path / "model.pte"),
+            output_format="executorch",
+            weight_streaming_budget="auto",
+        )
+
+
+@pytest.mark.unit
+def test_save_rejects_negative_budget(tmp_path):
+    with pytest.raises(ValueError):
+        save(
+            torch.nn.Linear(1, 1),
+            str(tmp_path / "model.pte"),
+            output_format="executorch",
+            weight_streaming_budget=-1,
+        )
+
+
+@pytest.mark.unit
+def test_save_rejects_unknown_executorch_kwarg(tmp_path):
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        save(
+            torch.nn.Linear(1, 1),
+            str(tmp_path / "model.pte"),
+            output_format="executorch",
+            weight_streaming_budgett=4096,
+        )

--- a/tests/py/dynamo/executorch/test_weight_streaming_budget.py
+++ b/tests/py/dynamo/executorch/test_weight_streaming_budget.py
@@ -1,0 +1,326 @@
+"""CPU-only tests for the ExecuTorch weight streaming budget option.
+
+These exercise the export-time plumbing: budget validation and the compile spec
+carried into the delegate. The automatic default is applied by the C++ delegate
+at load time, so it is not covered here.
+"""
+
+import importlib
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("executorch.exir")
+
+import torch  # noqa: E402
+from executorch.exir.backend.compile_spec_schema import CompileSpec  # noqa: E402
+from torch_tensorrt._compile import save  # noqa: E402
+from torch_tensorrt.executorch.partitioner import (  # noqa: E402
+    normalize_weight_streaming_budget_per_engine,
+    WEIGHT_STREAMING_BUDGET_COMPILE_SPEC_KEY,
+)
+
+_KEY = WEIGHT_STREAMING_BUDGET_COMPILE_SPEC_KEY
+
+
+class FakeExportedProgram:
+    pass
+
+
+class FakeTensorRTPartitioner:
+    def __init__(self, compile_specs):
+        self.compile_specs = compile_specs
+
+
+def _budget_spec(specs):
+    for spec in specs:
+        if spec.key == _KEY:
+            return spec
+    return None
+
+
+def _patch_lowering(monkeypatch, engine_counts=None):
+    """Stub out everything export() needs except the compile-spec resolution itself.
+
+    Engines and ExecuTorch lowering are irrelevant to where the budget spec lands, and
+    stubbing them keeps these tests CPU-only.
+    """
+    import executorch.exir
+    import torch_tensorrt._features as features
+    import torch_tensorrt.executorch as executorch_api
+    import torch_tensorrt.executorch._export_utils as export_utils
+
+    monkeypatch.setattr(
+        features,
+        "ENABLED_FEATURES",
+        features.ENABLED_FEATURES._replace(torch_tensorrt_runtime=True),
+    )
+    export_module = importlib.import_module("torch_tensorrt.executorch._export")
+    engine_counts = engine_counts or {}
+    lower = MagicMock(return_value=object())
+    monkeypatch.setattr(executorch.exir, "to_edge_transform_and_lower", lower)
+    monkeypatch.setattr(executorch_api, "TensorRTPartitioner", FakeTensorRTPartitioner)
+    monkeypatch.setattr(executorch_api, "get_edge_compile_config", lambda: "default")
+    monkeypatch.setattr(export_module, "ExportedProgram", FakeExportedProgram)
+    monkeypatch.setattr(
+        export_utils,
+        "validate_engine_program",
+        lambda program, resolved=None: engine_counts.get(program, 1),
+    )
+    monkeypatch.setattr(export_utils, "stage_exported_program", lambda program: program)
+    monkeypatch.setattr(
+        export_utils,
+        "replace_execute_engine",
+        lambda program, resolved=None: program,
+    )
+    return export_module, lower
+
+
+def _specs_by_method(lower):
+    """The TensorRT partitioner's compile specs, per method, from the lowering call."""
+    partitioner = lower.call_args.kwargs["partitioner"]
+    if not isinstance(partitioner, dict):
+        partitioner = {"forward": partitioner}
+    return {name: chain[0].compile_specs for name, chain in partitioner.items()}
+
+
+# ---------------------------------------------------------------------------
+# normalize_weight_streaming_budget_per_engine
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, None),
+        (0, b"0"),
+        (8589934592, b"8589934592"),
+    ],
+)
+def test_normalize_valid(value, expected):
+    assert normalize_weight_streaming_budget_per_engine(value) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", [-1, -(2**63), 2**63, 2**63 + 5])
+def test_normalize_out_of_range_raises(value):
+    with pytest.raises(ValueError):
+        normalize_weight_streaming_budget_per_engine(value)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", ["auto", "disabled", "1024"])
+def test_normalize_string_raises(value):
+    # Strings are not accepted; the budget is a non-negative int (or None).
+    with pytest.raises(TypeError):
+        normalize_weight_streaming_budget_per_engine(value)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", [True, False])
+def test_normalize_bool_raises(value):
+    with pytest.raises(TypeError):
+        normalize_weight_streaming_budget_per_engine(value)
+
+
+@pytest.mark.unit
+def test_normalize_float_raises():
+    with pytest.raises(TypeError):
+        normalize_weight_streaming_budget_per_engine(1.5)
+
+
+# ---------------------------------------------------------------------------
+# The budget reaching the TensorRT partitioner through export()
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.parametrize("budget,expected", [(0, b"0"), (8589934592, b"8589934592")])
+def test_kwarg_injects_compile_spec(monkeypatch, budget, expected):
+    export_module, lower = _patch_lowering(monkeypatch)
+    export_module.export(
+        FakeExportedProgram(), weight_streaming_budget_per_engine=budget
+    )
+    spec = _budget_spec(_specs_by_method(lower)["forward"])
+    assert spec is not None
+    assert spec.value == expected
+
+
+@pytest.mark.unit
+def test_kwarg_injects_compile_spec_into_every_method(monkeypatch):
+    export_module, lower = _patch_lowering(monkeypatch)
+    export_module.export(
+        {"forward": FakeExportedProgram(), "decode": FakeExportedProgram()},
+        weight_streaming_budget_per_engine=4096,
+    )
+    per_method = _specs_by_method(lower)
+    assert set(per_method) == {"forward", "decode"}
+    for name, specs in per_method.items():
+        spec = _budget_spec(specs)
+        assert spec is not None, name
+        assert spec.value == b"4096"
+
+
+@pytest.mark.unit
+def test_no_spec_injected_without_budget(monkeypatch):
+    # No budget: nothing is injected. The delegate applies the automatic budget
+    # itself for streaming-built engines.
+    export_module, lower = _patch_lowering(monkeypatch)
+    export_module.export(FakeExportedProgram())
+    assert _budget_spec(_specs_by_method(lower)["forward"]) is None
+
+
+@pytest.mark.unit
+def test_caller_compile_specs_passed_through(monkeypatch):
+    # Non-budget caller compile_specs are forwarded alongside the budget.
+    export_module, lower = _patch_lowering(monkeypatch)
+    caller = CompileSpec("target_device", b"cuda:1")
+    export_module.export(
+        FakeExportedProgram(),
+        compile_specs=[caller],
+        weight_streaming_budget_per_engine=4096,
+    )
+    specs = _specs_by_method(lower)["forward"]
+    assert caller in specs
+    assert _budget_spec(specs).value == b"4096"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("budget", [None, 4096])
+def test_caller_budget_spec_in_compile_specs_raises(monkeypatch, budget):
+    # The budget must come from the kwarg, not a manually-pinned compile spec.
+    export_module, _ = _patch_lowering(monkeypatch)
+    with pytest.raises(ValueError, match=_KEY):
+        export_module.export(
+            FakeExportedProgram(),
+            compile_specs=[CompileSpec(_KEY, b"4096")],
+            weight_streaming_budget_per_engine=budget,
+        )
+
+
+@pytest.mark.unit
+def test_invalid_budget_raises_from_export(monkeypatch):
+    export_module, _ = _patch_lowering(monkeypatch)
+    with pytest.raises(TypeError):
+        export_module.export(
+            FakeExportedProgram(), weight_streaming_budget_per_engine="auto"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-engine warning
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_multi_engine_explicit_warns(monkeypatch, caplog):
+    program = FakeExportedProgram()
+    export_module, _ = _patch_lowering(monkeypatch, engine_counts={program: 2})
+    with caplog.at_level(logging.WARNING, logger="torch_tensorrt.executorch._export"):
+        export_module.export(program, weight_streaming_budget_per_engine=4096)
+    assert "weight_streaming_budget_per_engine applies to each" in caplog.text
+
+
+@pytest.mark.unit
+def test_multi_engine_none_does_not_warn(monkeypatch, caplog):
+    program = FakeExportedProgram()
+    export_module, lower = _patch_lowering(monkeypatch, engine_counts={program: 2})
+    with caplog.at_level(logging.WARNING, logger="torch_tensorrt.executorch._export"):
+        export_module.export(program)
+    assert _budget_spec(_specs_by_method(lower)["forward"]) is None
+    assert "weight_streaming_budget_per_engine applies to each" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# save() entry-point guards
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_save_rejects_bool_budget(tmp_path):
+    with pytest.raises(TypeError):
+        save(
+            torch.nn.Linear(1, 1),
+            str(tmp_path / "model.pte"),
+            output_format="executorch",
+            weight_streaming_budget_per_engine=True,
+        )
+
+
+@pytest.mark.unit
+def test_save_rejects_string_budget(tmp_path):
+    with pytest.raises(TypeError):
+        save(
+            torch.nn.Linear(1, 1),
+            str(tmp_path / "model.pte"),
+            output_format="executorch",
+            weight_streaming_budget_per_engine="auto",
+        )
+
+
+@pytest.mark.unit
+def test_save_rejects_negative_budget(tmp_path):
+    with pytest.raises(ValueError):
+        save(
+            torch.nn.Linear(1, 1),
+            str(tmp_path / "model.pte"),
+            output_format="executorch",
+            weight_streaming_budget_per_engine=-1,
+        )
+
+
+@pytest.mark.unit
+def test_save_rejects_unknown_executorch_kwarg(tmp_path):
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        save(
+            torch.nn.Linear(1, 1),
+            str(tmp_path / "model.pte"),
+            output_format="executorch",
+            weight_streaming_budget_per_enginet=4096,
+        )
+
+
+@pytest.mark.unit
+def test_save_warns_when_budget_used_with_non_executorch_format(tmp_path, caplog):
+    """The docstring says the executorch-only kwargs are ignored with a warning for
+    other formats. compile_specs and backend_config warn; the budget must too.
+
+    The save is expected to fail afterwards (a plain nn.Module is not an
+    ExportedProgram), so the warning is asserted independently of the outcome.
+    """
+    with caplog.at_level(logging.WARNING):
+        try:
+            save(
+                torch.nn.Linear(1, 1),
+                str(tmp_path / "model.ep"),
+                output_format="exported_program",
+                weight_streaming_budget_per_engine=4096,
+            )
+        except Exception:
+            pass
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        "weight_streaming_budget_per_engine=" in m and "will be ignored" in m
+        for m in messages
+    ), messages
+
+
+@pytest.mark.unit
+def test_save_forwards_the_budget_to_export(monkeypatch, tmp_path):
+    """save() must actually pass the budget on; a dropped kwarg is silent otherwise."""
+    import torch_tensorrt._compile as compile_module
+
+    seen = {}
+
+    def fake_export(program, **kwargs):
+        seen.update(kwargs)
+        raise RuntimeError("stop after the forward")
+
+    monkeypatch.setattr("torch_tensorrt.executorch.export", fake_export)
+    # _compile.py binds ENABLED_FEATURES at import, so patch the name it holds.
+    monkeypatch.setattr(
+        compile_module,
+        "ENABLED_FEATURES",
+        compile_module.ENABLED_FEATURES._replace(torch_tensorrt_runtime=True),
+    )
+    with pytest.raises(RuntimeError, match="stop after the forward"):
+        compile_module._save_as_executorch(
+            object(),
+            str(tmp_path / "model.pte"),
+            weight_streaming_budget_per_engine=4096,
+        )
+    assert seen["weight_streaming_budget_per_engine"] == 4096


### PR DESCRIPTION
## Summary

Add TensorRT weight streaming support to the Torch-TensorRT ExecuTorch delegate, so a model whose weights do not all fit in GPU memory can run when exported to an ExecuTorch program. Ref #4334.

Torch-TensorRT already builds a weight streamable engine when you compile with `enable_weight_streaming=True`, but the ExecuTorch delegate never set a budget on the engine at load time, so large models could not stream. This change sets the budget in the delegate `init()`, after the engine is deserialized and before the execution context is created, which is the same pattern the other Torch-TensorRT runtimes already use.

## How it works

By default the delegate applies TensorRT's automatic budget, computed at load time from the free memory on the actual GPU, gated on `getStreamableWeightsSize() > 0`. So an engine built with `enable_weight_streaming=True` runs out of the box and adapts to the deploy device. Nothing is baked into the `.pte` for this default case.

An explicit budget is a non-negative number of bytes and can be set two ways, in order of precedence:

1. **Load time (preferred):** an ExecuTorch backend option named `weight_streaming_budget`, passed by the caller via `Module::load(LoadBackendOptionsMap)` and read in `init()` with `BackendInitContext::get_runtime_spec`. This lets a deployment size the budget for its own GPU without re-exporting. It is the same load-time pattern CoreML and XNNPACK use.
2. **Export time (default / fallback):** the same backend-option key baked into the `.pte` via `torch_tensorrt.save(output_format="executorch", weight_streaming_budget_per_engine=N)`. The Python keyword is named `_per_engine` because `weight_streaming_budget` already means a program-wide total on `MutableTorchTensorRTModule`; the key on the wire is unchanged. This is used when no load-time option is given, and it is the only channel for loaders that cannot pass backend options yet (the ExecuTorch Python and Android runtimes).

Resolution order in the delegate is: load-time option, then the baked value, then automatic. The value is a decimal string on the wire because ExecuTorch's typed integer option is only 32 bit and a byte budget can exceed 2 GB.

```python
import torch_tensorrt

compiled = torch_tensorrt.compile(
    model, arg_inputs=example_inputs, enable_weight_streaming=True
)

# Default: the delegate applies the automatic budget at load, so a large model runs.
torch_tensorrt.save(
    compiled, "model.pte", arg_inputs=example_inputs, output_format="executorch"
)

# Optional export-time default budget (overridable at load):
torch_tensorrt.save(
    compiled, "model.pte", arg_inputs=example_inputs,
    output_format="executorch",
    weight_streaming_budget_per_engine=8 * 1024**3,  # 8 GiB
)
```

```cpp
// C++ runtime: use the automatic or baked budget (no change needed), or override
// the budget at load for this specific GPU with a backend option.
executorch::runtime::BackendOptions<1> trt_opts;
trt_opts.set_option("weight_streaming_budget", "8589934592");  // 8 GiB
executorch::runtime::LoadBackendOptionsMap options;
options.set_options("TensorRTBackend", trt_opts.view());

executorch::extension::Module module("model.pte");
module.load(options);
auto outputs = module.forward(inputs);
```

## Changes

* `TensorRTBackend::init` applies the budget via `setWeightStreamingBudgetV2` before creating the execution context, gated on `getStreamableWeightsSize() > 0`. It resolves the budget as load-time runtime spec, then baked compile spec, then automatic.
* New standalone `WeightStreamingBudget` parser (`cpp/include` and `cpp/src`), unit tested without a GPU. It uses `std::from_chars` and accepts only a non-negative decimal integer.
* `torch_tensorrt.executorch.export(..., weight_streaming_budget_per_engine=...)` writes the export-time default into the TensorRT partitioner's compile specs, for every method of a multi-method export. `torch_tensorrt.save(output_format="executorch")` forwards the same argument. Validation lives next to the compile spec key in `torch_tensorrt/executorch/partitioner.py`. Passing the budget through `compile_specs` by hand is rejected in favor of the keyword argument, because that route skips the validation.
* C++ gtest cases for the parser and a CPU Python test suite.
* Bazel and CMake wiring for the new files.

## Requirements

The load-time override uses ExecuTorch's `BackendInitContext::get_runtime_spec` and `LoadBackendOptionsMap`. The export-time default and the automatic budget work without it.

## Backward compatibility

* The new code only runs when the engine was built for weight streaming. Engines built with the default settings report zero streamable weights and skip the new path, so they behave exactly as before. This covers every existing `.pte`.
* There is no change to the `.pte` format or the engine blob.
* The one intended behavior change is that a streamable engine now applies the automatic budget at load, which enables the large model case and matches the PyTorch runtimes.

## Edge cases

* A budget on an engine that was not built for streaming is ignored with a log.
* An explicit budget larger than the streamable size is clamped.
* A malformed or negative budget is rejected at export (TypeError or ValueError) and at load (`Error::InvalidProgram`).
* If the automatic budget cannot be applied, the runtime retries with maximum streaming before failing.
* For a model split into more than one engine, an explicit byte budget applies to each engine and emits a warning. Leave `weight_streaming_budget_per_engine` as `None` for multi-engine models.

## Status and validation

* The C++ value parser was built and its gtest cases run on CPU.
* The new Python tests run on CPU. 29 tests pass, covering budget validation, the compile spec
  reaching the TensorRT partitioner for single-method and multi-method exports, the rejection of a
  hand-written spec, the multi-engine warning, and the `save()` argument guards. Each was checked to
  fail when the code it covers is removed.
* Running the whole `tests/py/dynamo/executorch` directory on this change and on the base branch
  gives the same set of failures, so the change adds no new ones. Those shared failures are from the
  test machine having no GPU and no compiled Torch-TensorRT runtime, not from the code.
* Everything that needs a GPU, including weight streaming actually running on a device, is covered
  by CI rather than by hand here.

## Follow-ups

* Expose `LoadBackendOptionsMap` in ExecuTorch's Python (and Android) runtime bindings so non-C++ loaders can also set the budget at load. Until then the export-time default covers them.
* Add a live, after-load setter (change the budget on an already loaded model) via the backend `set_option` API. This needs the execution context to be destroyed and recreated, like `TRTEngine::set_device_memory_budget`, so it is deferred.
* Cover the budget logic in `init()` with a test: runtime-spec versus compile-spec precedence, the clamp to `getStreamableWeightsSize()`, and the automatic-budget fallback. The current tests cover the byte-string parser and the export-time plumbing only. This needs an engine actually built with `enable_weight_streaming=True`, so it belongs in the GPU delegate lane rather than here.

## Behavior change worth calling out

`save(output_format="executorch", ...)` now raises `TypeError` on an unrecognised keyword argument instead of ignoring it. This turns a silent typo into a hard failure, which is the point, but it is a behavior change for anyone who was passing an unused kwarg. It is scoped to `output_format="executorch"`, so the other output formats are unaffected.

