### PR TITLE
namedtuple in input

### DIFF
--- a/docsrc/user_guide/compilation/dynamic_shapes.rst
+++ b/docsrc/user_guide/compilation/dynamic_shapes.rst
@@ -121,6 +121,44 @@ can be shared simultaneously with ``shared_dims={0: "B", 1: "S"}``.
 
 See the full runnable example: :ref:`shared_dynamic_dims`.
 
+Namedtuple Shorthand for Shared Dims
+-------------------------------------
+
+Passing a ``namedtuple`` as ``min_shape`` / ``opt_shape`` / ``max_shape`` is a
+shorthand for the ``shared_dims`` pattern above.  Field names become axis names
+automatically — no ``shared_dims`` kwarg required.  Dynamic axes (``min != max``)
+with the same field name across inputs are exported as one shared
+``torch.export.Dim``; static axes (``min == max``) are ignored.
+
+.. code-block:: python
+
+    from collections import namedtuple
+    import torch
+    import torch_tensorrt
+
+    model = MyHFEncoder().eval().cuda()
+
+    S = namedtuple("shape", ["batch", "seq"])
+
+    inputs = [
+        torch_tensorrt.Input(
+            min_shape=S(1, 16), opt_shape=S(4, 16), max_shape=S(8, 16),
+            dtype=torch.int64, name="input_ids",
+        ),
+        torch_tensorrt.Input(
+            min_shape=S(1, 16), opt_shape=S(4, 16), max_shape=S(8, 16),
+            dtype=torch.int64, name="attention_mask",
+        ),
+    ]
+    # "batch" is dynamic (1→8) on both inputs → one shared Dim("batch")
+    # "seq"   is static  (16==16)             → no Dim needed
+
+    trt_model = torch_tensorrt.compile(model, ir="dynamo", inputs=inputs)
+
+This is equivalent to passing ``shared_dims={0: "batch"}`` on each input
+individually.  The two styles cannot be combined on the same ``Input`` — use
+one or the other.
+
 Dynamic shapes using torch.compile (JIT)
 ------------------------------------
 

--- a/py/torch_tensorrt/_Input.py
+++ b/py/torch_tensorrt/_Input.py
@@ -183,7 +183,42 @@ class Input(object):
                         "if you try to run inference with empty tensor inputs."
                     )
 
+                # Namedtuple shape API: field names encode per-axis dimension names.
+                # Convert to shared_dims so _tracer.py needs no changes — axes with the
+                # same name across inputs become one shared torch.export.Dim.
+                if hasattr(kwargs["min_shape"], "_fields"):
+                    fields = kwargs["min_shape"]._fields
+                    if not (
+                        hasattr(kwargs["opt_shape"], "_fields")
+                        and hasattr(kwargs["max_shape"], "_fields")
+                    ):
+                        raise TypeError(
+                            "If min_shape is a namedtuple, opt_shape and max_shape must also be namedtuples"
+                        )
+                    if not (
+                        kwargs["opt_shape"]._fields == fields
+                        and kwargs["max_shape"]._fields == fields
+                    ):
+                        raise ValueError(
+                            "min_shape, opt_shape, max_shape namedtuples must have identical field names"
+                        )
+                    # Only tag dynamic axes (min != max); static axes need no shared Dim.
+                    self.shared_dims = {
+                        i: name
+                        for i, name in enumerate(fields)
+                        if self.shape["min_shape"][i] != self.shape["max_shape"][i]
+                    }
+
                 if "shared_dims" in kwargs and kwargs["shared_dims"]:
+                    if hasattr(kwargs["min_shape"], "_fields"):
+                        # Not allowed:
+                        #   S = namedtuple('S', ['b', 'c'])
+                        #   Input(min_shape=S(1,2), opt_shape=S(4,2), max_shape=S(8,2),
+                        #         shared_dims={0: "b"})   # ← redundant and ambiguous
+                        raise ValueError(
+                            "Cannot specify both a namedtuple min_shape and shared_dims; "
+                            "use one or the other to name dynamic axes."
+                        )
                     self.shared_dims = Input._parse_shared_dims(
                         kwargs["shared_dims"], self.shape
                     )

