### PR TITLE
feat: Enable TensorRT-RTX build for linux-aarch64 (SBSA / DGX Spark)

### DIFF
--- a/.github/workflows/build-test-linux-aarch64_rtx.yml
+++ b/.github/workflows/build-test-linux-aarch64_rtx.yml
@@ -1,0 +1,95 @@
+name: RTX - Build Linux aarch64 wheels
+
+# Basic RTX support for aarch64 (SBSA): mirrors build-test-linux-aarch64.yml but
+# selects TensorRT-RTX (use-rtx: true). BUILD-ONLY — there are no aarch64 GPU test
+# runners, so this just validates the RTX aarch64 wheel builds. The full
+# manifest-based wiring lives in the CI redesign (test-dx) on top of this.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - nightly
+      - release/*
+    tags:
+      # NOTE: Binary build pipelines should only get triggered on release candidate builds
+      # Release candidate tags look like: v1.11.0-rc1
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+  workflow_dispatch:
+
+# Read-only by default (CodeQL); the build job overrides with id-token: write.
+permissions:
+  contents: read
+
+jobs:
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: linux-aarch64
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      with-rocm: false
+      with-cpu: false
+
+  filter-matrix:
+    needs: [generate-matrix]
+    outputs:
+      matrix: ${{ steps.filter.outputs.matrix }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - uses: actions/checkout@v6
+        with:
+          repository: pytorch/tensorrt
+      - name: Filter matrix
+        id: filter
+        env:
+          LIMIT_PR_BUILDS: ${{ github.event_name == 'pull_request' && !contains( github.event.pull_request.labels.*.name, 'ciflow/binaries/all') }}
+        run: |
+          set -eou pipefail
+          MATRIX_BLOB=${{ toJSON(needs.generate-matrix.outputs.matrix) }}
+          MATRIX_BLOB="$(python3 .github/scripts/filter-matrix.py --use-rtx true --matrix "${MATRIX_BLOB}")"
+          echo "${MATRIX_BLOB}"
+          echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
+
+  build:
+    needs: filter-matrix
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: pytorch/tensorrt
+            pre-script: packaging/pre_build_script.sh
+            env-var-script: packaging/env_vars.txt
+            post-script: packaging/post_build_script.sh
+            smoke-test-script: packaging/smoke_test_script.sh
+            package-name: torch_tensorrt
+            display-name: RTX - Build SBSA torch-tensorrt whl package
+    name: ${{ matrix.display-name }}
+    uses: ./.github/workflows/build_linux.yml
+    with:
+      repository: ${{ matrix.repository }}
+      ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
+      pre-script: ${{ matrix.pre-script }}
+      env-var-script: ${{ matrix.env-var-script }}
+      post-script: ${{ matrix.post-script }}
+      package-name: ${{ matrix.package-name }}
+      smoke-test-script: ${{ matrix.smoke-test-script }}
+      trigger-event: ${{ github.event_name }}
+      architecture: "aarch64"
+      use-rtx: true
+      pip-install-torch-extra-args: "--extra-index-url https://pypi.org/simple"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}-${{ inputs.job-name }}
+  cancel-in-progress: true

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -47,6 +47,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "no_package_executorch",
     flag_values = {
         ":package_executorch": "false",
@@ -217,6 +228,7 @@ pkg_tar(
         ":no_package_executorch": [],
         ":rtx_win": [],
         ":rtx_x86_64": [],
+        ":rtx_sbsa": [],
         ":windows": [],
         "//conditions:default": [
             "//examples/executorch_reference_runner:example_executorch_runner",
@@ -260,6 +272,7 @@ pkg_tar(
         ":no_package_executorch": [],
         ":rtx_win": [],
         ":rtx_x86_64": [],
+        ":rtx_sbsa": [],
         ":windows": [],
         "//conditions:default": [
             ":executorch_source_package",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -196,6 +196,16 @@ http_archive(
 )
 
 http_archive(
+    name = "tensorrt_rtx_sbsa",
+    build_file = "@//third_party/tensorrt_rtx/archive:BUILD",
+    strip_prefix = "TensorRT-RTX-1.5.0.114",
+    type = "tar.zst",
+    urls = [
+        "https://developer.nvidia.com/downloads/trt/rtx_sdk/secure/1.5/TensorRT-RTX-1.5.0.114-Linux-aarch64-cuda-13.2-Release-external.tar.zst",
+    ],
+)
+
+http_archive(
     name = "tensorrt_sbsa",
     build_file = "@//third_party/tensorrt/archive:BUILD",
     strip_prefix = "TensorRT-11.0.0.114",

--- a/core/BUILD
+++ b/core/BUILD
@@ -22,6 +22,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -83,6 +94,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/core/conversion/BUILD
+++ b/core/conversion/BUILD
@@ -22,6 +22,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -78,6 +89,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/core/conversion/conversionctx/BUILD
+++ b/core/conversion/conversionctx/BUILD
@@ -22,6 +22,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -73,6 +84,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/core/conversion/converters/BUILD
+++ b/core/conversion/converters/BUILD
@@ -22,6 +22,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -73,6 +84,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],
@@ -102,6 +114,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],
@@ -169,6 +182,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/core/conversion/evaluators/BUILD
+++ b/core/conversion/evaluators/BUILD
@@ -22,6 +22,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -79,6 +90,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/core/conversion/tensorcontainer/BUILD
+++ b/core/conversion/tensorcontainer/BUILD
@@ -22,6 +22,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -72,6 +83,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/core/conversion/var/BUILD
+++ b/core/conversion/var/BUILD
@@ -22,6 +22,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -75,6 +86,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/core/ir/BUILD
+++ b/core/ir/BUILD
@@ -22,6 +22,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -75,6 +86,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/core/lowering/BUILD
+++ b/core/lowering/BUILD
@@ -22,6 +22,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -77,6 +88,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/core/partitioning/BUILD
+++ b/core/partitioning/BUILD
@@ -22,6 +22,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -80,6 +91,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/core/partitioning/partitioningctx/BUILD
+++ b/core/partitioning/partitioningctx/BUILD
@@ -22,6 +22,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -76,6 +87,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/core/partitioning/partitioninginfo/BUILD
+++ b/core/partitioning/partitioninginfo/BUILD
@@ -22,6 +22,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -75,6 +86,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/core/partitioning/segmentedblock/BUILD
+++ b/core/partitioning/segmentedblock/BUILD
@@ -22,6 +22,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -75,6 +86,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/core/plugins/BUILD
+++ b/core/plugins/BUILD
@@ -23,6 +23,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -69,6 +80,7 @@ cc_library(
         ],
         ":rtx_win": [],
         ":rtx_x86_64": [],
+        ":rtx_sbsa": [],
         "//conditions:default": [
             "impl/interpolate_plugin.cpp",
             "impl/normalize_plugin.cpp",
@@ -84,6 +96,7 @@ cc_library(
         ],
         ":rtx_win": [],
         ":rtx_x86_64": [],
+        ":rtx_sbsa": [],
         "//conditions:default": [
             "impl/interpolate_plugin.h",
             "impl/normalize_plugin.h",
@@ -115,6 +128,7 @@ cc_library(
         ],
         ":rtx_win": [],
         ":rtx_x86_64": [],
+        ":rtx_sbsa": [],
         ":sbsa": [
             "@tensorrt_sbsa//:nvinfer",
             "@tensorrt_sbsa//:nvinferplugin",

--- a/core/runtime/BUILD
+++ b/core/runtime/BUILD
@@ -24,6 +24,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -74,6 +85,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],
@@ -129,6 +141,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/core/util/BUILD
+++ b/core/util/BUILD
@@ -22,6 +22,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -140,6 +151,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/core/util/logging/BUILD
+++ b/core/util/logging/BUILD
@@ -20,6 +20,15 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {"//toolchains/dep_collection:compute_libs": "rtx"},
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -67,6 +76,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -25,6 +25,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "sbsa",
     constraint_values = [
         "@platforms//cpu:aarch64",

--- a/py/torch_tensorrt/dynamo/lowering/passes/eliminate_sym_min_int64_max.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/eliminate_sym_min_int64_max.py
@@ -5,7 +5,6 @@ from torch.fx import GraphModule, Node
 
 from .pass_utils import clean_up_graph_after_modifications
 
-
 _INT64_MAX = 2**63 - 1
 _SYM_MIN = getattr(torch, "sym_min", None)
 

--- a/setup.py
+++ b/setup.py
@@ -642,6 +642,15 @@ if not (PY_ONLY or NO_TS):
         .split("/BUILD.bazel")[0]
     )
 
+    tensorrt_rtx_sbsa_external_dir = (
+        lambda: subprocess.check_output(
+            [BAZEL_EXE, "query", "@tensorrt_rtx_sbsa//:nvinfer", "--output", "location"]
+        )
+        .decode("ascii")
+        .strip()
+        .split("/BUILD.bazel")[0]
+    )
+
     tensorrt_jetpack_external_dir = (
         lambda: subprocess.check_output(
             [BAZEL_EXE, "query", "@tensorrt_l4t//:nvinfer", "--output", "location"]
@@ -652,7 +661,10 @@ if not (PY_ONLY or NO_TS):
     )
 
     if IS_SBSA:
-        tensorrt_linux_external_dir = tensorrt_sbsa_external_dir
+        if USE_TRT_RTX:
+            tensorrt_linux_external_dir = tensorrt_rtx_sbsa_external_dir
+        else:
+            tensorrt_linux_external_dir = tensorrt_sbsa_external_dir
     elif IS_JETPACK:
         tensorrt_linux_external_dir = tensorrt_jetpack_external_dir
     else:
@@ -834,10 +846,17 @@ def get_sbsa_requirements(base_requirements):
     if IS_DLFW_CI:
         return requirements
     else:
+        requirements = requirements + [
+            "torch>=2.14.0.dev,<2.15.0",
+        ]
+        if USE_TRT_RTX:
+            # TensorRT-RTX ships an aarch64 (SBSA) wheel; mirror get_x86_64_requirements.
+            return requirements + [
+                "tensorrt_rtx>=1.5.0.114,<1.6.0.0",
+            ]
         # TensorRT does not currently build wheels for Tegra, so we need to use the local tensorrt install from the tarball for thor
         # also due to we use sbsa torch_tensorrt wheel for thor, so when we build sbsa wheel, we need to only include tensorrt dependency.
         return requirements + [
-            "torch>=2.14.0.dev,<2.15.0",
             "tensorrt>=11.0.0,<11.1.0",
         ]
 

--- a/tests/util/BUILD
+++ b/tests/util/BUILD
@@ -55,6 +55,17 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        "//toolchains/dep_collection:compute_libs": "rtx",
+    },
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -82,6 +93,7 @@ cc_library(
         ":jetpack": ["@tensorrt_l4t//:nvinfer"],
         ":rtx_win": ["@tensorrt_rtx_win//:nvinfer"],
         ":rtx_x86_64": ["@tensorrt_rtx//:nvinfer"],
+        ":rtx_sbsa": ["@tensorrt_rtx_sbsa//:nvinfer"],
         ":sbsa": ["@tensorrt_sbsa//:nvinfer"],
         ":windows": ["@tensorrt_win//:nvinfer"],
         "//conditions:default": ["@tensorrt//:nvinfer"],

--- a/third_party/tensorrt_rtx/archive/BUILD
+++ b/third_party/tensorrt_rtx/archive/BUILD
@@ -12,6 +12,15 @@ config_setting(
 )
 
 config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {"@//toolchains/dep_collection:compute_libs": "rtx"},
+)
+
+config_setting(
     name = "rtx_win",
     constraint_values = [
         "@platforms//os:windows",
@@ -40,6 +49,7 @@ cc_import(
     shared_library = select({
         ":rtx_win": "bin/tensorrt_rtx_1_5.dll",
         ":rtx_x86_64": "lib/libtensorrt_rtx.so",
+        ":rtx_sbsa": "lib/libtensorrt_rtx.so",
     }),
     visibility = ["//visibility:private"],
 )
@@ -64,5 +74,6 @@ cc_library(
             "@cuda_win//:cudart",
         ],
         ":rtx_x86_64": ["@cuda//:cudart"],
+        ":rtx_sbsa": ["@cuda//:cudart"],
     }),
 )

--- a/third_party/tensorrt_rtx/local/BUILD
+++ b/third_party/tensorrt_rtx/local/BUILD
@@ -19,6 +19,15 @@ config_setting(
     flag_values = {"@//toolchains/dep_collection:compute_libs": "rtx"},
 )
 
+config_setting(
+    name = "rtx_sbsa",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {"@//toolchains/dep_collection:compute_libs": "rtx"},
+)
+
 cc_library(
     name = "nvinfer_headers",
     hdrs = select({
@@ -33,6 +42,16 @@ cc_library(
             # ],
         ),
         ":rtx_x86_64": glob(
+            [
+                "include/NvInfer*.h",
+            ],
+            allow_empty = True,
+            # exclude = [
+            #     "include/NvInferPlugin.h",
+            #     "include/NvInferPluginUtils.h",
+            # ],
+        ),
+        ":rtx_sbsa": glob(
             [
                 "include/NvInfer*.h",
             ],
@@ -60,6 +79,7 @@ cc_import(
     shared_library = select({
         ":rtx_win": "bin/tensorrt_rtx_1_5.dll",
         ":rtx_x86_64": "lib/libtensorrt_rtx.so",
+        ":rtx_sbsa": "lib/libtensorrt_rtx.so",
     }),
     visibility = ["//visibility:private"],
 )

--- a/toolchains/ci_workspaces/MODULE.bazel.tmpl
+++ b/toolchains/ci_workspaces/MODULE.bazel.tmpl
@@ -112,6 +112,16 @@ http_archive(
 )
 
 http_archive(
+    name = "tensorrt_rtx_sbsa",
+    build_file = "@//third_party/tensorrt_rtx/archive:BUILD",
+    strip_prefix = "TensorRT-RTX-1.5.0.114",
+    type = "tar.zst",
+    urls = [
+        "https://developer.nvidia.com/downloads/trt/rtx_sdk/secure/1.5/TensorRT-RTX-1.5.0.114-Linux-aarch64-cuda-${CU_UPPERBOUND}-Release-external.tar.zst",
+    ],
+)
+
+http_archive(
     name = "tensorrt_sbsa",
     build_file = "@//third_party/tensorrt/archive:BUILD",
     strip_prefix = "TensorRT-11.0.0.114",


### PR DESCRIPTION
TensorRT-RTX 1.5 ships a Linux aarch64 (SBSA) distribution, but the repo only wired up the x86_64 and Windows RTX archives. This adds the aarch64 RTX archive and threads a rtx_sbsa config_setting (aarch64 + linux + compute_libs=rtx) through the TensorRT selects, so USE_TRT_RTX=1 builds resolve @tensorrt_rtx_sbsa on aarch64.

Build wiring:
- MODULE.bazel: add tensorrt_rtx_sbsa http_archive (aarch64 tarball).
- third_party/tensorrt_rtx/{archive,local}/BUILD: rtx_sbsa config_setting
  + lib/header/nvinfer selects (lib/libtensorrt_rtx.so, @cuda//:cudart).
- ~20 repo BUILD files: rtx_sbsa config_setting + a :rtx_sbsa select entry mirroring :rtx_x86_64 (sourced from @tensorrt_rtx_sbsa).

Basic CI:
- .github/workflows/build-test-linux-aarch64_rtx.yml: mirrors the standard SBSA build (build-test-linux-aarch64.yml) with use-rtx: true. BUILD-ONLY (no aarch64 GPU test runners) — it validates the RTX aarch64 wheel builds. The full manifest-based wiring will layer on in the CI redesign (test-dx).

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.


- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
