### PR TITLE
fix test sdpa converter test cpp build issue

### DIFF
--- a/core/runtime/execute_engine.cpp
+++ b/core/runtime/execute_engine.cpp
@@ -390,16 +390,6 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
           compiled_engine->cudagraph.capture_begin();
           ctx->enqueueV3(recording_stream);
           compiled_engine->cudagraph.capture_end();
-          // Newer torch reworked at::cuda::CUDAGraph: capture_end() no longer
-          // instantiates the executable graph here, and the C++ replay() (unlike
-          // the Python wrapper) does not instantiate on demand -- it throws
-          // "replay before instantiated". Instantiate explicitly once the graph
-          // is captured. Guarded by has_graph_exec() so it stays correct if a
-          // future torch goes back to instantiating inside capture_end().
-          if (!compiled_engine->cudagraph.has_graph_exec()) {
-            compiled_engine->cudagraph.instantiate();
-          }
-
           if (compiled_engine->profile_execution) {
             cudaError_t debug_dump_err = cudaGraphDebugDotPrint(
                 compiled_engine->cudagraph.raw_cuda_graph(),

--- a/tests/core/conversion/converters/test_scaled_dot_product_attention.cpp
+++ b/tests/core/conversion/converters/test_scaled_dot_product_attention.cpp
@@ -79,7 +79,8 @@ TEST(Converters, ATenScaledDotProductAttnMaskBoolDoesNotProduceNaN) {
   auto value = at::arange(16, {at::kCUDA}).to(at::kFloat).reshape({1, 1, 4, 4}) / 11.0;
   auto attn_mask =
       at::tensor(
-          {1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1}, at::TensorOptions().dtype(at::kBool).device(at::kCUDA))
+          {true, false, true, false, false, true, false, true, true, true, false, false, false, false, true, true},
+          at::TensorOptions().device(at::kCUDA))
           .reshape({1, 1, 4, 4});
   auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
   auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {query, key, value, attn_mask});

--- a/tests/core/conversion/converters/test_scaled_dot_product_attention.cpp
+++ b/tests/core/conversion/converters/test_scaled_dot_product_attention.cpp
@@ -89,8 +89,8 @@ TEST(Converters, ATenScaledDotProductAttnMaskBoolDoesNotProduceNaN) {
   params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
   auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {query, key, value, attn_mask});
 
-  ASSERT_FALSE(torch::isnan(jit_results[0]).any().item<bool>());
-  ASSERT_FALSE(torch::isnan(trt_results[0]).any().item<bool>());
+  ASSERT_FALSE(at::isnan(jit_results[0]).any().item<bool>());
+  ASSERT_FALSE(at::isnan(trt_results[0]).any().item<bool>());
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0]));
 }
 

--- a/tests/py/dynamo/conversion/harness.py
+++ b/tests/py/dynamo/conversion/harness.py
@@ -311,11 +311,12 @@ class DispatchTestCase(TRTTestCase):
     ):
         mod = mod.eval()
         if use_dynamo_tracer:
+            device = default_device()
+            mod = mod.to(device.to(torch.device))
             if torch_export_dynamic_shapes is None:
                 torch_export_dynamic_shapes = get_dynamic_shapes_args(
                     mod, original_inputs
                 )
