### PR TITLE
fix the cuda graph issue

### DIFF
--- a/core/runtime/TRTEngine.h
+++ b/core/runtime/TRTEngine.h
@@ -259,7 +259,11 @@ struct TRTEngine : torch::CustomClassHolder {
   std::vector<std::string> serialize();
 
   // CUDAGraph-Related Functionality
-  at::cuda::CUDAGraph cudagraph = {};
+  // Keep the captured graph so its executable can be instantiated explicitly.
+  // PyTorch builds differ on whether capture_end() instantiates automatically;
+  // explicit ownership makes capture/replay behavior consistent across x86-64
+  // and AArch64.
+  at::cuda::CUDAGraph cudagraph = {true};
   at::cuda::CUDAStream engine_stream = c10::cuda::getDefaultCUDAStream();
   at::cuda::CUDAStream caller_stream = c10::cuda::getDefaultCUDAStream();
   at::cuda::CUDAStream default_stream = c10::cuda::getDefaultCUDAStream();

--- a/core/runtime/execute_engine.cpp
+++ b/core/runtime/execute_engine.cpp
@@ -477,6 +477,7 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
           compiled_engine->cudagraph.capture_begin();
           ctx->enqueueV3(recording_stream);
           compiled_engine->cudagraph.capture_end();
+          compiled_engine->cudagraph.instantiate();
           if (compiled_engine->profile_execution) {
             cudaError_t debug_dump_err = cudaGraphDebugDotPrint(
                 compiled_engine->cudagraph.raw_cuda_graph(),


### PR DESCRIPTION
# Description
fixed the cuda graph issue and verified with the following test
 ```
 python -m pytest -ra -v \
tests/py/dynamo/runtime/test_002_cudagraphs_cpp.py::TestCudagraphsCPP::test_cudagraphs_enabled_inference_cpp

  python -m pytest -ra -v \
    tests/py/dynamo/runtime/test_002_cudagraphs_cpp.py::TestCudagraphsCPP::test_cudagraphs_recapture_cpp

  python -m pytest -ra -v \
    tests/py/dynamo/runtime/test_002_cudagraphs_cpp.py

```

Fixes # (issue)
```
File "/workspace/TensorRT/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py", line 712, in forward
    outputs: List[torch.Tensor] = torch.ops.tensorrt.execute_engine(
  File "/opt/conda/envs/py310/lib/python3.10/site-packages/torch/_ops.py", line 1350, in __call__
    return self._op(*args, **kwargs)
RuntimeError: Called CUDAGraph::replay before the graph was instantiated; call instantiate() first.
WARNING: [Torch-TensorRT - Debug Build] - RuntimeCacheHandle::serialize() invoked on a non-RTX build; returning empty bytes.
```

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
