### PR TITLE
Use runtime platform for TensorRT engine target checks

### DIFF
--- a/core/runtime/TRTEngine.cpp
+++ b/core/runtime/TRTEngine.cpp
@@ -123,9 +123,14 @@ TRTEngine::TRTEngine(
     const std::string& serialized_metadata,
     const ResourceAllocationStrategy resource_allocation_strategy) {
   TORCHTRT_CHECK(
+      target_platform._platform != Platform::PlatformEnum::kUNKNOWN,
+      "The serialized TensorRT engine target platform is unknown. Torch-TensorRT cannot verify that the engine "
+      "matches the loaded TensorRT runtime platform. Rebuild or reserialize the engine with a Torch-TensorRT version "
+      "that records a supported target platform.");
+  TORCHTRT_CHECK(
       is_supported_on_current_platform(target_platform),
-      "This engine was not built to run on this platform (built for: " << target_platform << ", current platform: "
-                                                                       << get_current_platform() << ")");
+      "This engine was not built to run on the loaded TensorRT runtime platform (built for: "
+          << target_platform << ", current runtime platform: " << get_current_platform() << ")");
   this->target_platform = target_platform;
 
   this->hardware_compatible = hardware_compatible;

--- a/py/torch_tensorrt/_enums.py
+++ b/py/torch_tensorrt/_enums.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from enum import Enum, auto
-from typing import Any, Optional, Type, Union
+from typing import Any, Optional, Type, Union, cast
 
 import numpy as np
 import tensorrt as trt
