### PR TITLE
feat: flag-gated upstream complex decomposition adapter 

### DIFF
--- a/py/torch_tensorrt/_features.py
+++ b/py/torch_tensorrt/_features.py
@@ -27,6 +27,7 @@ FeatureSet = namedtuple(
         "tensorrt_rtx",
         "trtllm_for_nccl",
         "native_trt_collectives",
+        "complex_decomposition",
     ],
 )
 
@@ -49,6 +50,11 @@ _TENSORRT_RTX = getattr(tensorrt, "_package_name", "") == "tensorrt_rtx"
 _TS_FE_AVAIL = os.path.isfile(linked_file_full_path)
 _TORCHTRT_RT_AVAIL = _TS_FE_AVAIL or os.path.isfile(linked_file_runtime_full_path)
 _DYNAMO_FE_AVAIL = version.parse(sanitized_torch_version()) >= version.parse("2.1.dev")
+# PyTorch's upstream complex-tensor decomposition (pytorch/pytorch#169832) ships
+# in torch>=2.14.dev; gates the complex_decomposition_adapter lowering pass.
+_COMPLEX_DECOMP_AVAIL = version.parse(sanitized_torch_version()) >= version.parse(
+    "2.14.dev"
+)
 _FX_FE_AVAIL = False if _TENSORRT_RTX else True
 _REFIT_AVAIL = True
 _WINDOWS_CROSS_COMPILE = check_cross_compile_trt_win_lib()
@@ -87,6 +93,7 @@ ENABLED_FEATURES = FeatureSet(
     _TENSORRT_RTX,
     _TRTLLM_AVAIL,
     _NATIVE_TRT_COLLECTIVES_AVAIL,
+    _COMPLEX_DECOMP_AVAIL,
 )
 
 T = TypeVar("T")
@@ -94,8 +101,17 @@ T = TypeVar("T")
 
 def _enabled_features_str() -> str:
     enabled = lambda x: "ENABLED" if x else "DISABLED"
-    out_str: str = f"Enabled Features:\n - Dynamo Frontend: {enabled(_DYNAMO_FE_AVAIL)}\n - Torch-TensorRT Runtime: {enabled(_TORCHTRT_RT_AVAIL)}\n - FX Frontend: {enabled(_FX_FE_AVAIL)}\n - TorchScript Frontend: {enabled(_TS_FE_AVAIL)}\n - Refit: {enabled(_REFIT_AVAIL)}\n - QDP Plugin: {enabled(_QDP_PLUGIN_AVAIL)} \n - TensorRT-RTX: {enabled(_TENSORRT_RTX)}\n - TensorRT-LLM for NCCL: {enabled(_TRTLLM_AVAIL)}\n - Native TRT Collectives: {enabled(_NATIVE_TRT_COLLECTIVES_AVAIL)}\n"  # type: ignore[no-untyped-call]
+    out_str: str = f"Enabled Features:\n - Dynamo Frontend: {enabled(_DYNAMO_FE_AVAIL)}\n - Torch-TensorRT Runtime: {enabled(_TORCHTRT_RT_AVAIL)}\n - FX Frontend: {enabled(_FX_FE_AVAIL)}\n - TorchScript Frontend: {enabled(_TS_FE_AVAIL)}\n - Refit: {enabled(_REFIT_AVAIL)}\n - QDP Plugin: {enabled(_QDP_PLUGIN_AVAIL)} \n - TensorRT-RTX: {enabled(_TENSORRT_RTX)}\n - TensorRT-LLM for NCCL: {enabled(_TRTLLM_AVAIL)}\n - Native TRT Collectives: {enabled(_NATIVE_TRT_COLLECTIVES_AVAIL)}\n - Complex Decomposition: {enabled(_COMPLEX_DECOMP_AVAIL)}\n"  # type: ignore[no-untyped-call]
     return out_str
+
+
+def has_complex_decomposition() -> bool:
+    """Check if PyTorch's upstream complex-tensor decomposition is available.
+
+    Returns:
+        bool: True if torch>=2.14.dev (ships decompose_complex_in_graph, PR #169832)
+    """
+    return bool(ENABLED_FEATURES.complex_decomposition)
 
 
 # Inline helper functions for checking feature availability

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -5,7 +5,6 @@ import logging
 import os
 import platform
 import warnings
-
 from typing import Any, Collection, Dict, List, Optional, Sequence, Tuple, Union
 
 import sympy
