### PR TITLE
feat: limit RAM usage in bazel build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -47,3 +47,6 @@ build:use_precompiled_torchtrt --define=torchtrt_src=prebuilt
 
 test:ci_testing --define=torchtrt_src=prebuilt --cxxopt="-DDISABLE_TEST_IN_CI" --action_env "NVIDIA_TF32_OVERRIDE=0"
 test:use_precompiled_torchtrt --define=torchtrt_src=prebuilt
+
+# Load optional per-developer overrides, such as local resource limits.
+try-import %workspace%/.bazelrc.user

--- a/.bazelrc.user
+++ b/.bazelrc.user
@@ -1,0 +1,7 @@
+# Local build overrides for memory-constrained machines.
+# When RAM is limited, a full-core debug build (one heavy C++ action per core) OOM kills the Bazel server.
+#
+# Cap concurrent actions and let Bazel schedule against a RAM budget. Tune
+# --jobs up/down based on how much headroom `free -g` shows during a build.
+build --jobs=6
+build --local_resources=memory=HOST_RAM*.7

--- a/.bazelrc.user
+++ b/.bazelrc.user
@@ -1,7 +1,0 @@
-# Local build overrides for memory-constrained machines.
-# When RAM is limited, a full-core debug build (one heavy C++ action per core) OOM kills the Bazel server.
-#
-# Cap concurrent actions and let Bazel schedule against a RAM budget. Tune
-# --jobs up/down based on how much headroom `free -g` shows during a build.
-build --jobs=6
-build --local_resources=memory=HOST_RAM*.7

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bazel-bazel-test
 bazel-bin
 bazel-genfiles
 bazel-out
+.bazelrc.user
 bazel-testlogs
 bazel-TRTorch
 bazel-trtorch-testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,15 @@ Do try to fill an issue with your feature or bug before filling a PR (op support
 
 Our build system relies on `bazel` (https://bazel.build/). Though there are many ways to install `bazel`, the preferred method is to use `bazelisk` (https://github.com/bazelbuild/bazelisk) which makes it simple to set up the correct version of bazel on the fly. Additional development dependencies can be installed via the `requirements-dev.txt` file.
 
+Developers can define Bazel settings in `.bazelrc.user`, which is gitignored and loaded optionally by the repository's `.bazelrc`. For example, resource-constrained machines can limit local build parallelism:
+
+```text
+build --jobs=6
+build --local_resources=memory=HOST_RAM*.7
+```
+
+Do not commit `.bazelrc.user`; tune these values for your local machine.
+
 #### Editor / clangd setup (optional)
 
 For C++ code intelligence (go-to-definition, accurate diagnostics, completions) in any clangd-based editor — e.g. VSCode with the [clangd extension](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd), Cursor, Neovim, Emacs — generate a Bazel-aware compilation database:


### PR DESCRIPTION
# Description

When building torch-trt from source, the bazel often gets stuck and gets OOM if memory is limited, as it runs 32 actions in parallel. This PR defaults to:
```
build --jobs=6
build --local_resources=memory=HOST_RAM*.7
```
It caps concurrent actions and let bazel schedule against a RAM budget. Feel free to tune --jobs up/down based on how much headroom `free -g` shows during a build.

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