--- a/py/torch_tensorrt/_Input.py
+++ b/py/torch_tensorrt/_Input.py
@@ -74,18 +74,41 @@ class Input(object):
 
         Keyword Arguments:
             shape (Tuple or List, optional): Static shape of input tensor
-            min_shape (Tuple or List, optional): Min size of input tensor's shape range
-                Note: All three of min_shape, opt_shape, max_shape must be provided, there must be no positional arguments, shape must not be defined and implicitly this sets Input's shape_mode to DYNAMIC
-            opt_shape (Tuple or List, optional): Opt size of input tensor's shape range
-                Note: All three of min_shape, opt_shape, max_shape must be provided, there must be no positional arguments, shape must not be defined and implicitly this sets Input's shape_mode to DYNAMIC
-            max_shape (Tuple or List, optional): Max size of input tensor's shape range
-                Note: All three of min_shape, opt_shape, max_shape must be provided, there must be no positional arguments, shape must not be defined and implicitly this sets Input's shape_mode to DYNAMIC
+            min_shape (Tuple, List, torch.Size, or NamedTuple, optional): Min size of input tensor's shape range.
+                Note: All three of min_shape, opt_shape, max_shape must be provided, there must be no positional arguments, shape must not be defined and implicitly this sets Input's shape_mode to DYNAMIC.
+                If a namedtuple is provided, its field names are used as axis names — see the namedtuple shape spec note below.
+            opt_shape (Tuple, List, torch.Size, or NamedTuple, optional): Opt size of input tensor's shape range.
+                Note: All three of min_shape, opt_shape, max_shape must be provided, there must be no positional arguments, shape must not be defined and implicitly this sets Input's shape_mode to DYNAMIC.
+                Must be a namedtuple with identical fields to min_shape if min_shape is a namedtuple.
+            max_shape (Tuple, List, torch.Size, or NamedTuple, optional): Max size of input tensor's shape range.
+                Note: All three of min_shape, opt_shape, max_shape must be provided, there must be no positional arguments, shape must not be defined and implicitly this sets Input's shape_mode to DYNAMIC.
+                Must be a namedtuple with identical fields to min_shape if min_shape is a namedtuple.
             dtype (torch.dtype or torch_tensorrt.dtype): Expected data type for input tensor (default: torch_tensorrt.dtype.float32)
             format (torch.memory_format or torch_tensorrt.TensorFormat): The expected format of the input tensor (default: torch_tensorrt.TensorFormat.NCHW)
             tensor_domain (Tuple(float, float), optional): The domain of allowed values for the tensor, as interval notation: [tensor_domain[0], tensor_domain[1]).
                 Note: Entering "None" (or not specifying) will set the bound to [0, 2)
             torch_tensor (torch.Tensor): Holds a corresponding torch tensor with this Input.
             name (str, optional): Name of this input in the input nn.Module's forward function. Used to specify dynamic shapes for the corresponding input in dynamo tracer.
+            shared_dims (Dict[int, str], optional): Maps axis indices to names. Axes with the same name across multiple inputs are exported as a single shared ``torch.export.Dim``. Cannot be combined with a namedtuple min_shape.
+
+        Note — namedtuple shape spec (shorthand for ``shared_dims``):
+            Passing a namedtuple as ``min_shape``/``opt_shape``/``max_shape`` is a shorthand
+            for declaring shared dynamic axes without writing ``shared_dims`` explicitly.
+            Each field name becomes the axis name; dynamic axes (min != max) with the same
+            name across inputs are automatically exported as one shared ``torch.export.Dim``.
+            Static axes (min == max) are ignored. Cannot be combined with ``shared_dims``::
+
+                from collections import namedtuple
+                S = namedtuple("shape", ["batch", "seq"])
+                inputs = [
+                    torch_tensorrt.Input(min_shape=S(1, 16), opt_shape=S(4, 16), max_shape=S(4, 16),
+                                         dtype=torch.int64, name="input_ids"),
+                    torch_tensorrt.Input(min_shape=S(1, 16), opt_shape=S(4, 16), max_shape=S(4, 16),
+                                         dtype=torch.int64, name="attention_mask"),
+                ]
+                # "batch" is dynamic (1→4) on both inputs → one shared Dim("batch")
+                # "seq" is static (16==16) → no shared dim needed
+
         Examples:
             - Input([1,3,32,32], dtype=torch.float32, format=torch.channel_last)
             - Input(shape=(1,3,32,32), dtype=torch_tensorrt.dtype.int32, format=torch_tensorrt.TensorFormat.NCHW)

