### PR TITLE
Bump ExecuTorch to 1.4.1

### DIFF
--- a/.github/workflows/executorch-build-linux.yml
+++ b/.github/workflows/executorch-build-linux.yml
@@ -79,7 +79,7 @@ jobs:
         export PATH="${RUNNER_TEMP}/bin:${PATH}"
         bazel --version
 
-        python -m pip install pyyaml "executorch==1.3.1"
+        python -m pip install pyyaml "executorch==1.4.1"
         export TORCH_TENSORRT_EXECUTORCH_RUNTIME_VERSION="$(python -c 'import importlib.metadata; print(importlib.metadata.version("torch-tensorrt"))')"
 
         # Build the no-compile-for-users Python runtime wheel.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -50,8 +50,8 @@ local_torch = use_repo_rule("//toolchains:local_torch.bzl", "local_torch")
 new_git_repository(
     name = "executorch",
     build_file = "@//third_party/executorch:BUILD",
-    # executorch==1.3.1
-    commit = "e2f18eb23c45bd22ca332b0b8b49a81de304b472",
+    # executorch==1.4.1
+    commit = "e4d02f41f7909e8ed5bf4a14ffc520d733453d9f",
     patch_cmds = [
         "find . -mindepth 2 \\( -name BUILD -o -name BUILD.bazel \\) -delete",
         "mkdir executorch && find . -mindepth 1 -maxdepth 1 ! -name executorch ! -name BUILD ! -name BUILD.bazel ! -name REPO.bazel -exec cp -a {} executorch/ \\;",

--- a/docker/MODULE.bazel.docker
+++ b/docker/MODULE.bazel.docker
@@ -62,12 +62,13 @@ new_local_repository(
     build_file = "third_party/libtorch/BUILD"
 )
 
-# Pinned to the ExecuTorch release/1.3 branch head.
+# Keep this pin synchronized with the ExecuTorch release installed in
+# py/torch-tensorrt-executorch-runtime/README.md.
 new_git_repository(
     name = "executorch",
     build_file = "@//third_party/executorch:BUILD",
-    # latest commit in release/1.3 branch
-    commit = "6118688a095fd9697224f5cad72ce42db641c9cd",
+    # executorch==1.4.1
+    commit = "e4d02f41f7909e8ed5bf4a14ffc520d733453d9f",
     patch_cmds = [
         "find . -mindepth 2 \\( -name BUILD -o -name BUILD.bazel \\) -delete",
         "mkdir executorch && find . -mindepth 1 -maxdepth 1 ! -name executorch ! -name BUILD ! -name BUILD.bazel ! -name REPO.bazel -exec cp -a {} executorch/ \\;",

--- a/docker/MODULE.bazel.ngc
+++ b/docker/MODULE.bazel.ngc
@@ -71,12 +71,13 @@ new_local_repository(
     build_file = "third_party/libtorch/BUILD"
 )
 
-# Pinned to the ExecuTorch release/1.3 branch head.
+# Keep this pin synchronized with the ExecuTorch release installed in
+# py/torch-tensorrt-executorch-runtime/README.md.
 new_git_repository(
     name = "executorch",
     build_file = "@//third_party/executorch:BUILD",
-    # latest commit in release/1.3 branch
-    commit = "6118688a095fd9697224f5cad72ce42db641c9cd",
+    # executorch==1.4.1
+    commit = "e4d02f41f7909e8ed5bf4a14ffc520d733453d9f",
     recursive_init_submodules = True,
     patch_cmds = [
         "find . -mindepth 2 \\( -name BUILD -o -name BUILD.bazel \\) -delete",

--- a/py/torch-tensorrt-executorch-runtime/README.md
+++ b/py/torch-tensorrt-executorch-runtime/README.md
@@ -39,7 +39,7 @@ of the wheel runtime contract.
 ```bash
 export TensorRT_ROOT=/path/to/TensorRT
 
-python -m pip install pyyaml "executorch==1.3.1"
+python -m pip install pyyaml "executorch==1.4.1"
 python -m pip wheel --no-build-isolation --no-deps \
   --wheel-dir dist py/torch-tensorrt-executorch-runtime
 ```
@@ -47,7 +47,7 @@ python -m pip wheel --no-build-isolation --no-deps \
 The native build obtains the ExecuTorch source through Bazel; no separate
 source checkout or `EXECUTORCH_SOURCE_DIR` setting is required. The source
 commit pinned in `MODULE.bazel` is the revision recorded by the
-`executorch==1.3.1` wheel.
+`executorch==1.4.1` wheel.
 
 The static ExecuTorch and delegate archives are intermediate build inputs;
 users receive the final native Python module and do not compile anything.

--- a/py/torch-tensorrt-executorch-runtime/pyproject.toml
+++ b/py/torch-tensorrt-executorch-runtime/pyproject.toml
@@ -6,6 +6,6 @@ requires = [
     # environment.
     # Builds must use --no-build-isolation; see README.md.
     "torch",
-    "executorch==1.3.1",
+    "executorch==1.4.1",
 ]
 build-backend = "setuptools.build_meta"

--- a/toolchains/ci_workspaces/MODULE.bazel.tmpl
+++ b/toolchains/ci_workspaces/MODULE.bazel.tmpl
@@ -214,8 +214,8 @@ new_local_repository(
 new_git_repository(
     name = "executorch",
     build_file = "@//third_party/executorch:BUILD",
-    # executorch==1.3.1
-    commit = "e2f18eb23c45bd22ca332b0b8b49a81de304b472",
+    # executorch==1.4.1
+    commit = "e4d02f41f7909e8ed5bf4a14ffc520d733453d9f",
     patch_cmds = [
         "find . -mindepth 2 \\( -name BUILD -o -name BUILD.bazel \\) -delete",
         "mkdir executorch && find . -mindepth 1 -maxdepth 1 ! -name executorch ! -name BUILD ! -name BUILD.bazel ! -name REPO.bazel -exec cp -a {} executorch/ \\;",


### PR DESCRIPTION
## The problem

The pinned ExecuTorch version was 1.3.1. This moves it to 1.4.1, the current stable
release.

## Why several files change

ExecuTorch is referenced twice in different forms. The Bazel build fetches a git commit,
and the Python runtime package installs a released wheel. If those two disagree, the C++
runtime and the Python package get built from different source, and the mismatch does not
show up until much later as a serialized engine layout error. So every place that names
the version moves together:

```
MODULE.bazel and its docker and CI copies    git commit for the 1.4.1 tag
the ExecuTorch build workflow                pip install executorch==1.4.1
the runtime package README and pyproject     same version
```

The comments in the docker and CI copies previously described the pin as a branch head.
They point at a release tag, so they now say so, matching `MODULE.bazel`.

## Testing

Verified that Bazel resolves the new pin, and that the source it resolves to is the
intended release rather than some other commit:

```
bazel fetch @executorch//...
  All external dependencies for the requested targets fetched successfully
fetched tree version.txt: 1.4.1
```
