### PR TITLE
test: re-enable cumsum tests on TensorRT-RTX

### DIFF
--- a/tests/py/dynamo/conversion/test_cumsum_aten.py
+++ b/tests/py/dynamo/conversion/test_cumsum_aten.py
@@ -1,5 +1,3 @@
-import unittest
-
 import torch
 import torch.nn as nn
 import torch_tensorrt
@@ -9,10 +7,6 @@ from torch.testing._internal.common_utils import run_tests
 from .harness import DispatchTestCase
 
 
-@unittest.skipIf(
-    torch_tensorrt.ENABLED_FEATURES.tensorrt_rtx,
-    "cumsum is not supported on TensorRT-RTX (build_serialized_network returns None on Linux as well as Windows)",
-)
 class TestCumsumConverter(DispatchTestCase):
     @parameterized.expand(
         [


### PR DESCRIPTION
## Summary

- remove the blanket TensorRT-RTX skip from the cumsum Dynamo converter tests
- let current-main CI determine whether the TRT-RTX 1.4-era regression tracked by NVBugs 6060938 still reproduces

## Local validation

- Windows 11, NVIDIA GeForce RTX 5090
- PyTorch 2.14.0.dev20260721+cu130
- Torch-TensorRT current main (210054596)
- TensorRT-RTX 1.6.1.13 from current local TRT/Myelin builds
- static and dynamic cumsum cases pass with immutable_weights=False and require_full_compilation=True
- historical pure-TensorRT refit/INT64 loop reduction also passes