### PR TITLE
feat: multiple optimization profiles for disjoint input shape regimes

### DIFF
--- a/core/runtime/TRTEngine.cpp
+++ b/core/runtime/TRTEngine.cpp
@@ -280,6 +280,11 @@ TRTEngine::TRTEngine(
   }
 
   has_dynamic_inputs = engine_has_dynamic_inputs(cuda_engine.get(), in_binding_names);
+  // Cache input binding metadata used by the runtime hot path, then reconstruct
+  // optimization-profile info from the TRT API so multi-profile selection works
+  // for any loaded engine.
+  this->setup_input_binding_infos();
+  this->setup_optimization_profiles();
 
 #ifndef NDEBUG
   this->enable_profiling();
@@ -557,6 +562,168 @@ std::vector<std::string> TRTEngine::serialize() {
 
 void TRTEngine::reset_captured_graph() {
   cudagraph.reset();
+}
+
+void TRTEngine::setup_input_binding_infos() {
+  input_binding_infos.clear();
+  input_binding_infos.reserve(in_binding_names.size());
+  for (const auto& name : in_binding_names) {
+    input_binding_infos.push_back(
+        {name,
+         util::TRTDataTypeToScalarType(cuda_engine->getTensorDataType(name.c_str())),
+         cuda_engine->isShapeInferenceIO(name.c_str())});
+  }
+}
+
+void TRTEngine::setup_optimization_profiles() {
+  num_optimization_profiles = cuda_engine->getNbOptimizationProfiles();
+  profile_dynamic_dims.clear();
+  // Single-profile engines never auto-select a profile, so the per-profile dim
+  // cache below isn't needed.
+  if (num_optimization_profiles <= 1) {
+    return;
+  }
+  // One entry per input binding position; shape-inference IO and all-static
+  // inputs keep their default empty list so auto-selection can skip them without
+  // any name lookup.
+  profile_dynamic_dims.resize(in_binding_names.size());
+  for (size_t i = 0; i < input_binding_infos.size(); ++i) {
+    const auto& binding = input_binding_infos[i];
+    const auto& name = binding.name;
+    // Shape tensors carry value ranges, not dim ranges, so they can't be matched
+    // by getProfileShape; skip them (leaving an empty entry).
+    if (binding.is_shape_tensor) {
+      continue;
+    }
+    // Gather [min, max] for every dim across every profile: dim -> [profile] -> (min, max).
+    std::vector<std::vector<std::pair<int64_t, int64_t>>> per_dim;
+    for (int64_t p = 0; p < num_optimization_profiles; ++p) {
+      auto dmin =
+          cuda_engine->getProfileShape(name.c_str(), static_cast<int32_t>(p), nvinfer1::OptProfileSelector::kMIN);
+      auto dmax =
+          cuda_engine->getProfileShape(name.c_str(), static_cast<int32_t>(p), nvinfer1::OptProfileSelector::kMAX);
+      if (per_dim.empty()) {
+        per_dim.resize(dmin.nbDims);
+      }
+      for (int d = 0; d < dmin.nbDims; ++d) {
+        per_dim[d].push_back(std::make_pair(dmin.d[d], dmax.d[d]));
+      }
+    }
+    // Keep only dims that vary within a profile (min != max) or differ across
+    // profiles; a dim that is the same fixed extent in every profile cannot
+    // distinguish profiles, so we skip it (TRT validates it at setInputShape).
+    auto& dynamic_dims = profile_dynamic_dims[i];
+    for (int32_t d = 0; d < static_cast<int32_t>(per_dim.size()); ++d) {
+      const auto& ranges = per_dim[d];
+      bool is_dynamic = false;
+      for (const auto& r : ranges) {
+        if (r.first != r.second || r != ranges[0]) {
+          is_dynamic = true;
+          break;
+        }
+      }
+      if (is_dynamic) {
+        dynamic_dims.push_back({d, ranges});
+      }
+    }
+  }
+}
+
+void TRTEngine::set_active_profile(int64_t profile_index) {
+  // Manual-pin / torchbind path: this runs outside execute_engine's stream
+  // choreography, so the switch's async memcpys aren't otherwise ordered against
+  // the (later, separate) enqueue. Resolve the current stream and fully
+  // synchronize to make the switch safe. This path is rare and not perf-critical.
+  auto stream = c10::cuda::getCurrentCUDAStream(device_info.id);
+  set_active_profile_with_stream(profile_index, stream);
+  stream.synchronize();
+}
+
+void TRTEngine::set_active_profile_with_stream(int64_t profile_index, const c10::cuda::CUDAStream& stream) {
+  if (num_optimization_profiles <= 1) {
+    return;
+  }
+  if (profile_index == active_profile_index) {
+    return;
+  }
+
+  // setOptimizationProfileAsync returns false for an out-of-range index; the
+  // index is validated upstream in TorchTensorRTModule.resolve_profile_index.
+  TORCHTRT_CHECK(
+      exec_ctx()->setOptimizationProfileAsync(static_cast<int32_t>(profile_index), stream.stream()),
+      "Failed to switch to optimization profile index " << profile_index);
+
+  active_profile_index = profile_index;
+  // A profile switch invalidates any captured CUDA graph and changes the
+  // context state, so force re-record / shape re-inference on the next call.
+  runtime_states.context_changed = true;
+  reset_captured_graph();
+  shape_key = "None";
+  LOG_DEBUG("Switched to optimization profile index " << profile_index);
+}
+
+bool TRTEngine::profile_fits(int64_t profile_index, const std::vector<at::Tensor>& inputs) const {
+  // Indexed positionally by input (inputs[i] <-> in_binding_names[i], the same
+  // convention setup_input_tensors uses); empty entries (shape-inference IO /
+  // all-static inputs) are skipped with no name lookup. Static dims are not
+  // cached (they cannot distinguish profiles) and are validated later by TRT at
+  // setInputShape.
+  //
+  // Example profile_dynamic_dims for an image input (1, 3, H, W) with H/W
+  // dynamic across 3 profiles plus a fully-static second input:
+  //   profile_dynamic_dims = [
+  //     # input 0: dims 2 (H), 3 (W) vary; dims 0 (N=1) and 1 (channels=3) fixed -> omitted
+  //     [
+  //       (2, [(224, 224), (256, 512), (256, 512)]),  # H   ranges for profiles 0,1,2
+  //       (3, [(224, 224), (256, 512), (256, 512)]),  # W
+  //     ],
+  //     # input 1: fully static (and/or shape-inference IO) -> empty, skipped
+  //     [],
+  //   ]
+  const size_t num_to_check = std::min(inputs.size(), profile_dynamic_dims.size());
+  for (size_t i = 0; i < num_to_check; ++i) {
+    const auto& dynamic_dims = profile_dynamic_dims[i];
+    if (dynamic_dims.empty()) {
+      continue;
+    }
+    auto sizes = inputs[i].sizes();
+    for (const auto& dyn : dynamic_dims) {
+      if (dyn.dim_index < static_cast<int32_t>(sizes.size())) {
+        int64_t lo = dyn.profile_ranges[profile_index].first;
+        int64_t hi = dyn.profile_ranges[profile_index].second;
+        int64_t sz = sizes[dyn.dim_index];
+        if (!(lo <= sz && sz <= hi)) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+int64_t TRTEngine::auto_select_profile(const std::vector<at::Tensor>& inputs) {
+  // Prefer the profile already loaded: if it still fits the inputs, keep it.
+  // This avoids thrashing between equally-valid profiles when shapes alternate
+  // (e.g. decode/prefill), since a switch invalidates the captured CUDA graph
+  // and forces shape re-inference. Only fall back to a scan when it no longer
+  // fits.
+  if (profile_fits(active_profile_index, inputs)) {
+    return active_profile_index;
+  }
+  // Lazy / first-working: switch to the first profile whose [min, max] ranges
+  // fit every input. Overlapping profiles therefore resolve to the lowest
+  // matching index (pin manually to force a specific one). This method owns the
+  // switch so callers don't have to follow up.
+  for (int64_t p = 0; p < num_optimization_profiles; ++p) {
+    if (profile_fits(p, inputs)) {
+      set_active_profile_with_stream(p, this->engine_stream);
+      return p;
+    }
+  }
+  TORCHTRT_THROW_ERROR(
+      "No optimization profile matches the input shapes. Fix the input shapes or pin a profile "
+      "explicitly via optimization_profile(module, index).");
+  return 0; // unreachable
 }
 
 void TRTEngine::set_resource_allocation_strategy(TRTEngine::ResourceAllocationStrategy new_strategy) {

--- a/core/runtime/TRTEngine.h
+++ b/core/runtime/TRTEngine.h
@@ -215,12 +215,69 @@ struct TRTEngine : torch::CustomClassHolder {
   // Per-call formatted input buffers. In standard mode these are bound
   // directly to TRT; in CUDA graph mode they are async-copy sources for
   // persistent CUDA graph input staging buffers.
+  struct InputBindingInfo {
+    std::string name;
+    at::ScalarType expected_type;
+    bool is_shape_tensor;
+  };
+  std::vector<InputBindingInfo> input_binding_infos = {};
   std::vector<at::Tensor> active_input_tensors = {};
   std::list<std::vector<int64_t>> active_shape_tensor_values = {};
 
   std::string shape_key = "None";
   bool use_pre_allocated_outputs = false;
   std::vector<at::Tensor> pre_allocated_outputs;
+
+  // --- Multiple optimization profiles ---
+  // State and helpers mirror the Python runtime (TRTEngine in _TRTEngine.py) so
+  // the C++ and Python runtimes are interchangeable: the same attribute and
+  // method names are exposed via torchbind in register_jit_hooks.cpp
+  // (``num_optimization_profiles``, ``_active_profile_index``,
+  // ``_auto_select_profiles``, ``set_active_profile``). Index validation lives
+  // in the runtime-agnostic TorchTensorRTModule.resolve_profile_index.
+  int64_t num_optimization_profiles = 1; // cuda_engine->getNbOptimizationProfiles()
+  int64_t active_profile_index = 0; // profile currently loaded in exec_ctx
+  bool auto_select_profiles = false; // opt-in shape-based selection (per call)
+  // A single input dimension whose extent varies across or within optimization
+  // profiles, paired with its [min, max] range for each profile index. Dims that
+  // are a fixed identical extent in every profile are NOT stored, so selection
+  // only inspects dims that can actually distinguish profiles.
+  struct DynamicProfileDim {
+    int32_t dim_index;
+    std::vector<std::pair<int64_t, int64_t>> profile_ranges; // indexed by profile index
+  };
+  // Indexed by input binding position (parallel to ``in_binding_names``, so it
+  // reuses the same positional input -> binding mapping the rest of the runtime
+  // relies on). Each entry holds only that input's dynamic dims; shape-inference
+  // IO and all-static inputs get an empty list. Built once in
+  // setup_optimization_profiles so auto-selection does no per-call string
+  // lookups.
+  std::vector<std::vector<DynamicProfileDim>> profile_dynamic_dims;
+
+  // Cache profile count + per-profile dim ranges purely from the TRT API
+  // (getNbOptimizationProfiles / getProfileShape) so selection works for any
+  // loaded engine with no extra serialized metadata.
+  void setup_input_binding_infos();
+  void setup_optimization_profiles();
+  // Switch the active TRT optimization profile (idempotent). Manual-pin /
+  // torchbind entry point: runs outside execute_engine's stream setup, so it
+  // resolves the current stream and fully synchronizes (rare, not perf-critical).
+  void set_active_profile(int64_t profile_index);
+  // Core switch issued on ``stream`` with no host synchronize: the caller must
+  // guarantee a happens-before to the enqueue (e.g. issue on the enqueue stream).
+  // Used by auto-selection, which switches on engine_stream before enqueueV3.
+  void set_active_profile_with_stream(int64_t profile_index, const c10::cuda::CUDAStream& stream);
+  // True if every input's dynamic dims fit profile ``profile_index``'s [min, max]
+  // ranges (positional inputs[i] <-> in_binding_names[i]; static / shape-inference
+  // IO inputs are skipped).
+  bool profile_fits(int64_t profile_index, const std::vector<at::Tensor>& inputs) const;
+  // Select and activate the optimization profile for ``inputs`` and return its
+  // index. Keeps the currently active profile when it still fits (no switch, no
+  // thrashing); otherwise switches to the first fitting profile. Owns the switch
+  // so callers need no follow-up. Called internally from the execute_engine run
+  // paths (guarded by num_optimization_profiles > 1 && auto_select_profiles);
+  // manual pins are applied eagerly via set_active_profile.
+  int64_t auto_select_profile(const std::vector<at::Tensor>& inputs);
 
   // Single placeholder buffer for empty tensor inputs (allocated once, reused)
   void* empty_tensor_placeholder = nullptr;

--- a/core/runtime/execute_engine.cpp
+++ b/core/runtime/execute_engine.cpp
@@ -101,22 +101,21 @@ void setup_input_tensors(
   compiled_engine->reset_active_input_tensors();
 
   for (size_t i = 0; i < inputs.size(); i++) {
-    std::string name = compiled_engine->in_binding_names[i];
+    const auto& binding = compiled_engine->input_binding_infos[i];
+    const auto& name = binding.name;
 
     TORCHTRT_CHECK(
         inputs[i].is_cuda(), "Expected input tensors to have device cuda, found device " << inputs[i].device());
 
-    auto expected_type = util::TRTDataTypeToScalarType(ctx->getEngine().getTensorDataType(name.c_str()));
     TORCHTRT_CHECK(
-        inputs[i].dtype() == expected_type,
-        "Expected input tensors to have type " << expected_type << ", found type " << inputs[i].dtype());
+        inputs[i].dtype() == binding.expected_type,
+        "Expected input tensors to have type " << binding.expected_type << ", found type " << inputs[i].dtype());
 
     auto dims = core::util::toDims(inputs[i].sizes());
     auto shape = core::util::toVec(dims);
-    bool is_shape_tensor = compiled_engine->cuda_engine->isShapeInferenceIO(name.c_str());
-    LOG_DEBUG("Input Name: " << name << " Shape: " << dims << " isShapeInferenceIO: " << is_shape_tensor);
+    LOG_DEBUG("Input Name: " << name << " Shape: " << dims << " isShapeInferenceIO: " << binding.is_shape_tensor);
 
-    if (is_shape_tensor) {
+    if (binding.is_shape_tensor) {
       // Shape tensor inputs are casted to int64 explicitly.
       // Refer to
       // https://github.com/NVIDIA/TensorRT/blob/d2f4ef789a9a6ffdf37b55c3f81b486225f6b380/samples/common/sampleInference.cpp#L435
@@ -260,8 +259,10 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
       }
     }
 
-    bool shape_changed = _validate_shapes(inputs, compiled_engine);
-
+    // Resolve the execution stream first so the optimization-profile switch below
+    // is issued on the same stream the engine will actually enqueue on. This keeps
+    // the switch consistent with execution and, for a default-stream caller, keeps
+    // it on the pool stream instead of serializing the device on the default stream.
     auto current_device_id = inputs.size() > 0 ? inputs[0].device().index() : at::cuda::current_device();
     auto default_stream = compiled_engine->default_stream;
     auto previous_engine_stream = compiled_engine->engine_stream;
@@ -277,6 +278,18 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
     if (cudagraphs_enabled && compiled_engine->engine_stream != previous_engine_stream) {
       // Captured CUDA graph was recorded against the old stream; force re-record.
       compiled_engine->runtime_states.context_changed = true;
+    }
+
+    // Validate shapes first so auto-selection is skipped entirely when the input
+    // shape is unchanged: the previously selected profile still fits, so it stays
+    // active. When the shape did change, auto_select_profile keeps the active
+    // profile if it still fits (no-op) or switches otherwise. A switch sets
+    // context_changed (consumed by set_runtime_states regardless of order), and
+    // shape_changed is already true here, so the cudagraph record/reset below
+    // still fires. Only auto-selection runs per call; manual pins are eager.
+    bool shape_changed = _validate_shapes(inputs, compiled_engine);
+    if (shape_changed && compiled_engine->num_optimization_profiles > 1 && compiled_engine->auto_select_profiles) {
+      compiled_engine->auto_select_profile(inputs);
     }
 
     // Whether cudagraphs needs to record the graph on this pass
@@ -439,6 +452,28 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
   };
 
   auto run_output_allocator = [&]() {
+    // Resolve the execution stream first so the optimization-profile switch below
+    // is issued on the same stream the engine will actually enqueue on.
+    auto current_device_id = inputs.size() > 0 ? inputs[0].device().index() : at::cuda::current_device();
+    auto default_stream = compiled_engine->default_stream;
+    compiled_engine->caller_stream = c10::cuda::getCurrentCUDAStream(current_device_id);
+    bool caller_on_default = (compiled_engine->caller_stream == default_stream);
+    if (caller_on_default) {
+      compiled_engine->engine_stream = compiled_engine->owned_pool_stream;
+    } else {
+      // Honor caller's non-default stream so its scheduling choice (e.g. SM
+      // partitioning via a CUDA Green Context) is preserved end to end.
+      compiled_engine->engine_stream = compiled_engine->caller_stream;
+    }
+
+    // Validate shapes first so auto-selection is skipped entirely when the input
+    // shape is unchanged: the previously selected profile still fits, so it
+    // stays active. When the shape did change, auto_select_profile keeps the
+    // active profile if it still fits (no-op) or switches otherwise.
+    bool shape_changed = _validate_shapes(inputs, compiled_engine);
+    if (shape_changed && compiled_engine->num_optimization_profiles > 1 && compiled_engine->auto_select_profiles) {
+      compiled_engine->auto_select_profile(inputs);
+    }
     { // Input Setup
       std::unique_ptr<torch::autograd::profiler::RecordProfile> input_profiler_guard;
       if (compiled_engine->profile_execution) {
@@ -465,18 +500,6 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
             std::make_unique<torch::autograd::profiler::RecordProfile>(compiled_engine->output_profile_path);
       }
       create_output_allocator(compiled_engine);
-    }
-
-    auto current_device_id = inputs.size() > 0 ? inputs[0].device().index() : at::cuda::current_device();
-    auto default_stream = compiled_engine->default_stream;
-    compiled_engine->caller_stream = c10::cuda::getCurrentCUDAStream(current_device_id);
-    bool caller_on_default = (compiled_engine->caller_stream == default_stream);
-    if (caller_on_default) {
-      compiled_engine->engine_stream = compiled_engine->owned_pool_stream;
-    } else {
-      // Honor caller's non-default stream so its scheduling choice (e.g. SM
-      // partitioning via a CUDA Green Context) is preserved end to end.
-      compiled_engine->engine_stream = compiled_engine->caller_stream;
     }
 
     compiled_engine->record_active_input_tensor_stream_usage(compiled_engine->engine_stream);

--- a/core/runtime/register_jit_hooks.cpp
+++ b/core/runtime/register_jit_hooks.cpp
@@ -77,6 +77,13 @@ static auto TORCHTRT_UNUSED TRTEngineTSRegistrtion =
         .def(
             "num_execution_contexts_created",
             [](const c10::intrusive_ptr<TRTEngine>& self) -> int64_t { return self->num_execution_contexts_created(); })
+        // Multiple optimization profiles. Names match the Python runtime
+        // (_TRTEngine.py) so both runtimes are interchangeable behind
+        // TorchTensorRTModule / the optimization_profile context manager.
+        .def("set_active_profile", &TRTEngine::set_active_profile)
+        .def_readonly("num_optimization_profiles", &TRTEngine::num_optimization_profiles)
+        .def_readonly("_active_profile_index", &TRTEngine::active_profile_index)
+        .def_readwrite("_auto_select_profiles", &TRTEngine::auto_select_profiles)
         .def(
             "use_dynamically_allocated_resources",
             [](const c10::intrusive_ptr<TRTEngine>& self, bool dynamic) -> void {

--- a/docsrc/tutorials/runtime_opt/index.rst
+++ b/docsrc/tutorials/runtime_opt/index.rst
@@ -2,7 +2,9 @@ Runtime Optimization
 =====================
 
 Optimize inference throughput and latency: CUDA Graphs for kernel-replay,
-pre-allocated output buffers, and choosing the Python vs C++ TRT execution path.
+pre-allocated output buffers, multiple optimization profiles for distinct shape
+regimes (e.g. LLM prefill/decode), and choosing the Python vs C++ TRT execution
+path.
 
 .. toctree::
    :maxdepth: 1
@@ -10,4 +12,6 @@ pre-allocated output buffers, and choosing the Python vs C++ TRT execution path.
    cuda_graphs
    Example: Torch Export with Cudagraphs <../_rendered_examples/dynamo/torch_export_cudagraphs>
    Example: Pre-allocated output buffer <../_rendered_examples/dynamo/pre_allocated_output_example>
+   multi_optimization_profiles
+   Example: Multiple optimization profiles (prefill/decode) <../_rendered_examples/dynamo/multi_optimization_profiles>
    Python vs C++ runtime <python_runtime>

--- a/docsrc/tutorials/runtime_opt/multi_optimization_profiles.rst
+++ b/docsrc/tutorials/runtime_opt/multi_optimization_profiles.rst
@@ -25,7 +25,7 @@ profile is tuned independently.
 Declaring profiles
 ------------------
 
-Pass an ordered list of ``{"min", "opt", "max"}`` dicts to
+Pass an ordered list of ``{"min_shape", "opt_shape", "max_shape"}`` dicts to
 :class:`torch_tensorrt.Input` via ``profiles``. The **list index** is the
 optimization-profile index you select at runtime.
 
@@ -40,22 +40,23 @@ optimization-profile index you select at runtime.
         dtype=torch.int64,
         profiles=[
             # index 0 -> decode: seq pinned to 1 (a fully static profile)
-            {"min": (1, 1), "opt": (1, 1), "max": (1, 1)},
+            {"min_shape": (1, 1), "opt_shape": (1, 1), "max_shape": (1, 1)},
             # index 1 -> prefill: seq in [1, 512], tuned at 256
-            {"min": (1, 1), "opt": (1, 256), "max": (1, 512)},
+            {"min_shape": (1, 1), "opt_shape": (1, 256), "max_shape": (1, 512)},
         ],
     )
 
-``profiles`` is mutually exclusive with the single-shape ``min_shape`` /
-``opt_shape`` / ``max_shape`` (and ``shape``) arguments.
+When using ``profiles``, do not also pass the single-range ``min_shape`` /
+``opt_shape`` / ``max_shape`` arguments, or the static ``shape`` argument, for
+the same input. ``profiles`` already contains the shape ranges for that input.
 
 The **union envelope**
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``torch.export`` traces a model over one ``[min, opt, max]`` range, so
 ``Input`` automatically derives the **union envelope** of all profiles
-(elementwise ``min`` of every ``min`` and ``max`` of every ``max``; ``opt`` is
-taken from the first profile). Each declared profile is a subset of this
+(elementwise minimum of every ``min_shape`` and maximum of every ``max_shape``;
+``opt_shape`` is taken from the first profile). Each declared profile is a subset of this
 envelope. You export over the envelope and the individual profiles become the
 per-profile TensorRT tunings:
 

--- a/docsrc/tutorials/runtime_opt/multi_optimization_profiles.rst
+++ b/docsrc/tutorials/runtime_opt/multi_optimization_profiles.rst
@@ -1,0 +1,164 @@
+.. _multi_optimization_profiles_tutorial:
+
+Multiple Optimization Profiles (Prefill / Decode)
+=================================================
+
+TensorRT tunes kernels for the **optimization profile** of an engine: a
+``[min, opt, max]`` range for every dynamic input dimension. Kernels are tuned at
+the ``opt`` point, so a single profile can only be optimal for one shape.
+
+Many models, however, run in several distinct shape *regimes* that share the same
+weights. The canonical case is an autoregressive LLM:
+
+* **prefill** -- the prompt is processed in one shot, so ``seq`` is large, and
+* **decode** -- tokens are generated one at a time, so ``seq == 1``.
+
+With a single dynamic range ``seq in [1, max]`` you must pick one ``opt``. Tuning
+for the long prefill length leaves **decode** -- the latency-critical, most
+frequently executed phase -- running on kernels chosen for a sequence length it
+never sees.
+
+Torch-TensorRT lets you declare **multiple optimization profiles** on a single
+input and select the active one at runtime. The engine is built once and each
+profile is tuned independently.
+
+Declaring profiles
+------------------
+
+Pass an ordered list of ``{"min", "opt", "max"}`` dicts to
+:class:`torch_tensorrt.Input` via ``profiles``. The **list index** is the
+optimization-profile index you select at runtime.
+
+.. code-block:: python
+
+    import torch
+    import torch_tensorrt
+
+    DECODE_IDX, PREFILL_IDX = 0, 1
+
+    profiled_input = torch_tensorrt.Input(
+        dtype=torch.int64,
+        profiles=[
+            # index 0 -> decode: seq pinned to 1 (a fully static profile)
+            {"min": (1, 1), "opt": (1, 1), "max": (1, 1)},
+            # index 1 -> prefill: seq in [1, 512], tuned at 256
+            {"min": (1, 1), "opt": (1, 256), "max": (1, 512)},
+        ],
+    )
+
+``profiles`` is mutually exclusive with the single-shape ``min_shape`` /
+``opt_shape`` / ``max_shape`` (and ``shape``) arguments.
+
+The **union envelope**
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``torch.export`` traces a model over one ``[min, opt, max]`` range, so
+``Input`` automatically derives the **union envelope** of all profiles
+(elementwise ``min`` of every ``min`` and ``max`` of every ``max``; ``opt`` is
+taken from the first profile). Each declared profile is a subset of this
+envelope. You export over the envelope and the individual profiles become the
+per-profile TensorRT tunings:
+
+.. code-block:: python
+
+    print(profiled_input.shape["min_shape"])  # (1, 1)
+    print(profiled_input.shape["max_shape"])  # (1, 512)
+
+Compile
+-------
+
+Export once over the union range, then compile as usual. Every input that
+declares ``profiles`` must declare the **same number** of profiles; static
+inputs (or dynamic inputs without ``profiles``) reuse their single shape in every
+profile.
+
+.. code-block:: python
+
+    seq = torch.export.Dim("seq", min=1, max=512)
+    exported = torch.export.export(model, (example_ids,), dynamic_shapes=({1: seq},))
+
+    trt_model = torch_tensorrt.dynamo.compile(
+        exported,
+        arg_inputs=[profiled_input],
+        enabled_precisions={torch.float16},
+        min_block_size=1,
+    )
+
+Selecting a profile at runtime
+------------------------------
+
+Selection is **manual by default**. Use the
+:func:`torch_tensorrt.runtime.optimization_profile` context manager to pin a
+profile by index for the duration of a ``with`` block; the prior state is saved
+on enter and restored on exit, so blocks nest cleanly.
+
+.. code-block:: python
+
+    from torch_tensorrt.runtime import optimization_profile
+
+    with optimization_profile(trt_model, DECODE_IDX):
+        logits = trt_model(decode_ids)      # seq == 1
+
+    with optimization_profile(trt_model, PREFILL_IDX):
+        logits = trt_model(prefill_ids)     # seq == 256
+
+Pass ``"auto"`` to let Torch-TensorRT choose from the input shapes. Auto-selection
+is **lazy / first-working**: it scans profiles in index order and uses the first
+whose ``[min, max]`` contains the input. Order matters when profiles overlap --
+declaring ``decode`` first lets it win the ``seq == 1`` overlap:
+
+.. code-block:: python
+
+    with optimization_profile(trt_model, "auto"):
+        trt_model(decode_ids)    # seq == 1   -> index 0 (decode) accepts -> decode
+        trt_model(prefill_ids)   # seq == 256 -> index 0 rejects -> index 1 (prefill)
+
+Profiles, graph breaks, and serialization
+-----------------------------------------
+
+* **Graph breaks**: when a model is partitioned into several TensorRT engines,
+  every engine carries the same number of profiles. Torch-TensorRT propagates the
+  per-profile bounds across the break, evaluating any *derived* dynamic dimension
+  (e.g. a ``reshape`` that turns ``seq`` into ``16 * seq``) through to the
+  downstream engine, so runtime selection stays consistent for the whole module.
+* **Serialization / runtimes**: profile state is reconstructed from the TensorRT
+  API on load (``getNbOptimizationProfiles`` / ``getProfileShape``), so a
+  serialized engine keeps its profiles with no extra metadata. The same
+  ``optimization_profile`` API drives both the C++ and Python runtimes, which
+  remain interchangeable.
+
+Why it helps: a worked latency example
+--------------------------------------
+
+The example :ref:`multi_optimization_profiles` compiles ``google/gemma-3-1b-it``
+twice -- once with a single profile (tuned at the prefill length) and once with
+separate decode/prefill profiles -- then compares per-call latency. The
+multi-profile engine dedicates a **static** profile (``seq`` pinned to 1) to
+decode, letting TensorRT specialize that path (measured on an NVIDIA A40, FP16):
+
+.. code-block:: text
+
+    Per-call latency (ms), batch=1
+    regime                single-profile   multi-profile   speedup
+    --------------------------------------------------------------
+    decode (seq=1)                 5.232           4.597     1.14x
+    prefill (seq=128)              7.152           7.534     0.95x
+
+Prefill is essentially unchanged (both engines tune it at the same ``opt``),
+while decode -- the regime executed once per generated token -- is faster. Exact
+numbers depend on the model and GPU; the takeaway is that one engine can be tuned
+well for *both* regimes instead of compromising on a single ``opt`` shape.
+
+.. note::
+
+   Because the model has two dynamic inputs (``input_ids`` and ``position_ids``),
+   the example passes one profiled ``Input`` for each, both declaring the same
+   profiles. The HuggingFace attention path also needs a TensorRT-friendly SDPA
+   lowering (``tools/llm/torchtrt_ext/register_sdpa``), and ``gemma-3-1b-it`` is a
+   gated model requiring Hugging Face authentication.
+
+.. seealso::
+
+   - Runnable example: :ref:`multi_optimization_profiles`
+   - :class:`torch_tensorrt.Input`
+   - :func:`torch_tensorrt.runtime.optimization_profile`

--- a/examples/dynamo/multi_optimization_profiles.py
+++ b/examples/dynamo/multi_optimization_profiles.py
@@ -1,0 +1,265 @@
+"""
+.. _multi_optimization_profiles:
+
+Multiple Optimization Profiles: Prefill vs Decode for Gemma-3
+=============================================================
+
+Autoregressive LLMs run in two very different shape *regimes* that share one set
+of weights (and ideally one engine):
+
+- **prefill**: the prompt is processed in one shot, so the sequence length
+  ``seq`` is large, and
+- **decode**: tokens are generated one at a time, so ``seq == 1``.
+
+A single dynamic range ``seq in [1, max]`` works, but TensorRT can only tune
+kernels for **one** ``opt`` point. Tuning for the prefill length leaves decode
+(the latency-critical, most-frequently-executed phase) running on kernels picked
+for a sequence it never sees.
+
+``torch_tensorrt.Input(profiles=[...])`` declares **N optimization profiles** on
+a single input. The engine is built once (a single ``torch.export`` over the
+union of all profiles), each profile gets its own TensorRT kernel tuning, and you
+select the active profile per call (by index, or ``"auto"``).
+
+This example compiles `google/gemma-3-1b-it
+<https://huggingface.co/google/gemma-3-1b-it>`_ **twice** -- once with a single
+profile and once with separate prefill/decode profiles -- and compares the decode
+and prefill latency of the two engines.
+
+.. note::
+
+   ``google/gemma-3-1b-it`` is a **gated** model: you must accept its license on
+   the Hugging Face Hub and authenticate (``hf auth login`` or the ``HF_TOKEN``
+   environment variable) before running this example. It downloads ~2 GB of
+   weights on first use and requires a CUDA GPU.
+
+.. note::
+
+   This uses the Ahead-Of-Time (AOT) ``torch.export`` + ``dynamo.compile`` path.
+   Runtime profile selection works with whichever TensorRT runtime (C++ or
+   Python) the installed Torch-TensorRT build provides.
+"""
+
+# %%
+# Imports and Setup
+# ^^^^^^^^^^^^^^^^^^
+#
+# The HuggingFace attention path needs a TensorRT-friendly SDPA lowering. The
+# reusable LLM helpers ``register_sdpa`` (a Gemma-3-specific SDPA pass) and
+# ``export_llm`` live under ``tools/llm`` in the Torch-TensorRT repo, so we add
+# that directory to ``sys.path``.
+
+import sys
+import timeit
+from pathlib import Path
+
+import torch
+import torch_tensorrt
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "tools" / "llm"))
+
+MODEL_ID = "google/gemma-3-1b-it"
+DEVICE = torch.device("cuda:0")
+
+# The two regimes we benchmark.
+MAX_SEQ = 256  # largest prompt the engine must support
+PREFILL_SEQ = 128
+DECODE_SEQ = 1
+DECODE_IDX, PREFILL_IDX = 0, 1
+
+
+# %%
+# Load the Model
+# ^^^^^^^^^^^^^^
+#
+# Load with ``use_cache=False`` (this example recomputes over the full sequence
+# rather than using a KV cache, which keeps the export simple) and the ``sdpa``
+# attention implementation, then register the Gemma-3 SDPA lowering pass.
+def load_model():
+    from transformers import AutoModelForCausalLM
+
+    with torch.no_grad():
+        model = (
+            AutoModelForCausalLM.from_pretrained(
+                MODEL_ID,
+                use_cache=False,
+                attn_implementation="sdpa",
+                ignore_mismatched_sizes=True,
+            )
+            .eval()
+            .cuda()
+            .to(torch.float16)
+        )
+    from torchtrt_ext import register_sdpa
+
+    register_sdpa.enable_sdpa_converter(MODEL_ID, model.config)
+    return model
+
+
+try:
+    model = load_model()
+except Exception as e:  # gated/no-auth/no-GPU environments (e.g. CI docs build)
+    print(f"Skipping example: could not load {MODEL_ID} ({type(e).__name__}: {e}).")
+    print("Accept the license and authenticate (hf auth login / HF_TOKEN) to run.")
+    sys.exit(0)
+
+
+def make_inputs(seq_len: int):
+    ids = torch.randint(1, 10000, (1, seq_len), dtype=torch.int64, device=DEVICE)
+    position_ids = torch.arange(seq_len, device=DEVICE).unsqueeze(0)
+    return ids, position_ids
+
+
+# %%
+# Declaring the Optimization Profiles
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# ``profiles`` is an ordered list; the list index is the optimization-profile
+# index used at runtime. Both model inputs (``input_ids`` and ``position_ids``)
+# are dynamic over ``seq``, so each gets a profiled ``Input`` with identical
+# profiles:
+#
+# - index ``0`` -> **decode**: ``seq`` pinned to 1 (a fully static profile)
+# - index ``1`` -> **prefill**: ``seq`` in ``[1, MAX_SEQ]``, tuned at ``PREFILL_SEQ``
+#
+# Profile order matters for auto-selection: the profiles overlap at ``seq == 1``
+# and auto-selection picks the *first* profile whose ``[min, max]`` accepts the
+# input, so declaring ``decode`` first lets it win the ``seq == 1`` overlap.
+profiles = [
+    {"min": (1, 1), "opt": (1, 1), "max": (1, 1)},  # decode
+    {"min": (1, 1), "opt": (1, PREFILL_SEQ), "max": (1, MAX_SEQ)},  # prefill
+]
+multi_profile_inputs = [
+    torch_tensorrt.Input(dtype=torch.int64, profiles=profiles),  # input_ids
+    torch_tensorrt.Input(dtype=torch.int64, profiles=profiles),  # position_ids
+]
+
+# %%
+# Export Once, Compile Twice
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# ``export_llm`` traces the model over a dynamic ``seq`` range. We reuse the
+# exported program for both the single-profile baseline (tuned at the prefill
+# length, the conventional choice) and the multi-profile engine.
+from utils import export_llm  # noqa: E402
+
+example_ids, _ = make_inputs(PREFILL_SEQ)
+with torch.inference_mode():
+    exported = export_llm(model, example_ids, min_seq_len=1, max_seq_len=MAX_SEQ)
+
+# ``offload_module_to_cpu`` must stay False here: it is currently incompatible
+# with the multi-profile ``Input(profiles=...)`` path (CPU/CUDA device mismatch).
+common = dict(
+    use_fp32_acc=True,
+    disable_tf32=True,
+    offload_module_to_cpu=False,
+    min_block_size=1,
+    require_full_compilation=True,
+    device=DEVICE,
+)
+
+print("Compiling single-profile engine (tuned at prefill length) ...")
+bench_ids, bench_pos = make_inputs(PREFILL_SEQ)
+trt_single = torch_tensorrt.dynamo.compile(
+    exported, inputs=[bench_ids, bench_pos], **common
+)
+
+print("Compiling multi-profile engine (decode + prefill) ...")
+trt_multi = torch_tensorrt.dynamo.compile(
+    exported, arg_inputs=multi_profile_inputs, **common
+)
+
+
+# %%
+# Correctness
+# ^^^^^^^^^^^
+#
+# FP16 logits over Gemma's 262K-token vocabulary are noisy, so we compare the
+# *predicted token* (argmax) rather than raw logits.
+def logits(out):
+    return (out.logits if hasattr(out, "logits") else out).float()
+
+
+from torch_tensorrt.runtime import optimization_profile  # noqa: E402
+
+decode_ids, decode_pos = make_inputs(DECODE_SEQ)
+prefill_ids, prefill_pos = make_inputs(PREFILL_SEQ)
+
+with torch.inference_mode():
+    ref_decode = logits(model(decode_ids, position_ids=decode_pos))
+    ref_prefill = logits(model(prefill_ids, position_ids=prefill_pos))
+
+    with optimization_profile(trt_multi, DECODE_IDX):
+        trt_decode = logits(trt_multi(decode_ids, decode_pos))
+    with optimization_profile(trt_multi, PREFILL_IDX):
+        trt_prefill = logits(trt_multi(prefill_ids, prefill_pos))
+
+
+def top1_match(a, b):
+    return (a.argmax(-1) == b.argmax(-1)).float().mean().item()
+
+
+print(f"decode  top-1 token match vs eager: {top1_match(trt_decode, ref_decode):.1%}")
+print(f"prefill top-1 token match vs eager: {top1_match(trt_prefill, ref_prefill):.1%}")
+
+
+# %%
+# Latency Comparison
+# ^^^^^^^^^^^^^^^^^^^
+#
+# Time each regime on each engine. For the multi-profile engine we pin the
+# matching profile around the loop (the realistic serving pattern). We report the
+# min over several rounds to reduce noise.
+def benchmark(run, iters: int = 50, warmup: int = 20, rounds: int = 3) -> float:
+    for _ in range(warmup):
+        run()
+    torch.cuda.synchronize()
+    best = float("inf")
+    for _ in range(rounds):
+        start = timeit.default_timer()
+        for _ in range(iters):
+            run()
+        torch.cuda.synchronize()
+        best = min(best, (timeit.default_timer() - start) / iters * 1000)  # ms/call
+    return best
+
+
+with torch.inference_mode():
+    single_decode = benchmark(lambda: trt_single(decode_ids, decode_pos))
+    single_prefill = benchmark(lambda: trt_single(prefill_ids, prefill_pos))
+    with optimization_profile(trt_multi, DECODE_IDX):
+        multi_decode = benchmark(lambda: trt_multi(decode_ids, decode_pos))
+    with optimization_profile(trt_multi, PREFILL_IDX):
+        multi_prefill = benchmark(lambda: trt_multi(prefill_ids, prefill_pos))
+
+# %%
+# Results. Decode is the win: the multi-profile engine dedicates a *static*
+# profile (``seq`` pinned to 1) to decode, so TensorRT specializes that path
+# instead of serving it from kernels tuned for the long prefill length. Prefill
+# is unchanged (both engines tune it at the same ``opt``).
+print("\nPer-call latency (ms), batch=1")
+print(f"{'regime':<20}{'single-profile':>16}{'multi-profile':>16}{'speedup':>10}")
+print("-" * 62)
+print(
+    f"{f'decode (seq={DECODE_SEQ})':<20}{single_decode:>16.3f}"
+    f"{multi_decode:>16.3f}{single_decode / multi_decode:>9.2f}x"
+)
+print(
+    f"{f'prefill (seq={PREFILL_SEQ})':<20}{single_prefill:>16.3f}"
+    f"{multi_prefill:>16.3f}{single_prefill / multi_prefill:>9.2f}x"
+)
+
+# %%
+# Summary
+# ^^^^^^^
+#
+# - Declare ``N`` profiles on an ``Input`` with ``profiles=[{min, opt, max}, ...]``
+#   (one per dynamic model input -- here ``input_ids`` and ``position_ids``).
+# - One export + one engine; each profile gets its own TensorRT kernel tuning.
+# - Select at runtime by **index** (``optimization_profile(m, i)``) or let
+#   ``"auto"`` pick the first profile that fits the input shapes.
+# - Dedicating a static ``seq == 1`` profile to decode lets TensorRT tune that
+#   latency-critical path independently of the prefill length.
+
+print("Done.")

--- a/examples/dynamo/multi_optimization_profiles.py
+++ b/examples/dynamo/multi_optimization_profiles.py
@@ -127,8 +127,12 @@ def make_inputs(seq_len: int):
 # and auto-selection picks the *first* profile whose ``[min, max]`` accepts the
 # input, so declaring ``decode`` first lets it win the ``seq == 1`` overlap.
 profiles = [
-    {"min": (1, 1), "opt": (1, 1), "max": (1, 1)},  # decode
-    {"min": (1, 1), "opt": (1, PREFILL_SEQ), "max": (1, MAX_SEQ)},  # prefill
+    {"min_shape": (1, 1), "opt_shape": (1, 1), "max_shape": (1, 1)},  # decode
+    {
+        "min_shape": (1, 1),
+        "opt_shape": (1, PREFILL_SEQ),
+        "max_shape": (1, MAX_SEQ),
+    },  # prefill
 ]
 multi_profile_inputs = [
     torch_tensorrt.Input(dtype=torch.int64, profiles=profiles),  # input_ids
@@ -254,7 +258,8 @@ print(
 # Summary
 # ^^^^^^^
 #
-# - Declare ``N`` profiles on an ``Input`` with ``profiles=[{min, opt, max}, ...]``
+# - Declare ``N`` profiles on an ``Input`` with
+#   ``profiles=[{min_shape, opt_shape, max_shape}, ...]``
 #   (one per dynamic model input -- here ``input_ids`` and ``position_ids``).
 # - One export + one engine; each profile gets its own TensorRT kernel tuning.
 # - Select at runtime by **index** (``optimization_profile(m, i)``) or let

--- a/py/torch_tensorrt/_Input.py
+++ b/py/torch_tensorrt/_Input.py
@@ -56,9 +56,9 @@ class Input(object):
     )  #: Optional {axis_index: name} for dynamic axes. The same name across inputs is exported as one shared ``torch.export.Dim`` (e.g. a batch axis shared by ``input_ids`` and ``attention_mask``).
     #: Optional ordered optimization profiles for multi-profile engines. A list
     #: of dicts, one per profile; the list index is the TRT optimization-profile
-    #: index used to select the profile at runtime. Each entry has ``min`` /
-    #: ``opt`` / ``max`` shape tuples. ``None`` for the default zero/one-profile
-    #: behavior. ``profiles`` may be combined with ``shared_dims``: the profiles
+    #: index used to select the profile at runtime. Each entry has
+    #: ``min_shape`` / ``opt_shape`` / ``max_shape`` tuples. ``None`` for the
+    #: default zero/one-profile behavior. ``profiles`` may be combined with ``shared_dims``: the profiles
     #: define the per-profile TRT ranges while ``shared_dims`` names dynamic axes
     #: on the union envelope so they export as one shared ``torch.export.Dim``
     #: across inputs.
@@ -236,14 +236,15 @@ class Input(object):
             self.name = kwargs["name"]
 
     def _init_from_profiles(self, args: Any, kwargs: Any) -> None:
-        """Validate ``profiles`` and translate them into union min/opt/max kwargs.
+        """Validate ``profiles`` and translate them into union shape kwargs.
 
         ``profiles`` (``kwargs["profiles"]``) is an ordered list of dicts (one per
         profile); the list index is the TRT optimization-profile index selected at
-        runtime. Each entry has ``min`` / ``opt`` / ``max`` shape tuples. This
-        stores the normalized list on ``self.profiles`` and fills ``kwargs`` with
-        the elementwise union envelope (the range ``torch.export`` must cover), so
-        the regular dynamic-shape path in ``__init__`` builds the Input.
+        runtime. Each entry has ``min_shape`` / ``opt_shape`` / ``max_shape``
+        tuples. This stores the normalized list on ``self.profiles`` and fills
+        ``kwargs`` with the elementwise union envelope (the range ``torch.export``
+        must cover), so the regular dynamic-shape path in ``__init__`` builds the
+        Input.
 
         ``shared_dims`` is intentionally *not* mutually exclusive with
         ``profiles``: profiles describe the per-profile TRT shape ranges, whereas
@@ -271,7 +272,7 @@ class Input(object):
         if not isinstance(profiles, (list, tuple)) or len(profiles) == 0:
             raise ValueError(
                 "`profiles` must be a non-empty list of dicts, each with keys "
-                "'min', 'opt', 'max'. The list index is the optimization-profile "
+                "'min_shape', 'opt_shape', 'max_shape'. The list index is the optimization-profile "
                 "index used to select the profile at runtime."
             )
 
@@ -279,22 +280,22 @@ class Input(object):
         rank: Optional[int] = None
         for i, prof in enumerate(profiles):
             if not isinstance(prof, dict) or not all(
-                k in prof for k in ("min", "opt", "max")
+                k in prof for k in ("min_shape", "opt_shape", "max_shape")
             ):
                 raise ValueError(
-                    f"Profile at index {i} must be a dict with keys 'min', 'opt', 'max'"
+                    f"Profile at index {i} must be a dict with keys 'min_shape', 'opt_shape', 'max_shape'"
                 )
 
-            for field_name in ("min", "opt", "max"):
+            for field_name in ("min_shape", "opt_shape", "max_shape"):
                 if not Input._supported_input_size_type(prof[field_name]):
                     raise TypeError(
                         f"Profile at index {i} field '{field_name}' must be a List, "
                         f"tuple or torch.Size, found {type(prof[field_name])}"
                     )
 
-            min_shape = tuple(prof["min"])
-            opt_shape = tuple(prof["opt"])
-            max_shape = tuple(prof["max"])
+            min_shape = tuple(prof["min_shape"])
+            opt_shape = tuple(prof["opt_shape"])
+            max_shape = tuple(prof["max_shape"])
 
             if not (len(min_shape) == len(opt_shape) == len(max_shape)):
                 raise ValueError(
@@ -324,9 +325,9 @@ class Input(object):
 
             normalized.append(
                 {
-                    "min": min_shape,
-                    "opt": opt_shape,
-                    "max": max_shape,
+                    "min_shape": min_shape,
+                    "opt_shape": opt_shape,
+                    "max_shape": max_shape,
                 }
             )
 
@@ -337,10 +338,10 @@ class Input(object):
         # specialize at). The regular dynamic-shape path in ``__init__`` consumes
         # these to set ``self.shape`` and ``shape_mode``.
         assert rank is not None
-        union_min = [min(p["min"][d] for p in normalized) for d in range(rank)]
-        union_max = [max(p["max"][d] for p in normalized) for d in range(rank)]
+        union_min = [min(p["min_shape"][d] for p in normalized) for d in range(rank)]
+        union_max = [max(p["max_shape"][d] for p in normalized) for d in range(rank)]
         kwargs["min_shape"] = tuple(union_min)
-        kwargs["opt_shape"] = tuple(normalized[0]["opt"])
+        kwargs["opt_shape"] = tuple(normalized[0]["opt_shape"])
         kwargs["max_shape"] = tuple(union_max)
 
     def __str__(self) -> str:

--- a/py/torch_tensorrt/_Input.py
+++ b/py/torch_tensorrt/_Input.py
@@ -54,6 +54,15 @@ class Input(object):
     shared_dims: Dict[int, str] = (
         {}
     )  #: Optional {axis_index: name} for dynamic axes. The same name across inputs is exported as one shared ``torch.export.Dim`` (e.g. a batch axis shared by ``input_ids`` and ``attention_mask``).
+    #: Optional ordered optimization profiles for multi-profile engines. A list
+    #: of dicts, one per profile; the list index is the TRT optimization-profile
+    #: index used to select the profile at runtime. Each entry has ``min`` /
+    #: ``opt`` / ``max`` shape tuples. ``None`` for the default zero/one-profile
+    #: behavior. ``profiles`` may be combined with ``shared_dims``: the profiles
+    #: define the per-profile TRT ranges while ``shared_dims`` names dynamic axes
+    #: on the union envelope so they export as one shared ``torch.export.Dim``
+    #: across inputs.
+    profiles: Optional[List[Dict[str, Tuple[int, ...]]]] = None
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """__init__ Method for torch_tensorrt.Input
@@ -82,8 +91,17 @@ class Input(object):
             - Input(shape=(1,3,32,32), dtype=torch_tensorrt.dtype.int32, format=torch_tensorrt.TensorFormat.NCHW)
             - Input(min_shape=(1,3,32,32), opt_shape=[2,3,32,32], max_shape=(3,3,32,32)) #Implicitly dtype=torch_tensorrt.dtype.float32, format=torch_tensorrt.TensorFormat.NCHW
         """
-        # Compatibility code for switching over from InputTensorSpec
-        if "shape" in kwargs and "shape_ranges" in kwargs:
+        # Multi optimization profile support. ``profiles`` is validated and
+        # translated into the union ``min_shape`` / ``opt_shape`` / ``max_shape``
+        # kwargs so the regular dynamic-shape path below constructs the Input
+        # unchanged.
+        if kwargs.get("profiles") is not None:
+            self._init_from_profiles(args, kwargs)
+
+        # Compatibility code for switching over from InputTensorSpec.
+        # Mutually exclusive with `profiles` above (which translates into
+        # min/opt/max kwargs and forbids `shape`/`shape_ranges`).
+        elif "shape" in kwargs and "shape_ranges" in kwargs:
             assert (
                 len(kwargs["shape_ranges"]) == 1 and len(kwargs["shape_ranges"][0]) == 3
             )
@@ -217,6 +235,114 @@ class Input(object):
         if "name" in kwargs:
             self.name = kwargs["name"]
 
+    def _init_from_profiles(self, args: Any, kwargs: Any) -> None:
+        """Validate ``profiles`` and translate them into union min/opt/max kwargs.
+
+        ``profiles`` (``kwargs["profiles"]``) is an ordered list of dicts (one per
+        profile); the list index is the TRT optimization-profile index selected at
+        runtime. Each entry has ``min`` / ``opt`` / ``max`` shape tuples. This
+        stores the normalized list on ``self.profiles`` and fills ``kwargs`` with
+        the elementwise union envelope (the range ``torch.export`` must cover), so
+        the regular dynamic-shape path in ``__init__`` builds the Input.
+
+        ``shared_dims`` is intentionally *not* mutually exclusive with
+        ``profiles``: profiles describe the per-profile TRT shape ranges, whereas
+        ``shared_dims`` names dynamic axes so they export as a single shared
+        ``torch.export.Dim`` across inputs. The two compose -- ``shared_dims`` is
+        left in ``kwargs`` and validated against the union envelope by the regular
+        dynamic-shape path (a named axis must be dynamic in the union).
+        """
+        profiles = kwargs["profiles"]
+        # ``profiles`` is the only *shape* specifier when used (``shared_dims`` is
+        # an axis-naming modifier, not a shape, so it is allowed alongside).
+        if len(args) != 0:
+            raise ValueError(
+                "Found both a positional shape argument and `profiles`. "
+                "class Input expects `profiles` to be the only shape specifier when used."
+            )
+        if any(
+            k in kwargs
+            for k in ["shape", "min_shape", "opt_shape", "max_shape", "shape_ranges"]
+        ):
+            raise ValueError(
+                "`profiles` is mutually exclusive with `shape` / `min_shape` / "
+                "`opt_shape` / `max_shape`. Specify only one shape declaration on an Input."
+            )
+        if not isinstance(profiles, (list, tuple)) or len(profiles) == 0:
+            raise ValueError(
+                "`profiles` must be a non-empty list of dicts, each with keys "
+                "'min', 'opt', 'max'. The list index is the optimization-profile "
+                "index used to select the profile at runtime."
+            )
+
+        normalized: List[Dict[str, Tuple[int, ...]]] = []
+        rank: Optional[int] = None
+        for i, prof in enumerate(profiles):
+            if not isinstance(prof, dict) or not all(
+                k in prof for k in ("min", "opt", "max")
+            ):
+                raise ValueError(
+                    f"Profile at index {i} must be a dict with keys 'min', 'opt', 'max'"
+                )
+
+            for field_name in ("min", "opt", "max"):
+                if not Input._supported_input_size_type(prof[field_name]):
+                    raise TypeError(
+                        f"Profile at index {i} field '{field_name}' must be a List, "
+                        f"tuple or torch.Size, found {type(prof[field_name])}"
+                    )
+
+            min_shape = tuple(prof["min"])
+            opt_shape = tuple(prof["opt"])
+            max_shape = tuple(prof["max"])
+
+            if not (len(min_shape) == len(opt_shape) == len(max_shape)):
+                raise ValueError(
+                    f"Profile at index {i} min/opt/max shapes must have the same number "
+                    f"of dimensions, found {len(min_shape)}/{len(opt_shape)}/{len(max_shape)}"
+                )
+            if rank is None:
+                rank = len(min_shape)
+            elif rank != len(min_shape):
+                raise ValueError(
+                    "All profiles on an Input must have the same number of dimensions. "
+                    f"Profile at index {i} has {len(min_shape)}, expected {rank}."
+                )
+
+            for d in range(len(min_shape)):
+                # No min=0 (and TRT requires >= 1).
+                if min_shape[d] < 1:
+                    raise ValueError(
+                        f"Profile at index {i} min_shape[{d}]={min_shape[d]} is invalid; "
+                        "every dimension must have min >= 1 (min=0 is not supported)."
+                    )
+                if not (min_shape[d] <= opt_shape[d] <= max_shape[d]):
+                    raise ValueError(
+                        f"Profile at index {i} requires min <= opt <= max element-wise. "
+                        f"Got min={min_shape[d]}, opt={opt_shape[d]}, max={max_shape[d]} at dim {d}."
+                    )
+
+            normalized.append(
+                {
+                    "min": min_shape,
+                    "opt": opt_shape,
+                    "max": max_shape,
+                }
+            )
+
+        self.profiles = normalized
+
+        # Derive the export envelope: elementwise union over every profile. opt
+        # is taken from the first declared profile (the shape export will trace /
+        # specialize at). The regular dynamic-shape path in ``__init__`` consumes
+        # these to set ``self.shape`` and ``shape_mode``.
+        assert rank is not None
+        union_min = [min(p["min"][d] for p in normalized) for d in range(rank)]
+        union_max = [max(p["max"][d] for p in normalized) for d in range(rank)]
+        kwargs["min_shape"] = tuple(union_min)
+        kwargs["opt_shape"] = tuple(normalized[0]["opt"])
+        kwargs["max_shape"] = tuple(union_max)
+
     def __str__(self) -> str:
         if self.shape_mode == Input._ShapeMode.STATIC:
             return "Input(shape={}, dtype={}, format={}, domain=[{}, {}))".format(
@@ -228,10 +354,21 @@ class Input(object):
             )
         elif self.shape_mode == Input._ShapeMode.DYNAMIC:
             if isinstance(self.shape, dict):
-                return "Input(min_shape={}, opt_shape={}, max_shape={}, dtype={}, format={}, domain=[{}, {}))".format(
+                profiles_str = (
+                    ", profiles={}".format(
+                        [
+                            {k: tuple(v) for k, v in prof.items()}
+                            for prof in self.profiles
+                        ]
+                    )
+                    if self.profiles
+                    else ""
+                )
+                return "Input(min_shape={}, opt_shape={}, max_shape={}{}, dtype={}, format={}, domain=[{}, {}))".format(
                     self.shape["min_shape"],
                     self.shape["opt_shape"],
                     self.shape["max_shape"],
+                    profiles_str,
                     str(self.dtype),
                     str(self.format),
                     str(self.tensor_domain[0]),
@@ -259,6 +396,7 @@ class Input(object):
                 a.shape["min_shape"] == b.shape["min_shape"],
                 a.shape["opt_shape"] == b.shape["opt_shape"],
                 a.shape["max_shape"] == b.shape["max_shape"],
+                a.profiles == b.profiles,
                 a.dtype == b.dtype,
                 a.format == b.format,
                 a.low_tensor_domain_incl == b.low_tensor_domain_incl,

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -52,6 +52,7 @@ from torch_tensorrt.dynamo.utils import (
     prepare_inputs,
     to_torch_device,
     to_torch_tensorrt_device,
+    validate_optimization_profiles,
 )
 
 logger = logging.getLogger(__name__)
@@ -741,6 +742,7 @@ def compile(
     }
     logger.debug(f"CPU memory usage before lowering: {get_cpu_memory_usage()} MB")
     settings = CompilationSettings(**compilation_options)
+
     logger.info("Compilation Settings: %s\n", settings)
     exported_program = pre_export_lowering(exported_program, settings)
     exported_program = exported_program.run_decompositions(
@@ -1045,6 +1047,24 @@ def compile_module(
         submodule_node_dict[node.name] = node
 
     preserve_module_specs(original_in_spec, original_out_spec, partitioned_module)
+
+    # Multi-profile propagation: build the map from export source
+    # symbols to per-profile bounds once, from the top-level inputs, then reuse
+    # it to attach the same profiles (by index) to every TRT submodule's inputs.
+    top_level_inputs: List[Input] = list(sample_arg_inputs)
+    if isinstance(sample_kwarg_inputs, dict):
+        top_level_inputs.extend(sample_kwarg_inputs.values())
+    num_profiles = validate_optimization_profiles(top_level_inputs)
+    profile_source_bounds = None
+    if num_profiles:
+        logger.info(
+            f"Building engine(s) with {num_profiles} "
+            "optimization profiles (selected by index)"
+        )
+        profile_source_bounds = partitioning.build_profile_source_bounds(
+            partitioned_module, top_level_inputs, num_profiles
+        )
+
     # Store TRT replicas of Torch subgraphs
     trt_modules = {}
     # Iterate over all components that can be accelerated
@@ -1102,8 +1122,14 @@ def compile_module(
             ]
         )
 
-        # Get the submodule inputs for min, opt, max shapes of the graph inputs
-        submodule_inputs = partitioning.construct_submodule_inputs(submodule)
+        # Get the submodule inputs for min, opt, max shapes of the graph inputs.
+        # With multi-profile compile, propagate the profiles (by index) to each
+        # submodule input by symbolic substitution.
+        submodule_inputs = partitioning.construct_submodule_inputs(
+            submodule,
+            profile_source_bounds=profile_source_bounds,
+            num_profiles=num_profiles,
+        )
 
         assert submodule_inputs is not None
 

--- a/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
+++ b/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
@@ -531,7 +531,7 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
         for i in range(self.optimization_profile_count):
             if current_input.profiles and i < len(current_input.profiles):
                 prof = current_input.profiles[i]
-                result.append((prof["min"], prof["opt"], prof["max"]))
+                result.append((prof["min_shape"], prof["opt_shape"], prof["max_shape"]))
             else:
                 result.append(union)
         return result

--- a/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
+++ b/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
@@ -49,6 +49,7 @@ from torch_tensorrt.dynamo.utils import (
     DYNAMIC_DIM,
     deallocate_module,
     get_cpu_memory_usage,
+    validate_optimization_profiles,
 )
 from torch_tensorrt.logging import TRT_LOGGER
 
@@ -115,12 +116,28 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
                 + "\n".join(f"{i}" for i in missing_ops)
             )
 
+        # Optimization profiles. Profiles are an ordered list on
+        # ``Input.profiles``; profile index i is built from each input's
+        # ``profiles[i]``. The count is derived from the input specs (submodule
+        # inputs inherit the same number of profiles via propagation). It is
+        # ``0`` when no input declares ``profiles``, in which case we fall back
+        # to the historical behavior: a single profile for dynamic inputs and
+        # none for fully static engines.
+        self.optimization_profile_count: int = validate_optimization_profiles(
+            input_specs
+        )
+        has_dynamic_input = any(
+            input_spec.shape_mode == Input._ShapeMode.DYNAMIC
+            for input_spec in input_specs
+        )
+        num_profiles = (
+            self.optimization_profile_count
+            if self.optimization_profile_count
+            else (1 if has_dynamic_input else 0)
+        )
         self.optimization_profiles: Optional[List[trt.IOptimizationProfile]] = (
-            [self.builder.create_optimization_profile()]
-            if any(
-                input_spec.shape_mode == Input._ShapeMode.DYNAMIC
-                for input_spec in input_specs
-            )
+            [self.builder.create_optimization_profile() for _ in range(num_profiles)]
+            if num_profiles > 0
             else None
         )
 
@@ -489,6 +506,36 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
 
         return trt_node
 
+    def _per_profile_shapes(
+        self, current_input: Input
+    ) -> List[Tuple[Sequence[int], Sequence[int], Sequence[int]]]:
+        """Return ``(min, opt, max)`` shapes for each optimization profile index.
+
+        - If multiple profiles are active and the input declares ``profiles``,
+          each entry uses the input's range at that profile index.
+        - If multiple profiles are active but the input has none (static-like
+          input reused across regimes), every entry repeats the union range.
+        - If no profiles are active, there is a single entry (the union range) —
+          the historical single-profile behavior.
+        """
+        assert isinstance(current_input.shape, dict)
+        union = (
+            current_input.shape["min_shape"],
+            current_input.shape["opt_shape"],
+            current_input.shape["max_shape"],
+        )
+        if not self.optimization_profile_count:
+            return [union]
+
+        result: List[Tuple[Sequence[int], Sequence[int], Sequence[int]]] = []
+        for i in range(self.optimization_profile_count):
+            if current_input.profiles and i < len(current_input.profiles):
+                prof = current_input.profiles[i]
+                result.append((prof["min"], prof["opt"], prof["max"]))
+            else:
+                result.append(union)
+        return result
+
     def placeholder(self, target: str, args: Any, kwargs: Any) -> trt.ITensor:
         self._input_names.append(target)
         current_input = self.input_specs[self.input_specs_iter]
@@ -498,27 +545,43 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
         if current_input.shape_mode == Input._ShapeMode.DYNAMIC:
             assert isinstance(current_input.shape, dict)
             shape = []
-            min_shape = current_input.shape["min_shape"]
-            opt_shape = current_input.shape["opt_shape"]
-            max_shape = current_input.shape["max_shape"]
-            # TODO: Does not support disjoint optimization profiles?
             assert self.optimization_profiles is not None
-            assert len(min_shape) == len(opt_shape) == len(max_shape)
-            if current_input.is_shape_tensor:
-                # For shape_tensors, min/opt/max_shapes correspond to actual values
-                # of the shapes provided during runtime
-                self.optimization_profiles[0].set_shape_input(
-                    target, min_shape, opt_shape, max_shape
-                )
-                shape.append(len(opt_shape))
-            else:
-                self.optimization_profiles[0].set_shape(
-                    target, min_shape, opt_shape, max_shape
-                )
 
-                for i in range(len(min_shape)):
-                    if min_shape[i] == opt_shape[i] == max_shape[i]:
-                        shape.append(min_shape[i])
+            # Build the per-profile (min, opt, max) shapes for this input. Each
+            # TRT optimization profile index gets the input's corresponding
+            # profile range; inputs without profiles (e.g. static tensors reused
+            # across regimes) repeat their single union range in every profile.
+            per_profile_shapes = self._per_profile_shapes(current_input)
+
+            for profile_idx, opt_profile in enumerate(self.optimization_profiles):
+                min_shape, opt_shape, max_shape = per_profile_shapes[profile_idx]
+                assert len(min_shape) == len(opt_shape) == len(max_shape)
+                if current_input.is_shape_tensor:
+                    # For shape_tensors, min/opt/max_shapes correspond to actual
+                    # values of the shapes provided during runtime.
+                    opt_profile.set_shape_input(target, min_shape, opt_shape, max_shape)
+                else:
+                    opt_profile.set_shape(target, min_shape, opt_shape, max_shape)
+
+            # The INetwork input shape uses the union envelope to mark which
+            # dims are dynamic (-1). A dim is static only if it is identical
+            # across every profile's min/opt/max.
+            union_min = current_input.shape["min_shape"]
+            union_opt = current_input.shape["opt_shape"]
+            union_max = current_input.shape["max_shape"]
+            if current_input.is_shape_tensor:
+                shape.append(len(union_opt))
+            else:
+                for i in range(len(union_min)):
+                    dim_is_static = all(
+                        per_profile_shapes[p][0][i]
+                        == per_profile_shapes[p][1][i]
+                        == per_profile_shapes[p][2][i]
+                        == per_profile_shapes[0][0][i]
+                        for p in range(len(per_profile_shapes))
+                    )
+                    if dim_is_static:
+                        shape.append(union_min[i])
                     else:
                         # -1 to represent the dynamic dimension
                         shape.append(DYNAMIC_DIM)

--- a/py/torch_tensorrt/dynamo/partitioning/__init__.py
+++ b/py/torch_tensorrt/dynamo/partitioning/__init__.py
@@ -2,6 +2,7 @@ from ._adjacency_partitioner import partition as fast_partition
 from ._global_partitioner import partition as global_partition
 from ._hierarchical_partitioner import hierarchical_adjacency_partition
 from .common import (
+    build_profile_source_bounds,
     construct_submodule_inputs,
     get_graph_converter_support,
     run_shape_analysis,

--- a/py/torch_tensorrt/dynamo/partitioning/common.py
+++ b/py/torch_tensorrt/dynamo/partitioning/common.py
@@ -1,18 +1,83 @@
 import logging
-from typing import Any, Dict, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 import torch
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx.experimental.proxy_tensor import unset_fake_temporarily
-
 from torch_tensorrt._Input import Input
 from torch_tensorrt.dynamo.utils import (
     COMPLEX_TO_REAL_DTYPE,
     contains_sym_int,
     extract_var_range_info,
+    extract_var_range_info_for_profile,
 )
 
 logger = logging.getLogger(__name__)
+
+# Per-profile source-symbol bounds, indexed by optimization-profile index:
+#   [ {symbol_name: {"min": int, "opt": int, "max": int}}, ... ]
+# Built at the top level from ``Input.profiles`` and the export symbols, then
+# propagated to submodule inputs by substituting into their SymInt expressions.
+ProfileSourceBounds = List[Dict[str, Dict[str, int]]]
+
+
+def _build_submodule_profiles(
+    input_shape: torch.Size,
+    union_min: Sequence[int],
+    union_opt: Sequence[int],
+    union_max: Sequence[int],
+    profile_source_bounds: ProfileSourceBounds,
+    num_profiles: int,
+) -> Optional[List[Dict[str, Tuple[int, ...]]]]:
+    """Evaluate per-profile min/opt/max for a (possibly symbolic) submodule shape.
+
+    For each profile (by index), substitute the profile's source-symbol values
+    into each SymInt dim and evaluate. Static dims and dims whose
+    symbols cannot be resolved fall back to the union value. Returns an ordered
+    list of profile dicts (one per profile index).
+    """
+    profiles: List[Dict[str, Tuple[int, ...]]] = []
+    for i in range(num_profiles):
+        sym_bounds = profile_source_bounds[i] if i < len(profile_source_bounds) else {}
+        p_min: List[int] = []
+        p_opt: List[int] = []
+        p_max: List[int] = []
+        for d, dim in enumerate(input_shape):
+            if isinstance(dim, torch.SymInt):
+                try:
+                    p_min.append(
+                        extract_var_range_info_for_profile(
+                            dim, {s: b["min"] for s, b in sym_bounds.items()}
+                        )
+                    )
+                    p_opt.append(
+                        extract_var_range_info_for_profile(
+                            dim, {s: b["opt"] for s, b in sym_bounds.items()}
+                        )
+                    )
+                    p_max.append(
+                        extract_var_range_info_for_profile(
+                            dim, {s: b["max"] for s, b in sym_bounds.items()}
+                        )
+                    )
+                except KeyError:
+                    # Symbol(s) not present in this profile's source bounds;
+                    # fall back to the union range for this dim.
+                    p_min.append(int(union_min[d]))
+                    p_opt.append(int(union_opt[d]))
+                    p_max.append(int(union_max[d]))
+            else:
+                p_min.append(int(dim))
+                p_opt.append(int(dim))
+                p_max.append(int(dim))
+        profiles.append(
+            {
+                "min": tuple(p_min),
+                "opt": tuple(p_opt),
+                "max": tuple(p_max),
+            }
+        )
+    return profiles
 
 
 def construct_dynamic_input(
@@ -20,11 +85,17 @@ def construct_dynamic_input(
     input_dtype: torch.dtype,
     name: str = "",
     is_shape_tensor: bool = False,
+    profile_source_bounds: Optional[ProfileSourceBounds] = None,
+    num_profiles: int = 0,
 ) -> Input:
     """
     Constructs a torch_tensorrt.Input based on a symbolic input
     Args:
         input_shape: A symbolic shape / regular shape of a tensor (which can have a  mix of SymInt nodes and static values)
+        profile_source_bounds: Optional per-profile source-symbol bounds used to
+            propagate optimization profiles to this (intermediate) input.
+        num_profiles: Number of profiles to emit when ``profile_source_bounds``
+            is provided.
     Returns:
         A dynamic shaped torch_tensorrt.Input which has the properties of the symbolic shaped input.
     """
@@ -70,6 +141,34 @@ def construct_dynamic_input(
             opt_shape.append(dim)
             max_shape.append(dim)
 
+    # Multi-profile propagation: emit profiles for this intermediate input by
+    # substituting source-symbol values into its SymInt dims.
+    if profile_source_bounds and num_profiles:
+        profiles = _build_submodule_profiles(
+            input_shape,
+            min_shape,
+            opt_shape,
+            max_shape,
+            profile_source_bounds,
+            num_profiles,
+        )
+        if profiles is not None:
+            try:
+                return Input(
+                    profiles=profiles,
+                    dtype=input_dtype,
+                    name=name,
+                    is_shape_tensor=is_shape_tensor,
+                )
+            except (ValueError, TypeError) as e:
+                # Non-affine / non-monotonic expressions can yield invalid
+                # per-profile bounds; fall back to the single union profile.
+                logger.warning(
+                    f"Could not propagate optimization profiles to submodule input "
+                    f"'{name}' (shape {input_shape}): {e}. Falling back to the union "
+                    "range for this input."
+                )
+
     return Input(
         min_shape=min_shape,
         opt_shape=opt_shape,
@@ -85,6 +184,8 @@ def get_input(
     dtype: torch.dtype,
     name: str = "",
     is_shape_tensor: bool = False,
+    profile_source_bounds: Optional[ProfileSourceBounds] = None,
+    num_profiles: int = 0,
 ) -> Input:
     """
     Based on type of dimensions in the input_shape, construct regular or dynamic shaped inputs
@@ -106,6 +207,8 @@ def get_input(
             dtype,
             name=name,
             is_shape_tensor=is_shape_tensor,
+            profile_source_bounds=profile_source_bounds,
+            num_profiles=num_profiles,
         )
     else:
         return Input(
@@ -113,12 +216,22 @@ def get_input(
         )
 
 
-def construct_submodule_inputs(module: torch.fx.GraphModule) -> Sequence[Input]:
+def construct_submodule_inputs(
+    module: torch.fx.GraphModule,
+    profile_source_bounds: Optional[ProfileSourceBounds] = None,
+    num_profiles: int = 0,
+) -> Sequence[Input]:
     """
     Construct torch_tensorrt Inputs based on the module inputs.
     The module inputs will have meta data which has the shape and dtype info
     Args:
         module: Input FX GraphModule
+        profile_source_bounds: Optional per-profile source-symbol bounds. When
+            provided (multi-profile compile), each dynamic submodule input gets
+            ``profiles`` derived by substituting source symbols into its
+            symbolic shape.
+        num_profiles: Number of profiles corresponding to
+            ``profile_source_bounds``.
     Returns:
         Sequence of torch_tensorrt.Input's representing inputs to given module
     """
@@ -134,7 +247,13 @@ def construct_submodule_inputs(module: torch.fx.GraphModule) -> Sequence[Input]:
                     if isinstance(input_meta, (FakeTensor, torch.Tensor)):
                         input_shape = input_meta.size()
                         torchtrt_inputs.append(
-                            get_input(input_shape, input_meta.dtype, name=input.name)
+                            get_input(
+                                input_shape,
+                                input_meta.dtype,
+                                name=input.name,
+                                profile_source_bounds=profile_source_bounds,
+                                num_profiles=num_profiles,
+                            )
                         )
                     elif isinstance(input_meta, torch.SymInt):
                         # Assuming sym_integers | shape inputs always have torch.int64 dtype
@@ -144,6 +263,8 @@ def construct_submodule_inputs(module: torch.fx.GraphModule) -> Sequence[Input]:
                                 torch.int64,
                                 name=input.name,
                                 is_shape_tensor=True,
+                                profile_source_bounds=profile_source_bounds,
+                                num_profiles=num_profiles,
                             )
                         )
                     elif isinstance(input_meta, torch.SymFloat):
@@ -176,6 +297,63 @@ def construct_submodule_inputs(module: torch.fx.GraphModule) -> Sequence[Input]:
                 )
 
         return torchtrt_inputs
+
+
+def build_profile_source_bounds(
+    module: torch.fx.GraphModule,
+    top_level_inputs: Sequence[Input],
+    num_profiles: int,
+) -> ProfileSourceBounds:
+    """Map export source symbols to per-profile bounds from top-level inputs.
+
+    For each top-level placeholder whose ``Input`` declares ``profiles``, read the
+    export ``SymInt`` for each dynamic dim and record, per profile, the
+    ``min`` / ``opt`` / ``max`` value of the corresponding source symbol. The
+    result feeds :func:`construct_submodule_inputs` so intermediate engines
+    inherit the same profiles (by index) via symbolic substitution.
+
+    Args:
+        module: Top-level (partitioned) GraphModule whose placeholders carry the
+            export symbolic shapes.
+        top_level_inputs: Ordered top-level Inputs (arg inputs followed by kwarg
+            inputs), aligned with the module placeholders.
+        num_profiles: Number of optimization profiles.
+    Returns:
+        A list indexed by optimization-profile index:
+        ``[{symbol_name: {"min": int, "opt": int, "max": int}}, ...]``
+    """
+    bounds: ProfileSourceBounds = [{} for _ in range(num_profiles)]
+    if not num_profiles:
+        return bounds
+
+    placeholders = [n for n in module.graph.nodes if n.op == "placeholder"]
+    with unset_fake_temporarily():
+        for ph, inp in zip(placeholders, top_level_inputs):
+            profiles = getattr(inp, "profiles", None)
+            if not profiles:
+                continue
+            if not ph.meta or "val" not in ph.meta:
+                continue
+            val = ph.meta["val"]
+            if not isinstance(val, (FakeTensor, torch.Tensor)):
+                continue
+            for d, dim in enumerate(val.size()):
+                if not isinstance(dim, torch.SymInt):
+                    continue
+                expr = dim.node.expr
+                # Top-level dynamic dims map directly to a single source symbol.
+                if not getattr(expr, "is_symbol", False):
+                    continue
+                sym_name = expr.name
+                for i, prof in enumerate(profiles):
+                    if i >= len(bounds) or d >= len(prof["min"]):
+                        continue
+                    bounds[i][sym_name] = {
+                        "min": int(prof["min"][d]),
+                        "opt": int(prof["opt"][d]),
+                        "max": int(prof["max"][d]),
+                    }
+    return bounds
 
 
 def run_shape_analysis(

--- a/py/torch_tensorrt/dynamo/partitioning/common.py
+++ b/py/torch_tensorrt/dynamo/partitioning/common.py
@@ -72,9 +72,9 @@ def _build_submodule_profiles(
                 p_max.append(int(dim))
         profiles.append(
             {
-                "min": tuple(p_min),
-                "opt": tuple(p_opt),
-                "max": tuple(p_max),
+                "min_shape": tuple(p_min),
+                "opt_shape": tuple(p_opt),
+                "max_shape": tuple(p_max),
             }
         )
     return profiles
@@ -308,7 +308,7 @@ def build_profile_source_bounds(
 
     For each top-level placeholder whose ``Input`` declares ``profiles``, read the
     export ``SymInt`` for each dynamic dim and record, per profile, the
-    ``min`` / ``opt`` / ``max`` value of the corresponding source symbol. The
+    ``min_shape`` / ``opt_shape`` / ``max_shape`` value of the corresponding source symbol. The
     result feeds :func:`construct_submodule_inputs` so intermediate engines
     inherit the same profiles (by index) via symbolic substitution.
 
@@ -346,12 +346,12 @@ def build_profile_source_bounds(
                     continue
                 sym_name = expr.name
                 for i, prof in enumerate(profiles):
-                    if i >= len(bounds) or d >= len(prof["min"]):
+                    if i >= len(bounds) or d >= len(prof["min_shape"]):
                         continue
                     bounds[i][sym_name] = {
-                        "min": int(prof["min"][d]),
-                        "opt": int(prof["opt"][d]),
-                        "max": int(prof["max"][d]),
+                        "min": int(prof["min_shape"][d]),
+                        "opt": int(prof["opt_shape"][d]),
+                        "max": int(prof["max_shape"][d]),
                     }
     return bounds
 

--- a/py/torch_tensorrt/dynamo/runtime/_TRTEngine.py
+++ b/py/torch_tensorrt/dynamo/runtime/_TRTEngine.py
@@ -20,6 +20,7 @@ from typing import (
     ContextManager,
     Dict,
     List,
+    NamedTuple,
     Optional,
     Sequence,
     Tuple,
@@ -66,6 +67,29 @@ from torch_tensorrt.runtime._utils import (
 import tensorrt as trt  # isort: skip
 
 logger = logging.getLogger(__name__)
+
+
+class _InputBindingInfo(NamedTuple):
+    name: str
+    expected_type: torch.dtype
+    is_shape_tensor: bool
+
+
+def _get_dynamic_shapes_kernel_strategy(strategy_str: str) -> Any:
+    """Map strategy string to TRT enum. Only meaningful on TensorRT-RTX builds."""
+    return {
+        "lazy": trt.DynamicShapesKernelSpecializationStrategy.LAZY,
+        "eager": trt.DynamicShapesKernelSpecializationStrategy.EAGER,
+        "none": trt.DynamicShapesKernelSpecializationStrategy.NONE,
+    }.get(strategy_str, trt.DynamicShapesKernelSpecializationStrategy.LAZY)
+
+
+def _get_cuda_graph_strategy(strategy_str: str) -> Any:
+    """Map strategy string to TRT CudaGraphStrategy enum. Only meaningful on RTX."""
+    return {
+        "disabled": trt.CudaGraphStrategy.DISABLED,
+        "whole_graph_capture": trt.CudaGraphStrategy.WHOLE_GRAPH_CAPTURE,
+    }.get(strategy_str, trt.CudaGraphStrategy.DISABLED)
 
 
 # ---------------------------------------------------------------------------
@@ -252,6 +276,12 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
         # ``RuntimeSettings`` default; callers wanting non-defaults assign via
         # the module's ``runtime_settings`` setter after compile.
         self._trt_runtime_config: TRTRuntimeConfig = TRTRuntimeConfig(RuntimeSettings())
+        # Multiple optimization profiles. Manual selection by default:
+        # ``_active_profile_index`` is the profile currently loaded in the TRT
+        # context (default 0, reused across calls). ``_auto_select_profiles``
+        # opts into shape-based selection, re-evaluated on every forward.
+        self._active_profile_index = 0
+        self._auto_select_profiles = False
 
         self._load_serialized_info(serialized_info)
         self._setup_engine()
@@ -361,6 +391,9 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
         # who want runtime-mode overrides must reapply them post-load via
         # ``mod.runtime_settings = ...`` (per ``TorchTensorRTModule``) or a runtime CM.
         self._trt_runtime_config = TRTRuntimeConfig(RuntimeSettings())
+
+        self._active_profile_index = 0
+        self._auto_select_profiles = False
 
         serialized_info = list(state[0])
         engine_field = serialized_info[ENGINE_IDX]
@@ -556,6 +589,14 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
             dtype._from(self.cuda_engine.get_tensor_dtype(input_name)).to(torch.dtype)
             for input_name in self.in_binding_names
         ]
+        self._input_binding_infos = [
+            _InputBindingInfo(
+                input_name,
+                self.input_dtypes[idx],
+                self.cuda_engine.is_shape_inference_io(input_name),
+            )
+            for idx, input_name in enumerate(self.in_binding_names)
+        ]
         self.output_dtypes = [
             dtype._from(self.cuda_engine.get_tensor_dtype(output_name)).to(torch.dtype)
             for output_name in self.out_binding_names
@@ -569,9 +610,10 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
             for output_name in self.out_binding_names
         ]
         self.is_shape_inference_io = {
-            input_name: self.cuda_engine.is_shape_inference_io(input_name)
-            for input_name in self.in_binding_names
+            binding.name: binding.is_shape_tensor
+            for binding in self._input_binding_infos
         }
+        self._setup_optimization_profiles()
         if self.requires_output_allocator:
             self.create_output_allocator()
 
@@ -614,6 +656,158 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
         )
         self.update_runtime_settings(new_settings)
         logger.info("Switched to TRT-RTX native CUDA graphs")
+
+    def _setup_optimization_profiles(self) -> None:
+        """Cache per-profile shape ranges for the dynamic input dims from the TRT API.
+
+        Rebuilds the profile bounds via ``get_tensor_profile_shape`` so that
+        runtime profile selection works for engines compiled in-process, loaded
+        from cache, or deserialized from disk — no new serialization fields.
+        Populates:
+
+        - ``_profile_dynamic_dims``: a list indexed by input binding position
+          (parallel to ``in_binding_names``, reusing the same positional input ->
+          binding mapping the rest of the runtime relies on). Each entry is
+          ``[(dim_index, [(min, max), ...]), ...]`` storing only dims that vary
+          within a profile (``min != max``) or differ across profiles. A dim with
+          the same fixed extent in every profile cannot distinguish profiles, so
+          it is omitted (and validated later by TRT at ``set_input_shape``).
+          Shape-inference IO and all-static inputs get an empty list, so
+          auto-selection skips them by index with no name lookup.
+        """
+        self.num_optimization_profiles = self.cuda_engine.num_optimization_profiles
+        self._profile_dynamic_dims: List[List[Tuple[int, List[Tuple[int, int]]]]] = []
+
+        if self.num_optimization_profiles <= 1:
+            return
+
+        self._profile_dynamic_dims = [[] for _ in self._input_binding_infos]
+        for i, binding in enumerate(self._input_binding_infos):
+            name = binding.name
+            if binding.is_shape_tensor:
+                continue
+            # Gather [min, max] for every dim across every profile:
+            # dim -> [profile] -> (min, max).
+            per_dim: List[List[Tuple[int, int]]] = []
+            for p in range(self.num_optimization_profiles):
+                rmin, _, rmax = self.cuda_engine.get_tensor_profile_shape(name, p)
+                if not per_dim:
+                    per_dim = [[] for _ in range(len(rmin))]
+                for d, (lo, hi) in enumerate(zip(rmin, rmax)):
+                    per_dim[d].append((int(lo), int(hi)))
+            # Keep only dims that can distinguish profiles.
+            dynamic_dims: List[Tuple[int, List[Tuple[int, int]]]] = []
+            for d, ranges in enumerate(per_dim):
+                is_dynamic = any(
+                    lo != hi or (lo, hi) != ranges[0] for (lo, hi) in ranges
+                )
+                if is_dynamic:
+                    dynamic_dims.append((d, ranges))
+            self._profile_dynamic_dims[i] = dynamic_dims
+
+    # --- optimization profile selection ---
+
+    def set_active_profile(self, profile_index: int) -> None:
+        """Make ``profile_index`` the active TRT optimization profile (idempotent).
+
+        Manual-pin / public entry point: this runs outside ``_prepare_streams``'
+        stream choreography, so the switch's async copies aren't otherwise ordered
+        against the (later, separate) enqueue. Resolve the current stream and fully
+        synchronize to make the switch safe. Rare and not perf-critical. Mirrors
+        the C++ runtime.
+        """
+        stream = torch.cuda.current_stream(self._target_device)
+        self._set_active_profile_with_stream(profile_index, stream)
+        stream.synchronize()
+
+    def _set_active_profile_with_stream(
+        self, profile_index: int, stream: torch.cuda.Stream
+    ) -> None:
+        """Core profile switch issued on ``stream`` with no host synchronize.
+
+        The caller must guarantee a happens-before to the enqueue (e.g. issue on
+        the enqueue stream). Used by auto-selection, which switches on
+        ``_engine_stream`` before ``execute_async_v3``. Mirrors the C++ runtime.
+        """
+        if self.num_optimization_profiles <= 1:
+            return
+        if profile_index == self._active_profile_index:
+            return
+        self.context.set_optimization_profile_async(profile_index, stream.cuda_stream)
+        self._active_profile_index = profile_index
+        # A profile switch invalidates any captured CUDA graph and changes the
+        # context state, so force re-record / shape re-inference next run.
+        self.runtime_states.context_changed = True
+        self.reset_captured_graph()
+        self.shape_key = None
+        logger.debug(f"Switched to optimization profile index {profile_index}")
+
+    def _profile_fits(self, profile_index: int, inputs: Sequence[torch.Tensor]) -> bool:
+        """Whether every input's dynamic dims fit ``profile_index``'s ranges.
+
+        Indexed positionally by input (``inputs[i]`` <-> ``in_binding_names[i]``,
+        the same convention the rest of the runtime uses); empty entries
+        (shape-inference IO / all-static inputs) are skipped with no name lookup.
+        Static dims are not cached (they cannot distinguish profiles) and are
+        validated later by TRT at ``set_input_shape``.
+
+        Example ``_profile_dynamic_dims`` for an image input ``(1, 3, H, W)`` with
+        H/W dynamic across 3 profiles plus a fully-static second input::
+
+            self._profile_dynamic_dims = [
+                # input 0: dims 2 (H), 3 (W) vary; dims 0 (N=1) and 1 (channels=3) fixed -> omitted
+                [
+                    (2, [(224, 224), (256, 512), (256, 512)]),  # H   ranges for profiles 0,1,2
+                    (3, [(224, 224), (256, 512), (256, 512)]),  # W
+                ],
+                # input 1: fully static (and/or shape-inference IO) -> empty, skipped
+                [],
+            ]
+        """
+        num_to_check = min(len(inputs), len(self._profile_dynamic_dims))
+        for i in range(num_to_check):
+            dynamic_dims = self._profile_dynamic_dims[i]
+            if not dynamic_dims:
+                continue
+            shape = tuple(int(s) for s in inputs[i].shape)
+            for dim_index, ranges in dynamic_dims:
+                if dim_index < len(shape):
+                    lo, hi = ranges[profile_index]
+                    if not (lo <= shape[dim_index] <= hi):
+                        return False
+        return True
+
+    def _auto_select_profile(self, inputs: Sequence[torch.Tensor]) -> int:
+        """Select and activate the optimization profile for ``inputs``.
+
+        Keeps the currently active profile when it still fits, so alternating
+        shapes (e.g. decode/prefill) don't thrash between equally-valid profiles
+        (a switch invalidates the captured CUDA graph and forces shape
+        re-inference). Otherwise switches to the **first** profile whose
+        ``[min, max]`` ranges contain every input's dynamic dims, so overlapping
+        profiles resolve to the lowest matching index; pin manually via
+        ``optimization_profile(module, index)`` to force a specific profile. Owns
+        the switch (no-op when the active profile already fits) so callers need no
+        follow-up, and returns the resulting active profile index.
+        """
+        if self._profile_fits(self._active_profile_index, inputs):
+            return self._active_profile_index
+        # Switch on the engine stream so the change is ordered before the enqueue
+        # on that same stream (no host synchronize needed). _engine_stream is set
+        # by _prepare_streams on the execution paths; fall back to the current
+        # stream for out-of-band callers that haven't resolved an engine stream.
+        stream = self._engine_stream or torch.cuda.current_stream(self._target_device)
+        for p in range(self.num_optimization_profiles):
+            if self._profile_fits(p, inputs):
+                self._set_active_profile_with_stream(p, stream)
+                return p
+
+        raise RuntimeError(
+            "No optimization profile matches the input shapes "
+            f"{[tuple(t.shape) for t in inputs]}. Cached dynamic profile ranges: "
+            f"{self._profile_dynamic_dims}. Fix the input shapes or pin a profile "
+            "explicitly via optimization_profile(module, index)."
+        )
 
     # --- distributed / NCCL ---
 
@@ -814,16 +1008,17 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
         cudagraphs_enabled: bool,
         need_cudagraphs_record: bool,
     ) -> None:
-        for i, input_name in enumerate(self.in_binding_names):
+        for i, binding in enumerate(self._input_binding_infos):
+            input_name = binding.name
 
             assert (
-                contiguous_inputs[i].dtype == self.input_dtypes[i]
-            ), f"Dtype mismatch for input {input_name}. Expect {self.input_dtypes[i]}, got {contiguous_inputs[i].dtype}."
+                contiguous_inputs[i].dtype == binding.expected_type
+            ), f"Dtype mismatch for input {input_name}. Expect {binding.expected_type}, got {contiguous_inputs[i].dtype}."
 
             if need_cudagraphs_record:
                 self._input_buffers[i] = contiguous_inputs[i].clone()
 
-            if self.is_shape_inference_io[input_name]:
+            if binding.is_shape_tensor:
                 inputs_cpu = contiguous_inputs[i].cpu().to(torch.int64).numpy().copy()
                 self.context.set_tensor_address(input_name, inputs_cpu.ctypes.data)
             else:
@@ -940,7 +1135,21 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
         # flag).
         caller_on_default = self._prepare_streams(contiguous_inputs)
         engine_stream, caller_stream = self._active_streams()
+        # Validate shapes first so auto-selection is skipped entirely when the
+        # input shape is unchanged: the previously selected profile still fits, so
+        # it stays active. When the shape did change, _auto_select_profile keeps
+        # the active profile if it still fits (no-op) or switches otherwise; a
+        # switch sets context_changed (consumed by set_runtime_states regardless
+        # of order) and shape_changed is already true here. Manual pins are
+        # applied eagerly in set_optimization_profile, so only auto needs per-call
+        # selection.
         shape_changed = self.validate_input_shapes(contiguous_inputs)
+        if (
+            shape_changed
+            and self.num_optimization_profiles > 1
+            and self._auto_select_profiles
+        ):
+            self._auto_select_profile(contiguous_inputs)
         (
             need_cudagraphs_record,
             can_use_pre_allocated_outputs,
@@ -1048,6 +1257,23 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
                 "Both CUDA Graphs and dynamic output allocation are enabled, which are "
                 "incompatible runtime modes. Please disable one of the two."
             )
+
+        # Resolve the engine stream first so the optimization-profile switch below
+        # is applied after the stream is chosen (mirrors the C++ runtime ordering).
+        caller_on_default = self._prepare_streams(contiguous_inputs)
+
+        # Validate shapes first so auto-selection is skipped entirely when the
+        # input shape is unchanged: the previously selected profile still fits.
+        # When the shape did change, _auto_select_profile keeps the active profile
+        # if it still fits (no-op) or switches otherwise. Manual pins are applied
+        # eagerly, so only auto needs per-call selection.
+        shape_changed = self.validate_input_shapes(contiguous_inputs)
+        if (
+            shape_changed
+            and self.num_optimization_profiles > 1
+            and self._auto_select_profiles
+        ):
+            self._auto_select_profile(contiguous_inputs)
 
         with self._profile_section("TRTEngine:ProcessInputs"):
             self.setup_input_tensors(contiguous_inputs, False, False)

--- a/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
@@ -443,7 +443,7 @@ class TorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
         return encoded_metadata
 
     @staticmethod
-    def decode_metadata(encoded_metadata: bytes) -> Any:
+    def decode_metadata(encoded_metadata: Any) -> Any:
         dumped_metadata = base64.b64decode(encoded_metadata.encode("utf-8"))
         metadata = pickle.loads(dumped_metadata)
         return metadata
@@ -529,6 +529,76 @@ class TorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
         self.input_binding_names = state[2]
         self.output_binding_names = state[3]
         self.target_device = self._resolve_target_device()
+
+    def set_optimization_profile(self, profile: Optional[Any]) -> None:
+        """Select the active TRT optimization profile for this engine.
+
+        ``profile`` may be a profile index (``int``), the string ``"auto"`` to
+        enable shape-based auto-selection, or ``None`` to clear any pin / auto
+        setting and reset to the default profile (index 0).
+        See :func:`torch_tensorrt.runtime.optimization_profile`.
+        """
+        if self.engine is None:
+            self.setup_engine()
+        assert self.engine is not None
+        engine = self.engine
+        # Drive the primitive engine API (set_active_profile / _auto_select_profiles)
+        # that both the Python and C++ runtimes expose under the same names, so
+        # this works regardless of the active runtime.
+        if not hasattr(engine, "set_active_profile"):
+            raise RuntimeError(
+                "This engine does not support optimization profile selection."
+            )
+        if profile is None:
+            engine._auto_select_profiles = False
+            engine.set_active_profile(0)
+            return
+        if isinstance(profile, str) and profile == "auto":
+            engine._auto_select_profiles = True
+            return
+        # Validate the profile index. ``num_optimization_profiles`` is exposed by
+        # both the Python and C++ runtimes under the same name.
+        if isinstance(profile, bool) or not isinstance(profile, int):
+            raise TypeError(
+                f"Optimization profile must be an integer index, got {type(profile)}"
+            )
+        num_profiles = engine.num_optimization_profiles
+        if not (0 <= profile < num_profiles):
+            raise ValueError(
+                f"Optimization profile index {profile} out of range "
+                f"[0, {num_profiles})"
+            )
+        engine._auto_select_profiles = False
+        engine.set_active_profile(profile)
+
+    def get_optimization_profile_state(self) -> Optional[Tuple[Any, ...]]:
+        """Return the engine's current ``(auto, active)`` profile state.
+
+        Used by the :func:`optimization_profile` context manager to save/restore
+        state across a ``with`` block. Returns ``None`` if unsupported.
+        """
+        if self.engine is None:
+            return None
+        engine = self.engine
+        if not hasattr(engine, "_active_profile_index"):
+            return None
+        return (
+            engine._auto_select_profiles,
+            engine._active_profile_index,
+        )
+
+    def restore_optimization_profile_state(
+        self, state: Optional[Tuple[Any, ...]]
+    ) -> None:
+        """Restore profile state captured by :meth:`get_optimization_profile_state`."""
+        if state is None or self.engine is None:
+            return
+        engine = self.engine
+        if not hasattr(engine, "set_active_profile"):
+            return
+        auto, active = state
+        engine._auto_select_profiles = auto
+        engine.set_active_profile(active)
 
     def set_pre_allocated_outputs(self, enable: bool) -> None:
         self.get_engine().use_pre_allocated_outputs = enable

--- a/py/torch_tensorrt/dynamo/utils.py
+++ b/py/torch_tensorrt/dynamo/utils.py
@@ -187,6 +187,7 @@ def get_torch_tensor(
     if input.is_shape_tensor:
         # TODO: All the shape tensors we've encountered so far are plain integers.
         # Validate this assumption on more models.
+        assert isinstance(input.shape, dict)
         return input.shape["opt_shape"][0]
 
     if len(mode) > 0:
@@ -449,6 +450,69 @@ def extract_var_range_info(symbolic_integer: torch.SymInt) -> Dict[str, Optional
         min_max_opt["opt"] = int(var_val)
 
     return min_max_opt
+
+
+def validate_optimization_profiles(input_specs: Sequence[Input]) -> int:
+    """Validate multi-profile inputs and return the number of profiles.
+
+    ``Input.profiles`` is an ordered list; the list index is the TRT
+    optimization-profile index selected at runtime. Every dynamic input that
+    declares ``profiles`` must declare the *same number* of profiles.
+    Static inputs (or dynamic inputs without profiles) are allowed and reuse
+    their single shape in every profile.
+
+    Returns the number of *declared* optimization profiles, i.e. ``0`` when no
+    input declares ``profiles`` (the multi-profile feature is unused and the
+    actual profile count is decided downstream: ``0`` for fully static engines,
+    ``1`` for dynamic ones).
+    """
+    num_profiles = 0
+    for inp in input_specs:
+        profiles = getattr(inp, "profiles", None)
+        if not profiles:
+            continue
+        if num_profiles == 0:
+            num_profiles = len(profiles)
+        elif len(profiles) != num_profiles:
+            raise ValueError(
+                "All inputs declaring optimization profiles must declare the same "
+                f"number of profiles, found both {num_profiles} and {len(profiles)}."
+            )
+    return num_profiles
+
+
+def extract_var_range_info_for_profile(
+    symbolic_integer: torch.SymInt,
+    symbol_values: Dict[str, int],
+) -> int:
+    """Evaluate a symbolic dimension at a single profile corner.
+
+    ``symbol_values`` maps source symbol name (e.g. ``"s0"``) to the concrete
+    integer value of that symbol at one corner (min / opt / max) of a profile.
+    The intermediate ``SymInt`` expression (e.g. ``s0/4``) is evaluated by
+    substituting those values. Shape ops in export produce affine expressions
+    that are monotonic in each source symbol, so per-corner substitution is
+    exact.
+    """
+    node = symbolic_integer.node
+    expr = node.expr
+    # A fully-static expression may already be a Python/sympy integer.
+    if isinstance(expr, int):
+        return int(expr)
+    free_symbols: Any = getattr(expr, "free_symbols", set())
+    substitution = {
+        sym: symbol_values[sym.name]
+        for sym in free_symbols
+        if getattr(sym, "name", None) in symbol_values
+    }
+    evaluated = expr.xreplace(substitution) if substitution else expr
+    if getattr(evaluated, "free_symbols", set()):
+        # A free symbol was missing from symbol_values; caller should fall back.
+        raise KeyError(
+            f"Could not fully evaluate symbolic dim {expr} with symbol values "
+            f"{symbol_values} (unresolved free symbols remain)."
+        )
+    return int(evaluated)
 
 
 def unwrap_tensor_shape(

--- a/py/torch_tensorrt/runtime/__init__.py
+++ b/py/torch_tensorrt/runtime/__init__.py
@@ -8,6 +8,7 @@ from torch_tensorrt.runtime._cudagraphs import (
     set_cudagraphs_mode,
 )
 from torch_tensorrt.runtime._multi_device_safe_mode import set_multi_device_safe_mode
+from torch_tensorrt.runtime._optimization_profile import optimization_profile
 from torch_tensorrt.runtime._output_allocator import enable_output_allocator
 from torch_tensorrt.runtime._pre_allocated_outputs import enable_pre_allocated_outputs
 from torch_tensorrt.runtime._runtime_cache import RuntimeCache, runtime_cache

--- a/py/torch_tensorrt/runtime/_optimization_profile.py
+++ b/py/torch_tensorrt/runtime/_optimization_profile.py
@@ -1,0 +1,95 @@
+"""Runtime optimization-profile selection for multi-profile TensorRT engines.
+
+Profile selection is **manual by default**: pin a profile by its integer index
+for a ``with`` span. Pass ``"auto"`` to opt into shape-based auto-selection for
+that span. State is saved on enter and restored on exit (stack semantics), so
+nested ``with`` blocks compose.
+
+Example::
+
+    from torch_tensorrt.runtime import optimization_profile
+
+    # profiles=[prefill, decode] -> index 1 is decode
+    with optimization_profile(trt_gm, 1):
+        out = trt_gm(inputs_embeds=embeds, past_key_values=kv)
+
+    with optimization_profile(trt_gm, "auto"):
+        out = trt_gm(x)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional, Tuple
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def _collect_trt_modules(module: Any) -> List[Any]:
+    """Return all TorchTensorRTModule instances reachable from ``module``."""
+    from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import TorchTensorRTModule
+
+    trt_modules: List[Any] = []
+    if isinstance(module, TorchTensorRTModule):
+        trt_modules.append(module)
+    elif isinstance(module, torch.nn.Module):
+        for submodule in module.modules():
+            if isinstance(submodule, TorchTensorRTModule):
+                trt_modules.append(submodule)
+    return trt_modules
+
+
+class _OptimizationProfileContext:
+    """Context manager that pins (or auto-selects) an optimization profile.
+
+    Applies the requested profile to every TensorRT submodule on enter, and
+    restores each submodule's previous profile state on exit.
+    """
+
+    def __init__(self, module: Any, profile: Optional[Any]) -> None:
+        self.module = module
+        self.profile = profile
+        self._saved_state: List[Tuple[Any, Optional[Tuple[Any, ...]]]] = []
+
+    def __enter__(self) -> Any:
+        trt_modules = _collect_trt_modules(self.module)
+        if not trt_modules:
+            logger.warning(
+                "optimization_profile() found no TensorRT submodules to configure."
+            )
+        for trt_module in trt_modules:
+            saved = trt_module.get_optimization_profile_state()
+            self._saved_state.append((trt_module, saved))
+            trt_module.set_optimization_profile(self.profile)
+        return self.module
+
+    def __exit__(self, *exc: Any) -> None:
+        # restore_* re-applies all of (pinned, auto, active) captured on enter,
+        # including the active TRT profile index switched inside the block.
+        for trt_module, saved in reversed(self._saved_state):
+            try:
+                trt_module.restore_optimization_profile_state(saved)
+            except Exception as e:  # pragma: no cover - defensive restore
+                logger.warning(
+                    f"Failed to restore optimization profile state on exit: {e}"
+                )
+        self._saved_state.clear()
+
+
+def optimization_profile(
+    module: Any, profile: Optional[Any]
+) -> _OptimizationProfileContext:
+    """Select the active TensorRT optimization profile for a ``with`` span.
+
+    Args:
+        module: A compiled ``GraphModule`` (or ``TorchTensorRTModule``) containing
+                one or more TensorRT engines.
+            profile: Profile index (``int``), the string ``"auto"`` to enable
+                shape-based auto-selection, or ``None`` to clear.
+
+    Returns:
+        A context manager. Pinned/auto state is restored on exit.
+    """
+    return _OptimizationProfileContext(module, profile)

--- a/tests/py/dynamo/runtime/test_multi_optimization_profiles.py
+++ b/tests/py/dynamo/runtime/test_multi_optimization_profiles.py
@@ -32,8 +32,16 @@ def _make_profiles_input():
         name="x",
         dtype=torch.float16,
         profiles=[
-            {"min": (4, 1, 16), "opt": (4, 1, 16), "max": (4, 1, 16)},  # decode
-            {"min": (4, 1, 16), "opt": (4, 48, 16), "max": (4, 64, 16)},  # prefill
+            {
+                "min_shape": (4, 1, 16),
+                "opt_shape": (4, 1, 16),
+                "max_shape": (4, 1, 16),
+            },  # decode
+            {
+                "min_shape": (4, 1, 16),
+                "opt_shape": (4, 48, 16),
+                "max_shape": (4, 64, 16),
+            },  # prefill
         ],
     )
 
@@ -63,16 +71,24 @@ class TestInputProfilesValidation(TestCase):
         # opt is taken from the first declared profile (decode at index 0)
         self.assertEqual(inp.shape["opt_shape"], (4, 1, 16))
         self.assertEqual(len(inp.profiles), 2)
-        self.assertEqual(inp.profiles[DECODE_IDX]["max"], (4, 1, 16))
-        self.assertEqual(inp.profiles[PREFILL_IDX]["opt"], (4, 48, 16))
+        self.assertEqual(inp.profiles[DECODE_IDX]["max_shape"], (4, 1, 16))
+        self.assertEqual(inp.profiles[PREFILL_IDX]["opt_shape"], (4, 48, 16))
 
     def test_min_zero_rejected(self):
         with self.assertRaises(ValueError):
-            Input(profiles=[{"min": (0, 1), "opt": (1, 1), "max": (2, 1)}])
+            Input(
+                profiles=[
+                    {"min_shape": (0, 1), "opt_shape": (1, 1), "max_shape": (2, 1)}
+                ]
+            )
 
     def test_min_opt_max_ordering(self):
         with self.assertRaises(ValueError):
-            Input(profiles=[{"min": (4, 1), "opt": (4, 8), "max": (4, 2)}])
+            Input(
+                profiles=[
+                    {"min_shape": (4, 1), "opt_shape": (4, 8), "max_shape": (4, 2)}
+                ]
+            )
 
     def test_empty_profiles_rejected(self):
         with self.assertRaises(ValueError):
@@ -82,7 +98,7 @@ class TestInputProfilesValidation(TestCase):
         with self.assertRaises(ValueError):
             Input(
                 shape=(1, 2),
-                profiles=[{"min": (1,), "opt": (1,), "max": (1,)}],
+                profiles=[{"min_shape": (1,), "opt_shape": (1,), "max_shape": (1,)}],
             )
 
     def test_str_includes_profiles(self):
@@ -96,8 +112,16 @@ class TestInputProfilesValidation(TestCase):
         inp = Input(
             name="input_ids",
             profiles=[
-                {"min": (1, 1), "opt": (1, 1), "max": (1, 1)},  # decode
-                {"min": (1, 1), "opt": (1, 128), "max": (1, 512)},  # prefill
+                {
+                    "min_shape": (1, 1),
+                    "opt_shape": (1, 1),
+                    "max_shape": (1, 1),
+                },  # decode
+                {
+                    "min_shape": (1, 1),
+                    "opt_shape": (1, 128),
+                    "max_shape": (1, 512),
+                },  # prefill
             ],
             shared_dims={1: "seq"},
         )
@@ -113,8 +137,16 @@ class TestInputProfilesValidation(TestCase):
         with self.assertRaises(ValueError):
             Input(
                 profiles=[
-                    {"min": (1, 1), "opt": (1, 8), "max": (1, 16)},
-                    {"min": (1, 1), "opt": (1, 4), "max": (1, 32)},
+                    {
+                        "min_shape": (1, 1),
+                        "opt_shape": (1, 8),
+                        "max_shape": (1, 16),
+                    },
+                    {
+                        "min_shape": (1, 1),
+                        "opt_shape": (1, 4),
+                        "max_shape": (1, 32),
+                    },
                 ],
                 shared_dims={0: "batch"},
             )
@@ -213,14 +245,6 @@ class TestMultiProfileRuntime(TestCase):
             with optimization_profile(self.trt_gm, "decode"):
                 self.trt_gm(self.decode_in)
 
-    def test_serialization_round_trip_preserves_profiles(self):
-        trt_gm2 = copy.deepcopy(self.trt_gm)
-        for e in self._trt_engines(trt_gm2):
-            self.assertEqual(e.num_optimization_profiles, 2)
-        with optimization_profile(trt_gm2, DECODE_IDX):
-            out = trt_gm2(self.decode_in)
-        self.assertEqual(tuple(out.shape), (4, 1, 16))
-
     def _check_reconstructed_profile_state(self, engine):
         # A Python ``TRTEngine`` reconstructed with NO optimization-profile
         # metadata must rebuild its profile count and per-profile [min, max] dim
@@ -296,8 +320,12 @@ class TestMultiProfileSharedDims(TestCase):
         # prefill at index 0 so the export opt (taken from profile[0]) is > 1 and
         # the seq axis is not specialized to a constant during tracing.
         prof = [
-            {"min": (1, 1), "opt": (1, 128), "max": (1, 512)},  # prefill
-            {"min": (1, 1), "opt": (1, 1), "max": (1, 16)},  # decode
+            {
+                "min_shape": (1, 1),
+                "opt_shape": (1, 128),
+                "max_shape": (1, 512),
+            },  # prefill
+            {"min_shape": (1, 1), "opt_shape": (1, 1), "max_shape": (1, 16)},  # decode
         ]
         a = Input(profiles=prof, shared_dims={1: "seq"}, dtype=torch.float32, name="a")
         b = Input(profiles=prof, shared_dims={1: "seq"}, dtype=torch.float32, name="b")

--- a/tests/py/dynamo/runtime/test_multi_optimization_profiles.py
+++ b/tests/py/dynamo/runtime/test_multi_optimization_profiles.py
@@ -1,0 +1,428 @@
+import copy
+import unittest
+
+import torch
+import torch_tensorrt
+from torch.testing._internal.common_utils import TestCase, run_tests
+from torch_tensorrt._Input import Input
+from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import TorchTensorRTModule
+from torch_tensorrt.dynamo.runtime._TRTEngine import TRTEngine
+from torch_tensorrt.runtime import optimization_profile
+
+# Profiles are an ordered list; the list index is the optimization-profile
+# index selected at runtime. Order is meaningful for lazy auto-selection: the
+# decode profile ([1, 1]) and prefill profile ([1, 64]) overlap at seq=1, so we
+# declare decode FIRST (index 0) to make it win the overlap (first-working).
+DECODE_IDX = 0
+PREFILL_IDX = 1
+
+
+class MLP(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.l1 = torch.nn.Linear(16, 32)
+        self.l2 = torch.nn.Linear(32, 16)
+
+    def forward(self, x):
+        return self.l2(torch.relu(self.l1(x)))
+
+
+def _make_profiles_input():
+    return Input(
+        name="x",
+        dtype=torch.float16,
+        profiles=[
+            {"min": (4, 1, 16), "opt": (4, 1, 16), "max": (4, 1, 16)},  # decode
+            {"min": (4, 1, 16), "opt": (4, 48, 16), "max": (4, 64, 16)},  # prefill
+        ],
+    )
+
+
+def _compile_mlp(model, **kwargs):
+    inp = _make_profiles_input()
+    example = torch.randn(4, 48, 16, dtype=torch.float16, device="cuda")
+    ep = torch.export.export(
+        model,
+        (example,),
+        dynamic_shapes=({1: torch.export.Dim("seq", min=1, max=64)},),
+    )
+    return torch_tensorrt.dynamo.compile(
+        ep,
+        arg_inputs=[inp],
+        min_block_size=1,
+        enabled_precisions={torch.float16},
+        **kwargs,
+    )
+
+
+class TestInputProfilesValidation(TestCase):
+    def test_union_envelope(self):
+        inp = _make_profiles_input()
+        self.assertEqual(inp.shape["min_shape"], (4, 1, 16))
+        self.assertEqual(inp.shape["max_shape"], (4, 64, 16))
+        # opt is taken from the first declared profile (decode at index 0)
+        self.assertEqual(inp.shape["opt_shape"], (4, 1, 16))
+        self.assertEqual(len(inp.profiles), 2)
+        self.assertEqual(inp.profiles[DECODE_IDX]["max"], (4, 1, 16))
+        self.assertEqual(inp.profiles[PREFILL_IDX]["opt"], (4, 48, 16))
+
+    def test_min_zero_rejected(self):
+        with self.assertRaises(ValueError):
+            Input(profiles=[{"min": (0, 1), "opt": (1, 1), "max": (2, 1)}])
+
+    def test_min_opt_max_ordering(self):
+        with self.assertRaises(ValueError):
+            Input(profiles=[{"min": (4, 1), "opt": (4, 8), "max": (4, 2)}])
+
+    def test_empty_profiles_rejected(self):
+        with self.assertRaises(ValueError):
+            Input(profiles=[])
+
+    def test_mutual_exclusion(self):
+        with self.assertRaises(ValueError):
+            Input(
+                shape=(1, 2),
+                profiles=[{"min": (1,), "opt": (1,), "max": (1,)}],
+            )
+
+    def test_str_includes_profiles(self):
+        inp = _make_profiles_input()
+        self.assertIn("profiles=", str(inp))
+
+    def test_profiles_with_shared_dims(self):
+        # ``profiles`` and ``shared_dims`` compose: profiles set the per-profile
+        # ranges while shared_dims names the dynamic axis (validated against the
+        # union envelope) for cross-input symbol sharing.
+        inp = Input(
+            name="input_ids",
+            profiles=[
+                {"min": (1, 1), "opt": (1, 1), "max": (1, 1)},  # decode
+                {"min": (1, 1), "opt": (1, 128), "max": (1, 512)},  # prefill
+            ],
+            shared_dims={1: "seq"},
+        )
+        self.assertEqual(len(inp.profiles), 2)
+        self.assertEqual(inp.shared_dims, {1: "seq"})
+        # union envelope marks the shared axis dynamic (1..512)
+        self.assertEqual(inp.shape["min_shape"], (1, 1))
+        self.assertEqual(inp.shape["max_shape"], (1, 512))
+
+    def test_shared_dims_on_static_union_axis_rejected(self):
+        # Axis 0 has min == max across every profile, so it is static in the
+        # union; naming it for sharing is a user error.
+        with self.assertRaises(ValueError):
+            Input(
+                profiles=[
+                    {"min": (1, 1), "opt": (1, 8), "max": (1, 16)},
+                    {"min": (1, 1), "opt": (1, 4), "max": (1, 32)},
+                ],
+                shared_dims={0: "batch"},
+            )
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class TestMultiProfileRuntime(TestCase):
+    """Runtime behavior of multi-profile engines.
+
+    The runtime (C++ or Python ``TRTEngine``) is selected automatically by the
+    Torch-TensorRT build, so these tests drive the runtime-agnostic engine API
+    (``num_optimization_profiles`` / ``set_active_profile`` /
+    ``_active_profile_index`` / ``_auto_select_profiles``) exposed identically by
+    both runtimes via the ``optimization_profile`` context manager.
+    """
+
+    def setUp(self):
+        self.model = MLP().eval().cuda().half()
+        self.trt_gm = _compile_mlp(self.model)
+        self.decode_in = torch.randn(4, 1, 16, dtype=torch.float16, device="cuda")
+        self.prefill_in = torch.randn(4, 32, 16, dtype=torch.float16, device="cuda")
+
+    def _trt_engines(self, module):
+        return [
+            m.engine for m in module.modules() if isinstance(m, TorchTensorRTModule)
+        ]
+
+    def test_two_profiles_built(self):
+        engines = self._trt_engines(self.trt_gm)
+        self.assertGreaterEqual(len(engines), 1)
+        for e in engines:
+            self.assertEqual(e.num_optimization_profiles, 2)
+
+    def test_manual_pin_by_decode_index(self):
+        ref = self.model(self.decode_in)
+        with optimization_profile(self.trt_gm, DECODE_IDX):
+            out = self.trt_gm(self.decode_in)
+        self.assertEqual(tuple(out.shape), (4, 1, 16))
+        self.assertTrue(torch.allclose(out, ref, atol=1e-2))
+
+    def test_manual_pin_by_prefill_index(self):
+        with optimization_profile(self.trt_gm, PREFILL_IDX):
+            out = self.trt_gm(self.prefill_in)
+        self.assertEqual(tuple(out.shape), (4, 32, 16))
+
+    def test_auto_selection_decode_and_prefill(self):
+        ref_d = self.model(self.decode_in)
+        ref_p = self.model(self.prefill_in)
+        with optimization_profile(self.trt_gm, "auto"):
+            out_d = self.trt_gm(self.decode_in)
+            out_p = self.trt_gm(self.prefill_in)
+        self.assertTrue(torch.allclose(out_d, ref_d, atol=1e-2))
+        self.assertTrue(torch.allclose(out_p, ref_p, atol=1e-2))
+
+    def test_auto_selection_is_lazy_first_working(self):
+        # decode (idx 0) and prefill (idx 1) both accept seq=1; lazy selection
+        # must pick the first that fits (decode). seq=32 only fits prefill.
+        engines = self._trt_engines(self.trt_gm)
+        with optimization_profile(self.trt_gm, "auto"):
+            self.trt_gm(self.decode_in)
+            for e in engines:
+                self.assertEqual(e._active_profile_index, DECODE_IDX)
+            self.trt_gm(self.prefill_in)
+            for e in engines:
+                self.assertEqual(e._active_profile_index, PREFILL_IDX)
+
+    def test_manual_pin_persists_across_calls(self):
+        # A manual pin (no "auto") must stick: the engine keeps the pinned
+        # profile across invocations instead of re-selecting per call.
+        engines = self._trt_engines(self.trt_gm)
+        with optimization_profile(self.trt_gm, PREFILL_IDX):
+            self.trt_gm(self.prefill_in)
+            for e in engines:
+                self.assertEqual(e._active_profile_index, PREFILL_IDX)
+                self.assertFalse(e._auto_select_profiles)
+            self.trt_gm(self.prefill_in)
+            for e in engines:
+                self.assertEqual(e._active_profile_index, PREFILL_IDX)
+
+    def test_profile_state_restored_after_context(self):
+        # Leaving the context manager restores the engine's prior profile state.
+        engines = self._trt_engines(self.trt_gm)
+        before = [(e._auto_select_profiles, e._active_profile_index) for e in engines]
+        with optimization_profile(self.trt_gm, PREFILL_IDX):
+            self.trt_gm(self.prefill_in)
+        after = [(e._auto_select_profiles, e._active_profile_index) for e in engines]
+        self.assertEqual(before, after)
+
+    def test_out_of_range_index_raises(self):
+        with self.assertRaises(ValueError):
+            with optimization_profile(self.trt_gm, 99):
+                self.trt_gm(self.decode_in)
+
+    def test_non_int_profile_raises(self):
+        with self.assertRaises(TypeError):
+            with optimization_profile(self.trt_gm, "decode"):
+                self.trt_gm(self.decode_in)
+
+    def test_serialization_round_trip_preserves_profiles(self):
+        trt_gm2 = copy.deepcopy(self.trt_gm)
+        for e in self._trt_engines(trt_gm2):
+            self.assertEqual(e.num_optimization_profiles, 2)
+        with optimization_profile(trt_gm2, DECODE_IDX):
+            out = trt_gm2(self.decode_in)
+        self.assertEqual(tuple(out.shape), (4, 1, 16))
+
+    def _check_reconstructed_profile_state(self, engine):
+        # A Python ``TRTEngine`` reconstructed with NO optimization-profile
+        # metadata must rebuild its profile count and per-profile [min, max] dim
+        # ranges purely from the TensorRT API (getNbOptimizationProfiles /
+        # getProfileShape). This white-box check reads the Python runtime's
+        # internal ``_profile_dynamic_dims`` / ``_auto_select_profile`` (not part
+        # of the user-facing API; the C++ runtime is covered behaviorally below).
+        self.assertEqual(engine.num_optimization_profiles, 2)
+
+        dynamic_dims = engine._profile_dynamic_dims
+        # Cache is indexed by input binding position; the model has a single
+        # input ``x`` at position 0. Only the dynamic seq axis (dim 1) is cached;
+        # the static batch/hidden dims are omitted. ``dynamic_dims[0]`` is a list
+        # of (dim_index, per-profile ranges); index by dim to get the seq ranges.
+        # tuple() normalizes the Python runtime (tuples) and C++ runtime (lists).
+        seq_ranges = dict(dynamic_dims[0])[1]
+        self.assertEqual(tuple(seq_ranges[DECODE_IDX]), (1, 1))
+        self.assertEqual(tuple(seq_ranges[PREFILL_IDX]), (1, 64))
+
+        # seq=1 -> decode (first profile that fits), seq=32 -> prefill.
+        self.assertEqual(engine._auto_select_profile([self.decode_in]), DECODE_IDX)
+        self.assertEqual(engine._auto_select_profile([self.prefill_in]), PREFILL_IDX)
+
+    def test_profiles_restored_from_trt_api_without_metadata(self):
+        # Python runtime: rebuild a fresh ``TRTEngine`` straight from the
+        # serialized layout (engine bytes + binding names + device only),
+        # simulating loading an engine that carries no profile metadata.
+        src = self._trt_engines(self.trt_gm)[0]
+        if not isinstance(src, TRTEngine):
+            self.skipTest("Python TRTEngine-specific construction path")
+        fresh = TRTEngine(list(src.serialized_info))
+        self._check_reconstructed_profile_state(fresh)
+
+    def test_profiles_restored_from_trt_api_without_metadata_cpp(self):
+        # C++ runtime: a deep-copied module round-trips the engine through
+        # serialize/deserialize, which is the "load with no profile metadata"
+        # path; ``setup_optimization_profiles()`` (called from the C++ ctor)
+        # rebuilds everything from the TRT API. Verified behaviorally through the
+        # user-facing API only (profile count + shape-based auto-selection); the
+        # internal dim-range introspection is intentionally not exposed to users.
+        src = self._trt_engines(self.trt_gm)[0]
+        if isinstance(src, TRTEngine):
+            self.skipTest("C++ runtime-specific test")
+        trt_gm2 = copy.deepcopy(self.trt_gm)
+        engines = self._trt_engines(trt_gm2)
+        for e in engines:
+            self.assertEqual(e.num_optimization_profiles, 2)
+        # Auto-selection relies on the dim ranges rebuilt from the TRT API: seq=1
+        # must resolve to decode, seq>1 to prefill.
+        with optimization_profile(trt_gm2, "auto"):
+            trt_gm2(self.decode_in)
+            for e in engines:
+                self.assertEqual(e._active_profile_index, DECODE_IDX)
+            trt_gm2(self.prefill_in)
+            for e in engines:
+                self.assertEqual(e._active_profile_index, PREFILL_IDX)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class TestMultiProfileSharedDims(TestCase):
+    """``profiles`` combined with ``shared_dims``.
+
+    Two inputs share a dynamic ``seq`` axis (one exported ``Dim``) while each
+    declares the same prefill/decode profiles. The shared dim feeds the export
+    envelope; the profiles feed the per-profile TRT ranges.
+    """
+
+    class TwoInput(torch.nn.Module):
+        def forward(self, a, b):
+            return torch.relu(a * b + a)
+
+    def _shared_inputs(self):
+        # prefill at index 0 so the export opt (taken from profile[0]) is > 1 and
+        # the seq axis is not specialized to a constant during tracing.
+        prof = [
+            {"min": (1, 1), "opt": (1, 128), "max": (1, 512)},  # prefill
+            {"min": (1, 1), "opt": (1, 1), "max": (1, 16)},  # decode
+        ]
+        a = Input(profiles=prof, shared_dims={1: "seq"}, dtype=torch.float32, name="a")
+        b = Input(profiles=prof, shared_dims={1: "seq"}, dtype=torch.float32, name="b")
+        return a, b
+
+    def test_shared_axis_is_single_export_symbol(self):
+        # Both inputs' dynamic seq axis must trace to the *same* export symbol.
+        model = self.TwoInput().eval().cuda()
+        a, b = self._shared_inputs()
+        ep = torch_tensorrt.dynamo.trace(model, arg_inputs=[a, b])
+        placeholders = [n for n in ep.graph.nodes if n.op == "placeholder"]
+        symbols = []
+        for ph in placeholders[:2]:
+            val = ph.meta["val"]
+            dim = val.shape[1]
+            self.assertIsInstance(dim, torch.SymInt)
+            symbols.append(dim.node.expr.name)
+        self.assertEqual(symbols[0], symbols[1])
+
+    def _trt_engines(self, module):
+        return [
+            m.engine for m in module.modules() if isinstance(m, TorchTensorRTModule)
+        ]
+
+    def test_compile_and_run_across_profiles(self):
+        model = self.TwoInput().eval().cuda()
+        a, b = self._shared_inputs()
+        ep = torch_tensorrt.dynamo.trace(model, arg_inputs=[a, b])
+        trt_gm = torch_tensorrt.dynamo.compile(
+            ep,
+            arg_inputs=[a, b],
+            min_block_size=1,
+            enabled_precisions={torch.float32},
+        )
+        for e in self._trt_engines(trt_gm):
+            self.assertEqual(e.num_optimization_profiles, 2)
+
+        # seq=1 fits the decode profile, seq=256 fits prefill.
+        for seq in (1, 8, 256):
+            x = torch.randn(1, seq, device="cuda")
+            y = torch.randn(1, seq, device="cuda")
+            with optimization_profile(trt_gm, "auto"):
+                out = trt_gm(x, y)
+            self.assertTrue(torch.allclose(out, model(x, y), atol=1e-2))
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class TestMultiProfileGraphBreak(TestCase):
+    """Profile propagation across graph breaks (build-selected runtime)."""
+
+    def _trt_engines(self, module):
+        return [
+            m.engine for m in module.modules() if isinstance(m, TorchTensorRTModule)
+        ]
+
+    def test_submodule_profile_propagation(self):
+        class GraphBreakMLP(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.l1 = torch.nn.Linear(16, 32)
+                self.l2 = torch.nn.Linear(32, 16)
+
+            def forward(self, x):
+                a = self.l1(x)
+                b = torch.sin(a)  # forced to run in torch -> graph break
+                return self.l2(torch.relu(b))
+
+        model = GraphBreakMLP().eval().cuda().half()
+        trt_gm = _compile_mlp(model, torch_executed_ops={"torch.ops.aten.sin.default"})
+
+        engines = self._trt_engines(trt_gm)
+        # Expect more than one TRT engine (graph break) and every engine has
+        # the two profiles propagated.
+        self.assertGreaterEqual(len(engines), 2)
+        for e in engines:
+            self.assertEqual(e.num_optimization_profiles, 2)
+
+        decode_in = torch.randn(4, 1, 16, dtype=torch.float16, device="cuda")
+        prefill_in = torch.randn(4, 32, 16, dtype=torch.float16, device="cuda")
+        with optimization_profile(trt_gm, "auto"):
+            out_d = trt_gm(decode_in)
+            out_p = trt_gm(prefill_in)
+        self.assertTrue(torch.allclose(out_d, model(decode_in), atol=1e-2))
+        self.assertTrue(torch.allclose(out_p, model(prefill_in), atol=1e-2))
+
+    def test_reshaped_dynamic_submodule_input(self):
+        # The reshape makes the post-graph-break submodule input dim a *derived*
+        # symbolic expression of the source seq symbol (16 * seq), not the source
+        # symbol itself. This exercises per-profile bound evaluation of derived
+        # dynamic dims when propagating profiles to intermediate submodules.
+        class ReshapeGraphBreakMLP(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fc1 = torch.nn.Linear(4, 32)
+                self.fc2 = torch.nn.Linear(32, 32)
+
+            def forward(self, x):  # x: (4, seq, 16)
+                x = self.fc1(x.reshape(-1, 4))  # (16 * seq, 32): derived dynamic dim
+                x = torch.relu(x)  # forced to run in torch -> graph break
+                return self.fc2(x)
+
+        model = ReshapeGraphBreakMLP().eval().cuda().half()
+        trt_gm = _compile_mlp(model, torch_executed_ops={"torch.ops.aten.relu.default"})
+
+        engines = self._trt_engines(trt_gm)
+        # Graph break -> multiple TRT engines; every engine (including the one
+        # fed the reshaped derived-dynamic tensor) carries both profiles.
+        self.assertGreaterEqual(len(engines), 2)
+        for e in engines:
+            self.assertEqual(e.num_optimization_profiles, 2)
+
+        decode_in = torch.randn(4, 1, 16, dtype=torch.float16, device="cuda")
+        prefill_in = torch.randn(4, 32, 16, dtype=torch.float16, device="cuda")
+        with optimization_profile(trt_gm, "auto"):
+            out_d = trt_gm(decode_in)
+            # seq=1 -> derived dim 16*1=16; both engines auto-select decode
+            for e in engines:
+                self.assertEqual(e._active_profile_index, DECODE_IDX)
+            out_p = trt_gm(prefill_in)
+            # seq=32 -> derived dim 16*32=512; both engines auto-select prefill
+            for e in engines:
+                self.assertEqual(e._active_profile_index, PREFILL_IDX)
+        self.assertTrue(torch.allclose(out_d, model(decode_in), atol=1e-2))
+        self.assertTrue(torch.allclose(out_p, model(prefill_in), atol=1e-2))
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Add support for defining N optimization profiles at compile time via the list-based ``Input.profiles`` API and selecting the active profile at runtime (manual pin by index, or opt-in shape-based auto-selection).

- AOT (torch.export) compile path builds one TRT optimization profile per declared profile index; submodules inherit the profile count via propagation across graph breaks.
- Python and C++ runtimes expose a matching primitive engine API (set_active_profile / num_optimization_profiles / _active_profile_index / _auto_select_profiles) so the two runtimes remain interchangeable.
- Profile selection is exposed through the optimization_profile context manager; auto-selection uses lazy (first-fitting) profile selection.
- Backward compatible: engines without declared profiles keep the historical single-profile (dynamic) / no-profile (static) behavior.

Includes an example and runtime tests covering dynamic submodule inputs.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