@@ -1385,7 +1385,15 @@ class Platform(Enum):
         Returns:
             Platform: Current platform
         """
+        # Prefer the compiled runtime's platform: it reflects the ABI engines are
+        # built for (and checked against), which platform.machine() gets wrong under emulation.
+        if ENABLED_FEATURES.torch_tensorrt_runtime:
+            return cls._from_serialized_rt_platform(
+                torch.ops.tensorrt.get_current_platform()
+            )
+
         import platform
+        import sysconfig
 
         if platform.system().lower().startswith("linux"):
             # linux
@@ -1396,7 +1404,13 @@ class Platform(Enum):
 
         elif platform.system().lower().startswith("windows"):
             # Windows...
-            if platform.machine().lower().startswith("amd64"):
+            machine = platform.machine().lower()
+            python_platform = sysconfig.get_platform().lower()
+            if (
+                machine.startswith("amd64")
+                or machine.startswith("x86_64")
+                or python_platform in ("win-amd64", "win_amd64")
+            ):
                 return Platform.WIN_X86_64
 
         return Platform.UNKNOWN
@@ -1407,13 +1421,22 @@ class Platform(Enum):
 
     @needs_torch_tensorrt_runtime  # type: ignore
     def _to_serialized_rt_platform(self) -> str:
-        val: str = torch.ops.tensorrt._platform_unknown()
-
         if self == Platform.LINUX_X86_64:
-            val = torch.ops.tensorrt._platform_linux_x86_64()
+            return cast(str, torch.ops.tensorrt._platform_linux_x86_64())
         elif self == Platform.LINUX_AARCH64:
-            val = torch.ops.tensorrt._platform_linux_aarch64()
+            return cast(str, torch.ops.tensorrt._platform_linux_aarch64())
         elif self == Platform.WIN_X86_64:
-            val = torch.ops.tensorrt._platform_win_x86_64()
+            return cast(str, torch.ops.tensorrt._platform_win_x86_64())
 
-        return val
+        return cast(str, torch.ops.tensorrt._platform_unknown())
+
+    @classmethod
+    def _from_serialized_rt_platform(cls, val: str) -> Platform:
+        # Inverse of _to_serialized_rt_platform; compared against the runtime ops so the two stay in lockstep.
+        if val == torch.ops.tensorrt._platform_linux_x86_64():
+            return cls.LINUX_X86_64
+        elif val == torch.ops.tensorrt._platform_linux_aarch64():
+            return cls.LINUX_AARCH64
+        elif val == torch.ops.tensorrt._platform_win_x86_64():
+            return cls.WIN_X86_64
+        return cls.UNKNOWN

--- a/py/torch_tensorrt/dynamo/runtime/_TRTEngine.py
+++ b/py/torch_tensorrt/dynamo/runtime/_TRTEngine.py
@@ -22,7 +22,7 @@ import torch.distributed as dist
 import torch_tensorrt
 from torch._library.opaque_object import register_opaque_type
 from torch._opaque_base import OpaqueBase
-from torch_tensorrt._enums import dtype
+from torch_tensorrt._enums import Platform, dtype
 from torch_tensorrt._features import ENABLED_FEATURES
 from torch_tensorrt.dynamo._defaults import DEBUG_LOGGING_DIR
 from torch_tensorrt.dynamo._settings import CompilationSettings
@@ -384,9 +384,23 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
 
     def _setup_engine(self) -> None:
         multi_gpu_device_check()
+        if self.serialized_target_platform == str(Platform.UNKNOWN):
+            raise RuntimeError(
+                "The serialized TensorRT engine target platform is unknown. "
+                "Torch-TensorRT cannot verify that the engine matches the loaded TensorRT runtime platform."
+            )
+
+        current_platform = str(Platform.current_platform())
+        if self.serialized_target_platform != current_platform:
+            raise RuntimeError(
+                "TensorRT engine was not built to target the loaded TensorRT runtime platform "
+                f"(target: {self.serialized_target_platform}, current: {current_platform})"
+            )
+
         self.runtime = trt.Runtime(TRT_LOGGER)
         self.cuda_engine = self.runtime.deserialize_cuda_engine(self.serialized_engine)
-        assert self.cuda_engine is not None, "Failed to deserialize TensorRT engine"
+        if self.cuda_engine is None:
+            raise RuntimeError("Unable to deserialize the TensorRT engine")
 
         if self.cuda_engine.streamable_weights_size > 0:
             budget_bytes = self.cuda_engine.get_weight_streaming_automatic_budget()
@@ -558,7 +572,7 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
         self.output_tensors_are_unowned = enabled
 
     def are_output_tensors_unowned(self) -> bool:
-        return self.output_tensors_are_unowned
+        return bool(self.output_tensors_are_unowned)
 
     # --- profiling / inspection ---
 
@@ -721,7 +735,12 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
         ):
             # Captured CUDA graph was recorded against the old stream.
             self.runtime_states.context_changed = True
-        return caller_on_default
+        return bool(caller_on_default)
+
+    def _active_streams(self) -> Tuple[torch.cuda.Stream, torch.cuda.Stream]:
+        assert self._engine_stream is not None
+        assert self._caller_stream is not None
+        return self._engine_stream, self._caller_stream
 
     def _execute_standard(
         self, contiguous_inputs: List[torch.Tensor]
@@ -732,6 +751,7 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
         # cudagraph recapture (set_runtime_states consumes and resets the
         # flag).
         caller_on_default = self._prepare_streams(contiguous_inputs)
+        engine_stream, caller_stream = self._active_streams()
         shape_changed = self.validate_input_shapes(contiguous_inputs)
         (
             need_cudagraphs_record,
@@ -789,8 +809,8 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
 
         with self._profile_section("TRTEngine:TensorRTRuntime"):
             if caller_on_default:
-                self._engine_stream.wait_stream(self._caller_stream)
-            with torch.cuda.stream(self._engine_stream):
+                engine_stream.wait_stream(caller_stream)
+            with torch.cuda.stream(engine_stream):
                 if self.resource_allocation_strategy:
                     self._dynamic_workspace = torch.empty(
                         self.cuda_engine.device_memory_size_v2,
@@ -804,22 +824,18 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
                         self.cudagraph = torch.cuda.CUDAGraph()
                         if self._profile_execution:
                             self.cudagraph.enable_debug_mode()
-                        with torch.cuda.graph(
-                            self.cudagraph, stream=self._engine_stream
-                        ):
-                            self.context.execute_async_v3(
-                                self._engine_stream.cuda_stream
-                            )
+                        with torch.cuda.graph(self.cudagraph, stream=engine_stream):
+                            self.context.execute_async_v3(engine_stream.cuda_stream)
                         if self._profile_execution:
                             self.cudagraph.debug_dump(
                                 f"{DEBUG_LOGGING_DIR}/{self.name}_cudagraph.dot"
                             )
                     self.cudagraph.replay()  # type: ignore[union-attr]
                 else:
-                    self.context.execute_async_v3(self._engine_stream.cuda_stream)
+                    self.context.execute_async_v3(engine_stream.cuda_stream)
 
             if caller_on_default:
-                self._caller_stream.wait_stream(self._engine_stream)
+                caller_stream.wait_stream(engine_stream)
 
         if self.use_pre_allocated_outputs and (
             self.output_tensors_are_unowned
@@ -859,14 +875,15 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
                     )
 
         caller_on_default = self._prepare_streams(contiguous_inputs)
+        engine_stream, caller_stream = self._active_streams()
 
         with self._profile_section("TRTEngine:TensorRTRuntime"):
             if caller_on_default:
-                self._engine_stream.wait_stream(self._caller_stream)
-            with torch.cuda.stream(self._engine_stream):
-                self.context.execute_async_v3(self._engine_stream.cuda_stream)
+                engine_stream.wait_stream(caller_stream)
+            with torch.cuda.stream(engine_stream):
+                self.context.execute_async_v3(engine_stream.cuda_stream)
             if caller_on_default:
-                self._caller_stream.wait_stream(self._engine_stream)
+                caller_stream.wait_stream(engine_stream)
 
         outputs = []
         assert self.output_allocator is not None

--- a/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
@@ -186,7 +186,6 @@ class TorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
                 else self.engine.are_output_tensors_unowned()
             ),
         }
-
         engine_info: List[str | bytes] = [""] * SERIALIZATION_LEN
         engine_info[ABI_TARGET_IDX] = (
             torch.ops.tensorrt.ABI_VERSION()

--- a/tests/py/core/test_classes.py
+++ b/tests/py/core/test_classes.py
@@ -1,9 +1,11 @@
 import copy
 import unittest
 from typing import Dict
+from unittest import mock
 
 import torch
 import torch_tensorrt as torchtrt
+import torch_tensorrt._enums as torchtrt_enums
 from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import TorchTensorRTModule
 
 
@@ -64,3 +66,36 @@ class TestPlatform(unittest.TestCase):
         py_plat_str = torchtrt.Platform.current_platform()._to_serialized_rt_platform()
         cpp_plat_str = torch.ops.tensorrt.get_current_platform()
         self.assertEqual(py_plat_str, cpp_plat_str)
+
+    def test_current_platform_prefers_loaded_runtime_platform(self):
+        with mock.patch("platform.system", return_value="Windows"), mock.patch(
+            "platform.machine", return_value="ARM64"
+        ), mock.patch.object(
+            torch.ops.tensorrt,
+            "get_current_platform",
+            return_value=torch.ops.tensorrt._platform_win_x86_64(),
+        ):
+            self.assertEqual(
+                torchtrt.Platform.current_platform(), torchtrt.Platform.WIN_X86_64
+            )
+
+    def test_current_platform_python_fallback_uses_python_windows_arch(self):
+        disabled_runtime_features = torchtrt_enums.ENABLED_FEATURES._replace(
+            torch_tensorrt_runtime=False
+        )
+        with mock.patch.object(
+            torchtrt_enums, "ENABLED_FEATURES", disabled_runtime_features
+        ), mock.patch("platform.system", return_value="Windows"), mock.patch(
+            "platform.machine", return_value="ARM64"
+        ), mock.patch(
+            "sysconfig.get_platform", return_value="win-amd64"
+        ):
+            self.assertEqual(
+                torchtrt.Platform.current_platform(), torchtrt.Platform.WIN_X86_64
+            )
+
+    def test_unknown_platform_serializes_to_runtime_token(self):
+        self.assertEqual(
+            torchtrt.Platform.UNKNOWN._to_serialized_rt_platform(),
+            torch.ops.tensorrt._platform_unknown(),
+        )


### PR DESCRIPTION
# Description

Use runtime platform for TensorRT engine target checks.
Reject unknown engine target platforms before serialization and deserialization.

This fixes an issue where running as an x86 process on ARM hardware trips a check in `TRTEngine`'s constructor due to a platform mismatch. Windows ARM supports emulation for x86 processes.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