-            device = default_device()
             torch_export_inputs = get_torch_inputs(original_inputs, device)
             exported_program = torch.export.export(
                 mod,


### PR DESCRIPTION
# Description

Got the following build issue in dlfw cpp tests:

```
[› |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  core/runtime/execute_engine.cpp: In lambda function:
  core/runtime/execute_engine.cpp:399:43: error: 'struct at::cuda::CUDAGraph' has no member named 'has_graph_exec'; did you mean 'bool
  at::cuda::CUDAGraph::has_graph_exec_'? (not accessible from this context)
    399 |           if (!compiled_engine->cudagraph.has_graph_exec()) {
        |                                           ^~~~~~~~~~~~~~
  In file included from ./core/runtime/TRTEngine.h:11,
                   from ./core/runtime/runtime.h:11,
                   from core/runtime/execute_engine.cpp:9:
  bazel-out/k8-fastbuild/bin/external/+_repo_rules3+libtorch/_virtual_includes/ATen/ATen/cuda/CUDAGraph.h:109:8: note: declared protected here
    109 |   bool has_graph_exec_ = false;
        |        ^~~~~~~~~~~~~~~
  Target //tests/core/conversion/converters:test_scaled_dot_product_attention failed to build
  Use --verbose_failures to see the command lines of failed build steps.
  INFO: Elapsed time: 36.046s, Critical Path: 23.08s
  INFO: 8394 processes: 8312 internal, 82 processwrapper-sandbox.
  ERROR: Build did NOT complete successfully](`url`)
```

```
tests/core/conversion/converters/test_scaled_dot_product_attention.cpp:92:3: error: expected primary-expression before '(' token
2026-07-13T17:46:28.998059Z 01E    92 |   ASSERT_FALSE(torch::isnan(jit_results[0]).any().item<bool>());
2026-07-13T17:46:28.998061Z 01E       |   ^~~~~~~~~~~~
2026-07-13T17:46:28.998062Z 01E tests/core/conversion/converters/test_scaled_dot_product_attention.cpp:92:23: error: 'isnan' is not a member of 'torch'
2026-07-13T17:46:28.998064Z 01E    92 |   ASSERT_FALSE(torch::isnan(jit_results[0]).any().item<bool>());
2026-07-13T17:46:28.998066Z 01E       |                       ^~~~~
2026-07-13T17:46:28.998068Z 01E tests/core/conversion/converters/test_scaled_dot_product_attention.cpp:92:23: note: suggested alternatives:
2026-07-13T17:46:28.998070Z 01E bazel-out/k8-dbg/bin/external/+_repo_rules+libtorch/_virtual_includes/c10_cuda/c10/util/complex_utils.h:43:6: note:   'std::isnan'
2026-07-13T17:46:28.998072Z 01E    43 | bool isnan(const c10::complex<T>& v) {
2026-07-13T17:46:28.998074Z 01E       |      ^~~~~
2026-07-13T17:46:28.998075Z 01E bazel-out/k8-dbg/bin/external/+_repo_rules+libtorch/_virtual_includes/ATen/ATen/ops/isnan.h:28:19: note:   'at::isnan'
2026-07-13T17:46:28.998077Z 01E    28 | inline at::Tensor isnan(const at::Tensor & self) {
2026-07-13T17:46:28.998079Z 01E       |                   ^~~~~
2026-07-13T17:46:28.998080Z 01E bazel-out/k8-dbg/bin/external/+_repo_rules+libtorch/_virtual_includes/ATen/ATen/core/interned_strings.h:351:1: note:   'c10::aten::isnan'
2026-07-13T17:46:28.998082Z 01E   351 | FORALL_NS_SYMBOLS(DEFINE_SYMBOL)
2026-07-13T17:46:28.998084Z 01E       | ^~~~~~~~~~~~~~~~~
2026-07-13T17:46:28.998085Z 01E bazel-out/k8-dbg/bin/external/+_repo_rules+libtorch/_virtual_includes/ATen/ATen/ops/isnan_ops.h:19:18: note:   'at::_ops::isnan'
2026-07-13T17:46:28.998088Z 01E    19 | struct TORCH_API isnan {
2026-07-13T17:46:28.998089Z 01E       |                  ^~~~~
2026-07-13T17:46:28.998090Z 01E bazel-out/k8-dbg/bin/external/+_repo_rules+libtorch/_virtual_includes/ATen/ATen/ops/isnan_native.h:21:22: note:   'at::native::isnan'
2026-07-13T17:46:28.998093Z 01E    21 | TORCH_API at::Tensor isnan(const at::Tensor & self);
2026-07-13T17:46:28.998094Z 01E       |                      ^~~~~
2026-07-13T17:46:28.998096Z 01E tests/core/conversion/converters/test_scaled_dot_product_attention.cpp:92:56: error: expected primary-expression before 'bool'
2026-07-13T17:46:28.998098Z 01E    92 |   ASSERT_FALSE(torch::isnan(jit_results[0]).any().item<bool>());
2026-07-13T17:46:28.998100Z 01E       |                                                        ^~~~
2026-07-13T17:46:28.998102Z 01E tests/core/conversion/converters/test_scaled_dot_product_attention.cpp:92:56: error: expected ')' before 'bool'
2026-07-13T17:46:28.998104Z 01E tests/core/conversion/converters/test_scaled_dot_product_attention.cpp:92:3: note: to match this '('
2026-07-13T17:46:28.998106Z 01E    92 |   ASSERT_FALSE(torch::isnan(jit_results[0]).any().item<bool>());
2026-07-13T17:46:28.998108Z 01E       |   ^~~~~~~~~~~~
2026-07-13T17:46:28.998109Z 01E tests/core/conversion/converters/test_scaled_dot_product_attention.cpp:92:3: error: expected ')' before ';' token
2026-07-13T17:46:28.998111Z 01E    92 |   ASSERT_FALSE(torch::isnan(jit_results[0]).any().item<bool>());
2026-07-13T17:46:28.998113Z 01E       |   ^~~~~~~~~~~~
2026-07-13T17:46:28.998114Z 01E tests/core/conversion/converters/test_scaled_dot_product_attention.cpp:93:23: error: 'isnan' is not a member of 'torch'
2026-07-13T17:46:28.998116Z 01E    93 |   ASSERT_FALSE(torch::isnan(trt_results[0]).any().item<bool>());
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
