### PR TITLE
feat(dynamo): add target_executorch setting to keep output-allocator ops in PyTorch

### DIFF
--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -109,6 +109,7 @@ def cross_compile_for_windows(
     dynamically_allocate_resources: bool = _defaults.DYNAMICALLY_ALLOCATE_RESOURCES,
     decompose_attention: bool = _defaults.DECOMPOSE_ATTENTION,
     attn_bias_is_causal: bool = _defaults.ATTN_BIAS_IS_CAUSAL,
+    fallback_data_dependent_ops: bool = _defaults.FALLBACK_DATA_DEPENDENT_OPS,
     **kwargs: Any,
 ) -> torch.fx.GraphModule:
     """Compile an ExportedProgram module using TensorRT in Linux for Inference in Windows
@@ -186,6 +187,7 @@ def cross_compile_for_windows(
         dynamically_allocate_resources (bool): Dynamically allocate resources during engine execution.
         decompose_attention (bool): Whether to decompose attention layers. We have converters for handling attention ops, but if you want to decompose them into smaller ops, you can set this to True.
         attn_bias_is_causal (bool): Whether the attn_bias in efficient SDPA is causal. Default is True. This can accelerate models from HF because attn_bias is always a causal mask in HF. If you want to use non-causal attn_bias, you can set this to False.
+        fallback_data_dependent_ops (bool): If True, operators whose converters require a TensorRT output allocator (i.e. data-dependent output shapes, such as nonzero) are added to torch_executed_ops and run in PyTorch instead of being lowered into a TensorRT engine. This is useful when targeting runtimes that cannot consume a TensorRT output allocator. Default is False.
         **kwargs: Any,
     Returns:
         torch.fx.GraphModule: Compiled FX Module, when run it will execute via TensorRT
@@ -338,6 +340,7 @@ def cross_compile_for_windows(
         "dynamically_allocate_resources": dynamically_allocate_resources,
         "decompose_attention": decompose_attention,
         "attn_bias_is_causal": attn_bias_is_causal,
+        "fallback_data_dependent_ops": fallback_data_dependent_ops,
     }
 
     # disable the following settings is not supported for cross compilation for windows feature
@@ -460,6 +463,7 @@ def compile(
     dynamically_allocate_resources: bool = _defaults.DYNAMICALLY_ALLOCATE_RESOURCES,
     decompose_attention: bool = _defaults.DECOMPOSE_ATTENTION,
     attn_bias_is_causal: bool = _defaults.ATTN_BIAS_IS_CAUSAL,
+    fallback_data_dependent_ops: bool = _defaults.FALLBACK_DATA_DEPENDENT_OPS,
     **kwargs: Any,
 ) -> torch.fx.GraphModule:
     """Compile an ExportedProgram module for NVIDIA GPUs using TensorRT
