### PR TITLE
MD-TRT changes for release 2.13

### DIFF
--- a/core/runtime/BUILD
+++ b/core/runtime/BUILD
@@ -104,8 +104,7 @@ cc_library(
         "TensorRTBindingNames.h",
         "runtime.h",
     ],
-    copts = if_torch_nccl(["-DUSE_C10D_NCCL"]),
-    defines = select({
+    defines = if_torch_nccl(["USE_C10D_NCCL"]) + select({
         # nvinfer1::IRuntimeConfig (and the matching ICudaEngine::createRuntimeConfig
         # / createExecutionContext(IRuntimeConfig*) overloads) was introduced in
         # TensorRT 10.11. The TensorRT shipped with the Jetpack l4t-r36.4 toolchain

--- a/py/torch_tensorrt/_utils.py
+++ b/py/torch_tensorrt/_utils.py
@@ -135,7 +135,7 @@ def is_platform_supported_for_trtllm() -> bool:
         return True
 
     except Exception as e:
-        logger.warning(f"Failed to detect CUDA version: {e}")
+        logger.info(f"Failed to detect CUDA version: {e}")
         return False
 
     return True
@@ -236,7 +236,7 @@ def download_and_get_plugin_lib_path() -> Optional[str]:
         wheel_path.unlink(missing_ok=True)
         logger.debug(f"Deleted wheel file: {wheel_path}")
     except Exception as e:
-        logger.warning(f"Could not delete wheel file {wheel_path}: {e}")
+        logger.info(f"Could not delete wheel file {wheel_path}: {e}")
     if not plugin_lib_path.exists():
         logger.error(
             f"Plugin library not found at expected location: {plugin_lib_path}"
@@ -356,7 +356,7 @@ def load_tensorrt_llm_for_nccl() -> bool:
             "on",
         )
         if not use_trtllm_plugin:
-            logger.warning(
+            logger.info(
                 "Neither TRTLLM_PLUGIN_PATH is set nor is it directed to download the shared library. Please set either of the two to use TRT-LLM libraries in torchTRT"
             )
             return False

--- a/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
+++ b/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
@@ -199,6 +199,18 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
     ) -> trt.IBuilderConfig:
         builder_config = self.builder.create_builder_config()
 
+        # Enable TRT's native multi-device runtime preview feature when the
+        # Torch-TRT runtime was built with NCCL collectives support. Without
+        # this, IBuilder::buildEngineWithConfig() rejects networks that contain
+        # IDistCollectiveLayer with "PreviewFeature::kMULTIDEVICE_RUNTIME_10_16
+        # is not enabled in the builder config".
+        if ENABLED_FEATURES.native_trt_collectives and hasattr(
+            trt.PreviewFeature, "MULTIDEVICE_RUNTIME_10_16"
+        ):
+            builder_config.set_preview_feature(
+                trt.PreviewFeature.MULTIDEVICE_RUNTIME_10_16, True
+            )
+
         if self._debugger_config and self._debugger_config.engine_builder_monitor:
             builder_config.progress_monitor = TRTBulderMonitor()
 


### PR DESCRIPTION
- Enable MULTIDEVICE_RUNTIME_10_16 preview feature in the builder config (guarded on native_trt_collectives + hasattr) so buildEngineWithConfig accepts networks with IDistCollectiveLayer. Reqd for TRT version greater than 10.16 and less than 11
- core/runtime/BUILD: switch USE_C10D_NCCL from copts to defines so the macro propagates to dependent targets.
- Demote three non-fatal, auto-fired TRT-LLM fallback logs (warning → info); explicit opt-in load/init failures stay at warning.