### PR TITLE
refactor(dynamo): make _requires_output_allocator a pure predicate

### DIFF
--- a/py/torch_tensorrt/dynamo/partitioning/_adjacency_partitioner.py
+++ b/py/torch_tensorrt/dynamo/partitioning/_adjacency_partitioner.py
@@ -53,7 +53,12 @@ class OpSupportTester(ops.OperatorSupportBase):  # type: ignore
                 )
             return False
 
-        if TorchTensorRTOperatorSupport._requires_output_allocator(node):
+        settings = CONVERTERS.compilation_settings
+        if (
+            settings is not None
+            and settings.fallback_data_dependent_ops
+            and TorchTensorRTOperatorSupport._requires_output_allocator(node)
+        ):
             # data-dependent output shape needs a TRT output allocator, which some
             # runtimes cannot consume; honor the fallback and run the node in PyTorch
             if not node.is_impure():

--- a/py/torch_tensorrt/dynamo/partitioning/_global_partitioner.py
+++ b/py/torch_tensorrt/dynamo/partitioning/_global_partitioner.py
@@ -168,11 +168,9 @@ class TorchTensorRTOperatorSupport(OperatorSupport):  # type: ignore[misc]
 
     @staticmethod
     def _requires_output_allocator(node: torch.fx.Node) -> bool:
-        # A converter that needs a TRT output allocator has a data-dependent output
-        # shape; route the node to PyTorch when fallback_data_dependent_ops is set.
-        settings = CONVERTERS.compilation_settings
-        if settings is None or not settings.fallback_data_dependent_ops:
-            return False
+        # True if the converter selected for this node needs a TRT output allocator,
+        # i.e. the node has a data-dependent output shape (e.g. nonzero or boolean
+        # index). The fallback_data_dependent_ops setting is honored by the caller.
         converter_packet = CONVERTERS.get(node)
         return converter_packet is not None and converter_packet[2].get(
             "requires_output_allocator", False
@@ -192,7 +190,12 @@ class TorchTensorRTOperatorSupport(OperatorSupport):  # type: ignore[misc]
                 )
             return False
 
-        if self._requires_output_allocator(node):
+        settings = CONVERTERS.compilation_settings
+        if (
+            settings is not None
+            and settings.fallback_data_dependent_ops
+            and self._requires_output_allocator(node)
+        ):
             # data-dependent output shape needs a TRT output allocator, which some
             # runtimes cannot consume; honor the fallback and run the node in PyTorch
             if not node.is_impure():

--- a/tests/py/dynamo/models/test_fallback_data_dependent_ops.py
+++ b/tests/py/dynamo/models/test_fallback_data_dependent_ops.py
@@ -43,21 +43,29 @@ def _nonzero_node() -> torch.fx.Node:
     )
 
 
-def test_output_allocator_node_falls_back_only_when_enabled():
-    # nonzero's selected converter requires an output allocator, so the partitioner
-    # marks the node unsupported only when the flag is on. This is decided per node
-    # (via the selected converter), not by op target.
+def test_requires_output_allocator_is_setting_independent():
+    # _requires_output_allocator is a pure predicate: it reports whether the
+    # converter selected for the node needs a TRT output allocator (decided per node
+    # via the selected converter, not by op target), independent of any setting.
     node = _nonzero_node()
+    assert TorchTensorRTOperatorSupport._requires_output_allocator(node) is True
+
+
+def test_output_allocator_node_falls_back_only_when_enabled():
+    # The node is routed to PyTorch (unsupported) only when fallback_data_dependent_ops
+    # is on; with it off the node stays on TensorRT.
+    node = _nonzero_node()
+    support = TorchTensorRTOperatorSupport()
     original = CONVERTERS.compilation_settings
     try:
         CONVERTERS.set_compilation_settings(
             CompilationSettings(fallback_data_dependent_ops=False)
         )
-        assert TorchTensorRTOperatorSupport._requires_output_allocator(node) is False
+        assert support.is_node_supported({}, node) is True
         CONVERTERS.set_compilation_settings(
             CompilationSettings(fallback_data_dependent_ops=True)
         )
-        assert TorchTensorRTOperatorSupport._requires_output_allocator(node) is True
+        assert support.is_node_supported({}, node) is False
     finally:
         CONVERTERS.compilation_settings = original
 


### PR DESCRIPTION
## Description

Follow-up cleanup to #4355.

The `_requires_output_allocator` helper in the partitioner previously folded the `fallback_data_dependent_ops` setting into its return value: it returned `False` for a node that genuinely required a TRT output allocator whenever the setting was disabled (the default). That made the name misleading at the call sites — `_requires_output_allocator(node) == False` did not actually mean "this node does not require an output allocator," it usually meant "the setting is off."

This flips the semantics so the helper is a **pure predicate**: it reports whether the converter selected for a node needs a TRT output allocator (data-dependent output shape, e.g. `nonzero` or boolean `index.Tensor`), independent of any setting. The `fallback_data_dependent_ops` gate moves to the two operator-support call sites (`TorchTensorRTOperatorSupport.is_node_supported` and `OpSupportTester.is_node_supported`).

The setting is still checked first at the call sites, preserving the short-circuit that skips the converter-registry lookup in the default (off) case. Behavior is unchanged end to end.

## Details

- `_global_partitioner.py`: `_requires_output_allocator` no longer reads `compilation_settings`; the caller now guards with `settings is not None and settings.fallback_data_dependent_ops and self._requires_output_allocator(node)`.
- `_adjacency_partitioner.py`: same gate added at the `OpSupportTester` call site.

## Tests

`tests/py/dynamo/models/test_fallback_data_dependent_ops.py`:

- Added `test_requires_output_allocator_is_setting_independent`: the pure predicate returns `True` for `nonzero` regardless of the setting.
- Updated `test_output_allocator_node_falls_back_only_when_enabled`: now drives `is_node_supported(...)` and asserts the node stays on TensorRT (`True`) when the flag is off and falls back (`False`) when it is on — testing the real partitioner decision rather than the helper in isolation.

## Type of change

- Refactor / code-quality improvement (non-breaking, no behavior change)

## Checklist

- [x] My code follows the style guidelines of this project (isort + black, passed via pre-commit)
- [x] I have added/updated tests
- [x] Commit is signed off (DCO)