### PR TITLE
fix: add missing serialized_aliased_io arg to no_op_placeholder op schema

### DIFF
--- a/py/torch_tensorrt/dynamo/runtime/meta_ops/register_meta_ops.py
+++ b/py/torch_tensorrt/dynamo/runtime/meta_ops/register_meta_ops.py
@@ -321,6 +321,7 @@ def no_op_placeholder_for_execute_engine(
     serialized_require_output_allocator: str,
     serialized_resource_allocation_strategy: str,
     serialized_requires_native_multidevice: str,
+    serialized_aliased_io: str,
 ) -> List[torch.Tensor]:
     raise RuntimeError(
         "The saved model is cross compiled for windows in Linux, should only be loadded in Windows via torch_tensorrt.load_cross_compiled_exported_program() api."
@@ -342,6 +343,7 @@ def fake_no_op_placeholder_for_execute_engine(
     serialized_require_output_allocator: str,
     serialized_resource_allocation_strategy: str,
     serialized_requires_native_multidevice: str,
+    serialized_aliased_io: str,
 ) -> List[torch.Tensor]:
     """Fake kernel for no_op_placeholder_for_execute_engine.
 

--- a/tests/py/dynamo/executorch/test_backend.py
+++ b/tests/py/dynamo/executorch/test_backend.py
@@ -1,3 +1,5 @@
+import ast
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -7,6 +9,7 @@ executorch = pytest.importorskip("executorch.exir")
 import torch  # noqa: E402
 from torch.export.graph_signature import InputKind  # noqa: E402
 from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import (  # noqa: E402
+    ALIASED_IO_IDX,
     DEVICE_IDX,
     ENGINE_IDX,
     INPUT_BINDING_NAMES_IDX,
@@ -107,6 +110,32 @@ def _make_multi_engine_program(engine_info):
 
 def _engine_tensor(payload: bytes) -> torch.Tensor:
     return torch.frombuffer(bytearray(payload), dtype=torch.uint8)
+
+
+@pytest.mark.unit
+def test_no_op_placeholder_schema_matches_serialized_engine_layout():
+    meta_ops_path = (
+        Path(__file__).parents[4]
+        / "py/torch_tensorrt/dynamo/runtime/meta_ops/register_meta_ops.py"
+    )
+    module = ast.parse(meta_ops_path.read_text())
+    signatures = {
+        node.name: [arg.arg for arg in node.args.args]
+        for node in module.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name
+        in {
+            "no_op_placeholder_for_execute_engine",
+            "fake_no_op_placeholder_for_execute_engine",
+        }
+    }
+
+    expected_arg_count = SERIALIZATION_LEN + 1
+    for args in signatures.values():
+        assert len(args) == expected_arg_count
+        assert args[ALIASED_IO_IDX + 1] == "serialized_aliased_io"
+    assert len(signatures) == 2
+    assert len({tuple(args) for args in signatures.values()}) == 1
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

The serialized engine layout gained `ALIASED_IO_IDX = 12` (so `SERIALIZATION_LEN = 13`) in #4251. `_replace_execute_engine_with_no_op` in `_compile.py` builds the `tensorrt::no_op_placeholder_for_execute_engine` node with `inputs + SERIALIZATION_LEN = 14` args, but the custom op and its `register_fake` were never updated and still declare only 13 params.

As a result, **every ExecuTorch `.pte` export fails** during `torch_tensorrt.save(...)`:

```
RuntimeError: tensorrt::no_op_placeholder_for_execute_engine() expected at most 13 argument(s) but received 14 argument(s).
```

This currently breaks the `executorch-static-build` CI job on all PRs (e.g. #4421, #4415), regardless of their content.

## Fix

Add the trailing `serialized_aliased_io: str` parameter (matching `ALIASED_IO_IDX`) to both `no_op_placeholder_for_execute_engine` and `fake_no_op_placeholder_for_execute_engine`. The param order now matches `SerializedInfoIndex` exactly (fields 0-12). The fake kernel still derives output shapes from `serialized_metadata`, so the new field is accepted but not otherwise used, mirroring the other serialized fields.

## Testing

- Verified param count is now 14 (inputs + 13 serialized fields) and each param aligns with its `SerializedInfoIndex`.
- `black`/AST clean.
- Unblocks the ExecuTorch `.pte` export step in `verify-executorch-reference-runner.sh`.