### PR TITLE
executorch: persist external .ptd weights and preserve lifted constant dtype/device

### DIFF
--- a/docsrc/user_guide/runtime_performance/saving_models.rst
+++ b/docsrc/user_guide/runtime_performance/saving_models.rst
@@ -22,6 +22,7 @@ specifying the `output_format` flag. Here are the options `output_format` will a
 * `exported_program` : This is the default. We perform transformations on the graphmodule first and use `torch.export.save` to save the module.
 * `torchscript` : We trace the graphmodule via `torch.jit.trace` and save it via `torch.jit.save`.
 * `PT2 Format` : This is a next generation runtime for PyTorch models, allowing them to run in Python and in C++
+* `executorch` : We lower the graphmodule to an ExecuTorch ``.pte`` program, delegating the TensorRT engines to the ExecuTorch backend. Linux-only; requires the ``executorch`` package.
 
 a) ExportedProgram
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -217,6 +218,64 @@ can be loaded in Python or C++ without a Torch-TensorRT runtime dependency.
 
 For dynamic shapes, C++ deployment, and a full comparison with the ExportedProgram format,
 see :ref:`aot_inductor`.
+
+
+.. _executorch_save:
+
+c) ExecuTorch (.pte)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``executorch`` output format lowers the compiled module to an ExecuTorch
+``.pte`` program, delegating the TensorRT engines to the Torch-TensorRT ExecuTorch
+backend. It requires the ``executorch`` package (``pip install
+"torch_tensorrt[executorch]"``) and is Linux-only.
+
+.. code-block:: python
+
+    import torch
+    import torch_tensorrt
+
+    model = MyModel().eval().cuda()
+    inputs = [torch.randn((1, 3, 224, 224)).cuda()]
+    trt_gm = torch_tensorrt.compile(model, ir="dynamo", arg_inputs=inputs)
+    torch_tensorrt.save(
+        trt_gm, "trt.pte", output_format="executorch",
+        retrace=False, arg_inputs=inputs,
+    )
+
+**Coalesced TensorRT + CUDA .pte**
+
+To run the ops TensorRT does not take on ExecuTorch's CUDA (AOTInductor) backend
+instead of leaving them non-delegated, pass a ``CudaPartitioner`` via
+``partitioners=``. It is appended after the TensorRT partitioner, so TensorRT
+claims what it can and the ``CudaPartitioner`` picks up the rest as a catch-all:
+
+.. code-block:: python
+
+    from executorch.backends.cuda.cuda_backend import CudaBackend
+    from executorch.backends.cuda.cuda_partitioner import CudaPartitioner
+
+    torch_tensorrt.save(
+        trt_gm, "trt.pte", output_format="executorch",
+        retrace=False, arg_inputs=inputs,
+        partitioners=[
+            CudaPartitioner(
+                [CudaBackend.generate_method_name_compile_spec("forward")]
+            )
+        ],
+    )
+
+This needs ExecuTorch's CUDA backend and a CUDA toolkit (nvcc/ptxas) at export
+time, and produces a ``.pte`` that requires a CUDA runtime at load. Any external
+CUDA weights are written as ``.ptd`` data file(s) next to the ``.pte``; the runtime
+must be pointed at those data files to load them.
+
+.. warning::
+
+    The CUDA backend names its external weight blob per-device (e.g.
+    ``aoti_cuda_blob.ptd``), not per-model, so saving two different coalesced
+    ``.pte`` into the same directory overwrites the blob and the first ``.pte``
+    will fail to load. Save each coalesced model into its own directory.
 
 
 Saving torch.compile models

--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -4,6 +4,7 @@ import collections.abc
 import importlib
 import inspect
 import logging
+import os
 import platform
 import warnings
 from enum import Enum
