### PR TITLE
Fixed graph break serialization bug

### DIFF
--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -245,29 +245,6 @@ def lift(
     return gm, graph_signature, state_dict, constants
 
 
-def get_duplicate_nodes(
-    gm: torch.fx.GraphModule, submodule: torch.fx.GraphModule
-) -> Tuple[Sequence[Any], Sequence[Any]]:
-    """
-    We check if there are duplicate nodes when we copy submodule graph into gm.
-    Handle the case where the subgraph input placeholders are same as
-    gm placeholders. This happens when the first submodule in the graph is
-    a pytorch submodule
-    """
-    submodule_placeholder_inputs = [
-        node for node in submodule.graph.nodes if node.op == "placeholder"
-    ]
-    submodule_input_node_names = [node.name for node in submodule_placeholder_inputs]
-    gm_node_names = [node.name for node in gm.graph.nodes]
-    submodule_duplicate_inputs = [
-        node for node in submodule_placeholder_inputs if node.name in gm_node_names
-    ]
-    gm_duplicate_inputs = [
-        node for node in gm.graph.nodes if node.name in submodule_input_node_names
-    ]
-    return submodule_duplicate_inputs, gm_duplicate_inputs
-
-
 def inline_torch_modules(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
     """
     Inline a submodule within the parent graph (gm). All `call_module` nodes
@@ -281,47 +258,34 @@ def inline_torch_modules(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
         if gm_node.op == "call_module" and "_run_on_gpu" in gm_node.name:
             submodule = getattr(gm, gm_node.name)
             with gm.graph.inserting_before(gm_node):
-                # Get inputs of submodule node which are most likely outputs of a previous TRT node
-                # or a placeholder of the main graph
+                # Inputs of the submodule node in the parent graph, in order.
+                # These are the actual producer nodes (e.g. a previous TRT
+                # engine's getitem) and are already topologically before gm_node.
                 submodule_inputs = gm_node.args
-
-                submodule_duplicate_inputs, gm_duplicate_inputs = get_duplicate_nodes(
-                    gm, submodule
+                submodule_placeholders = [
+                    node for node in submodule.graph.nodes if node.op == "placeholder"
+                ]
+                assert len(submodule_placeholders) == len(submodule_inputs), (
+                    f"Submodule {gm_node.name} has {len(submodule_placeholders)} "
+                    f"placeholders but the call node provides "
+                    f"{len(submodule_inputs)} inputs."
                 )
-                assert len(submodule_duplicate_inputs) == len(gm_duplicate_inputs)
-                # Avoid creating new copies of duplicate inputs by creating a mapping
-                val_map = {}
-                for i in range(len(submodule_duplicate_inputs)):
-                    val_map[submodule_duplicate_inputs[i]] = gm_duplicate_inputs[i]
 
-                # Copy all nodes in the submodule into gm and
-                # store the output node of this submodule which is now present in gm
+                # Map each submodule placeholder directly to the corresponding
+                # parent input node (positional). Relying on the call-node args
+                # rather than matching by node name is essential: inline_trt_modules
+                # may have created/renamed getitem nodes so a placeholder's name
+                # now collides with an unrelated (and possibly later-defined) node,
+                # which would otherwise wire the body to the wrong producer and
+                # break topological ordering.
+                val_map: Dict[Any, Any] = dict(
+                    zip(submodule_placeholders, submodule_inputs)
+                )
+
+                # Copy the submodule body into gm. Placeholders are pre-seeded in
+                # val_map so graph_copy wires copied nodes to the real inputs
+                # instead of duplicating placeholder nodes.
                 submodule_output = gm.graph.graph_copy(submodule.graph, val_map)
-
-                # Get their references (since we copied) in the parent graph (gm)
-                if len(submodule_duplicate_inputs) == 0:
-                    submodule_placeholder_input_names = [
-                        node.name
-                        for node in submodule.graph.nodes
-                        if node.op == "placeholder"
-                    ]
-                    gm_added_placeholder_inputs = [
-                        node
-                        for node in gm.graph.nodes
-                        if node.name in submodule_placeholder_input_names
-                    ]
-
-                    assert len(submodule_inputs) == len(gm_added_placeholder_inputs)
-
-                    # Replace the added placeholder inputs with original inputs to this submodule node
-                    for idx in range(len(gm_added_placeholder_inputs)):
-                        gm_added_placeholder_inputs[idx].replace_all_uses_with(
-                            submodule_inputs[idx]
-                        )
-
-                    # Erase the placeholder input nodes in the gm
-                    for idx in range(len(gm_added_placeholder_inputs)):
-                        gm.graph.erase_node(gm_added_placeholder_inputs[idx])
 
                 # Replace the pytorch submodule node (call_module) with the inlined subgraph output
                 # Special handling when submodule returns multiple outputs (tuple)


### PR DESCRIPTION
# Fix: `inline_torch_modules` topological-ordering bug in `_exporter.py`

## Context

When you compile with `torch_executed_ops={torch.ops.aten.relu.default}`, the
partitioner splits the model into alternating submodules:

- `_run_on_acc_*` → run in TensorRT engines
- `_run_on_gpu_*` → run in PyTorch (the relu fallbacks)

At save time (`output_format="exported_program"`), `transform()` flattens these
submodules into a single graph in two passes:

1. `inline_trt_modules` — replaces each `_run_on_acc_*` with an `execute_engine`
   node + `getitem` output node(s).
2. `inline_torch_modules` — copies each `_run_on_gpu_*` submodule's body (the
   relu) into the main graph.

Then `eliminate_dead_code()` runs `lint()`, which enforces that every node's
inputs are defined before it.

## The cause

`lint()` failed with:

```
Argument 'getitem' of Node 'relu' was used before it has been defined!
```

From the dumped graph:

```
%getitem_8 = getitem(execute_engine_default, 0)    # engine 0 output
%relu      = relu(%getitem)                         # WRONG input
...
%getitem   = getitem(execute_engine_default_1, 0)   # engine 1 output, defined LATER
```

`relu` should consume `%getitem_8` (engine 0, immediately above it), but it was
wired to `%getitem` — a completely different node defined further down — hence
"used before defined."

The reason is how `inline_torch_modules` matched submodule inputs to graph nodes.
It used a helper, `get_duplicate_nodes`, that paired each fallback submodule's
input placeholders to nodes in the main graph by matching node names:

```python
# old, buggy approach
submodule_duplicate_inputs = [ph for ph in submodule_placeholders if ph.name in gm_node_names]
gm_duplicate_inputs        = [n  for n  in gm.graph.nodes        if n.name  in submodule_input_node_names]
val_map = {sub_ph: gm_node_with_same_name ...}
```

That assumes node names are stable, unique identifiers — which they are **not**
after the first pass:

- The partitioner had already created `getitem`, `getitem_1`, … for the
  multi-output engines.
- `inline_trt_modules` then created new `getitem` nodes for the single-output
  engines. Since `getitem` was taken, FX auto-renamed them `getitem_8`,
  `getitem_9`, …

So the relu submodule's input placeholder (named `getitem`, after its original
producer) name-matched to the unrelated `getitem` belonging to a later engine,
instead of the engine-0 output it was actually fed by. Result: relu wired to a
node defined later → topological violation. (And even when it didn't crash, it
would silently produce wrong results by reading the wrong tensor.)

## The fix

Wire the submodule body to the actual `call_module` arguments positionally,
ignoring names entirely. The `_run_on_gpu_*` call node's `args` are the real
producer nodes, in order, and are already topologically before the call site:

```python
# new approach
submodule_inputs = gm_node.args                              # real producers, in order
submodule_placeholders = [n for n in submodule.graph.nodes if n.op == "placeholder"]
val_map = dict(zip(submodule_placeholders, submodule_inputs))
submodule_output = gm.graph.graph_copy(submodule.graph, val_map)
```

By pre-seeding `val_map` with every placeholder → its real input, `graph_copy`
skips copying placeholders and rewrites each copied body node's args to the
correct producers. Since the producers already exist earlier in the graph and the
body is copied `inserting_before(gm_node)`, ordering is guaranteed correct.

I also deleted the now-unused, name-based `get_duplicate_nodes` helper and the
placeholder-cleanup branch it required (with positional mapping, no stray
placeholder nodes are ever created).

**Why it's robust:** `gm_node.args` is the ground truth of "what feeds this
submodule" — it survives any renaming the earlier passes do, whereas name
matching is coincidental and breaks exactly when two passes both mint `getitem`
nodes.

## Verification

The repro now finishes with `max diff: 0.0` (loaded ExportedProgram is
numerically identical to the in-memory module) and no lint/ordering errors.
