### PR TITLE
tests(cross-runtime-serde): hide torch-trt DLLs on Windows too

### DIFF
--- a/tests/py/dynamo/models/_cross_runtime_load_helper.py
+++ b/tests/py/dynamo/models/_cross_runtime_load_helper.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import glob
 import os
+import sys
 
 
 def _build_small_conv_model(torch):
@@ -76,11 +77,20 @@ def _hide_so_files(pkg_dir: str) -> list[tuple[str, str]]:
     lib_dir = os.path.join(pkg_dir, "lib")
     if not os.path.isdir(lib_dir):
         return []
+    # Linux/macOS uses `libtorchtrt*` (the `lib` prefix); Windows uses
+    # `torchtrt*.dll` / `torchtrt*.lib` (no prefix). See ``_features.py``
+    # for the matching read side.
+    patterns = (
+        ["torchtrt*.dll", "torchtrt*.lib"]
+        if sys.platform.startswith("win")
+        else ["libtorchtrt*"]
+    )
     moved: list[tuple[str, str]] = []
-    for path in glob.glob(os.path.join(lib_dir, "libtorchtrt*")):
-        bak = path + ".bak"
-        os.rename(path, bak)
-        moved.append((bak, path))
+    for pattern in patterns:
+        for path in glob.glob(os.path.join(lib_dir, pattern)):
+            bak = path + ".bak"
+            os.rename(path, bak)
+            moved.append((bak, path))
     return moved
 
 


### PR DESCRIPTION
# Description

`tests/py/dynamo/models/_cross_runtime_load_helper.py:_hide_so_files()` only globbed the
Linux/macOS-style `libtorchtrt*` pattern. On Windows the Torch-TensorRT runtime libraries
are named `torchtrt.dll` / `torchtrt_runtime.dll` (no `lib` prefix; see
`py/torch_tensorrt/_features.py`), so the glob returned an empty list and the spawned
Python-only subprocess kept `torch_tensorrt_runtime == True`, tripping the
`C++ runtime should be disabled` assertion.

Make the glob platform-aware:
- Windows: `torchtrt*.dll`, `torchtrt*.lib`
- Linux/macOS: `libtorchtrt*` (unchanged)

Fixes the three `test_cross_runtime_serde.py` failures on the Windows L2 dynamo compile
runners surfaced in #4330:
- `test_save_cpp_load_python`
- `test_save_python_load_python`
- `test_save_python_load_cpp`

## Type of change

- Bug fix (test-only; no runtime API change)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified