### PR TITLE
fix: resolve ExecuTorch TRT target_device per partition (coalesced multi-engine)

### DIFF
--- a/py/torch_tensorrt/executorch/backend.py
+++ b/py/torch_tensorrt/executorch/backend.py
@@ -37,18 +37,25 @@ def _schema_name(target: Any) -> str:
     return ""
 
 
+_ENGINE_OP_SCHEMA_NAMES = (
+    "tensorrt::execute_engine",
+    "tensorrt::no_op_placeholder_for_execute_engine",
+)
+
+
+def _get_engine_nodes_in(nodes: Any) -> List[Any]:
+    """Return the TRT engine nodes in an iterable of FX nodes (graph or partition)."""
+    return [
+        node
+        for node in nodes
+        if node.op == "call_function"
+        and _schema_name(node.target) in _ENGINE_OP_SCHEMA_NAMES
+    ]
+
+
 def _get_engine_nodes_from_edge_program(edge_program: ExportedProgram) -> List[Any]:
     """Return all TRT engine nodes found in a lowered ExecuTorch partition."""
-    engine_nodes = []
-    for node in edge_program.graph_module.graph.nodes:
-        if node.op != "call_function":
-            continue
-        if _schema_name(node.target) in (
-            "tensorrt::execute_engine",
-            "tensorrt::no_op_placeholder_for_execute_engine",
-        ):
-            engine_nodes.append(node)
-    return engine_nodes
+    return _get_engine_nodes_in(edge_program.graph_module.graph.nodes)
 
 
 def _get_engine_info_from_edge_program(edge_program: ExportedProgram) -> List[Any]:
@@ -64,15 +71,22 @@ def _get_engine_info_from_edge_program(edge_program: ExportedProgram) -> List[An
     Uses schema name comparison (not object identity) so it works for both
     OpOverload and EdgeOpOverload targets.
     """
-    gm = edge_program.graph_module
     engine_nodes = _get_engine_nodes_from_edge_program(edge_program)
     if len(engine_nodes) != 1:
         raise RuntimeError(
             "TensorRT ExecuTorch backend expects exactly 1 engine node per "
             f"partition, found {len(engine_nodes)}."
         )
+    return _get_engine_info_for_node(edge_program, engine_nodes[0])
 
-    node = engine_nodes[0]
+
+def _get_engine_info_for_node(
+    edge_program: ExportedProgram, node: torch.fx.Node
+) -> List[Any]:
+    # Engine-info extraction for a single TRT node; callable per-partition so a
+    # coalesced multi-engine graph can resolve each engine without the
+    # whole-program "exactly 1 engine" assumption.
+    gm = edge_program.graph_module
     name = _schema_name(node.target)
 
     if name == "tensorrt::no_op_placeholder_for_execute_engine":

--- a/py/torch_tensorrt/executorch/partitioner.py
+++ b/py/torch_tensorrt/executorch/partitioner.py
@@ -12,11 +12,12 @@ from executorch.exir.backend.partitioner import (
 )
 from executorch.exir.backend.utils import tag_constant_data
 from torch.export import ExportedProgram
-from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
+from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner, Partition
 from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import DEVICE_IDX
 from torch_tensorrt.executorch.backend import (
     TensorRTBackend,
-    _get_engine_info_from_edge_program,
+    _get_engine_info_for_node,
+    _get_engine_nodes_in,
     _parse_device_id,
 )
 from torch_tensorrt.executorch.operator_support import TensorRTOperatorSupport
@@ -66,8 +67,8 @@ class TensorRTPartitioner(Partitioner):  # type: ignore[misc]
         # Mirror CudaPartitioner: a target_device CompileSpec drives ExecuTorch's
         # PropagateDevicePass, which tags delegate I/O TensorSpecs with the device
         # and serializes it into the .pte's extra_tensor_info. When the caller pins
-        # it we use that verbatim; otherwise it is derived per export from the
-        # engine's real device in partition() (engine nodes are not available here)
+        # it we use that verbatim; otherwise each partition's device is derived from
+        # its own engine node in partition() (engine nodes are not available here)
         # so a cuda:N engine is not mislabeled cuda:0.
         self._has_explicit_target_device = any(
             s.key == _TARGET_DEVICE_COMPILE_SPEC_KEY for s in self.compile_specs
@@ -77,27 +78,34 @@ class TensorRTPartitioner(Partitioner):  # type: ignore[misc]
             compile_specs=self.compile_specs,
         )
 
-    def _resolve_target_device(self, exported_program: ExportedProgram) -> bytes:
-        """Best-effort ``target_device`` for the delegate-boundary TensorSpecs.
+    def _resolve_target_device_for_partition(
+        self, exported_program: ExportedProgram, partition: Partition
+    ) -> bytes:
+        """Best-effort ``target_device`` for one partition's delegate boundary.
 
-        Reuses the backend's own engine-info extraction so the device index
-        cannot drift from the runtime blob. Any extraction failure -- no single
-        engine node (zero or multiple TRT partitions) or an unreadable index --
-        falls back to ``cuda:0``; per-partition multi-GPU labeling is left to a
-        follow-up.
+        Derives the device from this partition's own TRT engine node, so a
+        coalesced multi-engine graph labels each delegate with its correct GPU
+        instead of stamping every partition with a single whole-program value.
+        Any extraction failure falls back to ``cuda:0``.
         """
         try:
-            engine_info = _get_engine_info_from_edge_program(exported_program)
+            engine_nodes = _get_engine_nodes_in(partition.nodes)
+            if len(engine_nodes) != 1:
+                raise RuntimeError(
+                    f"expected exactly 1 engine node in partition "
+                    f"{getattr(partition, 'id', '?')}, found {len(engine_nodes)}"
+                )
+            engine_info = _get_engine_info_for_node(exported_program, engine_nodes[0])
             return f"cuda:{_parse_device_id(engine_info[DEVICE_IDX])}".encode()
         except Exception as e:
             # Broad by design: any extraction failure must fall back, not abort
             # the export. Warn so a non-default GPU silently labeled cuda:0 stays
             # diagnosable.
             logger.warning(
-                "Could not derive target_device from the TensorRT engine (%s); "
-                "falling back to cuda:0. A non-default GPU engine may be "
-                'mislabeled -- pin it via CompileSpec("target_device", '
+                "Could not derive target_device for partition %s (%s); falling "
+                'back to cuda:0. Pin it via CompileSpec("target_device", '
                 'b"cuda:<index>").',
+                getattr(partition, "id", "?"),
                 e,
             )
             return b"cuda:0"
@@ -110,26 +118,26 @@ class TensorRTPartitioner(Partitioner):  # type: ignore[misc]
         )
         partition_list = capability_partitioner.propose_partitions()
 
-        if self._has_explicit_target_device:
-            delegation_spec = self.delegation_spec
-        else:
-            delegation_spec = DelegationSpec(
-                backend_id=TensorRTBackend.__name__,
-                compile_specs=self.compile_specs
-                + [
-                    CompileSpec(
-                        _TARGET_DEVICE_COMPILE_SPEC_KEY,
-                        self._resolve_target_device(exported_program),
-                    )
-                ],
-            )
-
         partition_tags: Dict[str, DelegationSpec] = {}
         for partition in partition_list:
             tag = f"tensorrt_{partition.id}"
             for node in partition.nodes:
                 node.meta["delegation_tag"] = tag
-            partition_tags[tag] = delegation_spec
+            if self._has_explicit_target_device:
+                partition_tags[tag] = self.delegation_spec
+            else:
+                partition_tags[tag] = DelegationSpec(
+                    backend_id=TensorRTBackend.__name__,
+                    compile_specs=self.compile_specs
+                    + [
+                        CompileSpec(
+                            _TARGET_DEVICE_COMPILE_SPEC_KEY,
+                            self._resolve_target_device_for_partition(
+                                exported_program, partition
+                            ),
+                        )
+                    ],
+                )
 
         tag_constant_data(exported_program)
 

--- a/tests/py/dynamo/executorch/test_api.py
+++ b/tests/py/dynamo/executorch/test_api.py
@@ -202,3 +202,67 @@ def test_resolve_lifted_custom_obj_unwraps_fake_script_object():
     resolved = _resolve_lifted_custom_obj(ep, _stub_node("obj_engine"))
     assert not isinstance(resolved, FakeScriptObject)
     assert isinstance(resolved, _Real)
+
+
+# --- per-partition target_device (TensorRTPartitioner) -----------------------
+# These exercise the partitioner directly, so they need ExecuTorch installed;
+# they run in the dedicated executorch CI job and skip elsewhere.
+
+
+@pytest.mark.unit
+def test_resolve_target_device_uses_partition_engine(monkeypatch):
+    pytest.importorskip("executorch.exir")
+    from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import DEVICE_IDX
+    from torch_tensorrt.executorch import partitioner as P
+
+    part = P.TensorRTPartitioner()
+    engine_node = object()
+    monkeypatch.setattr(P, "_get_engine_nodes_in", lambda nodes: [engine_node])
+    info = ["0"] * (DEVICE_IDX + 1)
+    info[DEVICE_IDX] = "2"
+    monkeypatch.setattr(P, "_get_engine_info_for_node", lambda ep, n: info)
+
+    partition = types.SimpleNamespace(id=0, nodes=[engine_node])
+    assert part._resolve_target_device_for_partition(object(), partition) == b"cuda:2"
+
+
+@pytest.mark.unit
+def test_resolve_target_device_falls_back_when_not_one_engine(monkeypatch):
+    pytest.importorskip("executorch.exir")
+    from torch_tensorrt.executorch import partitioner as P
+
+    part = P.TensorRTPartitioner()
+    partition = types.SimpleNamespace(id=1, nodes=[])
+
+    monkeypatch.setattr(P, "_get_engine_nodes_in", lambda nodes: [])
+    assert part._resolve_target_device_for_partition(object(), partition) == b"cuda:0"
+
+    monkeypatch.setattr(P, "_get_engine_nodes_in", lambda nodes: [object(), object()])
+    assert part._resolve_target_device_for_partition(object(), partition) == b"cuda:0"
+
+
+@pytest.mark.unit
+def test_per_partition_distinct_target_devices(monkeypatch):
+    pytest.importorskip("executorch.exir")
+    from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import DEVICE_IDX
+    from torch_tensorrt.executorch import partitioner as P
+
+    part = P.TensorRTPartitioner()
+    # Each partition's engine node carries its own device id as its value.
+    monkeypatch.setattr(P, "_get_engine_nodes_in", lambda nodes: [nodes[0]])
+
+    def fake_info(ep, node):
+        info = ["0"] * (DEVICE_IDX + 1)
+        info[DEVICE_IDX] = str(node)
+        return info
+
+    monkeypatch.setattr(P, "_get_engine_info_for_node", fake_info)
+    d0 = part._resolve_target_device_for_partition(
+        object(), types.SimpleNamespace(id=0, nodes=["0"])
+    )
+    d1 = part._resolve_target_device_for_partition(
+        object(), types.SimpleNamespace(id=1, nodes=["1"])
+    )
+    assert d0 == b"cuda:0"
+    assert d1 == b"cuda:1"
+    assert d0 != d1

--- a/tests/py/dynamo/executorch/test_partitioner_target_device.py
+++ b/tests/py/dynamo/executorch/test_partitioner_target_device.py
@@ -17,11 +17,13 @@ from torch_tensorrt.executorch.partitioner import (  # noqa: E402
 )
 
 
-# A realistic single-engine edge program so partition() runs the *real*
-# _get_engine_info_from_edge_program / _parse_device_id path. That is what
-# guards "an engine node is present and its device is extractable at partition()
-# time" -- a monkeypatched extractor would not. Mirrors the mocked edge programs
-# in tests/py/dynamo/executorch/test_backend.py.
+# A realistic engine node so partition() runs the *real* per-partition
+# _get_engine_info_for_node / _parse_device_id path. target_device is now
+# derived from each partition's OWN engine node (so a coalesced multi-engine
+# graph labels each delegate with its correct GPU), which means the engine node
+# must live in the partition's node list -- a monkeypatched extractor would not
+# guard that. Mirrors the mocked edge programs in
+# tests/py/dynamo/executorch/test_backend.py.
 class _SchemaTarget:
     def __init__(self, name):
         self._schema = SimpleNamespace(name=name)
@@ -36,6 +38,7 @@ def _engine_node(device_id):
         target=_SchemaTarget("tensorrt::no_op_placeholder_for_execute_engine"),
         args=(["x"], *engine_info),
         name="trt_node",
+        meta={},
     )
 
 
@@ -47,17 +50,25 @@ def _edge_program(*nodes):
 
 
 class _FakeCapabilityPartitioner:
-    def __init__(self, *args, **kwargs):
-        pass
+    # One partition per graph node -- each TRT engine node becomes its own
+    # partition, as the real CapabilityBasedPartitioner does here -- so the
+    # per-partition device resolution under test runs against the engine node
+    # that actually belongs to each partition.
+    def __init__(self, graph_module, *args, **kwargs):
+        self._graph_module = graph_module
 
     def propose_partitions(self):
-        return [SimpleNamespace(id=1, nodes=[SimpleNamespace(meta={})])]
+        return [
+            SimpleNamespace(id=i, nodes=[node])
+            for i, node in enumerate(self._graph_module.graph.nodes)
+        ]
 
 
 @pytest.fixture(autouse=True)
 def _stub_partition_internals(monkeypatch):
-    # Both need a real fx GraphModule, so stub them out -- the engine-info
-    # extraction under test still runs for real against the mocked node.
+    # The partition proposal needs a real fx GraphModule, so stub it out -- the
+    # per-partition engine-info extraction under test still runs for real
+    # against the mocked engine nodes.
     monkeypatch.setattr(
         "torch_tensorrt.executorch.partitioner.CapabilityBasedPartitioner",
         _FakeCapabilityPartitioner,
@@ -68,8 +79,8 @@ def _stub_partition_internals(monkeypatch):
     )
 
 
-def _target_device(result):
-    spec = result.partition_tags["tensorrt_1"]
+def _target_device(result, tag="tensorrt_0"):
+    spec = result.partition_tags[tag]
     for cs in spec.compile_specs:
         if cs.key == _TARGET_DEVICE_COMPILE_SPEC_KEY:
             return cs.value
@@ -84,14 +95,49 @@ def test_target_device_derived_for_default_gpu():
 
 @pytest.mark.unit
 def test_target_device_derived_for_nonzero_gpu():
-    # The bug this fixes: a cuda:1 engine must not be mislabeled cuda:0.
+    # A cuda:1 engine must not be mislabeled cuda:0.
     result = TensorRTPartitioner().partition(_edge_program(_engine_node("1")))
     assert _target_device(result) == b"cuda:1"
 
 
 @pytest.mark.unit
-def test_target_device_falls_back_to_cuda0_on_multiple_engines():
-    # >1 engine node -> real extraction raises -> contract fallback to cuda:0.
+def test_per_partition_devices_for_coalesced_multi_engine():
+    # The fix in this PR: each partition is labeled from its OWN engine's device,
+    # so a coalesced multi-engine graph is not stamped with a single
+    # whole-program device.
+    result = TensorRTPartitioner().partition(
+        _edge_program(_engine_node("0"), _engine_node("1"))
+    )
+    assert _target_device(result, "tensorrt_0") == b"cuda:0"
+    assert _target_device(result, "tensorrt_1") == b"cuda:1"
+
+
+@pytest.mark.unit
+def test_target_device_falls_back_to_cuda0_on_malformed_partition():
+    # A partition whose nodes carry no extractable engine makes the real
+    # extraction raise; the broadened except must fall back to cuda:0 rather
+    # than abort the export.
+    bad_node = SimpleNamespace(
+        op="call_function", target=SimpleNamespace(), name="x", meta={}
+    )
+    result = TensorRTPartitioner().partition(_edge_program(bad_node))
+    assert _target_device(result) == b"cuda:0"
+
+
+@pytest.mark.unit
+def test_target_device_falls_back_to_cuda0_when_partition_has_multiple_engines(
+    monkeypatch,
+):
+    # A single partition holding >1 engine node is ambiguous, so device
+    # resolution must fall back to cuda:0 rather than guess.
+    monkeypatch.setattr(
+        "torch_tensorrt.executorch.partitioner.CapabilityBasedPartitioner",
+        lambda *args, **kwargs: SimpleNamespace(
+            propose_partitions=lambda: [
+                SimpleNamespace(id=0, nodes=[_engine_node("1"), _engine_node("2")])
+            ]
+        ),
+    )
     result = TensorRTPartitioner().partition(
         _edge_program(_engine_node("1"), _engine_node("2"))
     )
@@ -99,18 +145,9 @@ def test_target_device_falls_back_to_cuda0_on_multiple_engines():
 
 
 @pytest.mark.unit
-def test_target_device_falls_back_to_cuda0_on_malformed_graph():
-    # An unexpected graph shape makes the real extraction raise; the broadened
-    # except must still fall back to cuda:0 rather than abort the export.
-    bad_node = SimpleNamespace(op="call_function", target=SimpleNamespace(), name="x")
-    result = TensorRTPartitioner().partition(_edge_program(bad_node))
-    assert _target_device(result) == b"cuda:0"
-
-
-@pytest.mark.unit
 def test_explicit_target_device_used_verbatim():
     # Engine reports cuda:0, but the caller pinned cuda:3 -> the pin wins and
-    # extraction is skipped entirely.
+    # per-partition extraction is skipped entirely.
     partitioner = TensorRTPartitioner(
         compile_specs=[CompileSpec(_TARGET_DEVICE_COMPILE_SPEC_KEY, b"cuda:3")]
     )


### PR DESCRIPTION
## What's broken
When coalescing TensorRT with other delegates into one `.pte`, the graph has **multiple** TensorRT engines. `TensorRTPartitioner` resolved `target_device` once for the whole program via `_get_engine_info_from_edge_program()`, which requires **exactly one** engine node. With more than one engine it raised, so every TensorRT partition fell back to `cuda:0` with a spurious warning:
```
Could not derive target_device from the TensorRT engine (... expects exactly 1
engine node per partition, found 2); falling back to cuda:0.
```
On a single GPU this is just noise, but a multi-GPU graph cannot label each delegate with its own device.

## The fix
Extract `_get_engine_info_for_node()` (single-node engine-info extraction) out of `_get_engine_info_from_edge_program()` (which keeps its one-engine contract used by `preprocess()`), then resolve `target_device` **per partition** from that partition's own engine node.
- Single-GPU behavior is unchanged (still `cuda:0`), minus the spurious warning.
- Multi-engine / multi-GPU graphs now get a correct per-delegate device label.
- Any extraction failure (no single engine node in the partition, or an unreadable index) still falls back to `cuda:0` rather than aborting the export.

## Test
- Unit tests over the partitioner path in `tests/py/dynamo/executorch/test_partitioner_target_device.py` and `tests/py/dynamo/executorch/test_api.py`: default GPU, non-zero GPU, a coalesced multi-engine graph resolving partition 0 → `cuda:0` and partition 1 → `cuda:1`, the >1-engine-in-one-partition fallback, a malformed-partition fallback, and an explicit `target_device` pin taking precedence.
- Verified on a coalesced TensorRT → Another → TensorRT model (two TRT engines plus one other delegate): the `.pte` still contains both `TensorRTBackend` and `AnotherBackend`, and the "found 2 engines" warning no longer fires.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project (isort + black)
- [x] I have added tests that prove my fix is effective
- [x] Commit is signed off (DCO)