@@ -84,6 +83,7 @@ def cross_compile_for_windows(
     dla_local_dram_size: int = _defaults.DLA_LOCAL_DRAM_SIZE,
     dla_global_dram_size: int = _defaults.DLA_GLOBAL_DRAM_SIZE,
     truncate_double: bool = _defaults.TRUNCATE_DOUBLE,
+    use_complex_decomposition: bool = _defaults.USE_COMPLEX_DECOMPOSITION,
     require_full_compilation: bool = _defaults.REQUIRE_FULL_COMPILATION,
     min_block_size: int = _defaults.MIN_BLOCK_SIZE,
     torch_executed_ops: Optional[Collection[Target]] = None,
@@ -163,6 +163,7 @@ def cross_compile_for_windows(
         dla_local_dram_size (int): Host RAM used by DLA to share intermediate tensor data across operations
         dla_global_dram_size (int): Host RAM used by DLA to store weights and metadata for execution
         truncate_double (bool): Truncate weights provided in double (float64) to float32
+        use_complex_decomposition (bool): Use PyTorch's upstream complex decomposition (requires torch>=2.14) instead of the legacy hand-rolled complex rewriter. Falls back to the legacy pass when unavailable.
         require_full_compilation (bool): Require modules to be compiled end to end or return an error as opposed to returning a hybrid graph where operations that cannot be run in TensorRT are run in PyTorch
         min_block_size (int): The minimum number of contiguous TensorRT convertible operations in order to run a set of operations in TensorRT
         torch_executed_ops (Collection[Target]): Set of aten operators that must be run in PyTorch. An error will be thrown if this set is not empty but ``require_full_compilation`` is True
@@ -329,6 +330,7 @@ def cross_compile_for_windows(
         "version_compatible": version_compatible,
         "optimization_level": optimization_level,
         "truncate_double": truncate_double,
+        "use_complex_decomposition": use_complex_decomposition,
         "use_fast_partitioner": use_fast_partitioner,
         "num_avg_timing_iters": num_avg_timing_iters,
         "enable_experimental_decompositions": enable_experimental_decompositions,
@@ -436,6 +438,7 @@ def compile(
     dla_local_dram_size: int = _defaults.DLA_LOCAL_DRAM_SIZE,
     dla_global_dram_size: int = _defaults.DLA_GLOBAL_DRAM_SIZE,
     truncate_double: bool = _defaults.TRUNCATE_DOUBLE,
+    use_complex_decomposition: bool = _defaults.USE_COMPLEX_DECOMPOSITION,
     require_full_compilation: bool = _defaults.REQUIRE_FULL_COMPILATION,
     min_block_size: int = _defaults.MIN_BLOCK_SIZE,
     torch_executed_ops: Optional[Collection[Target]] = None,
@@ -530,6 +533,7 @@ def compile(
         dla_local_dram_size (int): Host RAM used by DLA to share intermediate tensor data across operations
         dla_global_dram_size (int): Host RAM used by DLA to store weights and metadata for execution
         truncate_double (bool): Truncate weights provided in double (float64) to float32
+        use_complex_decomposition (bool): Use PyTorch's upstream complex decomposition (requires torch>=2.14) instead of the legacy hand-rolled complex rewriter. Falls back to the legacy pass when unavailable.
         require_full_compilation (bool): Require modules to be compiled end to end or return an error as opposed to returning a hybrid graph where operations that cannot be run in TensorRT are run in PyTorch
         min_block_size (int): The minimum number of contiguous TensorRT convertible operations in order to run a set of operations in TensorRT
         torch_executed_ops (Optional[Collection[Target]]): Set of aten operators that must be run in PyTorch. An error will be thrown if this set is not empty but ``require_full_compilation`` is True
@@ -728,6 +732,7 @@ def compile(
         "version_compatible": version_compatible,
         "optimization_level": optimization_level,
         "truncate_double": truncate_double,
+        "use_complex_decomposition": use_complex_decomposition,
         "use_fast_partitioner": use_fast_partitioner,
         "num_avg_timing_iters": num_avg_timing_iters,
         "enable_experimental_decompositions": enable_experimental_decompositions,
@@ -1685,6 +1690,7 @@ def convert_exported_program_to_serialized_trt_engine(
     dla_local_dram_size: int = _defaults.DLA_LOCAL_DRAM_SIZE,
     dla_global_dram_size: int = _defaults.DLA_GLOBAL_DRAM_SIZE,
     truncate_double: bool = _defaults.TRUNCATE_DOUBLE,
+    use_complex_decomposition: bool = _defaults.USE_COMPLEX_DECOMPOSITION,
     require_full_compilation: bool = _defaults.REQUIRE_FULL_COMPILATION,
     min_block_size: int = _defaults.MIN_BLOCK_SIZE,
     torch_executed_ops: Optional[Collection[Target]] = None,
@@ -1777,6 +1783,7 @@ def convert_exported_program_to_serialized_trt_engine(
         dla_local_dram_size (int): Host RAM used by DLA to share intermediate tensor data across operations
         dla_global_dram_size (int): Host RAM used by DLA to store weights and metadata for execution
         truncate_double (bool): Truncate weights provided in double (float64) to float32
+        use_complex_decomposition (bool): Use PyTorch's upstream complex decomposition (requires torch>=2.14) instead of the legacy hand-rolled complex rewriter. Falls back to the legacy pass when unavailable.
         require_full_compilation (bool): Require modules to be compiled end to end or return an error as opposed to returning a hybrid graph where operations that cannot be run in TensorRT are run in PyTorch
         min_block_size (int): The minimum number of contiguous TensorRT convertible operations in order to run a set of operations in TensorRT
         torch_executed_ops (Optional[Collection[Target]]): Set of aten operators that must be run in PyTorch. An error will be thrown if this set is not empty but ``require_full_compilation`` is True
@@ -1951,6 +1958,7 @@ def convert_exported_program_to_serialized_trt_engine(
         "version_compatible": version_compatible,
         "optimization_level": optimization_level,
         "truncate_double": truncate_double,
+        "use_complex_decomposition": use_complex_decomposition,
         "use_fast_partitioner": use_fast_partitioner,
         "num_avg_timing_iters": num_avg_timing_iters,
         "enable_experimental_decompositions": enable_experimental_decompositions,

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -11,6 +11,7 @@ import sympy
 import torch
 from torch.export import ExportedProgram
 from torch.export.graph_signature import InputKind
+from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
 from torch.fx.node import Target
 from torch.utils._sympy.numbers import int_oo
 from torch_tensorrt._Device import Device
@@ -919,32 +920,64 @@ def _insert_complex_io_adapters(
         graph_modified = True
 
     # --- Output boundary: view_as_complex for complex outputs from TRT blocks ---
-    if complex_output_indices:
-        output_node = list(partitioned_module.graph.nodes)[-1]
-        outputs = list(output_node.args[0])
-        for idx in complex_output_indices:
-            if idx >= len(outputs):
-                continue
-            src = outputs[idx]
-            if not isinstance(src, torch.fx.Node):
-                continue
-            if src.op == "call_module" and (
-                "_run_on_acc" in str(src.target) or "_run_on_gpu" in str(src.target)
-            ):
-                with partitioned_module.graph.inserting_before(output_node):
-                    complex_node = partitioned_module.graph.call_function(
-                        torch.ops.aten.view_as_complex.default, args=(src,)
-                    )
-                logger.info(
-                    f"Inserted view_as_complex for complex output index {idx} "
-                    f"from TRT block '{src.target}'"
+    # Also runs when there's no complex output (complex_output_indices empty)
+    # but there IS complex input (function didn't early-return above): a
+    # single-output graph's output node arg is a bare Node rather than a
+    # tuple/list of Nodes, and _PyTreeCodeGen's generated forward() requires
+    # the tuple-wrapped form to correctly unflatten the result -- otherwise
+    # it hands the bare result tensor itself to tree_unflatten, which reads
+    # its first dim as a (wrong) leaf count.
+    output_node = list(partitioned_module.graph.nodes)[-1]
+    output_arg = output_node.args[0]
+    outputs = (
+        list(output_arg) if isinstance(output_arg, (list, tuple)) else [output_arg]
+    )
+    for idx in complex_output_indices:
+        if idx >= len(outputs):
+            continue
+        src = outputs[idx]
+        if not isinstance(src, torch.fx.Node):
+            continue
+        if src.op == "call_module" and (
+            "_run_on_acc" in str(src.target) or "_run_on_gpu" in str(src.target)
+        ):
+            with partitioned_module.graph.inserting_before(output_node):
+                complex_node = partitioned_module.graph.call_function(
+                    torch.ops.aten.view_as_complex.default, args=(src,)
                 )
-                outputs[idx] = complex_node
-                graph_modified = True
-        output_node.args = (tuple(outputs),)
+            logger.info(
+                f"Inserted view_as_complex for complex output index {idx} "
+                f"from TRT block '{src.target}'"
+            )
+            outputs[idx] = complex_node
+            graph_modified = True
+    if not isinstance(output_arg, (list, tuple)):
+        graph_modified = True
+    output_node.args = (tuple(outputs),)
 
     if graph_modified:
         partitioned_module.graph.lint()
+        partitioned_module.recompile()
+
+    # Ensure the final module's own forward() unflattens its result back to
+    # the user's original return shape (e.g. a bare tensor instead of a
+    # 1-tuple). complex_decomposition_adapter's make_fx retrace produces a
+    # plain (non-pytree) codegen partway through the pipeline, and that loss
+    # survives partitioning. Applied here -- after partitioning and boundary
+    # adapter insertion, once the module's true final leaf count is settled
+    # -- because setting it earlier (on the pre-partition graph) mismatches
+    # the leaf count at that intermediate stage and crashes on unflatten.
+    in_spec = getattr(gm, "_in_spec", None)
+    out_spec = getattr(gm, "_out_spec", None)
+    if in_spec is not None and out_spec is not None:
+        orig_args = [
+            node.name
+            for node in partitioned_module.graph.nodes
+            if node.op == "placeholder"
+        ]
+        partitioned_module.graph._codegen = _PyTreeCodeGen(
+            _PyTreeInfo(orig_args, in_spec, out_spec)
+        )
         partitioned_module.recompile()
 
 
@@ -1483,7 +1516,10 @@ def compile_module(
     if not settings.dryrun:
         output_node = list(partitioned_module.graph.nodes)[-1]
         for arg in output_node.args:
-            for output in arg:
+            # A single-output graph's output node arg is a bare Node rather
+            # than a tuple/list of Nodes.
+            outputs = arg if isinstance(arg, (list, tuple)) else [arg]
+            for output in outputs:
                 target = output.target
                 if "_run_on_acc" not in str(target):
                     continue

--- a/py/torch_tensorrt/dynamo/_defaults.py
+++ b/py/torch_tensorrt/dynamo/_defaults.py
@@ -22,6 +22,11 @@ VERSION_COMPATIBLE = False
 OPTIMIZATION_LEVEL = None
 SPARSE_WEIGHTS = False
 TRUNCATE_DOUBLE = False
+# When True, use PyTorch's upstream complex decomposition (pytorch/pytorch#169832)
+# via complex_decomposition_adapter instead of the legacy hand-rolled
+# complex_graph_detection pass.  Default False until the new path is validated
+# against the complex/RoPE test suites (issue #4390).
+USE_COMPLEX_DECOMPOSITION = False
 USE_FAST_PARTITIONER = True
 ENABLE_EXPERIMENTAL_DECOMPOSITIONS = False
 REQUIRE_FULL_COMPILATION = False

--- a/py/torch_tensorrt/dynamo/_defaults.py
+++ b/py/torch_tensorrt/dynamo/_defaults.py
@@ -5,6 +5,7 @@ import tempfile
 import torch
 from torch_tensorrt._Device import Device
 from torch_tensorrt._enums import EngineCapability, dtype
+from torch_tensorrt._features import has_complex_decomposition
 
 DEVICE = None
 DISABLE_TF32 = False
@@ -24,9 +25,14 @@ SPARSE_WEIGHTS = False
 TRUNCATE_DOUBLE = False
 # When True, use PyTorch's upstream complex decomposition (pytorch/pytorch#169832)
 # via complex_decomposition_adapter instead of the legacy hand-rolled
-# complex_graph_detection pass.  Default False until the new path is validated
-# against the complex/RoPE test suites (issue #4390).
-USE_COMPLEX_DECOMPOSITION = False
+# complex_graph_detection pass (issue #4390).
+#
+# Defaults to whether upstream supports it (torch>=2.14.dev): on a supported
+# torch the new path is used automatically, otherwise the legacy pass runs.
+# Users can always override explicitly -- passing use_complex_decomposition to
+# compile() wins over this default -- and the adapter re-checks the feature gate
+# and falls back to the legacy pass if upstream is unavailable.
+USE_COMPLEX_DECOMPOSITION = has_complex_decomposition()
 USE_FAST_PARTITIONER = True
 ENABLE_EXPERIMENTAL_DECOMPOSITIONS = False
 REQUIRE_FULL_COMPILATION = False

--- a/py/torch_tensorrt/dynamo/_settings.py
+++ b/py/torch_tensorrt/dynamo/_settings.py
@@ -49,6 +49,7 @@ from torch_tensorrt.dynamo._defaults import (
     TILING_OPTIMIZATION_LEVEL,
     TIMING_CACHE_PATH,
     TRUNCATE_DOUBLE,
+    USE_COMPLEX_DECOMPOSITION,
     USE_DISTRIBUTED_MODE_TRACE,
     USE_FAST_PARTITIONER,
     USE_FP32_ACC,
@@ -131,6 +132,7 @@ class CompilationSettings:
     version_compatible: bool = VERSION_COMPATIBLE
     optimization_level: Optional[int] = OPTIMIZATION_LEVEL
     truncate_double: bool = TRUNCATE_DOUBLE
+    use_complex_decomposition: bool = USE_COMPLEX_DECOMPOSITION
     use_fast_partitioner: bool = USE_FAST_PARTITIONER
     enable_experimental_decompositions: bool = ENABLE_EXPERIMENTAL_DECOMPOSITIONS
     device: Device = field(default_factory=default_device)

--- a/py/torch_tensorrt/dynamo/conversion/impl/elementwise/base.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/elementwise/base.py
@@ -3,6 +3,7 @@ import operator
 import warnings
 from typing import Any, Callable, Optional, Union
 
+import tensorrt as trt
 import torch
 from torch.fx.node import Target
 from torch_tensorrt import _enums
@@ -17,9 +18,7 @@ from torch_tensorrt.dynamo.conversion.converter_utils import (
     set_layer_name,
     to_torch,
 )
-from torch_tensorrt.dynamo.types import TRTElementWiseOp, TRTTensor
-
-import tensorrt as trt
+from torch_tensorrt.dynamo.types import TRTDataType, TRTElementWiseOp, TRTTensor
 
 logger = logging.getLogger(__name__)
 
@@ -127,10 +126,26 @@ def convert_binary_elementwise(
     # Note that the dtype here is supposed to be the same as the scalar
     # dtype but we don't have a way to detect whether it makes sense for the
     # scalar to be float or half. Hence we go with the lhs dtype.
+    def _scalar_wrap_dtype(
+        tensor_dtype: TRTDataType, scalar: Union[float, int, bool]
+    ) -> TRTDataType:
+        # bool combined with a non-bool scalar promotes to numeric (e.g.
+        # bool * int -> int64), not bool -- wrapping the scalar as bool
+        # here would make the later promotion step a no-op bool/bool match.
+        # Hit by PyTorch's upstream complex-acos decomposition, which computes
+        # sign(x) as signbit(x) * 2 - 1 (see complex_decomposition_adapter.py).
+        if tensor_dtype == trt.DataType.BOOL and not isinstance(scalar, bool):
+            torch_tensor_dtype = _enums.dtype._from(tensor_dtype).to(torch.dtype)
+            promoted = torch.result_type(
+                torch.empty([1], dtype=torch_tensor_dtype), scalar
+            )
+            return _enums.dtype._from(promoted).to(trt.DataType)
+        return tensor_dtype
+
     if is_lhs_trt_tensor and isinstance(rhs_val, (float, int, bool)):
-        rhs_val = to_torch(rhs_val, dtype=lhs_dtype)
+        rhs_val = to_torch(rhs_val, dtype=_scalar_wrap_dtype(lhs_dtype, rhs_val))
     if is_rhs_trt_tensor and isinstance(lhs_val, (float, int, bool)):
-        lhs_val = to_torch(lhs_val, dtype=rhs_dtype)
+        lhs_val = to_torch(lhs_val, dtype=_scalar_wrap_dtype(rhs_dtype, lhs_val))
     lhs_val = get_trt_tensor(ctx, lhs_val, f"{name}_lhs", lhs_dtype)
     rhs_val = get_trt_tensor(ctx, rhs_val, f"{name}_rhs", rhs_dtype)
 
@@ -147,6 +162,19 @@ def convert_binary_elementwise(
         )
     )
     trt_promoted_type = promoted_type.to(trt.DataType)
+
+    # TensorRT's elementwise layer only accepts bool operands for genuine
+    # boolean logic ops (AND/OR/XOR). Two bool operands (e.g. mask * mask)
+    # correctly promote to bool by PyTorch's own rules, but every other op
+    # (PROD, SUM, comparisons, ...) rejects bool inputs outright -- fall
+    # back to a numeric type first, matching how PyTorch eager already
+    # treats e.g. bool_tensor * bool_tensor as numeric under the hood.
+    if trt_promoted_type == trt.DataType.BOOL and op_type not in (
+        trt.ElementWiseOperation.AND,
+        trt.ElementWiseOperation.OR,
+        trt.ElementWiseOperation.XOR,
+    ):
+        trt_promoted_type = _enums.dtype._from(torch.int32).to(trt.DataType)
 
     if trt_promoted_type != lhs_val.dtype:
         lhs_val = cast_trt_tensor(

--- a/py/torch_tensorrt/dynamo/lowering/passes/_aten_lowering_pass.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/_aten_lowering_pass.py
@@ -11,6 +11,7 @@ from torch_tensorrt.dynamo.lowering.passes.pass_utils import (
 )
 
 from .annotate_fp8_sdpa import annotate_fp8_sdpa
+from .complex_decomposition_adapter import complex_decomposition_adapter
 from .complex_graph_rewrite import complex_graph_detection
 from .constant_folding import constant_fold
 from .decompose_dynamic_slice_scatter import decompose_dynamic_slice_scatter
@@ -34,6 +35,19 @@ pre_lowering_pass_list = [
     rule_based_autocast,
 ]
 
+
+def complex_lowering_pass(
+    gm: torch.fx.GraphModule, settings: CompilationSettings
+) -> torch.fx.GraphModule:
+    """Select the complex-numerics lowering by settings flag (issue #4390).
+
+    ``use_complex_decomposition`` routes to PyTorch's upstream decomposition;
+    otherwise the legacy hand-rolled rewriter runs.
+    """
+    if getattr(settings, "use_complex_decomposition", False):
+        return complex_decomposition_adapter(gm, settings)
+    return complex_graph_detection(gm, settings)
+
 post_lowering_pass_list = [
     replace_fused_rms_norm,
     remove_input_alias_fixing_clones,
@@ -43,7 +57,7 @@ post_lowering_pass_list = [
     replace_max_pool_with_indices,
     remove_assert_nodes,
     remove_num_users_is_0_nodes,
-    complex_graph_detection,
+    complex_lowering_pass,
     force_causal_efficient_attention,
     eliminate_sym_min_int64_max,
     normalize_negative_slice_stop,

--- a/py/torch_tensorrt/dynamo/lowering/passes/_aten_lowering_pass.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/_aten_lowering_pass.py
@@ -18,6 +18,7 @@ from .decompose_dynamic_slice_scatter import decompose_dynamic_slice_scatter
 from .eliminate_sym_min_int64_max import eliminate_sym_min_int64_max
 from .force_causal_efficient_attention import force_causal_efficient_attention
 from .fuse_prims_broadcast import fuse_prims_broadcast
+from .normalize_negative_slice_stop import normalize_negative_slice_stop
 from .pass_manager import DynamoPassManager
 from .remove_assert_nodes import remove_assert_nodes
 from .remove_detach import remove_detach
@@ -27,7 +28,6 @@ from .repair_input_as_output import repair_input_as_output
 from .replace_fused_rms_norm import replace_fused_rms_norm
 from .replace_max_pool_with_indices import replace_max_pool_with_indices
 from .rule_based_autocast import rule_based_autocast
-from .normalize_negative_slice_stop import normalize_negative_slice_stop
 
 pre_lowering_pass_list = [
     remove_detach,
@@ -47,6 +47,7 @@ def complex_lowering_pass(
     if getattr(settings, "use_complex_decomposition", False):
         return complex_decomposition_adapter(gm, settings)
     return complex_graph_detection(gm, settings)
+
 
 post_lowering_pass_list = [
     replace_fused_rms_norm,

--- a/py/torch_tensorrt/dynamo/lowering/passes/_aten_lowering_pass.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/_aten_lowering_pass.py
@@ -48,6 +48,7 @@ def complex_lowering_pass(
         return complex_decomposition_adapter(gm, settings)
     return complex_graph_detection(gm, settings)
 
+
 post_lowering_pass_list = [
     replace_fused_rms_norm,
     remove_input_alias_fixing_clones,

--- a/py/torch_tensorrt/dynamo/lowering/passes/_aten_lowering_pass.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/_aten_lowering_pass.py
@@ -11,7 +11,9 @@ from torch_tensorrt.dynamo.lowering.passes.pass_utils import (
 )
 
 from .annotate_fp8_sdpa import annotate_fp8_sdpa
-from .complex_decomposition_adapter import complex_decomposition_adapter
+from .complex_decomposition_adapter import (
+    complex_decomposition_adapter as _complex_decomposition_adapter_pass,
+)
 from .complex_graph_rewrite import complex_graph_detection
 from .constant_folding import constant_fold
 from .decompose_dynamic_slice_scatter import decompose_dynamic_slice_scatter
@@ -45,7 +47,7 @@ def complex_lowering_pass(
     otherwise the legacy hand-rolled rewriter runs.
     """
     if getattr(settings, "use_complex_decomposition", False):
-        return complex_decomposition_adapter(gm, settings)
+        return _complex_decomposition_adapter_pass(gm, settings)
     return complex_graph_detection(gm, settings)
 
 

--- a/py/torch_tensorrt/dynamo/lowering/passes/complex_decomposition_adapter.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/complex_decomposition_adapter.py
@@ -1,0 +1,169 @@
+"""Adopt PyTorch's upstream complex decomposition (pytorch/pytorch#169832).
+
+This is the "augment, not replace" path proposed in issue #4390.  Instead of the
+hand-maintained per-op rewriter in ``complex_graph_rewrite.py``, we delegate the
+interior complex -> real expansion to PyTorch's ``decompose_complex_in_graph``
+(a tensor-subclass / SoA retrace) and keep only the TRT-specific glue:
+
+  1. capture the complex I/O signature before rewriting (drives the boundary
+     adapters in ``_compiler._insert_complex_io_adapters``);
+  2. call upstream to expand every complex op into real ops on separate re/im;
+  3. normalize the SoA seams (``aten.complex`` / ``aten.real`` / ``aten.imag``)
+     into the interleaved ``[..., 2]`` layout the rest of the TRT flow expects,
+     so the engine only ever sees real tensors (Option A in the RFC).
+
+Gated by ``settings.use_complex_decomposition``; falls back to the legacy pass on
+older torch (the upstream API only exists in torch>=2.14.0.dev).
+
+NOTE: the exact shape of what ``decompose_complex_in_graph`` emits at the
+boundary must be confirmed by a spike (torch is required to run it).  The steps
+marked ``TODO(spike)`` encode assumptions to validate against real output.
+"""
+
+import logging
+
+import torch
+from torch.fx import GraphModule
+from torch_tensorrt._features import has_complex_decomposition
+from torch_tensorrt.dynamo._settings import CompilationSettings
+from torch_tensorrt.dynamo.lowering.passes.pass_utils import (
+    clean_up_graph_after_modifications,
+)
+
+# Reuse the I/O-signature capture helpers already written for the legacy pass.
+from .complex_graph_rewrite import (
+    _get_complex_input_dtypes,
+    _get_complex_input_names,
+    _get_complex_output_indices,
+    complex_graph_detection,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def complex_decomposition_adapter(
+    gm: GraphModule, settings: CompilationSettings
+) -> GraphModule:
+    """Delegate complex decomposition to upstream, keep TRT boundary glue ours."""
+    if not has_complex_decomposition():
+        logger.warning(
+            "complex decomposition requires torch>=2.14.dev; falling back to the "
+            "legacy complex_graph_detection pass."
+        )
+        return complex_graph_detection(gm, settings)
+
+    # (1) Capture the complex I/O signature BEFORE any rewrite mutates the graph.
+    #     Identical contract to the legacy pass so _insert_complex_io_adapters
+    #     keeps working unchanged.
+    gm.meta["complex_output_indices"] = _get_complex_output_indices(gm)
+    gm.meta["complex_input_names"] = _get_complex_input_names(gm)
+    gm.meta["complex_input_dtypes"] = _get_complex_input_dtypes(gm)
+    if not gm.meta["complex_input_names"] and not gm.meta["complex_output_indices"]:
+        # No complex I/O and no interior complex work -> nothing to do.  (Interior-
+        # only complex still shows up via inputs/outputs of the complex region, so
+        # this early-out matches the legacy pass's behavior.)
+        if not _graph_has_complex(gm):
+            return gm
+
+    # (2) Hand the interior expansion to upstream.
+    from torch._functorch._aot_autograd.complex_decomposition import (
+        decompose_complex_in_graph,
+    )
+
+    flat_args = _fake_flat_args(gm)
+    logger.debug("complex_decomposition_adapter: retracing under ComplexTensor")
+    gm = decompose_complex_in_graph(gm, flat_args)
+
+    # (3) Normalize SoA seams into the interleaved [..., 2] layout used by TRT.
+    gm = _normalize_complex_boundary_for_trt(gm)
+    gm = clean_up_graph_after_modifications(gm)
+    return gm
+
+
+def _graph_has_complex(gm: GraphModule) -> bool:
+    from torch_tensorrt.dynamo.utils import COMPLEX_DTYPES
+
+    for node in gm.graph.nodes:
+        val = node.meta.get("val", None)
+        if val is not None and getattr(val, "dtype", None) in COMPLEX_DTYPES:
+            return True
+    return False
+
+
+def _fake_flat_args(gm: GraphModule) -> list:
+    """Build the example inputs the upstream retrace (make_fx) needs.
+
+    We reuse the placeholders' existing fake tensors so the export ShapeEnv /
+    SymInt ranges are preserved through the retrace.  Whether dynamic shapes
+    actually survive make_fx is RFC open-question #1 -- assert-worthy in the spike.
+    """
+    args = []
+    for node in gm.graph.nodes:
+        if node.op != "placeholder":
+            continue
+        val = node.meta.get("val", None)
+        if val is None:
+            tm = node.meta["tensor_meta"]
+            val = torch.empty(tm.shape, dtype=tm.dtype, device=tm.device)
+        args.append(val)
+    return args
+
+
+def _normalize_complex_boundary_for_trt(gm: GraphModule) -> GraphModule:
+    """Fold upstream's SoA seams into the interleaved ``[..., 2]`` real layout.
+
+    Upstream leaves the graph in terms of separate re/im joined by
+    ``aten.complex(re, im)`` and unpacked by ``aten.real`` / ``aten.imag``.  TRT
+    has no converter for any of those.  We:
+
+      * ``real(z)`` / ``imag(z)`` where ``z = complex(re, im)``  -> re / im
+        (cancel the pack/unpack round-trip)
+      * remaining ``aten.complex(re, im)``  -> ``stack([re, im], -1)`` tagged as
+        complex-layout, so the [..., 2] tensor flows to the boundary adapters.
+
+    TODO(spike): confirm against real decompose_complex_in_graph output --
+    the op set at the boundary (aten.complex vs view_as_complex, real vs
+    select) and whether inputs are unpacked with real/imag or view_as_real.
+    """
+    g = gm.graph
+    aten = torch.ops.aten
+
+    # Pass A: cancel real(complex(re,im)) / imag(complex(re,im)) round-trips.
+    for node in list(g.nodes):
+        if node.op != "call_function" or node.target not in (
+            aten.real.default,
+            aten.imag.default,
+        ):
+            continue
+        # node is  real(z) / imag(z);  node.args[0] is that single arg z -- the
+        # tensor being unpacked (the "source" producer feeding this unpack).
+        src = node.args[0]
+        # Only fold when z was itself produced by aten.complex(re, im): then
+        # real(complex(re,im)) == re and imag(complex(re,im)) == im, so the
+        # pack/unpack round-trip is pure noise.  (isinstance guards against a
+        # non-Node arg, e.g. a constant, which has no .target.)
+        if isinstance(src, torch.fx.Node) and src.target == aten.complex.default:
+            # aten.complex stores re at args[0], im at args[1] -> pick the half
+            # this unpack wanted: real -> 0, imag -> 1.
+            idx = 0 if node.target == aten.real.default else 1
+            # Rewire every consumer of real(z)/imag(z) straight to re/im, then
+            # delete the now-orphaned real()/imag() node.
+            node.replace_all_uses_with(src.args[idx])
+            g.erase_node(node)
+
+    # Pass B: turn surviving aten.complex(re, im) into stack([re, im], -1).
+    for node in list(g.nodes):
+        if node.op != "call_function" or node.target != aten.complex.default:
+            continue
+        re, im = node.args[0], node.args[1]
+        with g.inserting_before(node):
+            re_u = g.call_function(aten.unsqueeze.default, (re, -1))
+            im_u = g.call_function(aten.unsqueeze.default, (im, -1))
+            packed = g.call_function(aten.cat.default, ([re_u, im_u], -1))
+        packed.meta["is_complex_layout"] = True
+        node.replace_all_uses_with(packed)
+        g.erase_node(node)
+
+    g.lint()
+    gm.recompile()
+    return gm

--- a/py/torch_tensorrt/dynamo/lowering/passes/complex_decomposition_adapter.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/complex_decomposition_adapter.py
@@ -53,12 +53,17 @@ def complex_decomposition_adapter(
         return complex_graph_detection(gm, settings)
 
     # (1) Capture the complex I/O signature BEFORE any rewrite mutates the graph.
-    #     Identical contract to the legacy pass so _insert_complex_io_adapters
-    #     keeps working unchanged.
-    gm.meta["complex_output_indices"] = _get_complex_output_indices(gm)
-    gm.meta["complex_input_names"] = _get_complex_input_names(gm)
-    gm.meta["complex_input_dtypes"] = _get_complex_input_dtypes(gm)
-    if not gm.meta["complex_input_names"] and not gm.meta["complex_output_indices"]:
+    #     We stash it in LOCALS (not gm.meta) because decompose_complex_in_graph is
+    #     functional -- it returns a NEW GraphModule via make_fx -- so anything we
+    #     wrote on this instance's module-level .meta would not ride along.  We
+    #     re-attach onto the returned module in step (4).  These three keys are the
+    #     contract _insert_complex_io_adapters reads post-partition to reinsert the
+    #     complex I/O boundary; losing them silently drops the boundary adapters and
+    #     the model returns real [...,2] instead of complex.
+    complex_output_indices = _get_complex_output_indices(gm)
+    complex_input_names = _get_complex_input_names(gm)
+    complex_input_dtypes = _get_complex_input_dtypes(gm)
+    if not complex_input_names and not complex_output_indices:
         # No complex I/O and no interior complex work -> nothing to do.  (Interior-
         # only complex still shows up via inputs/outputs of the complex region, so
         # this early-out matches the legacy pass's behavior.)
@@ -72,11 +77,17 @@ def complex_decomposition_adapter(
 
     flat_args = _fake_flat_args(gm)
     logger.debug("complex_decomposition_adapter: retracing under ComplexTensor")
-    gm = decompose_complex_in_graph(gm, flat_args)
+    gm = decompose_complex_in_graph(gm, flat_args)  # NOTE: returns a new module
 
     # (3) Normalize SoA seams into the interleaved [..., 2] layout used by TRT.
     gm = _normalize_complex_boundary_for_trt(gm)
     gm = clean_up_graph_after_modifications(gm)
+
+    # (4) Re-attach the captured I/O signature onto the RETURNED module so
+    #     _insert_complex_io_adapters can restore the complex boundary.
+    gm.meta["complex_output_indices"] = complex_output_indices
+    gm.meta["complex_input_names"] = complex_input_names
+    gm.meta["complex_input_dtypes"] = complex_input_dtypes
     return gm
 
 

--- a/py/torch_tensorrt/dynamo/lowering/passes/complex_decomposition_adapter.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/complex_decomposition_adapter.py
@@ -90,7 +90,7 @@ def _graph_has_complex(gm: GraphModule) -> bool:
     return False
 
 
-def _fake_flat_args(gm: GraphModule) -> list:
+def _fake_flat_args(gm: GraphModule) -> list[torch.Tensor]:
     """Build the example inputs the upstream retrace (make_fx) needs.
 
     We reuse the placeholders' existing fake tensors so the export ShapeEnv /

--- a/py/torch_tensorrt/dynamo/lowering/passes/complex_decomposition_adapter.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/complex_decomposition_adapter.py
@@ -13,16 +13,16 @@ interior complex -> real expansion to PyTorch's ``decompose_complex_in_graph``
      so the engine only ever sees real tensors (Option A in the RFC).
 
 Gated by ``settings.use_complex_decomposition``; falls back to the legacy pass on
-older torch (the upstream API only exists in torch>=2.14.0.dev).
-
-NOTE: the exact shape of what ``decompose_complex_in_graph`` emits at the
-boundary must be confirmed by a spike (torch is required to run it).  The steps
-marked ``TODO(spike)`` encode assumptions to validate against real output.
+older torch (the upstream API only exists in torch>=2.14.0.dev), or if
+``decompose_complex_in_graph`` itself raises (e.g. an op it doesn't support yet,
+such as ``aten.log2``/``aten.log10`` as of torch 2.14.dev).
 """
 
 import logging
+from typing import Any
 
 import torch
+from torch._export.utils import _detect_fake_mode_from_gm
 from torch.fx import GraphModule
 from torch_tensorrt._features import has_complex_decomposition
 from torch_tensorrt.dynamo._settings import CompilationSettings
@@ -63,6 +63,14 @@ def complex_decomposition_adapter(
     complex_output_indices = _get_complex_output_indices(gm)
     complex_input_names = _get_complex_input_names(gm)
     complex_input_dtypes = _get_complex_input_dtypes(gm)
+    # _compiler.py reads _in_spec/_out_spec off this module post-lowering to
+    # unflatten the final result back to the user's original return shape
+    # (e.g. a bare tensor instead of a 1-tuple). decompose_complex_in_graph's
+    # make_fx retrace returns a plain GraphModule that doesn't carry these
+    # torch.export-specific attributes, so without re-attaching them below,
+    # the unflatten step is silently skipped and callers get a raw tuple.
+    original_in_spec = getattr(gm, "_in_spec", None)
+    original_out_spec = getattr(gm, "_out_spec", None)
     if not complex_input_names and not complex_output_indices:
         # No complex I/O and no interior complex work -> nothing to do.  (Interior-
         # only complex still shows up via inputs/outputs of the complex region, so
@@ -77,7 +85,27 @@ def complex_decomposition_adapter(
 
     flat_args = _fake_flat_args(gm)
     logger.debug("complex_decomposition_adapter: retracing under ComplexTensor")
-    gm = decompose_complex_in_graph(gm, flat_args)  # NOTE: returns a new module
+    try:
+        # NOTE: returns a new module -- assign to a fresh name so that on
+        # failure `gm` still refers to the original, untouched module (this
+        # call either fully succeeds or raises; it never partially mutates
+        # anything, since it builds a new GraphModule rather than editing
+        # the existing one in place).
+        decomposed_gm = decompose_complex_in_graph(gm, flat_args)
+    except Exception as e:
+        # decompose_complex_in_graph is upstream, experimental PyTorch code
+        # (torch._functorch._aot_autograd.complex_decomposition) with
+        # incomplete op coverage today -- e.g. ComplexTensor has no
+        # __torch_dispatch__ for aten.log2/log10 as of torch 2.14.dev. Treat
+        # any failure here as "this op set isn't supported yet" and degrade
+        # to the legacy, well-tested rewriter for the whole graph rather
+        # than hard-failing the compile.
+        logger.warning(
+            f"complex decomposition failed ({type(e).__name__}: {e}); "
+            "falling back to the legacy complex_graph_detection pass."
+        )
+        return complex_graph_detection(gm, settings)
+    gm = decomposed_gm
 
     # (3) Normalize SoA seams into the interleaved [..., 2] layout used by TRT.
     gm = _normalize_complex_boundary_for_trt(gm)
@@ -88,6 +116,10 @@ def complex_decomposition_adapter(
     gm.meta["complex_output_indices"] = complex_output_indices
     gm.meta["complex_input_names"] = complex_input_names
     gm.meta["complex_input_dtypes"] = complex_input_dtypes
+    if original_in_spec is not None:
+        gm._in_spec = original_in_spec
+    if original_out_spec is not None:
+        gm._out_spec = original_out_spec
     return gm
 
 
@@ -105,8 +137,9 @@ def _fake_flat_args(gm: GraphModule) -> list[torch.Tensor]:
     """Build the example inputs the upstream retrace (make_fx) needs.
 
     We reuse the placeholders' existing fake tensors so the export ShapeEnv /
-    SymInt ranges are preserved through the retrace.  Whether dynamic shapes
-    actually survive make_fx is RFC open-question #1 -- assert-worthy in the spike.
+    SymInt ranges are preserved through the retrace. Dynamic shapes survive
+    make_fx (see the dynamic-shape cases in test_complex_ops.py and
+    test_rope_embedding.py).
     """
     args = []
     for node in gm.graph.nodes:
@@ -132,12 +165,30 @@ def _normalize_complex_boundary_for_trt(gm: GraphModule) -> GraphModule:
       * remaining ``aten.complex(re, im)``  -> ``stack([re, im], -1)`` tagged as
         complex-layout, so the [..., 2] tensor flows to the boundary adapters.
 
-    TODO(spike): confirm against real decompose_complex_in_graph output --
-    the op set at the boundary (aten.complex vs view_as_complex, real vs
-    select) and whether inputs are unpacked with real/imag or view_as_real.
+    Confirmed against real decompose_complex_in_graph output: the boundary op
+    set is aten.complex/real/imag as assumed above, unpacked via real/imag
+    (not view_as_real).
     """
     g = gm.graph
     aten = torch.ops.aten
+    fake_mode = _detect_fake_mode_from_gm(gm)
+
+    def _to_fake(arg: Any) -> Any:
+        if isinstance(arg, torch.fx.Node):
+            return arg.meta["val"]
+        if isinstance(arg, (list, tuple)):
+            return [_to_fake(a) for a in arg]
+        return arg
+
+    def _propagate_meta(node: torch.fx.Node) -> None:
+        # Newly inserted nodes (unsqueeze/cat below) have no "val" until we
+        # compute one -- downstream stages (dryrun metadata checks, symbolic
+        # shape extraction) require every node to carry one.
+        if fake_mode is None:
+            return
+        arg_vals = [_to_fake(arg) for arg in node.args]
+        with fake_mode:
+            node.meta["val"] = node.target(*arg_vals)
 
     # Pass A: cancel real(complex(re,im)) / imag(complex(re,im)) round-trips.
     for node in list(g.nodes):
@@ -169,8 +220,11 @@ def _normalize_complex_boundary_for_trt(gm: GraphModule) -> GraphModule:
         re, im = node.args[0], node.args[1]
         with g.inserting_before(node):
             re_u = g.call_function(aten.unsqueeze.default, (re, -1))
+            _propagate_meta(re_u)
             im_u = g.call_function(aten.unsqueeze.default, (im, -1))
+            _propagate_meta(im_u)
             packed = g.call_function(aten.cat.default, ([re_u, im_u], -1))
+            _propagate_meta(packed)
         packed.meta["is_complex_layout"] = True
         node.replace_all_uses_with(packed)
         g.erase_node(node)

--- a/py/torch_tensorrt/dynamo/lowering/passes/complex_decomposition_adapter.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/complex_decomposition_adapter.py
@@ -136,10 +136,20 @@ def _graph_has_complex(gm: GraphModule) -> bool:
 def _fake_flat_args(gm: GraphModule) -> list[torch.Tensor]:
     """Build the example inputs the upstream retrace (make_fx) needs.
 
-    We reuse the placeholders' existing fake tensors so the export ShapeEnv /
-    SymInt ranges are preserved through the retrace. Dynamic shapes survive
-    make_fx (see the dynamic-shape cases in test_complex_ops.py and
-    test_rope_embedding.py).
+    node.meta["val"] is always preferred: it's the live FakeTensor torch.export's
+    fake-tensor tracing sets on every node, carrying the real ShapeEnv/SymInt
+    objects, so reusing it (rather than rebuilding a tensor from its shape)
+    is what makes dynamic shapes survive the retrace (see the dynamic-shape
+    cases in test_complex_ops.py and test_rope_embedding.py).
+
+    node.meta["tensor_meta"] is only consulted as a fallback, for a
+    placeholder that somehow lacks "val" (e.g. a graph shape-propagated via
+    torch.fx.passes.shape_prop.ShapeProp instead of torch.export). That path
+    only ever records concrete shapes, so a symbolic dim reaching here means
+    the graph wasn't produced the way this function expects; we refuse to
+    synthesize a placeholder concrete dimension for it, since a silently
+    wrong shape could retrace successfully but produce numerically wrong
+    results, which is worse than failing loudly.
     """
     args = []
     for node in gm.graph.nodes:
@@ -148,6 +158,16 @@ def _fake_flat_args(gm: GraphModule) -> list[torch.Tensor]:
         val = node.meta.get("val", None)
         if val is None:
             tm = node.meta["tensor_meta"]
+            if any(isinstance(dim, torch.SymInt) for dim in tm.shape):
+                raise RuntimeError(
+                    f"complex_decomposition_adapter: placeholder '{node.name}' has "
+                    "no node.meta['val'] and its tensor_meta.shape contains a "
+                    "symbolic dimension, so a concrete example tensor can't be "
+                    "synthesized for decompose_complex_in_graph. This means the "
+                    "graph wasn't produced via torch.export's fake-tensor tracing "
+                    "(which always sets 'val') -- pass a graph traced that way "
+                    "instead of one shape-propagated via ShapeProp."
+                )
             val = torch.empty(tm.shape, dtype=tm.dtype, device=tm.device)
         args.append(val)
     return args

--- a/tests/py/dynamo/hlo/test_complex_graph_break.py
+++ b/tests/py/dynamo/hlo/test_complex_graph_break.py
@@ -28,11 +28,29 @@ import pytest
 import torch
 import torch.nn as nn
 import torch_tensorrt as torchtrt
+from torch_tensorrt._features import has_complex_decomposition
+from torch_tensorrt.dynamo._settings import CompilationSettings
 from torch_tensorrt.dynamo.lowering.passes.complex_graph_rewrite import (
     complex_graph_detection,
 )
-from torch_tensorrt.dynamo._settings import CompilationSettings
 from torch_tensorrt.dynamo.utils import COSINE_THRESHOLD, cosine_similarity
+
+# The structural tests below assert the LEGACY rewriter's graph-break mechanism
+# (wrapping an unhandled complex op with view_as_complex/view_as_real).  The
+# upstream decomposition path (use_complex_decomposition=True) may instead cover
+# the op outright, so it breaks on fewer ops and the structural shape differs --
+# those checks are therefore legacy-specific.  End-to-end numerical correctness,
+# however, must hold on BOTH paths, so that test is parametrized.
+_DECOMP_PARAMS = [
+    False,
+    pytest.param(
+        True,
+        marks=pytest.mark.skipif(
+            not has_complex_decomposition(),
+            reason="decompose_complex_in_graph requires torch>=2.14.dev",
+        ),
+    ),
+]
 
 try:
     from torch_tensorrt.dynamo.runtime import PythonTorchTensorRTModule
@@ -103,6 +121,11 @@ class ComplexMulThenCumsum(nn.Module):
 @pytest.mark.unit
 def test_unsupported_op_gets_complexify_wrap() -> None:
     """The rewriter wraps cumsum with view_as_complex/view_as_real.
+
+    LEGACY-path specific: this asserts the hand-rolled rewriter's fallback
+    mechanism.  The upstream decomposition path may cover cumsum outright (no
+    wrap / no graph break), so this structural shape does not apply there; the
+    decomp path is exercised via end-to-end correctness instead.
 
     Structural check (no TRT required):
       - After lowering, the graph contains ``view_as_complex`` immediately
@@ -200,35 +223,40 @@ class ComplexTwoTRTBlocksAroundCumsum(nn.Module):
 
 
 @pytest.mark.unit
-def test_complex_partial_lowering_with_graph_break() -> None:
-    """Lowerable complex ops compile to TRT; cumsum runs in PyTorch on complex input.
+@pytest.mark.parametrize("use_decomp", _DECOMP_PARAMS, ids=["legacy", "decomp"])
+def test_complex_partial_lowering_with_graph_break(use_decomp: bool) -> None:
+    """Lowerable complex ops compile to TRT; end-to-end result is correct.
 
-    Asserts:
-      1. The compiled model is numerically correct (cosine sim > threshold).
-      2. At least one ``PythonTorchTensorRTModule`` submodule exists — confirming
-         the lowerable complex ops were compiled to TRT, not all relegated to
-         PyTorch fallback.
-      3. After lowering, cumsum receives a complex-dtype tensor (the
-         view_as_complex wrapper was inserted correctly).
+    Runs on both paths:
+      1. The compiled model is numerically correct (cosine sim > threshold) —
+         holds regardless of whether cumsum graph-breaks (legacy) or is lowered
+         outright (decomp).
+      2. At least one ``PythonTorchTensorRTModule`` submodule exists — the
+         lowerable complex ops compile to TRT, not all relegated to fallback.
+      3. LEGACY only: cumsum receives a complex-dtype tensor (the view_as_complex
+         wrapper was inserted).  Skipped on the decomp path, whose graph-break
+         behavior differs.
     """
     model = ComplexTwoTRTBlocksAroundCumsum().eval().cuda()
     z = _make_freqs(8, 64)
     freqs = _make_freqs(8, 64)
     inputs = (z, freqs)
 
-    # Structural check: verify cumsum gets a complex input after lowering
-    gm = _export_and_lower(model, inputs)
-    for n in gm.graph.nodes:
-        if n.target == torch.ops.aten.cumsum.default:
-            vc_val = n.args[0].meta.get("val")
-            if vc_val is not None:
-                assert vc_val.dtype in (
-                    torch.complex64,
-                    torch.complex128,
-                ), f"cumsum should receive a complex tensor, got {vc_val.dtype}"
-            break
+    # (3) Structural check is legacy-mechanism-specific: verify cumsum gets a
+    # complex input after the legacy lowering.  The decomp path may not wrap it.
+    if not use_decomp:
+        gm = _export_and_lower(model, inputs)
+        for n in gm.graph.nodes:
+            if n.target == torch.ops.aten.cumsum.default:
+                vc_val = n.args[0].meta.get("val")
+                if vc_val is not None:
+                    assert vc_val.dtype in (
+                        torch.complex64,
+                        torch.complex128,
+                    ), f"cumsum should receive a complex tensor, got {vc_val.dtype}"
+                break
 
-    # End-to-end: compile and verify numerical correctness
+    # End-to-end: compile and verify numerical correctness on the selected path
     ep = torch.export.export(model, inputs)
     trt_model = torchtrt.dynamo.compile(
         ep,
@@ -236,6 +264,7 @@ def test_complex_partial_lowering_with_graph_break() -> None:
         min_block_size=1,
         pass_through_build_failures=True,
         use_python_runtime=True,
+        use_complex_decomposition=use_decomp,
     )
     py_out = model(*inputs)
     trt_out = trt_model(*inputs)

--- a/tests/py/dynamo/hlo/test_complex_ops.py
+++ b/tests/py/dynamo/hlo/test_complex_ops.py
@@ -22,6 +22,7 @@ import torch
 import torch.nn as nn
 import torch_tensorrt as torchtrt
 from torch.export import Dim
+from torch_tensorrt._features import has_complex_decomposition
 from torch_tensorrt.dynamo.utils import COSINE_THRESHOLD, cosine_similarity
 
 # ---------------------------------------------------------------------------
@@ -61,6 +62,34 @@ def _cossim_real(py_out: torch.Tensor, trt_out: torch.Tensor, tag: str) -> None:
 
 
 _COMPILE = dict(ir="dynamo", min_block_size=1, pass_through_build_failures=True)
+
+# Extra compile kwargs for the "explicit compile" tests (dynamic-shape and
+# truncate cases) that do NOT spread **_COMPILE.  The autouse fixture below
+# fills this with {"use_complex_decomposition": True} on the decomp param.
+_DECOMP: dict = {}
+
+
+@pytest.fixture(autouse=True, params=[False, True], ids=["legacy", "decomp"])
+def _complex_path(request):
+    """Run every complex test twice: once on the legacy hand-rolled rewriter and
+    once on PyTorch's upstream complex decomposition (issue #4390).
+
+    The flag is toggled on the shared _COMPILE dict (picked up by the ~28 tests
+    that spread **_COMPILE) and mirrored into _DECOMP (spread by the handful of
+    explicit torchtrt.dynamo.compile / truncate tests).
+    """
+    use_decomp = request.param
+    if use_decomp and not has_complex_decomposition():
+        pytest.skip("decompose_complex_in_graph requires torch>=2.14.dev")
+
+    _COMPILE.pop("use_complex_decomposition", None)
+    _DECOMP.clear()
+    if use_decomp:
+        _COMPILE["use_complex_decomposition"] = True
+        _DECOMP["use_complex_decomposition"] = True
+    yield
+    _COMPILE.pop("use_complex_decomposition", None)
+    _DECOMP.clear()
 
 
 # ===========================================================================
@@ -789,7 +818,11 @@ def test_complex_mul_dynamic_seqlen():
     dynamic_shapes = ({1: seq}, {0: seq})
     ep = torch.export.export(model, inputs, dynamic_shapes=dynamic_shapes)
     trt_model = torchtrt.dynamo.compile(
-        ep, inputs=inputs, min_block_size=1, pass_through_build_failures=True
+        ep,
+        inputs=inputs,
+        min_block_size=1,
+        pass_through_build_failures=True,
+        **_DECOMP,
     )
     py_out = model(*inputs)
     trt_out = trt_model(*inputs)
@@ -816,7 +849,11 @@ def test_complex_output_dynamic_batch():
     dynamic_shapes = ({0: batch}, {})
     ep = torch.export.export(model, inputs, dynamic_shapes=dynamic_shapes)
     trt_model = torchtrt.dynamo.compile(
-        ep, inputs=inputs, min_block_size=1, pass_through_build_failures=True
+        ep,
+        inputs=inputs,
+        min_block_size=1,
+        pass_through_build_failures=True,
+        **_DECOMP,
     )
     py_out = model(*inputs)
     trt_out = trt_model(*inputs)
@@ -856,6 +893,7 @@ def test_complex128_truncated_to_float32():
         min_block_size=1,
         pass_through_build_failures=True,
         truncate_double=True,
+        **_DECOMP,
     )
     py_out = model(*inputs).float()  # cast reference to float32 for comparison
     trt_out = trt_model(*inputs)

--- a/tests/py/dynamo/hlo/test_complex_ops.py
+++ b/tests/py/dynamo/hlo/test_complex_ops.py
@@ -65,7 +65,7 @@ _COMPILE = dict(ir="dynamo", min_block_size=1, pass_through_build_failures=True)
 
 # Extra compile kwargs for the "explicit compile" tests (dynamic-shape and
 # truncate cases) that do NOT spread **_COMPILE.  The autouse fixture below
-# fills this with {"use_complex_decomposition": True} on the decomp param.
+# fills this with the use_complex_decomposition value for the current param.
 _DECOMP: dict = {}
 
 
@@ -77,16 +77,20 @@ def _complex_path(request):
     The flag is toggled on the shared _COMPILE dict (picked up by the ~28 tests
     that spread **_COMPILE) and mirrored into _DECOMP (spread by the handful of
     explicit torchtrt.dynamo.compile / truncate tests).
+
+    Both params set the flag EXPLICITLY.  Relying on the default for the legacy
+    param would be wrong: USE_COMPLEX_DECOMPOSITION defaults to
+    has_complex_decomposition(), so on torch>=2.14 an absent key would silently
+    select the decomposition path and the [legacy] variant would stop testing
+    the legacy rewriter.
     """
-    use_decomp = request.param
+    use_decomp = bool(request.param)
     if use_decomp and not has_complex_decomposition():
         pytest.skip("decompose_complex_in_graph requires torch>=2.14.dev")
 
-    _COMPILE.pop("use_complex_decomposition", None)
+    _COMPILE["use_complex_decomposition"] = use_decomp
     _DECOMP.clear()
-    if use_decomp:
-        _COMPILE["use_complex_decomposition"] = True
-        _DECOMP["use_complex_decomposition"] = True
+    _DECOMP["use_complex_decomposition"] = use_decomp
     yield
     _COMPILE.pop("use_complex_decomposition", None)
     _DECOMP.clear()

--- a/tests/py/dynamo/hlo/test_complex_ops.py
+++ b/tests/py/dynamo/hlo/test_complex_ops.py
@@ -70,13 +70,16 @@ _DECOMP: dict = {}
 
 
 @pytest.fixture(autouse=True, params=[False, True], ids=["legacy", "decomp"])
-def _complex_path(request):
+def _complex_path(request, monkeypatch):
     """Run every complex test twice: once on the legacy hand-rolled rewriter and
     once on PyTorch's upstream complex decomposition (issue #4390).
 
     The flag is toggled on the shared _COMPILE dict (picked up by the ~28 tests
     that spread **_COMPILE) and mirrored into _DECOMP (spread by the handful of
-    explicit torchtrt.dynamo.compile / truncate tests).
+    explicit torchtrt.dynamo.compile / truncate tests), via monkeypatch.setitem
+    so the change is scoped to the current test and always reverted -- even if
+    the test itself fails -- rather than relying on manual dict mutation that
+    could leak across tests on a teardown failure.
 
     Both params set the flag EXPLICITLY.  Relying on the default for the legacy
     param would be wrong: USE_COMPLEX_DECOMPOSITION defaults to
@@ -88,12 +91,8 @@ def _complex_path(request):
     if use_decomp and not has_complex_decomposition():
         pytest.skip("decompose_complex_in_graph requires torch>=2.14.dev")
 
-    _COMPILE["use_complex_decomposition"] = use_decomp
-    _DECOMP.clear()
-    _DECOMP["use_complex_decomposition"] = use_decomp
-    yield
-    _COMPILE.pop("use_complex_decomposition", None)
-    _DECOMP.clear()
+    monkeypatch.setitem(_COMPILE, "use_complex_decomposition", use_decomp)
+    monkeypatch.setitem(_DECOMP, "use_complex_decomposition", use_decomp)
 
 
 # ===========================================================================

--- a/tests/py/dynamo/hlo/test_rope_embedding.py
+++ b/tests/py/dynamo/hlo/test_rope_embedding.py
@@ -17,7 +17,29 @@ import torch
 import torch.nn as nn
 import torch_tensorrt as torchtrt
 from torch.export import Dim
+from torch_tensorrt._features import has_complex_decomposition
 from torch_tensorrt.dynamo.utils import COSINE_THRESHOLD, cosine_similarity
+
+# Extra compile kwargs injected into every test's compile_spec by the autouse
+# fixture below: {} on the legacy path, {"use_complex_decomposition": True} on
+# the decomp path (issue #4390).
+_DECOMP: dict = {}
+
+
+@pytest.fixture(autouse=True, params=[False, True], ids=["legacy", "decomp"])
+def _complex_path(request):
+    """Run every RoPE test on both the legacy rewriter and PyTorch's upstream
+    complex decomposition. The dynamic cases here are the acceptance bar for
+    dynamic-shape survival through the upstream make_fx retrace."""
+    use_decomp = request.param
+    if use_decomp and not has_complex_decomposition():
+        pytest.skip("decompose_complex_in_graph requires torch>=2.14.dev")
+    _DECOMP.clear()
+    if use_decomp:
+        _DECOMP["use_complex_decomposition"] = True
+    yield
+    _DECOMP.clear()
+
 
 # ---------------------------------------------------------------------------
 # Shared helper modules
@@ -101,6 +123,7 @@ def test_rope_hf_style_static():
         "ir": "dynamo",
         "min_block_size": 1,
         "pass_through_build_failures": True,
+        **_DECOMP,
     }
     trt_model = torchtrt.compile(model, **compile_spec)
 
@@ -151,6 +174,7 @@ def test_rope_hf_style_dynamic():
         "inputs": inputs,
         "min_block_size": 1,
         "pass_through_build_failures": True,
+        **_DECOMP,
     }
     trt_model = torchtrt.dynamo.compile(exp_program, **compile_spec)
 
@@ -190,6 +214,7 @@ def test_rope_complex_form_static():
         "ir": "dynamo",
         "min_block_size": 1,
         "pass_through_build_failures": True,
+        **_DECOMP,
     }
     trt_model = torchtrt.compile(model, **compile_spec)
 
@@ -233,6 +258,7 @@ def test_rope_complex_form_dynamic():
         "inputs": inputs,
         "min_block_size": 1,
         "pass_through_build_failures": True,
+        **_DECOMP,
     }
     trt_model = torchtrt.dynamo.compile(exp_program, **compile_spec)
 
@@ -337,6 +363,7 @@ def test_rope_in_attention_block_static():
         "ir": "dynamo",
         "min_block_size": 1,
         "pass_through_build_failures": True,
+        **_DECOMP,
     }
     trt_model = torchtrt.compile(model, **compile_spec)
 
@@ -383,6 +410,7 @@ def test_rope_in_attention_block_dynamic():
         "inputs": inputs,
         "min_block_size": 1,
         "pass_through_build_failures": True,
+        **_DECOMP,
     }
     trt_model = torchtrt.dynamo.compile(exp_program, **compile_spec)
 
@@ -424,6 +452,7 @@ def test_rope_complex_form_serialization_retrace(tmp_path):
         "ir": "dynamo",
         "min_block_size": 1,
         "pass_through_build_failures": True,
+        **_DECOMP,
     }
     trt_model = torchtrt.compile(model, **compile_spec)
 
@@ -502,6 +531,7 @@ def test_complex_output_static():
         "ir": "dynamo",
         "min_block_size": 1,
         "pass_through_build_failures": True,
+        **_DECOMP,
     }
     trt_model = torchtrt.compile(model, **compile_spec)
 

--- a/tests/py/dynamo/hlo/test_rope_embedding.py
+++ b/tests/py/dynamo/hlo/test_rope_embedding.py
@@ -21,8 +21,8 @@ from torch_tensorrt._features import has_complex_decomposition
 from torch_tensorrt.dynamo.utils import COSINE_THRESHOLD, cosine_similarity
 
 # Extra compile kwargs injected into every test's compile_spec by the autouse
-# fixture below: {} on the legacy path, {"use_complex_decomposition": True} on
-# the decomp path (issue #4390).
+# fixture below: {"use_complex_decomposition": False} on the legacy path,
+# {"use_complex_decomposition": True} on the decomp path (issue #4390).
 _DECOMP: dict = {}
 
 
@@ -30,13 +30,19 @@ _DECOMP: dict = {}
 def _complex_path(request):
     """Run every RoPE test on both the legacy rewriter and PyTorch's upstream
     complex decomposition. The dynamic cases here are the acceptance bar for
-    dynamic-shape survival through the upstream make_fx retrace."""
-    use_decomp = request.param
+    dynamic-shape survival through the upstream make_fx retrace.
+
+    Both params set the flag EXPLICITLY.  Relying on the default for the legacy
+    param would be wrong: USE_COMPLEX_DECOMPOSITION defaults to
+    has_complex_decomposition(), so on torch>=2.14 an absent key would silently
+    select the decomposition path and the [legacy] variant would stop testing
+    the legacy rewriter.
+    """
+    use_decomp = bool(request.param)
     if use_decomp and not has_complex_decomposition():
         pytest.skip("decompose_complex_in_graph requires torch>=2.14.dev")
     _DECOMP.clear()
-    if use_decomp:
-        _DECOMP["use_complex_decomposition"] = True
+    _DECOMP["use_complex_decomposition"] = use_decomp
     yield
     _DECOMP.clear()
 

--- a/tests/py/dynamo/hlo/test_rope_embedding.py
+++ b/tests/py/dynamo/hlo/test_rope_embedding.py
@@ -27,10 +27,15 @@ _DECOMP: dict = {}
 
 
 @pytest.fixture(autouse=True, params=[False, True], ids=["legacy", "decomp"])
-def _complex_path(request):
+def _complex_path(request, monkeypatch):
     """Run every RoPE test on both the legacy rewriter and PyTorch's upstream
     complex decomposition. The dynamic cases here are the acceptance bar for
     dynamic-shape survival through the upstream make_fx retrace.
+
+    The flag is toggled on the shared _DECOMP dict via monkeypatch.setitem so
+    the change is scoped to the current test and always reverted -- even if
+    the test itself fails -- rather than relying on manual dict mutation that
+    could leak across tests on a teardown failure.
 
     Both params set the flag EXPLICITLY.  Relying on the default for the legacy
     param would be wrong: USE_COMPLEX_DECOMPOSITION defaults to
@@ -41,10 +46,7 @@ def _complex_path(request):
     use_decomp = bool(request.param)
     if use_decomp and not has_complex_decomposition():
         pytest.skip("decompose_complex_in_graph requires torch>=2.14.dev")
-    _DECOMP.clear()
-    _DECOMP["use_complex_decomposition"] = use_decomp
-    yield
-    _DECOMP.clear()
+    monkeypatch.setitem(_DECOMP, "use_complex_decomposition", use_decomp)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/py/dynamo/lowering/test_complex_decomposition_adapter.py
+++ b/tests/py/dynamo/lowering/test_complex_decomposition_adapter.py
@@ -1,0 +1,119 @@
+"""Unit tests for the complex_decomposition_adapter lowering pass (issue #4390).
+
+These tests exercise the TRT-specific glue around PyTorch's upstream complex
+decomposition -- they do NOT require a GPU or a TRT build:
+
+  * _normalize_complex_boundary_for_trt: folds the aten.complex / real / imag
+    seams that decompose_complex_in_graph leaves behind into the interleaved
+    [..., 2] real layout the rest of the TRT flow expects.
+  * the torch-version feature gate: when the upstream API is unavailable the
+    adapter must fall back to the legacy complex_graph_detection pass.
+"""
+
+import pytest
+import torch
+from torch_tensorrt.dynamo.lowering.passes import complex_decomposition_adapter as cda
+
+aten = torch.ops.aten
+
+
+def _targets(gm):
+    return [n.target for n in gm.graph.nodes if n.op == "call_function"]
+
+
+# ---------------------------------------------------------------------------
+# _normalize_complex_boundary_for_trt
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_folds_real_imag_of_complex():
+    """real(complex(re,im)) -> re ;  imag(complex(re,im)) -> im, and the
+    aten.complex / real / imag nodes are erased."""
+
+    class M(torch.nn.Module):
+        def forward(self, re, im):
+            z = torch.ops.aten.complex.default(re, im)
+            return torch.ops.aten.real.default(z), torch.ops.aten.imag.default(z)
+
+    re = torch.randn(4)
+    im = torch.randn(4)
+    gm = torch.fx.symbolic_trace(M())
+
+    gm = cda._normalize_complex_boundary_for_trt(gm)
+    targets = _targets(gm)
+
+    assert aten.real.default not in targets
+    assert aten.imag.default not in targets
+    assert aten.complex.default not in targets  # unused after folding -> DCE'd
+    # outputs should be re, im directly
+    out_re, out_im = gm(re, im)
+    assert torch.equal(out_re, re)
+    assert torch.equal(out_im, im)
+
+
+def test_normalize_packs_surviving_complex_to_interleaved():
+    """A complex(re,im) whose result is actually used becomes
+    cat([unsqueeze(re,-1), unsqueeze(im,-1)], -1) tagged is_complex_layout."""
+
+    class M(torch.nn.Module):
+        def forward(self, re, im):
+            return torch.ops.aten.complex.default(re, im)
+
+    re = torch.randn(3)
+    im = torch.randn(3)
+    gm = torch.fx.symbolic_trace(M())
+
+    gm = cda._normalize_complex_boundary_for_trt(gm)
+    targets = _targets(gm)
+
+    assert aten.complex.default not in targets
+    assert aten.cat.default in targets
+    assert aten.unsqueeze.default in targets
+
+    # the packed cat node must carry the complex-layout tag
+    cat_nodes = [
+        n for n in gm.graph.nodes if n.target == aten.cat.default
+    ]
+    assert cat_nodes and cat_nodes[0].meta.get("is_complex_layout") is True
+
+    # numerically: output is the [...,2] interleaved layout of re/im
+    out = gm(re, im)
+    assert out.shape == (3, 2)
+    assert torch.equal(out[..., 0], re)
+    assert torch.equal(out[..., 1], im)
+
+
+# ---------------------------------------------------------------------------
+# feature gate / fallback
+# ---------------------------------------------------------------------------
+
+
+def test_gate_falls_back_to_legacy_on_old_torch(monkeypatch):
+    """When has_complex_decomposition() is False, the adapter must delegate to
+    the legacy complex_graph_detection pass (and NOT import the upstream API)."""
+    calls = {}
+
+    def fake_legacy(gm, settings):
+        calls["legacy"] = True
+        return gm
+
+    monkeypatch.setattr(cda, "has_complex_decomposition", lambda: False)
+    monkeypatch.setattr(cda, "complex_graph_detection", fake_legacy)
+
+    gm = torch.fx.symbolic_trace(torch.nn.Identity())
+    out = cda.complex_decomposition_adapter(gm, settings=object())
+
+    assert calls.get("legacy") is True
+    assert out is gm
+
+
+@pytest.mark.skipif(
+    not cda.has_complex_decomposition(),
+    reason="decompose_complex_in_graph requires torch>=2.14.dev",
+)
+def test_upstream_api_importable():
+    """Smoke check: on a supported torch, the upstream entry point is importable
+    at the path the adapter uses."""
+    from torch._functorch._aot_autograd.complex_decomposition import (  # noqa: F401
+        decompose_complex_in_graph,
+    )

--- a/tests/py/dynamo/lowering/test_complex_decomposition_adapter.py
+++ b/tests/py/dynamo/lowering/test_complex_decomposition_adapter.py
@@ -115,3 +115,88 @@ def test_upstream_api_importable():
     from torch._functorch._aot_autograd.complex_decomposition import (  # noqa: F401
         decompose_complex_in_graph,
     )
+
+
+# ---------------------------------------------------------------------------
+# I/O-signature metadata survival across the functional decompose call (#7)
+# ---------------------------------------------------------------------------
+
+
+def test_io_metadata_reattached_to_returned_module(monkeypatch):
+    """decompose_complex_in_graph returns a NEW GraphModule, so the complex I/O
+    signature captured pre-decompose must be re-attached onto the returned module
+    -- otherwise _insert_complex_io_adapters reads empty meta and drops the
+    complex boundary. We stub the upstream call to return a fresh module (empty
+    meta) and assert the adapter carries the signature across."""
+    import sys
+    import types
+
+    class M(torch.nn.Module):
+        def forward(self, x):
+            return x
+
+    gm = torch.fx.symbolic_trace(M())
+    # Mark the placeholder/output as complex so the capture returns index [0].
+    for n in gm.graph.nodes:
+        if n.op == "placeholder":
+            n.meta["val"] = torch.zeros(4, dtype=torch.complex64)
+
+    # A DIFFERENT module object that the stubbed decompose "returns" (functional
+    # semantics), with a fresh empty .meta -- exactly the #7 hazard.
+    new_gm = torch.fx.symbolic_trace(M())
+
+    def fake_decompose(g, flat_args, *a, **k):
+        return new_gm
+
+    fake_mod = types.ModuleType("torch._functorch._aot_autograd.complex_decomposition")
+    fake_mod.decompose_complex_in_graph = fake_decompose
+    monkeypatch.setitem(
+        sys.modules,
+        "torch._functorch._aot_autograd.complex_decomposition",
+        fake_mod,
+    )
+    monkeypatch.setattr(cda, "has_complex_decomposition", lambda: True)
+
+    out = cda.complex_decomposition_adapter(gm, settings=object())
+
+    # Functional: we did NOT get the original module back...
+    assert out is not gm
+    # ...and the captured signature rode onto the returned module.
+    assert out.meta.get("complex_output_indices") == [0]
+    assert out.meta.get("complex_input_names") == ["x"]
+
+
+# ---------------------------------------------------------------------------
+# _fake_flat_args: prefer the live fake (ShapeEnv-carrying) over tensor_meta (#3)
+# ---------------------------------------------------------------------------
+
+
+def test_fake_flat_args_prefers_val_over_tensor_meta():
+    """The retrace must receive the placeholders' existing fake tensors unchanged
+    (so the export ShapeEnv/SymInts survive). Only when 'val' is absent do we
+    rebuild from tensor_meta (a lossy, static fallback)."""
+
+    class M(torch.nn.Module):
+        def forward(self, x, y):
+            return x + y
+
+    gm = torch.fx.symbolic_trace(M())
+    placeholders = [n for n in gm.graph.nodes if n.op == "placeholder"]
+
+    live_fake = torch.zeros(2, 3, dtype=torch.float32)
+    placeholders[0].meta["val"] = live_fake
+
+    class _TM:  # minimal tensor_meta stand-in (shape/dtype/device only)
+        shape = (4,)
+        dtype = torch.float32
+        device = torch.device("cpu")
+
+    placeholders[1].meta.pop("val", None)
+    placeholders[1].meta["tensor_meta"] = _TM()
+
+    args = cda._fake_flat_args(gm)
+
+    # The live fake is passed through by identity (ShapeEnv preserved untouched).
+    assert args[0] is live_fake
+    # The val-less placeholder is rebuilt from tensor_meta (static fallback).
+    assert tuple(args[1].shape) == (4,)

--- a/tests/py/dynamo/lowering/test_complex_decomposition_adapter.py
+++ b/tests/py/dynamo/lowering/test_complex_decomposition_adapter.py
@@ -71,9 +71,7 @@ def test_normalize_packs_surviving_complex_to_interleaved():
     assert aten.unsqueeze.default in targets
 
     # the packed cat node must carry the complex-layout tag
-    cat_nodes = [
-        n for n in gm.graph.nodes if n.target == aten.cat.default
-    ]
+    cat_nodes = [n for n in gm.graph.nodes if n.target == aten.cat.default]
     assert cat_nodes and cat_nodes[0].meta.get("is_complex_layout") is True
 
     # numerically: output is the [...,2] interleaved layout of re/im

--- a/tests/py/dynamo/lowering/test_complex_decomposition_adapter.py
+++ b/tests/py/dynamo/lowering/test_complex_decomposition_adapter.py
@@ -117,6 +117,21 @@ def test_upstream_api_importable():
     )
 
 
+def test_default_tracks_has_complex_decomposition():
+    """use_complex_decomposition's default tracks has_complex_decomposition()
+    rather than a fixed value, so this new path is auto-enabled on
+    torch>=2.14.dev instead of being opt-in (see PR description). Lock this
+    in so an accidental hardcoded default doesn't silently change that."""
+    from torch_tensorrt.dynamo import _defaults
+    from torch_tensorrt.dynamo._settings import CompilationSettings
+
+    assert _defaults.USE_COMPLEX_DECOMPOSITION == cda.has_complex_decomposition()
+    assert (
+        CompilationSettings().use_complex_decomposition
+        == cda.has_complex_decomposition()
+    )
+
+
 # ---------------------------------------------------------------------------
 # I/O-signature metadata survival across the functional decompose call (#7)
 # ---------------------------------------------------------------------------

--- a/tests/py/dynamo/lowering/test_complex_decomposition_adapter.py
+++ b/tests/py/dynamo/lowering/test_complex_decomposition_adapter.py
@@ -215,3 +215,32 @@ def test_fake_flat_args_prefers_val_over_tensor_meta():
     assert args[0] is live_fake
     # The val-less placeholder is rebuilt from tensor_meta (static fallback).
     assert tuple(args[1].shape) == (4,)
+
+
+def test_fake_flat_args_raises_on_symbolic_tensor_meta_without_val():
+    """If a placeholder has no "val" and its tensor_meta.shape contains a
+    symbolic dim, we can't synthesize a concrete example tensor safely --
+    fail loudly instead of silently guessing a wrong concrete shape."""
+
+    class M(torch.nn.Module):
+        def forward(self, x):
+            return x + 1
+
+    x = torch.randn(4)
+    ep = torch.export.export(
+        M(), (x,), dynamic_shapes={"x": {0: torch.export.Dim("n", min=1, max=16)}}
+    )
+    gm = ep.module()
+    placeholder = next(n for n in gm.graph.nodes if n.op == "placeholder")
+    sym_dim = placeholder.meta["val"].shape[0]  # a real SymInt, from real export
+
+    class _TM:  # tensor_meta stand-in with a symbolic dim
+        shape = (sym_dim,)
+        dtype = torch.float32
+        device = torch.device("cpu")
+
+    placeholder.meta.pop("val", None)
+    placeholder.meta["tensor_meta"] = _TM()
+
+    with pytest.raises(RuntimeError, match="symbolic dimension"):
+        cda._fake_flat_args(gm)


### PR DESCRIPTION
Adds an alternative complex-numerics lowering path that delegates the interior complex->real expansion to PyTorch's upstream decomposition (decompose_complex_in_graph, pytorch/pytorch#169832) instead of the hand-maintained per-op rewriter in complex_graph_rewrite.py.

The new complex_decomposition_adapter pass:
  - captures the complex I/O signature (reusing the existing helpers) so the post-partition _insert_complex_io_adapters boundary code works unchanged;
  - calls decompose_complex_in_graph on the exported graph, feeding it the placeholders' fake tensors to preserve the export ShapeEnv/SymInts;
  - normalizes the SoA aten.complex/real/imag seams it leaves behind into the interleaved [...,2] layout the rest of the TRT flow expects.

Wiring:
  - use_complex_decomposition setting (default: True when torch>=2.14.dev is installed, via has_complex_decomposition(); False otherwise) selects new vs legacy pass via complex_lowering_pass in _aten_lowering_pass;
  - falls back to complex_graph_detection both on the torch-version gate and if decompose_complex_in_graph itself raises (e.g. an unsupported op like aten.log2/log10 as of torch 2.14.dev).

Tests:
  - test_complex_ops.py parametrized [legacy]/[decomp] via an autouse fixture so the existing suite runs on both paths (decomp auto-skips on torch<2.14);
  - new GPU-free test_complex_decomposition_adapter.py covering the SoA->[...,2] normalization and the fallback gate.

**Behavioral change on torch>=2.14.dev:** this path is auto-enabled whenever the upstream torch feature is available, not opt-in. `use_complex_decomposition=False` forces the legacy path. On torch<2.14.dev, behavior is unchanged.

#4390