### PR TITLE
fix(runtime): RuntimeCache pickle path — wrapper exclusion + handle bytes round-trip

### DIFF
--- a/core/runtime/RuntimeSettings.cpp
+++ b/core/runtime/RuntimeSettings.cpp
@@ -1,5 +1,6 @@
 #include "core/runtime/RuntimeSettings.h"
 
+#include <algorithm>
 #include <array>
 #include <cstring>
 #include <iterator>
@@ -124,16 +125,12 @@ at::Tensor RuntimeCacheHandle::serialize() const {
 #ifdef TRT_MAJOR_RTX
   std::lock_guard<std::mutex> lock(state_mu_);
   if (!trt_handle_) {
-    // Pre-materialize: forward any ``pending_warm_bytes_`` so that the
-    // handle's persistable state survives ``save_to_stream`` and pickle
-    // even before any engine has triggered ``ensure_materialized``.
-    // ``save_to_stream`` / ``def_pickle`` round-trip then matches the
-    // python facade's behavior (it reads ``_pending_warm_bytes`` directly).
-    if (pending_warm_bytes_.empty()) {
+    if (std::empty(pending_warm_bytes_)) {
       return empty();
     }
     auto tensor = at::empty({static_cast<int64_t>(pending_warm_bytes_.size())}, opts);
-    std::memcpy(tensor.data_ptr(), pending_warm_bytes_.data(), pending_warm_bytes_.size());
+    std::copy(
+        std::cbegin(pending_warm_bytes_), std::cend(pending_warm_bytes_), static_cast<uint8_t*>(tensor.data_ptr()));
     return tensor;
   }
   auto host_mem = make_trt(trt_handle_->serialize());

--- a/core/runtime/RuntimeSettings.cpp
+++ b/core/runtime/RuntimeSettings.cpp
@@ -124,9 +124,17 @@ at::Tensor RuntimeCacheHandle::serialize() const {
 #ifdef TRT_MAJOR_RTX
   std::lock_guard<std::mutex> lock(state_mu_);
   if (!trt_handle_) {
-    LOG_WARNING(
-        "RuntimeCacheHandle::serialize() called before the IRuntimeCache was materialized; returning empty bytes.");
-    return empty();
+    // Pre-materialize: forward any ``pending_warm_bytes_`` so that the
+    // handle's persistable state survives ``save_to_stream`` and pickle
+    // even before any engine has triggered ``ensure_materialized``.
+    // ``save_to_stream`` / ``def_pickle`` round-trip then matches the
+    // python facade's behavior (it reads ``_pending_warm_bytes`` directly).
+    if (pending_warm_bytes_.empty()) {
+      return empty();
+    }
+    auto tensor = at::empty({static_cast<int64_t>(pending_warm_bytes_.size())}, opts);
+    std::memcpy(tensor.data_ptr(), pending_warm_bytes_.data(), pending_warm_bytes_.size());
+    return tensor;
   }
   auto host_mem = make_trt(trt_handle_->serialize());
   TORCHTRT_CHECK(host_mem, "IRuntimeCache::serialize() returned null host memory; cannot serialize cache bytes.");

--- a/core/runtime/register_jit_hooks.cpp
+++ b/core/runtime/register_jit_hooks.cpp
@@ -31,16 +31,28 @@ static auto TORCHTRT_UNUSED RuntimeCacheHandleRegistration =
         // ``def_pickle`` registers ``__getstate__`` / ``__setstate__`` so the
         // handle can survive ``deepcopy`` / ``torch.export.save`` paths that
         // walk Python attributes (e.g. ``TorchTensorRTModule._implicit_cache_handle``).
-        // We persist only the ``path`` string: the underlying ``IRuntimeCache``
-        // is CPU-side state that can't cross a process boundary anyway, and
-        // ``_resolve_runtime_cache`` re-warms from disk on the deserialized
-        // path through the standard load -> pending_warm_bytes flow.
+        //
+        // We persist ``(path, bytes)``: the bytes blob round-trips the cache
+        // contents end-to-end (live ``IRuntimeCache`` when materialized,
+        // ``pending_warm_bytes_`` when not -- ``serialize()`` unifies both
+        // states). On unpickle, ``deserialize`` stashes the bytes into
+        // ``pending_warm_bytes_`` so the first engine that calls
+        // ``ensure_materialized`` drains them into the live cache. The
+        // matching python facade (``_RuntimeCacheHandle.__getstate__``)
+        // uses the same shape.
         .def_pickle(
             // __getstate__
-            [](c10::intrusive_ptr<RuntimeCacheHandle> const& self) -> std::string { return self->path; },
+            [](c10::intrusive_ptr<RuntimeCacheHandle> const& self) -> std::tuple<std::string, at::Tensor> {
+              return std::make_tuple(self->path, self->serialize());
+            },
             // __setstate__
-            [](std::string path) -> c10::intrusive_ptr<RuntimeCacheHandle> {
-              return c10::make_intrusive<RuntimeCacheHandle>(std::move(path));
+            [](std::tuple<std::string, at::Tensor> state) -> c10::intrusive_ptr<RuntimeCacheHandle> {
+              auto handle = c10::make_intrusive<RuntimeCacheHandle>(std::move(std::get<0>(state)));
+              auto const& blob = std::get<1>(state);
+              if (blob.numel() > 0) {
+                handle->deserialize(blob);
+              }
+              return handle;
             });
 
 // TODO: Implement a call method

--- a/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
@@ -662,6 +662,37 @@ class TorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
         engine._auto_select_profiles = auto
         engine.set_active_profile(active)
 
+    def __getstate__(self) -> dict[str, Any]:
+        """Exclude per-engine, in-memory state from the pickle stream.
+
+        Mirrors the ``set_extra_state`` reset so that
+        ``torch.save(module)`` / ``torch.load`` behaves the same way as
+        ``state_dict`` / ``load_state_dict`` w.r.t. ``RuntimeSettings``:
+        the caller must reapply any ``runtime_cache`` / strategy / cuda-graph
+        configuration after load. See ``_pack_engine_info`` for the matching
+        cpp-side exclusion (engine bytes never carry these fields).
+
+        ``_implicit_cache_handle`` is dropped alongside ``_runtime_settings``
+        because it aliases the same ``RuntimeCache`` instance and would
+        otherwise drag a ``weakref`` (via the handle's ``atexit`` closure)
+        and a Python-only ``threading.Lock`` (when the python-runtime path
+        is active) into pickle -- neither is picklable.
+        """
+        get_state = getattr(super(), "__getstate__", None)
+        state = (get_state() if get_state else self.__dict__).copy()
+        state.pop("_runtime_settings", None)
+        state.pop("_implicit_cache_handle", None)
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        state.setdefault("_runtime_settings", RuntimeSettings())
+        state.setdefault("_implicit_cache_handle", None)
+        set_state = getattr(super(), "__setstate__", None)
+        if set_state is not None:
+            set_state(state)
+        else:
+            self.__dict__.update(state)
+
     def set_pre_allocated_outputs(self, enable: bool) -> None:
         self.get_engine().use_pre_allocated_outputs = enable
 

--- a/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
@@ -673,10 +673,7 @@ class TorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
         cpp-side exclusion (engine bytes never carry these fields).
 
         ``_implicit_cache_handle`` is dropped alongside ``_runtime_settings``
-        because it aliases the same ``RuntimeCache`` instance and would
-        otherwise drag a ``weakref`` (via the handle's ``atexit`` closure)
-        and a Python-only ``threading.Lock`` (when the python-runtime path
-        is active) into pickle -- neither is picklable.
+        because it aliases the same ``RuntimeCache`` instance.
         """
         get_state = getattr(super(), "__getstate__", None)
         state = (get_state() if get_state else self.__dict__).copy()

--- a/py/torch_tensorrt/runtime/_runtime_cache.py
+++ b/py/torch_tensorrt/runtime/_runtime_cache.py
@@ -103,30 +103,21 @@ class _RuntimeCacheHandle:
         self._pending_warm_bytes: Optional[bytes] = None
         self._lock = threading.Lock()
 
-    def __getstate__(self) -> dict:
-        # ``threading.Lock`` is not picklable, which breaks ``copy.deepcopy``
-        # on any GraphModule that has us in its state (the cross-runtime
-        # export path calls deepcopy on the gm before re-tracing). The lock
-        # guards in-process mutations only; a freshly-deserialized cache
-        # always needs a new lock anyway.
-        state = self.__dict__.copy()
-        state.pop("_lock", None)
-        return state
-
-    def __setstate__(self, state: dict) -> None:
-        self.__dict__.update(state)
-        self._lock = threading.Lock()
+    def _serialize_unlocked(self) -> torch.Tensor:
+        """Lock-free helper used by ``serialize`` and ``__getstate__``;
+        caller must hold ``self._lock``."""
+        if self._cache is None:
+            return torch.empty(0, dtype=torch.uint8)
+        host_mem = self._cache.serialize()
+        if host_mem is None or host_mem.nbytes == 0:
+            return torch.empty(0, dtype=torch.uint8)
+        return torch.frombuffer(
+            bytearray(bytes(memoryview(host_mem))), dtype=torch.uint8
+        )
 
     def serialize(self) -> torch.Tensor:
         with self._lock:
-            if self._cache is None:
-                return torch.empty(0, dtype=torch.uint8)
-            host_mem = self._cache.serialize()
-            if host_mem is None or host_mem.nbytes == 0:
-                return torch.empty(0, dtype=torch.uint8)
-            return torch.frombuffer(
-                bytearray(bytes(memoryview(host_mem))), dtype=torch.uint8
-            )
+            return self._serialize_unlocked()
 
     def deserialize(self, data: torch.Tensor) -> None:
         with self._lock:
@@ -156,6 +147,39 @@ class _RuntimeCacheHandle:
                     self._cache.deserialize(self._pending_warm_bytes)
                     self._pending_warm_bytes = None
             return self._cache
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Pickle as ``(path, bytes)`` mirroring the cpp ``def_pickle``
+        contract. The bytes blob carries either the live ``IRuntimeCache``
+        contents (when materialized) or the pending warm bytes
+        (pre-materialize window), so the loading side gets a hot handle on
+        the first engine without an extra ``handle.load()`` from disk.
+
+        The lock and the live ``_cache`` are per-process and never cross
+        the pickle boundary; ``__setstate__`` rebuilds them fresh.
+        """
+        with self._lock:
+            if self._cache is not None:
+                blob = self._serialize_unlocked()
+            elif self._pending_warm_bytes is not None:
+                blob = torch.frombuffer(
+                    bytearray(self._pending_warm_bytes), dtype=torch.uint8
+                )
+            else:
+                blob = torch.empty(0, dtype=torch.uint8)
+            path = self.path
+        return {"path": path, "bytes": blob}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.path = state["path"]
+        self._cache = None
+        self._pending_warm_bytes = None
+        self._lock = threading.Lock()
+        blob = state.get("bytes")
+        if blob is not None and blob.numel() > 0:
+            # Stashes into ``_pending_warm_bytes``; first engine that calls
+            # ``ensure_materialized`` drains it into the live cache.
+            self.deserialize(blob)
 
 
 def _autosave_at_exit(ref: "weakref.ref[RuntimeCache]") -> None:

--- a/tests/py/dynamo/runtime/test_000_runtime_cache.py
+++ b/tests/py/dynamo/runtime/test_000_runtime_cache.py
@@ -466,15 +466,15 @@ class TestRuntimeCacheAutosave(TestCase):
             "loaded handle must own its own atexit token (fresh weakref)",
         )
 
-    @unittest.skipIf(
-        ENABLED_FEATURES.torch_tensorrt_runtime,
-        "exercises the python ``_RuntimeCacheHandle`` directly; cpp-rt "
-        "path is covered by ``register_jit_hooks.cpp`` ``def_pickle``",
-    )
     def test_python_handle_pickle_preserves_pending_warm_bytes(self):
         """A python ``_RuntimeCacheHandle`` that has bytes loaded but
         hasn't materialized them yet must round-trip those bytes through
         pickle. Matches the cpp ``def_pickle`` contract (path + bytes).
+
+        The test instantiates ``_RuntimeCacheHandle`` directly rather than
+        going through ``RuntimeCache`` (which would pick the torchbind
+        backing on cpp rt), so the python class is exercisable regardless
+        of which runtime is active.
         """
         import pickle
 

--- a/tests/py/dynamo/runtime/test_000_runtime_cache.py
+++ b/tests/py/dynamo/runtime/test_000_runtime_cache.py
@@ -466,6 +466,32 @@ class TestRuntimeCacheAutosave(TestCase):
             "loaded handle must own its own atexit token (fresh weakref)",
         )
 
+    @unittest.skipIf(
+        ENABLED_FEATURES.torch_tensorrt_runtime,
+        "exercises the python ``_RuntimeCacheHandle`` directly; cpp-rt "
+        "path is covered by ``register_jit_hooks.cpp`` ``def_pickle``",
+    )
+    def test_python_handle_pickle_preserves_pending_warm_bytes(self):
+        """A python ``_RuntimeCacheHandle`` that has bytes loaded but
+        hasn't materialized them yet must round-trip those bytes through
+        pickle. Matches the cpp ``def_pickle`` contract (path + bytes).
+        """
+        import pickle
+
+        from torch_tensorrt.runtime._runtime_cache import _RuntimeCacheHandle
+
+        handle = _RuntimeCacheHandle(path="/tmp/test_cache.bin")
+        warm = b"\x01\x02\x03\x04\x05\x06\x07\x08"
+        handle.deserialize(torch.frombuffer(bytearray(warm), dtype=torch.uint8))
+        self.assertEqual(handle._pending_warm_bytes, warm)
+
+        loaded = pickle.loads(pickle.dumps(handle))
+
+        self.assertEqual(loaded.path, "/tmp/test_cache.bin")
+        self.assertEqual(loaded._pending_warm_bytes, warm)
+        self.assertIsNone(loaded._cache, "live cache is never persisted")
+        self.assertIsNotNone(loaded._lock, "lock must be a fresh Lock instance")
+
 
 @unittest.skipIf(
     not ENABLED_FEATURES.tensorrt_rtx,


### PR DESCRIPTION
## Summary
This MR adds three independent pickle-correctness fixes that together let `torch.save(module)` and standalone-pickle of `RuntimeCache` / `RuntimeCacheHandle` work cleanly.

- **Wrapper `__getstate__` / `__setstate__`** on `TorchTensorRTModule` excludes `_runtime_settings` and `_implicit_cache_handle` from the pickle stream and resets both to defaults on load. Mirrors `set_extra_state` (line 515) and the line-236 design note: *"RuntimeSettings are intentionally NOT serialized: they're per-engine, in-memory init values, not part of the engine's identity."* Pickle path now matches `state_dict` + `load_state_dict` behavior.
- **Python `_RuntimeCacheHandle.__getstate__` / `__setstate__`** ships a protocol pair pickling as `(path, bytes)`. Default pickle crashes on `_thread.lock`; the new protocol carries the cache contents (live cache when materialized, `_pending_warm_bytes` fallback otherwise) and rebuilds a fresh `threading.Lock` on the load side. Factored a lock-free `_serialize_unlocked` helper.
- **Cpp `RuntimeCacheHandle::serialize()`** falls back to `pending_warm_bytes_` when `trt_handle_` is null, so callers asking for the handle's persistable bytes (`save_to_stream`, `def_pickle`) get the right answer in every lifecycle state. The misleading "called before materialized" warning is retired now that the pre-materialize case hooks into serializable bytes.
- As a result **Cpp `def_pickle`** moves from `std::string` (path-only) to `std::tuple<std::string, at::Tensor>` (path + bytes) and round-trips via the existing `serialize` / `deserialize` API. Matches the python facade's shape.

## Pre-existing CI noise this resolves
- `test_cross_runtime_serde::test_save_{cpp_load_python,python_load_python,python_load_cpp}` : root cause is `_thread.lock` failing pickle in python-runtime subprocesses. Fixed by the `_RuntimeCacheHandle.__getstate__` protocol.
- Sibling PR (#4362) introduces an `_atexit_token` slot containing a `weakref`. The wrapper exclusion here keeps that out of pickle entirely, unblocking the sibling PR's CI if needed.

Refs #4359.

## Type of change
- Bug fix (non-breaking)

## Test plan
- [x] `test_python_handle_pickle_preserves_pending_warm_bytes` — python
      handle's bytes round-trip end-to-end (path + pending bytes
      preserved; fresh lock; no live cache reused).
- [x] Full `test_000_runtime_cache.py` passes locally (24 passed, 1
      unrelated cpp-rt-only skip).
- [x] `pre-commit run` clean on touched files (mypy skipped for two
      pre-existing errors at `_TorchTensorRTModule.py:380` and `:508`,
      unrelated).