@@ -547,6 +551,7 @@ def compile(
         dynamically_allocate_resources (bool): Dynamically allocate resources during engine execution.
         decompose_attention (bool): Whether to decompose attention layers. We have converters for handling attention ops, but if you want to decompose them into smaller ops, you can set this to True.
         attn_bias_is_causal (bool): Whether the attn_bias in efficient SDPA is causal. Default is True. This can accelerate models from HF because attn_bias is always a causal mask in HF. If you want to use non-causal attn_bias, you can set this to False.
+        fallback_data_dependent_ops (bool): If True, operators whose converters require a TensorRT output allocator (i.e. data-dependent output shapes, such as nonzero) are added to torch_executed_ops and run in PyTorch instead of being lowered into a TensorRT engine. This is useful when targeting runtimes that cannot consume a TensorRT output allocator. Default is False.
         **kwargs: Any,
     Returns:
         torch.fx.GraphModule: Compiled FX Module, when run it will execute via TensorRT
@@ -732,6 +737,7 @@ def compile(
         "dynamically_allocate_resources": dynamically_allocate_resources,
         "decompose_attention": decompose_attention,
         "attn_bias_is_causal": attn_bias_is_causal,
+        "fallback_data_dependent_ops": fallback_data_dependent_ops,
     }
     logger.debug(f"CPU memory usage before lowering: {get_cpu_memory_usage()} MB")
     settings = CompilationSettings(**compilation_options)
@@ -909,6 +915,13 @@ def compile_module(
     if sample_kwarg_inputs is None:
         sample_kwarg_inputs = {}
 
+    # fallback_data_dependent_ops runs data-dependent ops in PyTorch during
+    # partitioning, which cannot coexist with require_full_compilation.
+    if settings.fallback_data_dependent_ops and settings.require_full_compilation:
+        raise ValueError(
+            "fallback_data_dependent_ops runs data-dependent ops in PyTorch, which "
+            "is incompatible with require_full_compilation=True; enable only one."
+        )
     # Configure user compilation settings to converters.
     CONVERTERS.set_compilation_settings(settings)
 

--- a/py/torch_tensorrt/dynamo/_defaults.py
+++ b/py/torch_tensorrt/dynamo/_defaults.py
@@ -66,6 +66,7 @@ CPU_MEMORY_BUDGET = None
 DYNAMICALLY_ALLOCATE_RESOURCES = False
 DECOMPOSE_ATTENTION = False
 ATTN_BIAS_IS_CAUSAL = True
+FALLBACK_DATA_DEPENDENT_OPS = False
 
 if platform.system() == "Linux":
     import pwd

--- a/py/torch_tensorrt/dynamo/_settings.py
+++ b/py/torch_tensorrt/dynamo/_settings.py
@@ -30,6 +30,7 @@ from torch_tensorrt.dynamo._defaults import (
     ENABLE_RESOURCE_PARTITIONING,
     ENABLE_WEIGHT_STREAMING,
     ENGINE_CAPABILITY,
+    FALLBACK_DATA_DEPENDENT_OPS,
     HARDWARE_COMPATIBLE,
     IMMUTABLE_WEIGHTS,
     L2_LIMIT_FOR_TILING,
@@ -113,6 +114,7 @@ class CompilationSettings:
         dynamically_allocate_resources (bool): Dynamically allocate resources for TensorRT engines
         decompose_attention (bool): Whether to decompose attention layers. We have converters for handling attention ops, but if you want to decompose them into smaller ops, you can set this to True.
         attn_bias_is_causal (bool): Whether the attn_bias in efficient SDPA is causal. Default is True. This can accelerate models from HF because attn_bias is always a causal mask in HF. If you want to use non-causal attn_bias, you can set this to False.
+        fallback_data_dependent_ops (bool): If True, operators whose converters require a TensorRT output allocator (i.e. data-dependent output shapes, such as nonzero) are added to torch_executed_ops and run in PyTorch instead of being lowered into a TensorRT engine. This is useful when targeting runtimes that cannot consume a TensorRT output allocator. Default is False.
     """
 
     workspace_size: int = WORKSPACE_SIZE
@@ -171,6 +173,7 @@ class CompilationSettings:
     dynamically_allocate_resources: bool = DYNAMICALLY_ALLOCATE_RESOURCES
     decompose_attention: bool = DECOMPOSE_ATTENTION
     attn_bias_is_causal: bool = ATTN_BIAS_IS_CAUSAL
+    fallback_data_dependent_ops: bool = FALLBACK_DATA_DEPENDENT_OPS
 
     def __getstate__(self) -> dict[str, Any]:
         from torch_tensorrt.dynamo.conversion._ConverterRegistry import (
@@ -186,6 +189,7 @@ class CompilationSettings:
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         state.pop("use_python_runtime", None)
+        state.setdefault("fallback_data_dependent_ops", FALLBACK_DATA_DEPENDENT_OPS)
         self.__dict__.update(state)
 
 

--- a/py/torch_tensorrt/dynamo/partitioning/_adjacency_partitioner.py
+++ b/py/torch_tensorrt/dynamo/partitioning/_adjacency_partitioner.py
@@ -53,6 +53,15 @@ class OpSupportTester(ops.OperatorSupportBase):  # type: ignore
                 )
             return False
 
+        if TorchTensorRTOperatorSupport._requires_output_allocator(node):
+            # data-dependent output shape needs a TRT output allocator, which some
+            # runtimes cannot consume; honor the fallback and run the node in PyTorch
+            if not node.is_impure():
+                self.unsupported_operators[node_name] = (
+                    self.unsupported_operators.get(node_name, 0) + 1
+                )
+            return False
+
         if (
             (node in CONVERTERS or node.op == "get_attr")
             and node_name not in self.torch_executed_ops

--- a/py/torch_tensorrt/dynamo/partitioning/_global_partitioner.py
+++ b/py/torch_tensorrt/dynamo/partitioning/_global_partitioner.py
@@ -166,6 +166,18 @@ class TorchTensorRTOperatorSupport(OperatorSupport):  # type: ignore[misc]
                 return True
         return False
 
+    @staticmethod
+    def _requires_output_allocator(node: torch.fx.Node) -> bool:
+        # A converter that needs a TRT output allocator has a data-dependent output
+        # shape; route the node to PyTorch when fallback_data_dependent_ops is set.
+        settings = CONVERTERS.compilation_settings
+        if settings is None or not settings.fallback_data_dependent_ops:
+            return False
+        converter_packet = CONVERTERS.get(node)
+        return converter_packet is not None and converter_packet[2].get(
+            "requires_output_allocator", False
+        )
+
     def is_node_supported(
         self, submodules: Mapping[str, torch.nn.Module], node: torch.fx.Node
     ) -> bool:
@@ -174,6 +186,15 @@ class TorchTensorRTOperatorSupport(OperatorSupport):  # type: ignore[misc]
         if self._has_complex_dtype(node):
             # Complex-dtype tensors are not supported by TensorRT; force PyTorch fallback
             # so the graph breaks around the complex cluster inserted by complex_graph_detection.
+            if not node.is_impure():
+                self.unsupported_operators[node_name] = (
+                    self.unsupported_operators.get(node_name, 0) + 1
+                )
+            return False
+
+        if self._requires_output_allocator(node):
+            # data-dependent output shape needs a TRT output allocator, which some
+            # runtimes cannot consume; honor the fallback and run the node in PyTorch
             if not node.is_impure():
                 self.unsupported_operators[node_name] = (
                     self.unsupported_operators.get(node_name, 0) + 1

--- a/tests/py/dynamo/models/test_fallback_data_dependent_ops.py
+++ b/tests/py/dynamo/models/test_fallback_data_dependent_ops.py
@@ -1,0 +1,103 @@
+import pytest
+import torch
+import torch_tensorrt
+from torch_tensorrt.dynamo._settings import CompilationSettings
+from torch_tensorrt.dynamo.conversion import DYNAMO_CONVERTERS as CONVERTERS
+from torch_tensorrt.dynamo.partitioning._global_partitioner import (
+    TorchTensorRTOperatorSupport,
+)
+
+
+def test_fallback_data_dependent_ops_setting_default():
+    # Off by default; opt-in only.
+    assert CompilationSettings().fallback_data_dependent_ops is False
+    assert (
+        CompilationSettings(
+            fallback_data_dependent_ops=True
+        ).fallback_data_dependent_ops
+        is True
+    )
+
+
+def test_old_pickle_without_field_defaults_to_false():
+    # A settings object serialized before fallback_data_dependent_ops existed (no
+    # such key in the state) must restore to the default instead of raising.
+    state = CompilationSettings().__dict__.copy()
+    state.pop("fallback_data_dependent_ops", None)
+    restored = CompilationSettings.__new__(CompilationSettings)
+    restored.__setstate__(state)
+    assert restored.fallback_data_dependent_ops is False
+
+
+def _nonzero_node() -> torch.fx.Node:
+    class Model(torch.nn.Module):
+        def forward(self, x):
+            return torch.nonzero(x)
+
+    ep = torch.export.export(Model(), (torch.tensor([0, 3, 0, 5]),))
+    gm = ep.module()
+    return next(
+        n
+        for n in gm.graph.nodes
+        if n.op == "call_function" and n.target == torch.ops.aten.nonzero.default
+    )
+
+
+def test_output_allocator_node_falls_back_only_when_enabled():
+    # nonzero's selected converter requires an output allocator, so the partitioner
+    # marks the node unsupported only when the flag is on. This is decided per node
+    # (via the selected converter), not by op target.
+    node = _nonzero_node()
+    original = CONVERTERS.compilation_settings
+    try:
+        CONVERTERS.set_compilation_settings(
+            CompilationSettings(fallback_data_dependent_ops=False)
+        )
+        assert TorchTensorRTOperatorSupport._requires_output_allocator(node) is False
+        CONVERTERS.set_compilation_settings(
+            CompilationSettings(fallback_data_dependent_ops=True)
+        )
+        assert TorchTensorRTOperatorSupport._requires_output_allocator(node) is True
+    finally:
+        CONVERTERS.compilation_settings = original
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_fallback_data_dependent_ops_conflicts_with_require_full_compilation():
+    # Running data-dependent ops in PyTorch contradicts require_full_compilation.
+    class Model(torch.nn.Module):
+        def forward(self, x):
+            return torch.nonzero(x)
+
+    inputs = (torch.tensor([0, 3, 0, 5, 7], dtype=torch.int32, device="cuda"),)
+    ep = torch.export.export(Model().cuda(), inputs)
+    with pytest.raises(ValueError):
+        torch_tensorrt.dynamo.compile(
+            ep,
+            arg_inputs=list(inputs),
+            min_block_size=1,
+            fallback_data_dependent_ops=True,
+            require_full_compilation=True,
+            use_python_runtime=True,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_fallback_data_dependent_ops_routes_output_allocator_op_to_torch():
+    # End to end on GPU: with fallback_data_dependent_ops=True an output-allocator op
+    # (nonzero) falls back to PyTorch instead of being absorbed into a TensorRT engine.
+    class Model(torch.nn.Module):
+        def forward(self, x):
+            return torch.nonzero(x)
+
+    inputs = (torch.tensor([0, 3, 0, 5, 7], dtype=torch.int32, device="cuda"),)
+    ep = torch.export.export(Model().cuda(), inputs)
+    gm = torch_tensorrt.dynamo.compile(
+        ep,
+        arg_inputs=list(inputs),
+        min_block_size=1,
+        fallback_data_dependent_ops=True,
+        use_python_runtime=True,
+    )
+    targets = {n.target for n in gm.graph.nodes if n.op == "call_function"}
+    assert torch.ops.aten.nonzero.default in targets


### PR DESCRIPTION
## Description

Some converters require a TensorRT output allocator because their output shape is
data-dependent (for example `aten.nonzero` and boolean `aten.index.Tensor`). A
TensorRT engine that needs an output allocator cannot be consumed by every downstream
runtime that executes the compiled program (for instance, runtimes that rely on
ahead-of-time static memory planning and cannot size an output whose shape is only
known after the engine runs).

This adds a `fallback_data_dependent_ops` compile setting (default `False`). When
enabled, an operator runs in PyTorch instead of TensorRT iff the converter selected
for that specific node requires an output allocator. When disabled (the default),
behavior is unchanged.

### Details
- The decision is made per node in the partitioner operator-support check
  (`TorchTensorRTOperatorSupport` and `OpSupportTester`), which asks the converter
  registry which converter it would select for the node (honoring
  `capability_validator`). This matters for targets like `aten.index.Tensor` that
  register two converters: boolean indexing requires an output allocator and falls
  back, while ordinary integer gather indexing stays on TensorRT.
- Wired through `compile()` and `cross_compile_for_windows()`; the check runs during
  partitioning, which both entry points reach through `compile_module()`. It is
  intentionally not exposed on `convert_exported_program_to_serialized_trt_engine()`,
  where a single serialized engine cannot contain PyTorch fallbacks.
- Combining `fallback_data_dependent_ops` with `require_full_compilation` raises a
  clear error, since routing ops to PyTorch contradicts full compilation.
- `CompilationSettings.__setstate__` defaults the new field so older pickles load.

### Tests
`tests/py/dynamo/models/test_fallback_data_dependent_ops.py`:
- the setting defaults to `False` and is settable;
- a state missing the field (older pickle) restores to `False`;
- the per-node support decision for `nonzero` (CPU, no GPU needed);
- combining with `require_full_compilation` raises;
- end to end on GPU, a data-dependent op (`nonzero`) falls back to PyTorch.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] My code follows the style guidelines of this project (isort + black)
- [x] I have added tests that prove my fix/feature works
- [x] Commit is signed off (DCO)
