### PR TITLE
fix(executorch): correct missing-dependency install hint to torch_ten…

### DIFF
--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -768,7 +768,7 @@ def save(
         raise ImportError(
             "Saving in ExecuTorch format requires the executorch package "
             "with executorch.exir. Install with: pip install "
-            "\"executorch\" to use output_format='executorch'."
+            "\"torch_tensorrt[executorch]\" to use output_format='executorch'."
         )
 
     def _all_are_input_objects(obj: Any) -> bool:
@@ -1315,7 +1315,7 @@ def _save_as_executorch(exp_program: Any, file_path: str, **kwargs: Any) -> None
     except ImportError:
         raise ImportError(
             "ExecuTorch is not installed. Install with: pip install "
-            "\"executorch\" to use output_format='executorch'."
+            "\"torch_tensorrt[executorch]\" to use output_format='executorch'."
         )
     import torch_tensorrt.dynamo.runtime.meta_ops.register_meta_ops  # noqa: F401
     from torch_tensorrt.executorch import (

--- a/py/torch_tensorrt/executorch/__init__.py
+++ b/py/torch_tensorrt/executorch/__init__.py
@@ -18,7 +18,7 @@ if not _has_executorch_exir():
         raise ImportError(
             f"Cannot access torch_tensorrt.executorch.{name}: "
             "ExecuTorch with executorch.exir is required. "
-            'Install with: pip install "executorch"'
+            'Install with: pip install "torch_tensorrt[executorch]"'
         )
 
     __all__ = [


### PR DESCRIPTION
…sorrt[executorch]

The ImportErrors raised when executorch.exir is unavailable told users to `pip install "executorch"`, but tests/py/dynamo/executorch/test_api.py expects the extras-style hint `torch_tensorrt[executorch]`. This caused test_lazy_import_error_when_executorch_missing and test_save_executorch_error_when_executorch_missing to fail on release/2.13.

Fixes the lazy-import __getattr__ message (executorch/__init__.py) and both save()/_save_as_executorch messages (_compile.py). Backport of the corresponding hunks from e6f60a9ed ("Improve CI DX", #4352).

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
