### PR TITLE
fix: avoid linking transitive PyTorch CUDA libraries into libtorchtrt

### DIFF
--- a/tests/py/core/test_libtorchtrt_linkage.py
+++ b/tests/py/core/test_libtorchtrt_linkage.py
@@ -1,0 +1,78 @@
+import importlib.util
+import os
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+@unittest.skipUnless(sys.platform.startswith("linux"), "ELF linkage test")
+class TestLibTorchTensorRTLinkage(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        torch_spec = importlib.util.find_spec("torch")
+        torchtrt_spec = importlib.util.find_spec("torch_tensorrt")
+        if (
+            torch_spec is None
+            or torch_spec.origin is None
+            or torchtrt_spec is None
+            or torchtrt_spec.submodule_search_locations is None
+        ):
+            raise unittest.SkipTest("torch and torch_tensorrt must be installed")
+
+        cls.torch_lib_dir = Path(torch_spec.origin).parent / "lib"
+        cls.libtorchtrt = (
+            Path(next(iter(torchtrt_spec.submodule_search_locations)))
+            / "lib"
+            / "libtorchtrt.so"
+        )
+        if not cls.libtorchtrt.is_file():
+            raise AssertionError(
+                f"Installed torch_tensorrt package is missing {cls.libtorchtrt}"
+            )
+
+    def test_does_not_directly_need_pytorch_transitive_dsos(self) -> None:
+        dynamic_section = subprocess.run(
+            ["readelf", "-d", self.libtorchtrt],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        needed = re.findall(
+            r"\(NEEDED\).*Shared library: \[([^\]]+)\]", dynamic_section
+        )
+        forbidden_prefixes = ("libcudnn", "libcusparseLt", "libnvshmem_host")
+        direct_transitive_dependencies = [
+            soname for soname in needed if soname.startswith(forbidden_prefixes)
+        ]
+        self.assertEqual(direct_transitive_dependencies, [])
+
+    def test_loads_in_fresh_process_without_importing_torch(self) -> None:
+        env = os.environ.copy()
+        env["LD_LIBRARY_PATH"] = os.pathsep.join(
+            [
+                str(self.torch_lib_dir),
+                *filter(None, env.get("LD_LIBRARY_PATH", "").split(os.pathsep)),
+            ]
+        )
+        child = """
+import ctypes
+import os
+import sys
+
+assert "torch" not in sys.modules
+ctypes.CDLL(sys.argv[1], mode=os.RTLD_NOW | ctypes.RTLD_GLOBAL)
+assert "torch" not in sys.modules
+"""
+        result = subprocess.run(
+            [sys.executable, "-I", "-c", child, str(self.libtorchtrt)],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )

--- a/third_party/libtorch/BUILD
+++ b/third_party/libtorch/BUILD
@@ -33,9 +33,6 @@ cc_library(
     }) + glob(
         [
             "lib/libtorch_nvshmem.so*",
-            "nvidia/cusparselt/lib/libcusparseLt.so*",
-            "nvidia/cudnn/lib/libcudnn*.so*",
-            "nvidia/nvshmem/lib/libnvshmem_host.so*",
         ],
         allow_empty = True,
     ),

--- a/toolchains/local_torch.bzl
+++ b/toolchains/local_torch.bzl
@@ -93,12 +93,6 @@ def _local_torch_impl(ctx):
         if child.exists:
             ctx.symlink(child, sub)
 
-    # CUDA PyTorch wheels keep some transitive shared-library dependencies in
-    # a sibling nvidia package directory rather than under torch/lib.
-    nvidia_path = torch_path.dirname.get_child("nvidia")
-    if nvidia_path.exists:
-        ctx.symlink(nvidia_path, "nvidia")
-
     ctx.file("BUILD", ctx.read(Label("@//third_party/libtorch:BUILD")))
 
 local_torch = repository_rule(


### PR DESCRIPTION
## Description

Remove cuDNN, cuSparseLt, and NVSHMEM host libraries from the `srcs` of the
LibTorch Bazel target.

These libraries are transitive dependencies of PyTorch's `libtorch_cuda.so`,
not direct dependencies of Torch-TensorRT. Adding them to `srcs` causes Bazel
to propagate them into `libtorchtrt.so` as direct `DT_NEEDED` entries. As a
result, importing a locally built Torch-TensorRT wheel can fail with errors
such as:

```text
OSError: libcudnn_adv.so.9: cannot open shared object file
```

unless the corresponding `site-packages/nvidia/*/lib` directories are added
to `LD_LIBRARY_PATH`.

This primarily affects local builds because the local_torch repository rule
exposes the sibling site-packages/nvidia directory, allowing these globs to
match. In nightly CI, `@libtorch` points directly to site-packages/torch, so
the same globs are empty and the resulting nightly wheel does not acquire
these direct dependencies.

The existing local_torch NVIDIA symlink remains available for resolving
LibTorch's transitive dependencies during C++ linking. This change only
prevents those dependencies from becoming part of Torch-TensorRT's direct
link interface.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
