### PR TITLE
fix: restore static allocation on ResourceAllocationStrategy exit

### DIFF
--- a/py/torch_tensorrt/dynamo/runtime/_ResourceAllocator.py
+++ b/py/torch_tensorrt/dynamo/runtime/_ResourceAllocator.py
@@ -21,7 +21,6 @@ class ResourceAllocationStrategy(torch.nn.Module):  # type: ignore[misc]
         self.dynamically_allocate_resources = dynamically_allocate_resources
 
     def __enter__(self) -> None:
-        print("Entering resource allocator context")
         for name, submodule in self.compiled_module.named_modules():
             if "_run_on_acc" in name:
                 submodule.use_dynamically_allocated_resources(
@@ -32,5 +31,5 @@ class ResourceAllocationStrategy(torch.nn.Module):  # type: ignore[misc]
         for name, submodule in self.compiled_module.named_modules():
             if "_run_on_acc" in name:
                 submodule.use_dynamically_allocated_resources(
-                    dynamically_allocate_resources=self.dynamically_allocate_resources
+                    dynamically_allocate_resources=False
                 )


### PR DESCRIPTION
The __exit__ method re-applied the same dynamically_allocate_resources value used by __enter__, so leaving the context never restored the original (static) allocation mode as documented. Set it to False on exit and remove the leftover debug print in __enter__.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
