### PR TITLE
[cherry-pick][release/2.13] user provided bound for torchtrt compile (#4213)

### DIFF
--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -5,11 +5,14 @@ import logging
 import os
 import platform
 import warnings
-from typing import Any, Collection, List, Optional, Sequence, Union
+from typing import Any, Collection, Dict, List, Optional, Sequence, Tuple, Union
 
+import sympy
 import torch
 from torch.export import ExportedProgram
+from torch.export.graph_signature import InputKind
 from torch.fx.node import Target
+from torch.utils._sympy.numbers import int_oo
 from torch_tensorrt._Device import Device
 from torch_tensorrt._enums import EngineCapability, dtype
 from torch_tensorrt._features import ENABLED_FEATURES, needs_cross_compile
@@ -407,6 +410,7 @@ def cross_compile_for_windows(
         trt_arg_inputs,
         trt_kwarg_inputs,
         settings,
+        graph_signature=exported_program.graph_signature,
     )
     return trt_gm
 
@@ -793,7 +797,12 @@ def compile(
                 "Remaining GPU memory may not be enough to compile the TensorRT engine for this model resulting in an OOM error, Consider setting offload_module_to_cpu=True"
             )
     trt_gm = compile_module(
-        gm, trt_arg_inputs, trt_kwarg_inputs, settings, engine_cache
+        gm,
+        trt_arg_inputs,
+        trt_kwarg_inputs,
+        settings,
+        engine_cache,
+        graph_signature=exported_program.graph_signature,
     )
     return trt_gm
 
@@ -898,6 +907,170 @@ def _insert_complex_io_adapters(
         partitioned_module.recompile()
 
 
+def _build_user_symbol_bounds(
+    gm: torch.fx.GraphModule,
+    sample_arg_inputs: Sequence[Input],
+    sample_kwarg_inputs: dict[Any, Any],
+    graph_signature: torch.export.graph_signature.ExportGraphSignature,
+) -> Dict[sympy.Symbol, Tuple[int, int]]:
+    """Map ``sympy.Symbol -> (min, max)`` from dynamic ``Input``s, used to
+    fill ``Dim.DYNAMIC`` upper bounds without mutating ``ShapeEnv``.
+
+    Validates against finite exporter bounds: ``user_max > exp_max`` and
+    ``user_min < exp_min`` raise (TRT would reject those shapes at runtime);
+    a strict subset narrows the engine profile to the user's bounds (info
+    log only); the ``user_min=1, exp_min=2`` case warns -- it's PyTorch's
+    0/1 specialization artifact, not a user error.
+    """
+    all_placeholders = [n for n in gm.graph.nodes if n.op == "placeholder"]
+    placeholders = [
+        p
+        for p, s in zip(all_placeholders, graph_signature.input_specs)
+        if s.kind == InputKind.USER_INPUT
+    ]
+
+    in_spec = getattr(gm, "_in_spec", None)
+    assert in_spec is not None, "Exported graph module missing _in_spec"
+    flat_inputs = in_spec.flatten_up_to((list(sample_arg_inputs), sample_kwarg_inputs))
+
+    user_symbol_bounds: Dict[sympy.Symbol, Tuple[int, int]] = {}
+
+    for node, inp in zip(placeholders, flat_inputs):
+        if not (isinstance(inp, Input) and inp.shape_mode == Input._ShapeMode.DYNAMIC):
+            continue
+        fake_val = node.meta.get("val")
+        if not isinstance(fake_val, torch.Tensor):
+            continue
+
+        min_shape = inp.shape["min_shape"]
+        max_shape = inp.shape["max_shape"]
+
+        if len(fake_val.size()) != len(min_shape):
+            raise ValueError(
+                f"Input '{node.target}' has {len(fake_val.size())} dimensions in "
+                f"the exported program, but the provided Input specifies "
+                f"{len(min_shape)} dimensions. Ensure Input.min_shape, "
+                f"Input.opt_shape, and Input.max_shape each have "
+                f"{len(fake_val.size())} entries."
+            )
+
+        for d, dim in enumerate(fake_val.size()):
+            if not isinstance(dim, torch.SymInt):
+                if min_shape[d] != dim or max_shape[d] != dim:
+                    raise ValueError(
+                        f"Input '{node.target}' dim {d} is static (size={int(dim)}) "
+                        f"in the exported program, but the provided Input has "
+                        f"min_shape[{d}]={min_shape[d]}, max_shape[{d}]={max_shape[d]}. "
+                        f"Static dimensions must be fixed."
+                    )
+                continue
+            expr = dim.node.expr
+            # Composite exprs (e.g. ``2*s0``) are recomputed by
+            # ``ShapeEnv.bound_sympy``; overriding them directly would lie.
+            if not isinstance(expr, sympy.Symbol):
+                logger.debug(
+                    "Input '%s' dim %d is a composite symbolic expression (%s) "
+                    "bounded by another dynamic dimension; its range will be "
+                    "derived from constituent symbols via bound_sympy.",
+                    node.target,
+                    d,
+                    expr,
+                )
+                continue
+            if expr in user_symbol_bounds:
+                continue
+            user_min = int(min_shape[d])
+            user_max = int(max_shape[d])
+            user_symbol_bounds[expr] = (user_min, user_max)
+            logger.debug(
+                "Recorded user-supplied bounds for %s: [%d, %d]",
+                expr,
+                user_min,
+                user_max,
+            )
+
+            # The exported program may already bound this symbol to a finite
+            # range (e.g. Dim("batch", min=10, max=20)). The compiled TRT
+            # engine's optimization profile follows that range; any shape
+            # outside it is rejected by TensorRT at runtime
+            # (IExecutionContext::setInputShape "satisfyProfile" check).
+            # Validate the user's Input range against it here -- at compile
+            # time -- before they hit that opaque runtime error on a shape
+            # they explicitly declared in Input.min_shape / Input.max_shape.
+            shape_env = getattr(dim.node, "shape_env", None)
+            if shape_env is None:
+                continue
+            exp_range = shape_env.var_to_range.get(expr)
+            if exp_range is None:
+                continue
+            exp_lower = exp_range.lower
+            exp_upper = exp_range.upper
+            exp_max_unbounded = exp_upper is int_oo or exp_upper == sympy.oo
+            if exp_max_unbounded:
+                # Dim.DYNAMIC: user fills the gap (intended use).
+                continue
+            try:
+                exp_min = int(exp_lower)
+                exp_max = int(exp_upper)
+            except (TypeError, ValueError):
+                continue
+            if user_min == exp_min and user_max == exp_max:
+                continue
+
+            mismatch = (
+                f"Dynamic dimension '{expr}': "
+                f"Input range [{user_min}, {user_max}] vs "
+                f"exported program range [{exp_min}, {exp_max}]."
+            )
+
+            if user_max > exp_max:
+                raise ValueError(
+                    f"{mismatch} Input.max_shape ({user_max}) exceeds the "
+                    f"exported program's max ({exp_max}). The program was "
+                    f"exported with this dimension bounded to "
+                    f"[{exp_min}, {exp_max}], so the compiled TensorRT engine "
+                    f"cannot accept shapes above {exp_max}. Either re-export "
+                    f"with Dim('{expr}', max={user_max}) or set "
+                    f"Input.max_shape <= {exp_max}."
+                )
+
+            if user_min < exp_min:
+                # 1->2 is the 0/1 specialization artifact, not a user error.
+                if user_min == 1 and exp_min == 2:
+                    logger.warning(
+                        "%s Input.min_shape=1 but the exported program's min "
+                        "is 2 (PyTorch 0/1 specialization -- Dim(min=1) is "
+                        "recorded as min=2). The compiled engine's min will "
+                        "be 2.",
+                        mismatch,
+                    )
+                    continue
+                raise ValueError(
+                    f"{mismatch} Input.min_shape ({user_min}) is below the "
+                    f"exported program's min ({exp_min}). The program was "
+                    f"exported with this dimension bounded to "
+                    f"[{exp_min}, {exp_max}], so the compiled TensorRT engine "
+                    f"cannot accept shapes below {exp_min}. Either re-export "
+                    f"with Dim('{expr}', min={user_min}) or set "
+                    f"Input.min_shape >= {exp_min}."
+                )
+
+            # Strict subset: engine profile narrows to the user's bounds
+            # (applied in ``extract_var_range_info``). Not a warning -- the
+            # user got exactly what they asked for.
+            logger.info(
+                "%s Narrowing engine profile to user bounds [%d, %d] "
+                "(exported program range was [%d, %d]).",
+                mismatch,
+                user_min,
+                user_max,
+                exp_min,
+                exp_max,
+            )
+
+    return user_symbol_bounds
+
+
 @fn_supports_debugger  # type: ignore[misc]
 def compile_module(
     gm: torch.fx.GraphModule,
@@ -906,6 +1079,7 @@ def compile_module(
     settings: CompilationSettings = CompilationSettings(),
     engine_cache: Optional[BaseEngineCache] = None,
     *,
+    graph_signature: torch.export.graph_signature.ExportGraphSignature,
     _debugger_config: Optional[DebuggerConfig] = None,
 ) -> torch.fx.GraphModule:
     """Compile a traced FX module
@@ -928,6 +1102,20 @@ def compile_module(
     dryrun_tracker = DryRunTracker()
     if sample_kwarg_inputs is None:
         sample_kwarg_inputs = {}
+
+    # fallback_data_dependent_ops runs data-dependent ops in PyTorch during
+    # partitioning, which cannot coexist with require_full_compilation.
+    if settings.fallback_data_dependent_ops and settings.require_full_compilation:
+        raise ValueError(
+            "fallback_data_dependent_ops runs data-dependent ops in PyTorch, which "
+            "is incompatible with require_full_compilation=True; enable only one."
+        )
+
+    # Forwarded to the partitioner to fill Dim.DYNAMIC upper bounds.
+    # Read-only w.r.t. ShapeEnv so range_constraints survive save/re-export.
+    user_symbol_bounds = _build_user_symbol_bounds(
+        gm, sample_arg_inputs, sample_kwarg_inputs, graph_signature
+    )
 
     # Configure user compilation settings to converters.
     CONVERTERS.set_compilation_settings(settings)
@@ -1110,7 +1298,9 @@ def compile_module(
         )
 
         # Get the submodule inputs for min, opt, max shapes of the graph inputs
-        submodule_inputs = partitioning.construct_submodule_inputs(submodule)
+        submodule_inputs = partitioning.construct_submodule_inputs(
+            submodule, user_symbol_bounds=user_symbol_bounds
+        )
 
         assert submodule_inputs is not None
 

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -1079,7 +1079,9 @@ def compile_module(
     settings: CompilationSettings = CompilationSettings(),
     engine_cache: Optional[BaseEngineCache] = None,
     *,
-    graph_signature: torch.export.graph_signature.ExportGraphSignature,
+    graph_signature: Optional[
+        torch.export.graph_signature.ExportGraphSignature
+    ] = None,
     _debugger_config: Optional[DebuggerConfig] = None,
 ) -> torch.fx.GraphModule:
     """Compile a traced FX module
@@ -1113,8 +1115,13 @@ def compile_module(
 
     # Forwarded to the partitioner to fill Dim.DYNAMIC upper bounds.
     # Read-only w.r.t. ShapeEnv so range_constraints survive save/re-export.
-    user_symbol_bounds = _build_user_symbol_bounds(
-        gm, sample_arg_inputs, sample_kwarg_inputs, graph_signature
+    # graph_signature is None on the torch.compile path, which has no ExportedProgram.
+    user_symbol_bounds = (
+        _build_user_symbol_bounds(
+            gm, sample_arg_inputs, sample_kwarg_inputs, graph_signature
+        )
+        if graph_signature is not None
+        else {}
     )
 
     # Configure user compilation settings to converters.

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -1105,14 +1105,6 @@ def compile_module(
     if sample_kwarg_inputs is None:
         sample_kwarg_inputs = {}
 
-    # fallback_data_dependent_ops runs data-dependent ops in PyTorch during
-    # partitioning, which cannot coexist with require_full_compilation.
-    if settings.fallback_data_dependent_ops and settings.require_full_compilation:
-        raise ValueError(
-            "fallback_data_dependent_ops runs data-dependent ops in PyTorch, which "
-            "is incompatible with require_full_compilation=True; enable only one."
-        )
-
     # Forwarded to the partitioner to fill Dim.DYNAMIC upper bounds.
     # Read-only w.r.t. ShapeEnv so range_constraints survive save/re-export.
     # graph_signature is None on the torch.compile path, which has no ExportedProgram.

--- a/py/torch_tensorrt/dynamo/partitioning/common.py
+++ b/py/torch_tensorrt/dynamo/partitioning/common.py
@@ -1,10 +1,10 @@
 import logging
 from typing import Any, Dict, Optional, Sequence, Set, Tuple
 
+import sympy
 import torch
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx.experimental.proxy_tensor import unset_fake_temporarily
-
 from torch_tensorrt._Input import Input
 from torch_tensorrt.dynamo.utils import (
     COMPLEX_TO_REAL_DTYPE,
@@ -20,11 +20,14 @@ def construct_dynamic_input(
     input_dtype: torch.dtype,
     name: str = "",
     is_shape_tensor: bool = False,
+    user_symbol_bounds: Optional[Dict[sympy.Symbol, Tuple[int, int]]] = None,
 ) -> Input:
     """
     Constructs a torch_tensorrt.Input based on a symbolic input
     Args:
         input_shape: A symbolic shape / regular shape of a tensor (which can have a  mix of SymInt nodes and static values)
+        user_symbol_bounds: Optional ``{sym: (min, max)}`` map; forwarded to
+            :func:`extract_var_range_info` to fill unbounded exporter uppers.
     Returns:
         A dynamic shaped torch_tensorrt.Input which has the properties of the symbolic shaped input.
     """
@@ -33,7 +36,9 @@ def construct_dynamic_input(
     max_shape = []
     for d, dim in enumerate(input_shape):
         if isinstance(dim, torch.SymInt):
-            min_max_opt = extract_var_range_info(dim)
+            min_max_opt = extract_var_range_info(
+                dim, user_symbol_bounds=user_symbol_bounds
+            )
             unwrapped_min_max_opt: Dict[str, int] = {}
             if "min" not in min_max_opt or min_max_opt["min"] is None:
                 logger.warning(
@@ -85,9 +90,12 @@ def get_input(
     dtype: torch.dtype,
     name: str = "",
     is_shape_tensor: bool = False,
+    user_symbol_bounds: Optional[Dict[sympy.Symbol, Tuple[int, int]]] = None,
 ) -> Input:
     """
-    Based on type of dimensions in the input_shape, construct regular or dynamic shaped inputs
+    Based on type of dimensions in the input_shape, construct regular or dynamic shaped inputs.
+
+    ``user_symbol_bounds`` is forwarded to :func:`construct_dynamic_input`.
     """
     if dtype in COMPLEX_TO_REAL_DTYPE:
         real_dtype = COMPLEX_TO_REAL_DTYPE[dtype]
@@ -106,6 +114,7 @@ def get_input(
             dtype,
             name=name,
             is_shape_tensor=is_shape_tensor,
+            user_symbol_bounds=user_symbol_bounds,
         )
     else:
         return Input(
@@ -113,12 +122,17 @@ def get_input(
         )
 
 
-def construct_submodule_inputs(module: torch.fx.GraphModule) -> Sequence[Input]:
+def construct_submodule_inputs(
+    module: torch.fx.GraphModule,
+    user_symbol_bounds: Optional[Dict[sympy.Symbol, Tuple[int, int]]] = None,
+) -> Sequence[Input]:
     """
     Construct torch_tensorrt Inputs based on the module inputs.
     The module inputs will have meta data which has the shape and dtype info
     Args:
         module: Input FX GraphModule
+        user_symbol_bounds: Optional ``{sym: (min, max)}`` map; forwarded to
+            :func:`get_input` to fill unbounded exporter uppers.
     Returns:
         Sequence of torch_tensorrt.Input's representing inputs to given module
     """
@@ -134,7 +148,12 @@ def construct_submodule_inputs(module: torch.fx.GraphModule) -> Sequence[Input]:
                     if isinstance(input_meta, (FakeTensor, torch.Tensor)):
                         input_shape = input_meta.size()
                         torchtrt_inputs.append(
-                            get_input(input_shape, input_meta.dtype, name=input.name)
+                            get_input(
+                                input_shape,
+                                input_meta.dtype,
+                                name=input.name,
+                                user_symbol_bounds=user_symbol_bounds,
+                            )
                         )
                     elif isinstance(input_meta, torch.SymInt):
                         # Assuming sym_integers | shape inputs always have torch.int64 dtype
@@ -144,6 +163,7 @@ def construct_submodule_inputs(module: torch.fx.GraphModule) -> Sequence[Input]:
                                 torch.int64,
                                 name=input.name,
                                 is_shape_tensor=True,
+                                user_symbol_bounds=user_symbol_bounds,
                             )
                         )
                     elif isinstance(input_meta, torch.SymFloat):
@@ -153,6 +173,7 @@ def construct_submodule_inputs(module: torch.fx.GraphModule) -> Sequence[Input]:
                                 torch.float32,
                                 name=input.name,
                                 is_shape_tensor=False,  # Only SymInt inputs are treated as shape tensors
+                                user_symbol_bounds=user_symbol_bounds,
                             )
                         )
                     else:
@@ -164,7 +185,12 @@ def construct_submodule_inputs(module: torch.fx.GraphModule) -> Sequence[Input]:
                     input_meta = input.meta["tensor_meta"]
                     input_shape = input_meta.shape
                     torchtrt_inputs.append(
-                        get_input(input_shape, input_meta.dtype, name=input.name)
+                        get_input(
+                            input_shape,
+                            input_meta.dtype,
+                            name=input.name,
+                            user_symbol_bounds=user_symbol_bounds,
+                        )
                     )
                 else:
                     raise AssertionError(

--- a/py/torch_tensorrt/dynamo/utils.py
+++ b/py/torch_tensorrt/dynamo/utils.py
@@ -406,9 +406,16 @@ def contains_sym_int(tensor: torch.Tensor) -> bool:
     return any(isinstance(dim, torch.SymInt) for dim in tensor)
 
 
-def extract_var_range_info(symbolic_integer: torch.SymInt) -> Dict[str, Optional[int]]:
-    """
-    This function returns the min, max, opt values of a symbolic integer.
+def extract_var_range_info(
+    symbolic_integer: torch.SymInt,
+    user_symbol_bounds: Optional[Dict[sympy.Symbol, Tuple[int, int]]] = None,
+) -> Dict[str, Optional[int]]:
+    """Return ``{min, max, opt}`` for a symbolic integer.
+
+    ``user_symbol_bounds`` (read-only ``{sym: (min, max)}``) is consulted only
+    when the exporter's upper is unbounded; finite exporter bounds always win.
+    The lower is intersected with the exporter's so the 0/1 specialization
+    survives even if the user passes ``min_shape=0``.
     """
     node = symbolic_integer.node
     expr = node.expr
@@ -435,13 +442,42 @@ def extract_var_range_info(symbolic_integer: torch.SymInt) -> Dict[str, Optional
         or expr.xreplace(var_to_val_map)
     )
     assert var_range, var_val
-    min_val, max_val = (
-        int(var_range.lower),
-        int(var_range.upper) if var_range.upper != int_oo else None,
-    )
+
+    # ``var_to_range`` returns ``int_oo`` for unbounded; ``bound_sympy`` (used
+    # for composite exprs like ``s0+s1``) returns ``sympy.oo`` instead. They
+    # are distinct objects -- check both, else ``int(sympy.oo)`` raises.
+    def _bound_to_int_or_none(value: Any) -> Optional[int]:
+        if value is int_oo or value is -int_oo:
+            return None
+        if value == sympy.oo or value == -sympy.oo:
+            return None
+        try:
+            return int(value)
+        except (TypeError, OverflowError, AttributeError):
+            return None
+
+    min_val_opt = _bound_to_int_or_none(var_range.lower)
+    max_val = _bound_to_int_or_none(var_range.upper)
+    # Unbounded lower shouldn't happen for tensor dims; fall back to 1.
+    min_val = min_val_opt if min_val_opt is not None else 1
 
     # Torchdynamo 0/1 specialization outlier
     min_val = 1 if min_val == 2 else min_val
+
+    # Apply user bounds whenever present. ``_build_user_symbol_bounds`` already
+    # rejects user ranges that exceed the exporter, so the only cases reaching
+    # here are: Dim.DYNAMIC (max_val is None), strict subset, or the 1->2
+    # specialization. Clamp defensively in case validation was skipped (no
+    # ShapeEnv access path).
+    if (
+        user_symbol_bounds
+        and isinstance(expr, sympy.Symbol)
+        and expr in user_symbol_bounds
+    ):
+        user_min, user_max = user_symbol_bounds[expr]
+        min_val = max(min_val, int(user_min))
+        max_val = int(user_max) if max_val is None else min(max_val, int(user_max))
+
     min_max_opt: Dict[str, Optional[int]] = {}
     min_max_opt["min"] = min_val
     min_max_opt["max"] = max_val

--- a/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
+++ b/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
@@ -1,0 +1,554 @@
+# type: ignore
+"""Tests for ``user_symbol_bounds`` plumbed from ``compile_module`` through
+the partitioner into ``extract_var_range_info``."""
+
+import os
+import unittest
+
+import pytest
+import sympy
+import torch
+import torch_tensorrt as torchtrt
+from torch_tensorrt._Input import Input
+from torch_tensorrt.dynamo._compiler import _build_user_symbol_bounds
+from torch_tensorrt.dynamo.utils import extract_var_range_info
+
+assertions = unittest.TestCase()
+
+
+def _first_sym_placeholder(ep: torch.export.ExportedProgram, sym_dim: int = 0):
+    """First placeholder with a ``SymInt`` at ``sym_dim``; skips lifted
+    param/buffer placeholders that ``strict=False`` may prepend."""
+    for node in ep.graph.nodes:
+        if node.op != "placeholder":
+            continue
+        val = node.meta.get("val")
+        if not isinstance(val, torch.Tensor):
+            continue
+        if sym_dim < len(val.size()) and isinstance(val.size()[sym_dim], torch.SymInt):
+            return val, val.size()[sym_dim]
+    return None, None
+
+
+class _SmallLinear(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(8, 8)
+
+    def forward(self, x):
+        return self.linear(x).relu()
+
+
+@pytest.mark.unit
+def test_extract_var_range_info_fills_unbounded_max_from_user():
+    """User bounds must fill the gap when the exporter's upper is ``int_oo``,
+    and successive calls must not leak state across invocations."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(2, 8, device="cuda")
+
+    dyn_batch = torch.export.Dim.DYNAMIC
+    ep = torch.export.export(
+        model, (sample,), dynamic_shapes=({0: dyn_batch},), strict=False
+    )
+
+    fake_val, sym_dim = _first_sym_placeholder(ep, sym_dim=0)
+    assert sym_dim is not None
+    assert isinstance(sym_dim, torch.SymInt)
+    expr = sym_dim.node.expr
+    assert isinstance(expr, sympy.Symbol)
+
+    assert extract_var_range_info(sym_dim)["max"] is None
+
+    info_with_user = extract_var_range_info(sym_dim, user_symbol_bounds={expr: (1, 8)})
+    assert info_with_user["max"] == 8
+    assert info_with_user["min"] == 1
+
+    # Different map on the same SymInt must return the new bounds (no caching).
+    info_wider = extract_var_range_info(sym_dim, user_symbol_bounds={expr: (1, 16)})
+    assert info_wider["max"] == 16
+    assert info_wider["min"] == 1
+
+    # Dropping the map must revert (no ShapeEnv mutation).
+    assert extract_var_range_info(sym_dim)["max"] is None
+
+
+@pytest.mark.unit
+def test_extract_var_range_info_does_not_widen_lower_bound():
+    """Lower bound is intersected so the 0/1 specialization survives even
+    when the user passes ``min_shape=0``."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(2, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim.DYNAMIC},),
+        strict=False,
+    )
+    _, sym_dim = _first_sym_placeholder(ep, sym_dim=0)
+    assert sym_dim is not None
+    expr = sym_dim.node.expr
+
+    info = extract_var_range_info(sym_dim, user_symbol_bounds={expr: (0, 8)})
+    assert info["min"] == 1, "exporter lower must not be widened to user's 0"
+    assert info["max"] == 8
+
+
+@pytest.mark.unit
+def test_extract_var_range_info_does_not_override_finite_max():
+    """A finite exporter max must win over ``user_symbol_bounds``."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(2, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim("batch", min=1, max=4)},),
+        strict=False,
+    )
+    _, sym_dim = _first_sym_placeholder(ep, sym_dim=0)
+    assert sym_dim is not None
+    expr = sym_dim.node.expr
+
+    info = extract_var_range_info(sym_dim, user_symbol_bounds={expr: (1, 16)})
+    assert info["max"] == 4
+
+
+@pytest.mark.unit
+def test_extract_var_range_info_handles_sympy_oo_from_bound_sympy():
+    """Composite exprs (e.g. ``s0 + s1``) hit ``bound_sympy``, which returns
+    ``sympy.oo`` (not ``int_oo``) for unbounded operands. A naive
+    ``!= int_oo`` guard misses it and crashes on ``int(sympy.oo)``."""
+
+    class _ConcatBatch(torch.nn.Module):
+        def forward(self, a, b):
+            return torch.cat([a, b], dim=0)
+
+    model = _ConcatBatch().eval().cuda()
+    a = torch.randn(2, 8, device="cuda")
+    b = torch.randn(3, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (a, b),
+        dynamic_shapes=(
+            {0: torch.export.Dim.DYNAMIC},
+            {0: torch.export.Dim.DYNAMIC},
+        ),
+        strict=False,
+    )
+
+    cat_node = next(
+        (
+            n
+            for n in ep.graph.nodes
+            if n.op == "call_function" and "cat" in str(n.target)
+        ),
+        None,
+    )
+    if cat_node is None or "val" not in cat_node.meta:
+        pytest.skip("no cat node with composite SymInt on this PyTorch")
+
+    composite_dim = cat_node.meta["val"].size()[0]
+    if not isinstance(composite_dim, torch.SymInt):
+        pytest.skip("composite dim specialized to a concrete int")
+    if isinstance(composite_dim.node.expr, sympy.Symbol):
+        pytest.skip("expr collapsed to a plain symbol on this PyTorch")
+
+    # Pre-fix this raised ``AttributeError`` from ``int(sympy.oo)``.
+    info = extract_var_range_info(composite_dim)
+    assert info["max"] is None
+    assert info["min"] is not None
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_uses_dynamic_inputs_only():
+    """Static ``Input``s contribute nothing to the user-bounds map."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(2, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim.DYNAMIC},),
+        strict=False,
+    )
+
+    dynamic_input = Input(
+        min_shape=(1, 8),
+        opt_shape=(4, 8),
+        max_shape=(8, 8),
+        dtype=torch.float32,
+    )
+    bounds = _build_user_symbol_bounds(ep.module(), [dynamic_input], {})
+    assert len(bounds) == 1
+    ((sym, (lo, hi)),) = bounds.items()
+    assert isinstance(sym, sympy.Symbol)
+    assert (lo, hi) == (1, 8)
+
+    # Static input -> empty map.
+    static_input = Input(shape=(2, 8), dtype=torch.float32)
+    assert _build_user_symbol_bounds(ep.module(), [static_input], {}) == {}
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_warns_on_01_specialization(caplog):
+    """``user_min=1, exp_min=2`` is the 0/1 specialization artifact -- warn,
+    don't raise."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(2, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim.DYNAMIC},),
+        strict=False,
+    )
+    input_min1 = Input(
+        min_shape=(1, 8),
+        opt_shape=(4, 8),
+        max_shape=(8, 8),
+        dtype=torch.float32,
+    )
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="torch_tensorrt.dynamo._compiler"):
+        _build_user_symbol_bounds(ep.module(), [input_min1], {})
+
+    msgs = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    if msgs:
+        assert "0/1 specialization" in "\n".join(msgs)
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_raises_when_input_min_genuinely_below_export():
+    """``user_min < exp_min`` (not the 1->2 case) must raise."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(10, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim("batch", min=10, max=20)},),
+        strict=False,
+    )
+    input_too_low = Input(
+        min_shape=(2, 8),
+        opt_shape=(5, 8),
+        max_shape=(10, 8),
+        dtype=torch.float32,
+    )
+    with pytest.raises(ValueError) as exc_info:
+        _build_user_symbol_bounds(ep.module(), [input_too_low], {})
+    msg = str(exc_info.value)
+    assert "Input.min_shape" in msg and "exported program" in msg
+    assert "re-export" in msg.lower() or "Input.min_shape >=" in msg
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_raises_when_input_max_above_export():
+    """``user_max > exp_max`` must raise (TRT would reject at runtime)."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(10, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim("batch", min=10, max=20)},),
+        strict=False,
+    )
+    too_wide_input = Input(
+        min_shape=(10, 8),
+        opt_shape=(15, 8),
+        max_shape=(25, 8),
+        dtype=torch.float32,
+    )
+    with pytest.raises(ValueError) as exc_info:
+        _build_user_symbol_bounds(ep.module(), [too_wide_input], {})
+    msg = str(exc_info.value)
+    assert "Input.max_shape" in msg and "exported program" in msg
+    assert "re-export" in msg.lower() or "Input.max_shape <=" in msg
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_no_warning_on_matching_bounds(caplog):
+    """Matching bounds must not warn or raise."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(10, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim("batch", min=10, max=20)},),
+        strict=False,
+    )
+    matching_input = Input(
+        min_shape=(10, 8),
+        opt_shape=(15, 8),
+        max_shape=(20, 8),
+        dtype=torch.float32,
+    )
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="torch_tensorrt.dynamo._compiler"):
+        _build_user_symbol_bounds(ep.module(), [matching_input], {})
+
+    warning_messages = [
+        rec.message for rec in caplog.records if rec.levelno >= logging.WARNING
+    ]
+    assert not warning_messages, f"unexpected warnings: {warning_messages}"
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_narrows_to_user_on_subset(caplog):
+    """Strict-subset Input narrows the engine profile to the user's bounds.
+    No warning -- the user got exactly what they asked for; just an info log."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(10, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim("batch", min=10, max=20)},),
+        strict=False,
+    )
+    subset_input = Input(
+        min_shape=(12, 8),
+        opt_shape=(15, 8),
+        max_shape=(18, 8),
+        dtype=torch.float32,
+    )
+
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="torch_tensorrt.dynamo._compiler"):
+        bounds = _build_user_symbol_bounds(ep.module(), [subset_input], {})
+
+    # No warning -- subset is a valid, intended narrowing.
+    warning_messages = [
+        rec.message for rec in caplog.records if rec.levelno >= logging.WARNING
+    ]
+    assert not warning_messages, f"unexpected warnings: {warning_messages}"
+
+    # Narrowing must surface as an info log so users can see what envelope
+    # their engine actually has.
+    info_messages = [
+        rec.message for rec in caplog.records if rec.levelno == logging.INFO
+    ]
+    assert any("Narrowing engine profile" in m for m in info_messages), info_messages
+
+    # And the engine-side resolution must actually narrow to (12, 18).
+    _, sym_dim = _first_sym_placeholder(ep, sym_dim=0)
+    assert sym_dim is not None
+    info = extract_var_range_info(sym_dim, user_symbol_bounds=bounds)
+    assert info["min"] == 12, info
+    assert info["max"] == 18, info
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_no_warning_on_dim_dynamic(caplog):
+    """Dim.DYNAMIC + Input is the intended fill case -- no mismatch warning."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(2, 8, device="cuda")
+    ep = torch.export.export(
+        model,
+        (sample,),
+        dynamic_shapes=({0: torch.export.Dim.DYNAMIC},),
+        strict=False,
+    )
+    fill_input = Input(
+        min_shape=(1, 8),
+        opt_shape=(4, 8),
+        max_shape=(8, 8),
+        dtype=torch.float32,
+    )
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="torch_tensorrt.dynamo._compiler"):
+        _build_user_symbol_bounds(ep.module(), [fill_input], {})
+
+    mismatch_warnings = [
+        rec.message
+        for rec in caplog.records
+        if rec.levelno >= logging.WARNING and "differ from the exporter" in rec.message
+    ]
+    assert not mismatch_warnings, f"unexpected mismatch warnings: {mismatch_warnings}"
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_mixed_tensor_and_symint():
+    """Tensor + SymInt placeholders: only the tensor contributes to the map
+    (SymInt is filtered by the ``isinstance(fake_val, torch.Tensor)`` guard)."""
+
+    class _TensorAndScalar(torch.nn.Module):
+        def forward(self, x, k):
+            return x.relu() + k
+
+    model = _TensorAndScalar().eval().cuda()
+    x_sample = torch.randn(2, 8, device="cuda")
+    k_sample = 4  # >1 to avoid 0/1 specialization
+
+    dyn = torch.export.Dim.DYNAMIC
+    ep = torch.export.export(
+        model,
+        (x_sample, k_sample),
+        dynamic_shapes=({0: dyn}, dyn),
+        strict=False,
+    )
+
+    placeholders = [n for n in ep.graph.nodes if n.op == "placeholder"]
+    metas = [p.meta.get("val") for p in placeholders]
+    if not any(isinstance(m, torch.SymInt) for m in metas):
+        pytest.skip("export collapsed the scalar SymInt on this PyTorch")
+    assert any(isinstance(m, torch.Tensor) for m in metas)
+
+    tensor_input = Input(
+        min_shape=(1, 8),
+        opt_shape=(4, 8),
+        max_shape=(8, 8),
+        dtype=torch.float32,
+    )
+    # Index-aligned placeholder; never inspected (SymInt path skips it).
+    scalar_input = Input(
+        min_shape=(1,),
+        opt_shape=(1,),
+        max_shape=(1,),
+        dtype=torch.int64,
+    )
+
+    bounds = _build_user_symbol_bounds(ep.module(), [tensor_input, scalar_input], {})
+    assert len(bounds) == 1, bounds
+    ((sym, (lo, hi)),) = bounds.items()
+    assert isinstance(sym, sympy.Symbol)
+    assert (lo, hi) == (1, 8)
+
+
+@pytest.mark.unit
+def test_build_user_symbol_bounds_mixed_arg_and_kwarg():
+    """Positional args (matched by index) and kwargs (matched by name) both
+    contribute to the map."""
+
+    class _TwoTensors(torch.nn.Module):
+        def forward(self, x, y):
+            # Independent paths so the exporter doesn't unify x[0] and y[0].
+            return x.relu(), y.relu()
+
+    model = _TwoTensors().eval().cuda()
+    # Distinct sizes discourage symbol unification.
+    x_sample = torch.randn(2, 8, device="cuda")
+    y_sample = torch.randn(3, 8, device="cuda")
+
+    dyn = torch.export.Dim.DYNAMIC
+    ep = torch.export.export(
+        model,
+        args=(x_sample,),
+        kwargs={"y": y_sample},
+        dynamic_shapes={"x": {0: dyn}, "y": {0: dyn}},
+        strict=False,
+    )
+
+    placeholder_names = [n.target for n in ep.graph.nodes if n.op == "placeholder"]
+    assert "x" in placeholder_names, placeholder_names
+    assert "y" in placeholder_names, placeholder_names
+
+    # Distinct bounds for x and y so we can verify the kwarg path by value.
+    x_input = Input(
+        min_shape=(1, 8),
+        opt_shape=(2, 8),
+        max_shape=(8, 8),
+        dtype=torch.float32,
+    )
+    y_input = Input(
+        min_shape=(2, 8),
+        opt_shape=(3, 8),
+        max_shape=(6, 8),
+        dtype=torch.float32,
+    )
+
+    bounds = _build_user_symbol_bounds(
+        ep.module(),
+        sample_arg_inputs=[x_input],
+        sample_kwarg_inputs={"y": y_input},
+    )
+
+    bounds_values = set(bounds.values())
+    assert (1, 8) in bounds_values, bounds  # positional-arg branch
+    assert (2, 6) in bounds_values, bounds  # kwarg branch
+    assert len(bounds) == 2, bounds
+
+
+@pytest.mark.unit
+@pytest.mark.critical
+def test_dim_dynamic_save_preserves_range_constraints(tmpdir):
+    """End-to-end: Dim.DYNAMIC + Input(max_shape) round-trips through
+    ``torchtrt.save`` without mutating the exporter's range_constraints."""
+
+    model = _SmallLinear().eval().cuda()
+    sample = torch.randn(2, 8, device="cuda")
+
+    dyn_batch = torch.export.Dim.DYNAMIC
+    exp_program = torch.export.export(
+        model, (sample,), dynamic_shapes=({0: dyn_batch},), strict=False
+    )
+
+    # Snapshot before Torch-TRT touches anything.
+    expected_constraints = {
+        str(k): (v.lower, v.upper) for k, v in exp_program.range_constraints.items()
+    }
+
+    compile_spec = {
+        "inputs": [
+            Input(
+                min_shape=(1, 8),
+                opt_shape=(4, 8),
+                max_shape=(8, 8),
+                dtype=torch.float32,
+            )
+        ],
+        "ir": "dynamo",
+        "min_block_size": 1,
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+    trt_module = torchtrt.dynamo.compile(exp_program, **compile_spec)
+
+    after_constraints = {
+        str(k): (v.lower, v.upper) for k, v in exp_program.range_constraints.items()
+    }
+    assertions.assertEqual(expected_constraints, after_constraints)
+
+    trt_ep_path = os.path.join(tmpdir, "trt_dim_dynamic.ep")
+    torchtrt.save(
+        trt_module,
+        trt_ep_path,
+        output_format="exported_program",
+        arg_inputs=[sample],
+        dynamic_shapes=({0: dyn_batch},),
+        retrace=True,
+    )
+
+    reloaded = torch.export.load(trt_ep_path)
+    reloaded_constraints = {
+        str(k): (v.lower, v.upper) for k, v in reloaded.range_constraints.items()
+    }
+    assertions.assertEqual(expected_constraints, reloaded_constraints)
+
+    # Engine accepts shapes across [min_shape, max_shape].
+    trt_module(torch.randn(1, 8, device="cuda"))
+    trt_module(torch.randn(4, 8, device="cuda"))
+    trt_module(torch.randn(8, 8, device="cuda"))
+
+    # And rejects shapes beyond ``Input.max_shape`` even though the eager
+    # graph is unbounded -- ``Input(max_shape=8)`` is a strict cap. Pins
+    # the contract against regressions that re-widen to the heuristic.
+    too_big = torch.randn(16, 8, device="cuda")
+    with assertions.assertRaises(Exception):
+        trt_module(too_big)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Cherry-pick of #4213 onto `release/2.13`.

⚠️ **Note: #4213 is still OPEN (not merged).** This cherry-pick reflects the current state of that PR.

**Squashed**: the PR's 11 work-in-progress commits were collapsed into a single commit using the PR's net diff vs its merge-base with `main`, so unrelated `main` commits the branch had picked up (notably the 2.13→2.14 version bump #4338) are **excluded** — release/2.13 stays on 2.13.

**Conflict resolved** in `py/torch_tensorrt/dynamo/_compiler.py` (both additive): took the PR side for the `compile_module(..., graph_signature=exported_program.graph_signature)` call and the added `user_symbol_bounds` / `fallback_data_dependent_ops` block. The other 3 files applied cleanly.

🔎 **Pre-existing issue inherited from #4213 (not introduced here):** #4213 makes `graph_signature` a required keyword-only arg of `compile_module`, but `py/torch_tensorrt/dynamo/backend/backends.py` still calls `compile_module(...)` without it (true on both `main`/PR-head and here). The `torch.compile` backend path would raise `TypeError` until #4213 addresses this. Flagging for awareness.

Original PR: https://github.com/pytorch/TensorRT/pull/4213

🤖 Generated with [Claude Code](https://claude.com/claude-code)