### PR TITLE
fix: support ITensor amex in quantize and add `export_torch_mode()` wrapper

### DIFF
--- a/py/torch_tensorrt/dynamo/_tracer.py
+++ b/py/torch_tensorrt/dynamo/_tracer.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import importlib.util
 import logging
+from contextlib import nullcontext
 from inspect import signature
 from typing import Any, Optional, Tuple, Union
 
@@ -79,13 +81,22 @@ def trace(
     dim_registry = build_dim_registry(arg_inputs, kwarg_inputs)
     dynamic_shapes = get_dynamic_shapes_args(mod, arg_inputs, dim_registry)
     dynamic_shapes.update(get_dynamic_shapes_kwargs(kwarg_inputs, dim_registry))
-    exp_program = export(
-        mod,
-        tuple(torch_arg_inputs),
-        kwargs=torch_kwarg_inputs,
-        dynamic_shapes=dynamic_shapes,
-        strict=kwargs.get("strict", False),
-    )
+
+    export_context = nullcontext()
+    if importlib.util.find_spec("modelopt") is not None:
+        from modelopt.torch.quantization.utils import export_torch_mode, is_quantized
+
+        if is_quantized(mod):
+            export_context = export_torch_mode()
+
+    with export_context:
+        exp_program = export(
+            mod,
+            tuple(torch_arg_inputs),
+            kwargs=torch_kwarg_inputs,
+            dynamic_shapes=dynamic_shapes,
+            strict=kwargs.get("strict", False),
+        )
 
     return exp_program
 

--- a/py/torch_tensorrt/dynamo/_tracer.py
+++ b/py/torch_tensorrt/dynamo/_tracer.py
@@ -10,7 +10,11 @@ import torch
 from torch.export import Dim, export
 from torch_tensorrt._Input import Input
 from torch_tensorrt.dynamo._defaults import default_device
-from torch_tensorrt.dynamo.utils import get_torch_inputs, to_torch_device
+from torch_tensorrt.dynamo.utils import (
+    get_torch_inputs,
+    is_quantized_by_modelopt,
+    to_torch_device,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +72,7 @@ def trace(
             "'arg_inputs' and 'inputs' should not be used at the same time."
         )
     arg_inputs = inputs if inputs is not None else arg_inputs
+    assert arg_inputs is not None
 
     if kwarg_inputs is None:
         kwarg_inputs = {}
@@ -83,11 +88,16 @@ def trace(
     dynamic_shapes.update(get_dynamic_shapes_kwargs(kwarg_inputs, dim_registry))
 
     export_context = nullcontext()
-    if importlib.util.find_spec("modelopt") is not None:
-        from modelopt.torch.quantization.utils import export_torch_mode, is_quantized
 
-        if is_quantized(mod):
-            export_context = export_torch_mode()
+    if is_quantized_by_modelopt(mod):
+        if importlib.util.find_spec("modelopt") is None:
+            raise ImportError(
+                "The provided model is quantized by ModelOpt, but ModelOpt is not installed."
+            )
+
+        from modelopt.torch.quantization.utils import export_torch_mode
+
+        export_context = export_torch_mode()
 
     with export_context:
         exp_program = export(

--- a/py/torch_tensorrt/dynamo/conversion/impl/quantize.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/quantize.py
@@ -40,7 +40,7 @@ def quantize(
     source_ir: Optional[SourceIR],
     name: str,
     input_tensor: TRTTensor,
-    amax: Union[np.ndarray, torch.Tensor],
+    amax: Union[np.ndarray, torch.Tensor, TRTTensor],
     num_bits: int,
     exponent_bits: int,
 ) -> TRTTensor:
@@ -78,25 +78,27 @@ def quantize(
             max_bound = 448
 
         axis = None
-        # int8 weight quantization is per-channel quantization(it can have one or multiple amax values)
-        if dtype == trt.DataType.INT8 and amax.numel() > 1:
-            # if the amax has more than one element, calculate the axis, otherwise axis value will be ignored
-            amax_init_shape = amax.shape
-            amax = amax.squeeze().data
-            assert (
-                len(amax.shape) == 1
-            ), f"TensorRT does not support multi-axis quantization. {name=} {amax_init_shape=} {amax.shape=} "
-            axis = list(amax_init_shape).index(list(amax.shape)[0])
-            assert (
-                axis == 0
-            ), f"{name=} {amax=} is per-channel quantization, expected axis to be 0, but got {axis=}"
-        else:
-            # int8 activation and fp8 weight/activation quantization is per-tensor quantization, it can only have single amax value
-            assert (
-                amax.numel() == 1
-            ), f"{name=} is per-tensor quantization, expected amax is a singular value, but got {amax.shape=}"
-
+        # Dynamic amax (TRT ITensor) is always treated as per-tensor; numel()/shape
+        # checks only apply to constant torch/numpy amax values.
         if not isinstance(amax, trt.ITensor):
+            # int8 weight quantization is per-channel quantization(it can have one or multiple amax values)
+            if dtype == trt.DataType.INT8 and amax.numel() > 1:
+                # if the amax has more than one element, calculate the axis, otherwise axis value will be ignored
+                amax_init_shape = amax.shape
+                amax = amax.squeeze().data
+                assert (
+                    len(amax.shape) == 1
+                ), f"TensorRT does not support multi-axis quantization. {name=} {amax_init_shape=} {amax.shape=} "
+                axis = list(amax_init_shape).index(list(amax.shape)[0])
+                assert (
+                    axis == 0
+                ), f"{name=} {amax=} is per-channel quantization, expected axis to be 0, but got {axis=}"
+            else:
+                # int8 activation and fp8 weight/activation quantization is per-tensor quantization, it can only have single amax value
+                assert (
+                    amax.numel() == 1
+                ), f"{name=} is per-tensor quantization, expected amax is a singular value, but got {amax.shape=}"
+
             amax = to_torch(amax, None)
             scale = torch.divide(amax, max_bound)
             scale = get_trt_tensor(ctx, scale, name + "_scale", dtype=torch.float32)

--- a/py/torch_tensorrt/dynamo/lowering/passes/_aten_lowering_pass.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/_aten_lowering_pass.py
@@ -17,6 +17,7 @@ from .decompose_dynamic_slice_scatter import decompose_dynamic_slice_scatter
 from .eliminate_sym_min_int64_max import eliminate_sym_min_int64_max
 from .force_causal_efficient_attention import force_causal_efficient_attention
 from .fuse_prims_broadcast import fuse_prims_broadcast
+from .normalize_negative_slice_stop import normalize_negative_slice_stop
 from .pass_manager import DynamoPassManager
 from .remove_assert_nodes import remove_assert_nodes
 from .remove_detach import remove_detach
@@ -26,7 +27,6 @@ from .repair_input_as_output import repair_input_as_output
 from .replace_fused_rms_norm import replace_fused_rms_norm
 from .replace_max_pool_with_indices import replace_max_pool_with_indices
 from .rule_based_autocast import rule_based_autocast
-from .normalize_negative_slice_stop import normalize_negative_slice_stop
 
 pre_lowering_pass_list = [
     remove_detach,
@@ -138,7 +138,7 @@ def get_lowering_pass_config(lowering_pass: LoweringPassSignature) -> dict[str, 
 def post_lowering(
     gm: torch.fx.GraphModule, settings: CompilationSettings = CompilationSettings()
 ) -> torch.fx.GraphModule:
-    """Applies the lowering passes to a graph module after torch.export/ torch.compile and their decompositions, returns the modified GraphModule"""
+    """Applies the lowering passes to a graph module after torch.export/torch.compile and their decompositions, returns the modified GraphModule"""
     logging.debug(
         f"Invoking DynamoPassManager and applying lowering passes: {ATEN_POST_LOWERING_PASSES}"
     )
@@ -154,8 +154,8 @@ def post_lowering(
 def pre_export_lowering(
     ep: torch.export.ExportedProgram,
     settings: CompilationSettings = CompilationSettings(),
-) -> torch.fx.GraphModule:
-    """Applies the lowering passes to a graph module after torch.export/ torch.compile and their decompositions, returns the modified GraphModule"""
+) -> torch.export.ExportedProgram:
+    """Applies the lowering passes to an ExportedProgram after torch.export/torch.compile but before run_decompositions, returns the modified ExportedProgram."""
     logging.debug(
         f"Invoking DynamoPassManager and applying lowering passes: {ATEN_PRE_LOWERING_PASSES}"
     )

--- a/py/torch_tensorrt/dynamo/utils.py
+++ b/py/torch_tensorrt/dynamo/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ctypes
 import gc
+import importlib.util
 import logging
 import os
 import platform
@@ -1003,3 +1004,23 @@ def release_host_and_device_memory() -> None:
                 logger.warning("Failed to release CPU memory.")
         except Exception:
             logger.warning("Failed to release CPU memory.")
+
+
+def is_quantized_by_modelopt(model: torch.nn.Module) -> bool:
+    """
+    Check if the model has been quantized by NVIDIA ModelOpt library.
+    If ModelOpt is installed, use its function to check if the model is quantized.
+    Otherwise, do name/module-string checks. A caveat is that it can break if ModelOpt renames things.
+    """
+    if importlib.util.find_spec("modelopt") is not None:
+        from modelopt.torch.quantization.utils import is_quantized
+
+        return bool(is_quantized(model))
+
+    for m in model.modules():
+        cls = type(m)
+        if cls.__name__ == "TensorQuantizer" and cls.__module__.startswith(
+            "modelopt.torch.quantization"
+        ):
+            return True
+    return False


### PR DESCRIPTION
# Description

1. support ITensor amex in quantize
2. add `export_torch_mode()` wrapper in `torch_tensorrt.compile` to modelopt quant models 

Fixes #4429 #2976

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