@@ -749,6 +750,13 @@ def save(
                 ``backend_config=`` takes an ``Optional[ExecutorchBackendConfig]``
                 and is forwarded to ``to_executorch(config=...)`` to customize
                 ExecuTorch lowering (e.g. memory planning or device placement).
+                ``partitioners=`` appends caller partitioners after the TensorRT
+                partitioner, so ops TensorRT does not take can be routed to another
+                delegate -- e.g. a ``CudaPartitioner`` for a coalesced TensorRT +
+                CUDA ``.pte``. See :ref:`the ExecuTorch save guide
+                <executorch_save>` for the ``CudaPartitioner`` recipe, its
+                export-time requirements (CUDA backend + nvcc), and the external
+                ``.ptd`` weight caveats.
     """
     if isinstance(module, CudaGraphsTorchTensorRTModule):
         module = module.compiled_module
@@ -1327,6 +1335,29 @@ def _replace_execute_engine_for_executorch(exp_program: Any) -> Any:
     return exp_program
 
 
+def _write_external_tensor_data(executorch_program: Any, file_path: str) -> None:
+    """Write an ExecuTorch program's external named tensor data (``.ptd``) next to the ``.pte``.
+
+    The CUDA (AOTInductor) backend emits its weights as external named data
+    (``save_data_externally``), which ExecuTorch serializes only via
+    ``write_tensor_data_to_file`` -- ``ExecutorchProgram.write_to_file`` does not
+    persist it. So a partition that carries external weights (e.g. a
+    ``CudaPartitioner`` delegate) would lose its blob and the ``.pte`` could not
+    load. This writes the ``.ptd`` data file(s) into the ``.pte``'s directory when
+    the program has any; the runtime must then be given those data file(s) (e.g.
+    via the ExecuTorch ``Module`` data-files argument) to load the weights.
+    """
+    # Direct attribute access (no getattr default) so a future rename fails loud.
+    if executorch_program._tensor_data:
+        out_dir = os.path.dirname(os.path.abspath(file_path))
+        executorch_program.write_tensor_data_to_file(out_dir)
+        logger.info(
+            "Wrote external delegate weights (.ptd) to %s; point the runtime's "
+            "data-files at this directory to load them.",
+            out_dir,
+        )
+
+
 def _save_as_executorch(exp_program: Any, file_path: str, **kwargs: Any) -> None:
     """Save an ExportedProgram (with TensorRT execute_engine nodes) as an ExecuTorch .pte file.
 
@@ -1395,6 +1426,7 @@ def _save_as_executorch(exp_program: Any, file_path: str, **kwargs: Any) -> None
     executorch_program = edge_program.to_executorch(config=kwargs.get("backend_config"))
     with open(file_path, "wb") as f:
         executorch_program.write_to_file(f)
+    _write_external_tensor_data(executorch_program, file_path)
 
 
 def _normalize_engine_constants_to_python(exp_program: "ExportedProgram") -> None:

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -1,13 +1,12 @@
 import base64
 import copy
 import operator
-from typing import Any, Dict, Optional, Sequence, Tuple, cast
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 import torch
 from torch._export.non_strict_utils import make_constraints
 from torch._guards import detect_fake_mode
 from torch._library.fake_class_registry import FakeScriptObject
-from torch._subclasses.fake_tensor import FakeTensor
 from torch.export import ExportedProgram, ExportGraphSignature
 from torch.export._trace import _combine_args
 from torch.export.exported_program import (
@@ -202,12 +201,11 @@ def lift(
                 # Copy the node meta into this new placeholder node
                 const_placeholder_node.meta = node.meta
                 if isinstance(lift_val, torch.Tensor):
-                    const_placeholder_node.meta["val"] = cast(
-                        FakeTensor,
-                        torch.empty_strided(
-                            tuple(lift_val.shape),
-                            tuple([1] * len(lift_val.shape)),
-                        ),
+                    # Fakify the source constant through the graph's own fake_mode
+                    # so the placeholder meta preserves its dtype, device and
+                    # stride without allocating a real tensor on lift_val.device.
+                    const_placeholder_node.meta["val"] = fake_mode.from_tensor(
+                        lift_val, static_shapes=True
                     )
 
                 node.replace_all_uses_with(const_placeholder_node)

--- a/tests/py/dynamo/executorch/test_api.py
+++ b/tests/py/dynamo/executorch/test_api.py
@@ -7,8 +7,8 @@ from pathlib import Path
 import pytest
 import torch
 from torch._library.fake_class_registry import FakeScriptObject
-
-from torch_tensorrt.dynamo._exporter import _resolve_lifted_custom_obj
+from torch._subclasses.fake_tensor import FakeTensor
+from torch_tensorrt.dynamo._exporter import _resolve_lifted_custom_obj, lift
 
 
 @pytest.mark.unit
@@ -266,3 +266,70 @@ def test_per_partition_distinct_target_devices(monkeypatch):
     assert d0 == b"cuda:0"
     assert d1 == b"cuda:1"
     assert d0 != d1
+
+
+# --- lift() preserves constant dtype/device ----------------------------------
+# lift() replaces get_attr constants with placeholders and copies a fake meta
+# "val". It must fakify the source constant through the graph's own fake_mode
+# (fake_mode.from_tensor), preserving dtype, device and stride; otherwise a
+# non-fp32 or non-CPU lifted constant silently gets fp32/cpu meta.
+
+
+def _traced_gm_with_parameter(dtype, device):
+    """A symbolically-traced GraphModule with one get_attr parameter (`c`) of the
+    given dtype/device, plus a stub graph_signature lift() can mutate."""
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    class M(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.c = torch.nn.Parameter(
+                torch.zeros(3, 3, dtype=dtype, device=device), requires_grad=False
+            )
+
+        def forward(self, x):
+            return x + self.c
+
+    gm = torch.fx.symbolic_trace(M())
+    # lift() calls detect_fake_mode over the placeholder "val" metas, so the user
+    # input needs a FakeTensor meta.
+    fake_mode = FakeTensorMode()
+    with fake_mode:
+        fake_x = torch.empty(3, 3)
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            node.meta["val"] = fake_x
+    sig = types.SimpleNamespace(input_specs=[], output_specs=[], user_inputs=["x"])
+    return gm, sig
+
+
+def _lifted_constant_meta(gm, sig):
+    lifted_gm, _, _, _ = lift(gm, sig)
+    lifted = [
+        n for n in lifted_gm.graph.nodes if n.op == "placeholder" and n.name != "x"
+    ]
+    assert len(lifted) == 1, f"expected 1 lifted constant, got {len(lifted)}"
+    return lifted[0].meta["val"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "dtype, device",
+    [
+        (torch.bfloat16, "cpu"),
+        (torch.float32, "cuda"),
+    ],
+)
+def test_lift_preserves_constant_dtype_device(dtype, device):
+    # Runtime gate (not a module-level skipif, which resolves at collection time
+    # and is fragile on remote-GPU runners): skip the CUDA case only when no GPU.
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    gm, sig = _traced_gm_with_parameter(dtype, device)
+    val = _lifted_constant_meta(gm, sig)
+    assert isinstance(val, FakeTensor)
+    assert val.dtype == dtype
+    assert val.device.type == device
+    # The source constant is a contiguous 3x3, so from_tensor must carry its real
+    # (3, 1) stride onto the meta, not the old all-ones synthetic stride.
+    assert val.stride() == torch.zeros(3, 3).stride()

--- a/tests/py/dynamo/executorch/test_cuda_partitioner_composition.py
+++ b/tests/py/dynamo/executorch/test_cuda_partitioner_composition.py
@@ -1,0 +1,227 @@
+import importlib.util
+import os
+import shutil
+
+import pytest
+
+executorch = pytest.importorskip("executorch.exir")
+
+import torch  # noqa: E402
+
+
+def _cuda_backend_available() -> bool:
+    # find_spec() imports the parent packages of a dotted path and raises
+    # ModuleNotFoundError if a parent is absent (it only returns None when the
+    # parent exists but the leaf module doesn't). Guard against that so collection
+    # still succeeds where executorch.backends.cuda isn't packaged.
+    try:
+        spec = importlib.util.find_spec("executorch.backends.cuda.cuda_partitioner")
+    except ModuleNotFoundError:
+        return False
+    return spec is not None
+
+
+CUDA_BACKEND_AVAILABLE = _cuda_backend_available()
+
+
+def _nvcc_available() -> bool:
+    # The AOTInductor compile in the CUDA backend needs nvcc. It's on PATH in a
+    # standard CUDA install, but some environments ship the toolkit via CUDA_HOME
+    # and the compile resolves nvcc from there rather than PATH -- accept either.
+    if shutil.which("nvcc") is not None:
+        return True
+    try:
+        from torch.utils.cpp_extension import CUDA_HOME
+    except Exception:
+        CUDA_HOME = None
+    for home in (CUDA_HOME, os.environ.get("CUDA_HOME"), os.environ.get("CUDA_PATH")):
+        if home and os.path.exists(os.path.join(home, "bin", "nvcc")):
+            return True
+    return False
+
+
+def _skip_reason():
+    # Building a coalesced TRT + CUDA .pte needs a GPU, ExecuTorch's CUDA backend,
+    # and a CUDA toolkit (nvcc/ptxas) for the AOTInductor compile run during export.
+    if not torch.cuda.is_available():
+        return "CUDA GPU required for the CUDA backend"
+    if not CUDA_BACKEND_AVAILABLE:
+        return "executorch.backends.cuda not installed"
+    if not _nvcc_available():
+        return "nvcc required for the CUDA (AOTInductor) backend compile"
+    return None
+
+
+@pytest.fixture(autouse=True)
+def requires_cuda_backend():
+    # Evaluate the GPU/backend/nvcc gate at TEST RUNTIME, not at import. A
+    # module-level pytest.mark.skipif is resolved during collection; on remote-GPU
+    # runners collection happens off the GPU host, so the skip would be baked in
+    # and the runner would never attach a GPU for the (pre-skipped) test.
+    reason = _skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
+
+
+def _cuda_partitioner():
+    """A ``CudaPartitioner`` catch-all so ops TensorRT does not take route to the
+    ExecuTorch CUDA (AOTInductor) backend. This is the supported, flag-free way to
+    build a coalesced TensorRT + CUDA ``.pte`` via ``save(partitioners=[...])``."""
+    from executorch.backends.cuda.cuda_backend import CudaBackend
+    from executorch.backends.cuda.cuda_partitioner import CudaPartitioner
+
+    return CudaPartitioner([CudaBackend.generate_method_name_compile_spec("forward")])
+
+
+def _delegate_ids(pte_path):
+    """Backend ids of every delegate in the serialized program, in order."""
+    from executorch.exir._serialize._program import deserialize_pte_binary
+
+    program = deserialize_pte_binary(pte_path.read_bytes()).program
+    return [
+        delegate.id for plan in program.execution_plan for delegate in plan.delegates
+    ]
+
+
+# NOTE: these tests are COMPOSITION-ONLY. They assert the serialized .pte carries
+# both a TensorRTBackend and a CudaBackend delegate (and, below, that external
+# CUDA weights are persisted as a .ptd). They do NOT load or run the program: a
+# coalesced ATen-mode .pte cannot be loaded yet because memory-planned CUDA
+# buffers get a CPU data pointer, so Method::init fails the CUDA backend's device
+# check (tensor_parser_aten hardcodes CPU). A load-run-allclose test should be
+# added once that runtime fix lands (follow-up).
+
+
+def test_erfinv_routes_to_cuda_backend(tmp_path):
+    """A genuinely TRT-unsupported op (erfinv) is routed to the CUDA backend via a
+    CudaPartitioner catch-all -- no torch_executed_ops pin needed."""
+    import torch_tensorrt
+
+    # tanh keeps values in erfinv's (-1, 1) domain.
+    class ErfinvModel(torch.nn.Module):
+        def forward(self, x):
+            return torch.cos(torch.erfinv(torch.tanh(x)))
+
+    model = ErfinvModel().eval().to("cuda")
+    inputs = (torch.randn(64, 64, device="cuda"),)
+    exported = torch.export.export(model, inputs)
+    trt_gm = torch_tensorrt.dynamo.compile(
+        exported,
+        inputs=list(inputs),
+        min_block_size=1,
+        truncate_double=True,
+    )
+
+    out = tmp_path / "erfinv_cuda.pte"
+    torch_tensorrt.save(
+        trt_gm,
+        str(out),
+        output_format="executorch",
+        retrace=False,
+        arg_inputs=list(inputs),
+        partitioners=[_cuda_partitioner()],
+    )
+
+    delegate_ids = _delegate_ids(out)
+    assert (
+        "CudaBackend" in delegate_ids
+    ), f"erfinv did not route to the CUDA backend; delegates={delegate_ids}"
+    assert (
+        "TensorRTBackend" in delegate_ids
+    ), f"tanh/cos were not delegated to TensorRT; delegates={delegate_ids}"
+
+
+def test_weighted_partition_persists_external_data(tmp_path):
+    """A CUDA partition that carries weights must have its external data persisted
+    next to the .pte.
+
+    The CUDA (AOTInductor) backend emits weights as external named data
+    (save_data_externally). If save() only writes the .pte and not the .ptd data
+    file, the blob is lost and the program cannot load. Here mm(x, w) carries a
+    weight and is pinned out of TensorRT via torch_executed_ops, so it lands on the
+    CudaPartitioner and its weight becomes external CUDA data; tanh/cos stay on
+    TensorRT. We assert a .ptd is written alongside the .pte."""
+    import torch_tensorrt
+
+    class WeightedModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = torch.nn.Parameter(torch.randn(64, 64))
+
+        def forward(self, x):
+            x = torch.mm(x, self.w)
+            x = torch.tanh(x)
+            return torch.cos(x)
+
+    model = WeightedModel().eval().to("cuda")
+    inputs = (torch.randn(64, 64, device="cuda"),)
+    exported = torch.export.export(model, inputs)
+    # Pin mm out of TensorRT so its weight lands on the CudaPartitioner catch-all
+    # and is emitted as external CUDA data; tanh/cos still go to TensorRT.
+    trt_gm = torch_tensorrt.dynamo.compile(
+        exported,
+        inputs=list(inputs),
+        min_block_size=1,
+        truncate_double=True,
+        torch_executed_ops={"torch.ops.aten.mm.default"},
+    )
+
+    out = tmp_path / "weighted_cuda.pte"
+    torch_tensorrt.save(
+        trt_gm,
+        str(out),
+        output_format="executorch",
+        retrace=False,
+        arg_inputs=list(inputs),
+        partitioners=[_cuda_partitioner()],
+    )
+
+    delegate_ids = _delegate_ids(out)
+    assert (
+        "CudaBackend" in delegate_ids
+    ), f"the pinned mm did not route to the CUDA backend; delegates={delegate_ids}"
+    # Regression guard for dropped external CUDA weights: the .ptd data file must
+    # be written next to the .pte.
+    ptd_files = list(tmp_path.glob("*.ptd"))
+    assert ptd_files, f"no external .ptd data file was written next to {out}"
+    assert all(
+        p.stat().st_size > 0 for p in ptd_files
+    ), f"external .ptd data file is empty: {ptd_files}"
+
+
+def test_trt_only_writes_no_ptd(tmp_path):
+    """A TRT-only program (no CudaPartitioner) carries no external data, so no
+    .ptd is written -- exercises the real write_to_file / _tensor_data path."""
+    import torch_tensorrt
+
+    class Model(torch.nn.Module):
+        def forward(self, x):
+            return torch.cos(torch.tanh(x))
+
+    model = Model().eval().to("cuda")
+    inputs = (torch.randn(64, 64, device="cuda"),)
+    exported = torch.export.export(model, inputs)
+    trt_gm = torch_tensorrt.dynamo.compile(
+        exported,
+        inputs=list(inputs),
+        min_block_size=1,
+        truncate_double=True,
+    )
+
+    out = tmp_path / "trt_only.pte"
+    torch_tensorrt.save(
+        trt_gm,
+        str(out),
+        output_format="executorch",
+        retrace=False,
+        arg_inputs=list(inputs),
+    )
+
+    assert out.exists()
+    delegate_ids = _delegate_ids(out)
+    assert (
+        "CudaBackend" not in delegate_ids
+    ), f"unexpected CUDA delegate for a TRT-only model; delegates={delegate_ids}"
+    assert not list(
+        tmp_path.glob("*.ptd")
+    ), "TRT-only program must not write an external .ptd"

--- a/tests/py/dynamo/executorch/test_edge_cases.py
+++ b/tests/py/dynamo/executorch/test_edge_cases.py
@@ -1,10 +1,13 @@
+import os
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 import torch
 from torch_tensorrt._compile import (
     _count_executorch_engine_nodes,
     _validate_executorch_engine_info,
+    _write_external_tensor_data,
 )
 from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import (
     REQUIRES_OUTPUT_ALLOCATOR_IDX,
@@ -47,3 +50,39 @@ def test_count_executorch_engine_nodes_handles_execute_and_placeholder():
     )
 
     assert _count_executorch_engine_nodes(exp_program) == 2
+
+
+@pytest.mark.unit
+def test_write_external_tensor_data_writes_when_present(tmp_path):
+    # A program with external named data (e.g. a CudaPartitioner delegate's
+    # weights) must have its .ptd written into the .pte's directory.
+    prog = SimpleNamespace(
+        _tensor_data={"forward": b"weights"},
+        write_tensor_data_to_file=MagicMock(),
+    )
+    pte = tmp_path / "model.pte"
+    _write_external_tensor_data(prog, str(pte))
+    prog.write_tensor_data_to_file.assert_called_once_with(
+        os.path.dirname(os.path.abspath(str(pte)))
+    )
+
+
+@pytest.mark.unit
+def test_write_external_tensor_data_noop_when_empty(tmp_path):
+    # TRT-only programs have empty _tensor_data (falsy) -> no .ptd written.
+    prog = SimpleNamespace(
+        _tensor_data={},
+        write_tensor_data_to_file=MagicMock(),
+    )
+    _write_external_tensor_data(prog, str(tmp_path / "model.pte"))
+    prog.write_tensor_data_to_file.assert_not_called()
+
+
+@pytest.mark.unit
+def test_write_external_tensor_data_fails_loud_without_attr(tmp_path):
+    # _tensor_data always exists on a real ExecutorchProgram; it is accessed
+    # directly (no getattr default) so a future rename fails loudly instead of
+    # silently skipping the .ptd write and reintroducing the null-weights crash.
+    prog = SimpleNamespace(write_tensor_data_to_file=MagicMock())
+    with pytest.raises(AttributeError):
+        _write_external_tensor_data(prog, str(tmp_path / "model.pte"))


### PR DESCRIPTION
# Description

Reworked per review (previously "executorch: fall back to the CUDA backend..."):
this PR is trimmed to two standalone fixes and **drops the `cuda_fallback=True`
flag**. `save(output_format="executorch")` already appends caller partitioners
after the `TensorRTPartitioner`, so the supported way to get a coalesced
TensorRT + CUDA `.pte` is to pass `partitioners=[CudaPartitioner(...)]` (now
documented in `saving_models.rst` and the `save()` docstring). The flag only
duplicated that — and "fallback" wrongly implied a downgrade rather than a second
GPU delegate — so it's removed. This PR keeps the two pieces that are real fixes:

**External weights (`.ptd`).** The CUDA (AOTInductor) backend emits its weights as
external named data, which ExecuTorch serializes only via
`write_tensor_data_to_file` — `write_to_file` does not persist it. Without this, a
partition that carries external weights (e.g. a `CudaPartitioner` delegate) loses
its blob and the `.pte` can't load. `save()` now writes the `.ptd` next to the
`.pte` (extracted into `_write_external_tensor_data`, guarded on `_tensor_data`
directly so a future rename fails loud instead of silently skipping) and logs the
target directory, so a missing runtime data-file is an obvious breadcrumb rather
than a silent null-weights load. It's a no-op for TRT-only programs
(`_tensor_data` is empty). Co-locating the `.ptd` is a convention — the runtime
must still be pointed at the data file(s) to load them. The docs also warn that the
CUDA backend names its blob per-device, so each coalesced model must be saved into
its own directory.

**Lifted constant dtype/device (`_exporter.py`).** `lift()` built the lifted
placeholder's fake `meta["val"]` with `torch.empty_strided(...)` from shape only,
defaulting it to `cpu`/`float32`. A lifted non-fp32 or non-CPU parameter/buffer
therefore got the wrong meta (e.g. a `FakeTensorDeviceMismatchError`, cuda:0 vs
cpu, when a weighted op is excluded from TensorRT). Now it fakifies the source
constant through the graph's own `fake_mode` — `fake_mode.from_tensor(lift_val,
static_shapes=True)` — so the meta preserves the source dtype, device **and
stride** and belongs to the graph's `FakeTensorMode`, without allocating a real
tensor on `lift_val.device` (a CUDA constant no longer needs a live GPU, or risks
OOM, at export time). Independent bug fix; can stand alone.

# Testing

- `tests/py/dynamo/executorch/test_api.py` — `test_lift_preserves_constant_dtype_device`,
  parametrized over `(bfloat16, cpu)` and `(float32, cuda)` (the CUDA case is
  runtime-skipped when no GPU), asserts the lifted constant's meta is a
  `FakeTensor` and keeps the source dtype, device, and stride.
- `tests/py/dynamo/executorch/test_edge_cases.py` — unit tests for
  `_write_external_tensor_data`: writes the `.ptd` when external data is present,
  no-op when empty, and raises (fails loud) if `_tensor_data` is absent.
- `tests/py/dynamo/executorch/test_cuda_partitioner_composition.py` (build-only;
  skips without a GPU / CUDA backend / nvcc):
  - `test_erfinv_routes_to_cuda_backend` — `erfinv` (no TRT converter) routes to the
    CUDA backend via `partitioners=[CudaPartitioner(...)]` while `tanh`/`cos` stay on
    TensorRT.
  - `test_weighted_partition_persists_external_data` — a weighted, TRT-excluded `mm`
    lands on the CUDA backend and its external `.ptd` is written next to the `.pte`
    (asserted non-empty).
  - `test_trt_only_writes_no_ptd` — a TRT-only program writes no `.ptd` and has no
    CUDA delegate (exercises the real `write_to_file`/`_tensor_data` path).

Composition tests are build-only (delegate composition + external-data persistence,
not load/run) and skip cleanly without a GPU/CUDA backend/nvcc; a load-run-allclose
test is deferred to the runtime follow-up below.

# Follow-up

A coalesced ATen-mode `.pte` can be built but not yet loaded/run: memory-planned
CUDA buffers get a CPU data pointer (`tensor_parser_aten.cpp` hardcodes CPU), so
`Method::init` fails the CUDA backend's device check. That runtime fix (and the
load-run-allclose test) will land separately.
