### PR TITLE
Fix aten::any.dim truthiness for numeric tensors

### DIFF
--- a/core/conversion/converters/impl/reduce.cpp
+++ b/core/conversion/converters/impl/reduce.cpp
@@ -27,6 +27,18 @@ nvinfer1::ITensor* anyDimImplementation(
   // Reduce does not work on bool inputs
   if (in_tensor->getType() == nvinfer1::DataType::kBOOL) {
     in_tensor = castITensor(ctx, in_tensor, nvinfer1::DataType::kINT32, (util::node_info(n) + "_in").c_str());
+  } else {
+    // Numeric truthiness is based on nonzero elements, not the reduced sum of raw values.
+    auto zero_tensor = tensor_to_const(
+        ctx, torch::tensor({0}, util::TRTDataTypeToScalarType(in_tensor->getType())), util::node_info(n) + "_zero");
+    auto equal_zero_layer = add_elementwise(
+        ctx, nvinfer1::ElementWiseOperation::kEQUAL, in_tensor, zero_tensor, util::node_info(n) + "_is_zero");
+    TORCHTRT_CHECK(equal_zero_layer, "Unable to create equal layer from node: " << *n);
+    auto nonzero_layer = ctx->net->addUnary(*equal_zero_layer->getOutput(0), nvinfer1::UnaryOperation::kNOT);
+    TORCHTRT_CHECK(nonzero_layer, "Unable to create logical_not layer from node: " << *n);
+    nonzero_layer->setName((util::node_info(n) + "_nonzero").c_str());
+    in_tensor = castITensor(
+        ctx, nonzero_layer->getOutput(0), nvinfer1::DataType::kINT32, (util::node_info(n) + "_mask").c_str());
   }
   auto sum_layer = ctx->net->addReduce(*in_tensor, nvinfer1::ReduceOperation::kSUM, axis_mask, keepdim);
 

--- a/tests/core/conversion/converters/test_reduce.cpp
+++ b/tests/core/conversion/converters/test_reduce.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include <string>
 #include "core/compiler.h"
 #include "core/lowering/passes/passes.h"
@@ -60,6 +61,17 @@ std::string gen_keepdim_graph(const std::string& op) {
         %5 : Tensor = aten::)IR" +
       op + R"IR((%0, %2, %3, %4)
         return (%5))IR";
+}
+
+std::string gen_any_dim_graph(int dim, bool keepdim) {
+  return R"IR(
+    graph(%0 : Tensor):
+      %1 : int = prim::Constant[value=)IR" +
+      std::to_string(dim) + R"IR(]()
+      %3 : bool = prim::Constant[value=)IR" +
+      std::to_string(keepdim ? 1 : 0) + R"IR(]()
+      %5 : Tensor = aten::any(%0, %1, %3)
+      return (%5))IR";
 }
 
 void test_body(const std::string& graph, at::Tensor& in, bool dynamic = false) {
@@ -324,6 +336,43 @@ TEST(Converters, ATenAnyDimAllFalseConvertsCorrectly) {
       %5 : Tensor = aten::any(%0, %1, %3)
       return (%5))IR";
   auto in = at::zeros({3, 7, 4}, at::kCUDA).to(torch::kBool);
+  test_body(graph, in);
+}
+
+TEST(Converters, ATenAnyDimCancellingNumericValuesConvertsCorrectly) {
+  const auto graph = gen_any_dim_graph(0, false);
+  auto in = at::tensor({1, -1}, at::TensorOptions().dtype(at::kInt).device(at::kCUDA));
+  test_body(graph, in);
+}
+
+TEST(Converters, ATenAnyDimNegativeNumericValueConvertsCorrectly) {
+  const auto graph = gen_any_dim_graph(0, false);
+  auto in = at::tensor({0, -2}, at::TensorOptions().dtype(at::kInt).device(at::kCUDA));
+  test_body(graph, in);
+}
+
+TEST(Converters, ATenAnyDimNumericRowsWithCancellationConvertsCorrectly) {
+  const auto graph = gen_any_dim_graph(1, false);
+  auto in = at::tensor({{1, -1}, {0, 0}}, at::TensorOptions().dtype(at::kInt).device(at::kCUDA));
+  test_body(graph, in);
+}
+
+TEST(Converters, ATenAnyDimFloatNumericValuesConvertsCorrectly) {
+  const auto graph = gen_any_dim_graph(0, false);
+  auto in = at::tensor({1.0, -1.0}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
+  test_body(graph, in);
+}
+
+TEST(Converters, ATenAnyDimHalfNumericValuesConvertsCorrectly) {
+  const auto graph = gen_any_dim_graph(0, false);
+  auto in = at::tensor({1.0, -1.0}, at::TensorOptions().dtype(at::kHalf).device(at::kCUDA));
+  test_body(graph, in);
+}
+
+TEST(Converters, ATenAnyDimFloatNanValueConvertsCorrectly) {
+  const auto graph = gen_any_dim_graph(0, false);
+  auto in = at::tensor(
+      {0.0, std::numeric_limits<float>::quiet_NaN()}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
   test_body(graph, in);
 }
 


### PR DESCRIPTION
## Summary
- Convert numeric `aten::any.dim` inputs into an explicit nonzero mask before reducing.
- Keep bool inputs on the existing bool-to-int reduction path.
- Add deterministic regression tests for cancelling numeric values and negative nonzero values.

## Testing
- `git diff --check`
- `bazelisk test //tests/core/conversion/converters:test_reduce` was attempted locally. The first run was blocked by missing PyTorch; after installing PyTorch in a local venv and setting `TORCH_PATH`, Bazel stayed in analysis for several minutes on this local machine and was interrupted before running tests.