--- a/py/torch_tensorrt/dynamo/_tracer.py
+++ b/py/torch_tensorrt/dynamo/_tracer.py
@@ -86,6 +86,7 @@ def trace(
     dim_registry = build_dim_registry(arg_inputs, kwarg_inputs)
     dynamic_shapes = get_dynamic_shapes_args(mod, arg_inputs, dim_registry)
     dynamic_shapes.update(get_dynamic_shapes_kwargs(kwarg_inputs, dim_registry))
+    logger.debug("Derived dynamic_shapes for export: %s", dynamic_shapes)
 
     export_context = nullcontext()
 
@@ -137,6 +138,10 @@ def build_dim_registry(arg_inputs: Any, kwarg_inputs: Any) -> dict[str, Any]:
     """
     registry: dict[str, Any] = {}
     bounds: dict[str, tuple[int, int]] = {}
+    # {name: ["input_ids[0]", ...]} -- every axis fused under each name. Recorded
+    # during the loop because ``registry`` only keeps name -> Dim, losing the
+    # link back to the inputs that contributed it.
+    usage: dict[str, list[str]] = {}
     for inp in _collect_inputs(arg_inputs) + _collect_inputs(kwarg_inputs):
         shared_dims = getattr(inp, "shared_dims", None)
         if not shared_dims or inp.shape_mode != Input._ShapeMode.DYNAMIC:
@@ -146,16 +151,32 @@ def build_dim_registry(arg_inputs: Any, kwarg_inputs: Any) -> dict[str, Any]:
         max_shape = inp.shape["max_shape"]
         for axis, dim_name in shared_dims.items():
             lo, hi = int(min_shape[axis]), int(max_shape[axis])
+            site = f"{inp.name or '<unnamed>'}[{axis}]"
             if dim_name in bounds:
                 if bounds[dim_name] != (lo, hi):
                     raise ValueError(
                         f"Dimension name '{dim_name}' is used with conflicting ranges "
-                        f"{bounds[dim_name]} and {(lo, hi)}. A shared named dimension "
+                        f"{bounds[dim_name]} on {', '.join(usage[dim_name])} and "
+                        f"{(lo, hi)} on {site}. A shared named dimension "
                         f"must have identical (min, max) on every input that uses it."
                     )
             else:
                 bounds[dim_name] = (lo, hi)
                 registry[dim_name] = Dim(dim_name, min=lo, max=hi)
+            usage.setdefault(dim_name, []).append(site)
+
+    if registry:
+        logger.info(
+            "Resolved %d shared dynamic dim(s) from Input specs: %s. Axes listed "
+            "under one name are exported as a single symbol and are therefore "
+            "constrained equal at runtime.",
+            len(registry),
+            "; ".join(
+                f"'{name}' -> [{bounds[name][0]}, {bounds[name][1]}] on "
+                f"{', '.join(usage[name])}"
+                for name in registry
+            ),
+        )
     return registry
 
 

--- a/tests/py/dynamo/models/test_shared_dynamic_dim.py
+++ b/tests/py/dynamo/models/test_shared_dynamic_dim.py
@@ -243,5 +243,116 @@ def test_default_path_unchanged_for_static_inputs():
     assertions.assertTrue(cosine_similarity(ref, out) > COSINE_THRESHOLD)
 
 
+# ---------------------------------------------------------------------------
+# Namedtuple shape API tests
+# ---------------------------------------------------------------------------
+#
+# The namedtuple API lets users name axes by using a namedtuple as the shape
+# spec.  Field names that appear on multiple inputs are automatically treated
+# as a shared torch.export.Dim — no explicit shared_dims kwarg required.
+#
+#   input_shape1 = namedtuple('S', ['n', 'c', 'h', 'w'])
+#   input_shape2 = namedtuple('S', ['c', 'seq'])
+#   Both have field 'c' → one shared Dim("c").
+
+from collections import namedtuple
+
+
+@pytest.mark.unit
+@pytest.mark.critical
+def test_namedtuple_shared_batch_positional_inputs():
+    """Namedtuple field 'c' shared across two inputs — same as shared_dims={...:'c'}."""
+    model = _SharedBatchEncoder().eval().cuda()
+
+    # seq is static
+    S1 = namedtuple("shape", ["c", "seq"])
+
+    positional_inputs = [
+        torchtrt.Input(
+            min_shape=S1(1, 16),
+            opt_shape=S1(4, 16),
+            max_shape=S1(4, 16),
+            dtype=torch.int64,
+            name="input_ids",
+        ),
+        torchtrt.Input(
+            min_shape=S1(1, 16),
+            opt_shape=S1(4, 16),
+            max_shape=S1(4, 16),
+            dtype=torch.int64,
+            name="attention_mask",
+        ),
+    ]
+
+    trt_mod = torchtrt.compile(
+        model,
+        ir="dynamo",
+        inputs=positional_inputs,
+        min_block_size=1,
+        cache_built_engines=False,
+        reuse_cached_engines=False,
+    )
+
+    for bs in (4, 2):
+        ids = torch.randint(0, 1024, (bs, 16), dtype=torch.int64, device="cuda")
+        mask = torch.ones((bs, 16), dtype=torch.int64, device="cuda")
+        with torch.no_grad():
+            ref = model(ids, mask)
+            out = trt_mod(ids, mask)
+        cos_sim = cosine_similarity(ref, out)
+        assertions.assertTrue(
+            cos_sim > COSINE_THRESHOLD,
+            f"namedtuple shared batch (positional) out-of-tolerance at bs={bs}: cos_sim={cos_sim}",
+        )
+
+
+@pytest.mark.unit
+def test_namedtuple_static_axes_skipped():
+    """Static axes (min==max) in a namedtuple are not added to shared_dims."""
+    S = namedtuple("shape", ["batch", "seq"])
+    inp = torchtrt.Input(
+        min_shape=S(1, 16),
+        opt_shape=S(4, 16),
+        max_shape=S(4, 16),
+        dtype=torch.int64,
+        name="x",
+    )
+    # 'seq' axis: min=max=16 → static, must not appear in shared_dims
+    assertions.assertNotIn(1, inp.shared_dims)
+    # 'batch' axis: min=1, max=4 → dynamic, must appear
+    assertions.assertIn(0, inp.shared_dims)
+    assertions.assertEqual(inp.shared_dims[0], "batch")
+
+
+@pytest.mark.unit
+def test_namedtuple_mismatched_fields_raises():
+    """opt_shape namedtuple with different fields than min_shape is rejected."""
+    S1 = namedtuple("shape", ["b", "c"])
+    S2 = namedtuple("shape", ["b", "seq"])
+    with assertions.assertRaises(ValueError):
+        torchtrt.Input(
+            min_shape=S1(1, 16),
+            opt_shape=S2(4, 16),
+            max_shape=S1(4, 16),
+            dtype=torch.int64,
+            name="x",
+        )
+
+
+@pytest.mark.unit
+def test_namedtuple_and_shared_dims_together_raises():
+    """Passing both a namedtuple shape and shared_dims kwarg is rejected."""
+    S = namedtuple("shape", ["b", "c"])
+    with assertions.assertRaises(ValueError):
+        torchtrt.Input(
+            min_shape=S(1, 16),
+            opt_shape=S(4, 16),
+            max_shape=S(4, 16),
+            dtype=torch.int64,
+            name="x",
+            shared_dims={0: "b"},
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/py/dynamo/models/test_shared_dynamic_dim.py
+++ b/tests/py/dynamo/models/test_shared_dynamic_dim.py
@@ -17,6 +17,7 @@ call site.
 """
 
 import unittest
+from collections import namedtuple
 
 import pytest
 import torch
@@ -255,8 +256,6 @@ def test_default_path_unchanged_for_static_inputs():
 #   input_shape2 = namedtuple('S', ['c', 'seq'])
 #   Both have field 'c' → one shared Dim("c").
 
-from collections import namedtuple
-
 
 @pytest.mark.unit
 @pytest.mark.critical
@@ -303,6 +302,54 @@ def test_namedtuple_shared_batch_positional_inputs():
         assertions.assertTrue(
             cos_sim > COSINE_THRESHOLD,
             f"namedtuple shared batch (positional) out-of-tolerance at bs={bs}: cos_sim={cos_sim}",
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.critical
+def test_namedtuple_shared_batch_kwarg_inputs():
+    """Namedtuple field 'batch' shared across two kwarg inputs — exercises the
+    kwarg_inputs → build_dim_registry path end-to-end."""
+    model = _SharedBatchEncoder().eval().cuda()
+
+    S = namedtuple("shape", ["batch", "seq"])
+
+    kwarg_inputs = {
+        "input_ids": torchtrt.Input(
+            min_shape=S(1, 16),
+            opt_shape=S(4, 16),
+            max_shape=S(4, 16),
+            dtype=torch.int64,
+            name="input_ids",
+        ),
+        "attention_mask": torchtrt.Input(
+            min_shape=S(1, 16),
+            opt_shape=S(4, 16),
+            max_shape=S(4, 16),
+            dtype=torch.int64,
+            name="attention_mask",
+        ),
+    }
+
+    trt_mod = torchtrt.compile(
+        model,
+        ir="dynamo",
+        kwarg_inputs=kwarg_inputs,
+        min_block_size=1,
+        cache_built_engines=False,
+        reuse_cached_engines=False,
+    )
+
+    for bs in (4, 2):
+        ids = torch.randint(0, 1024, (bs, 16), dtype=torch.int64, device="cuda")
+        mask = torch.ones((bs, 16), dtype=torch.int64, device="cuda")
+        with torch.no_grad():
+            ref = model(input_ids=ids, attention_mask=mask)
+            out = trt_mod(input_ids=ids, attention_mask=mask)
+        cos_sim = cosine_similarity(ref, out)
+        assertions.assertTrue(
+            cos_sim > COSINE_THRESHOLD,
+            f"namedtuple shared batch (kwargs) out-of-tolerance at bs={bs}: cos_sim={cos_sim}",
         )
 
 

--- a/tests/py/dynamo/models/test_shared_dynamic_dim.py
+++ b/tests/py/dynamo/models/test_shared_dynamic_dim.py
@@ -16,6 +16,7 @@ the dynamic-shape intent lives on the ``Input`` objects -- no separate
 call site.
 """
 
+import logging
 import unittest
 from collections import namedtuple
 
@@ -399,6 +400,110 @@ def test_namedtuple_and_shared_dims_together_raises():
             name="x",
             shared_dims={0: "b"},
         )
+
+
+@pytest.mark.unit
+def test_namedtuple_requires_all_three_namedtuples():
+    """A namedtuple min_shape with plain-tuple opt/max_shape is rejected."""
+    S = namedtuple("shape", ["batch", "seq"])
+    with assertions.assertRaises(TypeError):
+        torchtrt.Input(
+            min_shape=S(1, 16),
+            opt_shape=(4, 16),  # plain tuple -- no field names to cross-check
+            max_shape=(4, 16),
+            dtype=torch.int64,
+            name="x",
+        )
+
+
+@pytest.mark.unit
+def test_conflicting_ranges_error_names_the_inputs():
+    """The conflict message identifies which input holds which range, not just
+    the two ranges -- otherwise it is unusable beyond two inputs."""
+    from torch_tensorrt.dynamo._tracer import build_dim_registry
+
+    S = namedtuple("shape", ["batch", "seq"])
+    inputs = {
+        "input_ids": torchtrt.Input(
+            min_shape=S(1, 16),
+            opt_shape=S(4, 16),
+            max_shape=S(4, 16),  # batch 1..4
+            dtype=torch.int64,
+            name="input_ids",
+        ),
+        "attention_mask": torchtrt.Input(
+            min_shape=S(1, 16),
+            opt_shape=S(8, 16),
+            max_shape=S(8, 16),  # batch 1..8 -- conflicts
+            dtype=torch.int64,
+            name="attention_mask",
+        ),
+    }
+    with assertions.assertRaises(ValueError) as ctx:
+        build_dim_registry((), inputs)
+
+    message = str(ctx.exception)
+    assertions.assertIn("input_ids[0]", message)
+    assertions.assertIn("attention_mask[0]", message)
+
+
+@pytest.mark.unit
+def test_disjoint_names_produce_independent_dims():
+    """Different names never fuse -- even with identical (min, max). The name
+    drives sharing, not the range."""
+    from torch_tensorrt.dynamo._tracer import build_dim_registry
+
+    S_image = namedtuple("shape", ["n", "c", "h", "w"])
+    S_text = namedtuple("shape", ["batch", "seq"])
+
+    inputs = [
+        torchtrt.Input(
+            min_shape=S_image(1, 3, 224, 224),
+            opt_shape=S_image(4, 3, 224, 224),
+            max_shape=S_image(8, 3, 224, 224),  # n 1..8; c/h/w static
+            dtype=torch.float32,
+            name="image",
+        ),
+        torchtrt.Input(
+            min_shape=S_text(1, 16),
+            opt_shape=S_text(4, 16),
+            max_shape=S_text(8, 16),  # batch 1..8 -- same range as n
+            dtype=torch.int64,
+            name="text",
+        ),
+    ]
+    registry = build_dim_registry(inputs, {})
+
+    assertions.assertEqual(set(registry), {"n", "batch"})
+    assertions.assertIsNot(registry["n"], registry["batch"])
+
+
+@pytest.mark.unit
+def test_shared_dims_resolution_is_logged(caplog):
+    """The resolved registry is reported, so a fusion that was not intended is
+    visible rather than silent."""
+    from torch_tensorrt.dynamo._tracer import build_dim_registry
+
+    S = namedtuple("shape", ["batch", "seq"])
+    inputs = {
+        name: torchtrt.Input(
+            min_shape=S(1, 16),
+            opt_shape=S(4, 16),
+            max_shape=S(4, 16),
+            dtype=torch.int64,
+            name=name,
+        )
+        for name in ("input_ids", "attention_mask")
+    }
+
+    with caplog.at_level(logging.INFO, logger="torch_tensorrt.dynamo._tracer"):
+        build_dim_registry((), inputs)
+
+    # Both contributing axes are named under the one shared dim -- that listing
+    # is what makes an accidental fuse spottable.
+    assertions.assertIn("'batch'", caplog.text)
+    assertions.assertIn("input_ids[0]", caplog.text)
+    assertions.assertIn("attention_mask[0]", caplog.text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Namedtuple shape spec for torch_tensorrt.Input

Adds a shorthand for declaring shared dynamic axes across inputs: pass a namedtuple as min_shape/opt_shape/max_shape and the field names are used as axis names. Axes with the same name across multiple Input objects are automatically exported as a single shared torch.export.Dim, without requiring the user to pass shared_dims explicitly.

```
Example:
S = namedtuple("shape", ["batch", "seq"])
inputs = [
    torch_tensorrt.Input(min_shape=S(1, 16), opt_shape=S(4, 16), max_shape=S(4, 16),
                         dtype=torch.int64, name="input_ids"),
    torch_tensorrt.Input(min_shape=S(1, 16), opt_shape=S(4, 16), max_shape=S(4, 16),
                         dtype=torch.int64, name="attention_mask"),
]
trt_mod = torch_tensorrt.compile(model, ir="dynamo", inputs=inputs, ...)
```