### PR TITLE
fix(dynamo): correct legacy exporter (retrace=False) submodule inlining for hybrid graphs

### DIFF
--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -4,6 +4,7 @@ import operator
 from typing import Any, Dict, Optional, Sequence, Tuple
 
 import torch
+import torch.utils._pytree as pytree
 from torch._export.non_strict_utils import make_constraints
 from torch._guards import detect_fake_mode
 from torch._library.fake_class_registry import FakeScriptObject
@@ -19,6 +20,7 @@ from torch.export.exported_program import (
     OutputSpec,
     TensorArgument,
 )
+from torch.fx.graph import _PyTreeCodeGen
 from torch_tensorrt._features import ENABLED_FEATURES
 from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import ENGINE_IDX, NAME_IDX
 
@@ -230,6 +232,12 @@ def lift(
                         kind=input_kind,
                         arg=input_spec_arg,
                         target=node.target,
+                        # torch>=2.3 requires an explicit persistent flag on BUFFER
+                        # specs. state_dict() excludes non-persistent buffers by
+                        # construction, so any buffer reaching this in-state_dict
+                        # branch is persistent (non-persistent buffers take the
+                        # not-in-state_dict path above and are lifted as constants).
+                        persistent=(True if input_kind == InputKind.BUFFER else None),
                     ),
                 )
                 non_user_input_idx += 1
@@ -243,29 +251,6 @@ def lift(
     gm.graph.lint()
 
     return gm, graph_signature, state_dict, constants
-
-
-def get_duplicate_nodes(
-    gm: torch.fx.GraphModule, submodule: torch.fx.GraphModule
-) -> Tuple[Sequence[Any], Sequence[Any]]:
-    """
-    We check if there are duplicate nodes when we copy submodule graph into gm.
-    Handle the case where the subgraph input placeholders are same as
-    gm placeholders. This happens when the first submodule in the graph is
-    a pytorch submodule
-    """
-    submodule_placeholder_inputs = [
-        node for node in submodule.graph.nodes if node.op == "placeholder"
-    ]
-    submodule_input_node_names = [node.name for node in submodule_placeholder_inputs]
-    gm_node_names = [node.name for node in gm.graph.nodes]
-    submodule_duplicate_inputs = [
-        node for node in submodule_placeholder_inputs if node.name in gm_node_names
-    ]
-    gm_duplicate_inputs = [
-        node for node in gm.graph.nodes if node.name in submodule_input_node_names
-    ]
-    return submodule_duplicate_inputs, gm_duplicate_inputs
 
 
 def inline_torch_modules(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
@@ -285,43 +270,31 @@ def inline_torch_modules(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 # or a placeholder of the main graph
                 submodule_inputs = gm_node.args
 
-                submodule_duplicate_inputs, gm_duplicate_inputs = get_duplicate_nodes(
-                    gm, submodule
-                )
-                assert len(submodule_duplicate_inputs) == len(gm_duplicate_inputs)
-                # Avoid creating new copies of duplicate inputs by creating a mapping
-                val_map = {}
-                for i in range(len(submodule_duplicate_inputs)):
-                    val_map[submodule_duplicate_inputs[i]] = gm_duplicate_inputs[i]
-
-                # Copy all nodes in the submodule into gm and
-                # store the output node of this submodule which is now present in gm
+                # Copy the submodule's nodes into gm, then wire its inputs POSITIONALLY.
+                #
+                # We deliberately do NOT pre-seed val_map by matching submodule input
+                # placeholders to gm nodes by NAME. Name matching silently binds an
+                # input to the WRONG node when names collide (e.g. a _run_on_gpu input
+                # placeholder whose name matches a different engine's getitem), which
+                # rewires a consumer to the wrong producer and orphans the real one --
+                # the orphan is then pruned by dead-code elimination, leaving a delegate
+                # short an output at runtime. It also leaks a mixed submodule's
+                # computed-intermediate inputs as spurious graph inputs. gm_node.args is
+                # the authoritative, ordered list of the real inputs, so we let
+                # graph_copy create a fresh (auto-renamed on collision) placeholder for
+                # every submodule input and rewire each to submodule_inputs[i] by
+                # position, then erase it.
+                val_map: Dict[Any, Any] = {}
                 submodule_output = gm.graph.graph_copy(submodule.graph, val_map)
 
-                # Get their references (since we copied) in the parent graph (gm)
-                if len(submodule_duplicate_inputs) == 0:
-                    submodule_placeholder_input_names = [
-                        node.name
-                        for node in submodule.graph.nodes
-                        if node.op == "placeholder"
-                    ]
-                    gm_added_placeholder_inputs = [
-                        node
-                        for node in gm.graph.nodes
-                        if node.name in submodule_placeholder_input_names
-                    ]
-
-                    assert len(submodule_inputs) == len(gm_added_placeholder_inputs)
-
-                    # Replace the added placeholder inputs with original inputs to this submodule node
-                    for idx in range(len(gm_added_placeholder_inputs)):
-                        gm_added_placeholder_inputs[idx].replace_all_uses_with(
-                            submodule_inputs[idx]
-                        )
-
-                    # Erase the placeholder input nodes in the gm
-                    for idx in range(len(gm_added_placeholder_inputs)):
-                        gm.graph.erase_node(gm_added_placeholder_inputs[idx])
+                submodule_placeholders = [
+                    node for node in submodule.graph.nodes if node.op == "placeholder"
+                ]
+                assert len(submodule_placeholders) == len(submodule_inputs)
+                for idx, submodule_placeholder in enumerate(submodule_placeholders):
+                    copied_placeholder = val_map[submodule_placeholder]
+                    copied_placeholder.replace_all_uses_with(submodule_inputs[idx])
+                    gm.graph.erase_node(copied_placeholder)
 
                 # Replace the pytorch submodule node (call_module) with the inlined subgraph output
                 # Special handling when submodule returns multiple outputs (tuple)
@@ -403,14 +376,29 @@ def create_trt_exp_program(
         input_specs=input_specs, output_specs=output_specs
     )
 
+    # A hybrid TRT+CUDA GraphModule from dynamo.compile carries a plain fx.CodeGen
+    # (no pytree_info): the module already returns a flat tuple, so rebuild
+    # in_spec/out_spec from the example inputs and the flat graph outputs. This
+    # matches retrace=True, which traces the same flat module and likewise cannot
+    # re-nest -- so the fallback never diverges from it.
+    codegen = gm.graph._codegen
+    if isinstance(codegen, _PyTreeCodeGen):
+        in_spec = codegen.pytree_info.in_spec
+        out_spec = codegen.pytree_info.out_spec
+    else:
+        example_args = tuple(arg_inputs) if arg_inputs is not None else ()
+        example_kwargs = kwarg_inputs or {}
+        in_spec = pytree.tree_flatten((example_args, example_kwargs))[1]
+        out_spec = pytree.tree_flatten(tuple(output_nodes))[1]
+
     module_call_graph = [
         ModuleCallEntry(
             "",
             ModuleCallSignature(
                 inputs=[],
                 outputs=[],
-                in_spec=gm.graph._codegen.pytree_info.in_spec,
-                out_spec=gm.graph._codegen.pytree_info.out_spec,
+                in_spec=in_spec,
+                out_spec=out_spec,
             ),
         )
     ]

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -4,6 +4,7 @@ import operator
 from typing import Any, Dict, Optional, Sequence, Tuple
 
 import torch
+import torch.utils._pytree as pytree
 from torch._export.non_strict_utils import make_constraints
 from torch._guards import detect_fake_mode
 from torch._library.fake_class_registry import FakeScriptObject
@@ -19,6 +20,7 @@ from torch.export.exported_program import (
     OutputSpec,
     TensorArgument,
 )
+from torch.fx.graph import _PyTreeCodeGen
 from torch_tensorrt._features import ENABLED_FEATURES
 from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import ENGINE_IDX, NAME_IDX
 
@@ -234,6 +236,12 @@ def lift(
                         kind=input_kind,
                         arg=input_spec_arg,
                         target=node.target,
+                        # torch>=2.3 requires an explicit persistent flag on BUFFER
+                        # specs. state_dict() excludes non-persistent buffers by
+                        # construction, so any buffer reaching this in-state_dict
+                        # branch is persistent (non-persistent buffers take the
+                        # not-in-state_dict path above and are lifted as constants).
+                        persistent=(True if input_kind == InputKind.BUFFER else None),
                     ),
                 )
                 non_user_input_idx += 1
@@ -247,29 +255,6 @@ def lift(
     gm.graph.lint()
 
     return gm, graph_signature, state_dict, constants
-
-
-def get_duplicate_nodes(
-    gm: torch.fx.GraphModule, submodule: torch.fx.GraphModule
-) -> Tuple[Sequence[Any], Sequence[Any]]:
-    """
-    We check if there are duplicate nodes when we copy submodule graph into gm.
-    Handle the case where the subgraph input placeholders are same as
-    gm placeholders. This happens when the first submodule in the graph is
-    a pytorch submodule
-    """
-    submodule_placeholder_inputs = [
-        node for node in submodule.graph.nodes if node.op == "placeholder"
-    ]
-    submodule_input_node_names = [node.name for node in submodule_placeholder_inputs]
-    gm_node_names = [node.name for node in gm.graph.nodes]
-    submodule_duplicate_inputs = [
-        node for node in submodule_placeholder_inputs if node.name in gm_node_names
-    ]
-    gm_duplicate_inputs = [
-        node for node in gm.graph.nodes if node.name in submodule_input_node_names
-    ]
-    return submodule_duplicate_inputs, gm_duplicate_inputs
 
 
 def inline_torch_modules(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
@@ -289,43 +274,31 @@ def inline_torch_modules(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 # or a placeholder of the main graph
                 submodule_inputs = gm_node.args
 
-                submodule_duplicate_inputs, gm_duplicate_inputs = get_duplicate_nodes(
-                    gm, submodule
-                )
-                assert len(submodule_duplicate_inputs) == len(gm_duplicate_inputs)
-                # Avoid creating new copies of duplicate inputs by creating a mapping
-                val_map = {}
-                for i in range(len(submodule_duplicate_inputs)):
-                    val_map[submodule_duplicate_inputs[i]] = gm_duplicate_inputs[i]
-
-                # Copy all nodes in the submodule into gm and
-                # store the output node of this submodule which is now present in gm
+                # Copy the submodule's nodes into gm, then wire its inputs POSITIONALLY.
+                #
+                # We deliberately do NOT pre-seed val_map by matching submodule input
+                # placeholders to gm nodes by NAME. Name matching silently binds an
+                # input to the WRONG node when names collide (e.g. a _run_on_gpu input
+                # placeholder whose name matches a different engine's getitem), which
+                # rewires a consumer to the wrong producer and orphans the real one --
+                # the orphan is then pruned by dead-code elimination, leaving a delegate
+                # short an output at runtime. It also leaks a mixed submodule's
+                # computed-intermediate inputs as spurious graph inputs. gm_node.args is
+                # the authoritative, ordered list of the real inputs, so we let
+                # graph_copy create a fresh (auto-renamed on collision) placeholder for
+                # every submodule input and rewire each to submodule_inputs[i] by
+                # position, then erase it.
+                val_map: Dict[Any, Any] = {}
                 submodule_output = gm.graph.graph_copy(submodule.graph, val_map)
 
-                # Get their references (since we copied) in the parent graph (gm)
-                if len(submodule_duplicate_inputs) == 0:
-                    submodule_placeholder_input_names = [
-                        node.name
-                        for node in submodule.graph.nodes
-                        if node.op == "placeholder"
-                    ]
-                    gm_added_placeholder_inputs = [
-                        node
-                        for node in gm.graph.nodes
-                        if node.name in submodule_placeholder_input_names
-                    ]
-
-                    assert len(submodule_inputs) == len(gm_added_placeholder_inputs)
-
-                    # Replace the added placeholder inputs with original inputs to this submodule node
-                    for idx in range(len(gm_added_placeholder_inputs)):
-                        gm_added_placeholder_inputs[idx].replace_all_uses_with(
-                            submodule_inputs[idx]
-                        )
-
-                    # Erase the placeholder input nodes in the gm
-                    for idx in range(len(gm_added_placeholder_inputs)):
-                        gm.graph.erase_node(gm_added_placeholder_inputs[idx])
+                submodule_placeholders = [
+                    node for node in submodule.graph.nodes if node.op == "placeholder"
+                ]
+                assert len(submodule_placeholders) == len(submodule_inputs)
+                for idx, submodule_placeholder in enumerate(submodule_placeholders):
+                    copied_placeholder = val_map[submodule_placeholder]
+                    copied_placeholder.replace_all_uses_with(submodule_inputs[idx])
+                    gm.graph.erase_node(copied_placeholder)
 
                 # Replace the pytorch submodule node (call_module) with the inlined subgraph output
                 # Special handling when submodule returns multiple outputs (tuple)
@@ -407,14 +380,40 @@ def create_trt_exp_program(
         input_specs=input_specs, output_specs=output_specs
     )
 
+    # A hybrid TRT+CUDA GraphModule from dynamo.compile carries a plain fx.CodeGen
+    # (no pytree_info): the module already returns a flat tuple, so rebuild
+    # in_spec/out_spec from the example inputs (or, when none are supplied,
+    # positionally from the graph placeholders) and the flat graph outputs. With
+    # inputs supplied this matches retrace=True, which traces the same flat module
+    # and likewise cannot re-nest.
+    codegen = gm.graph._codegen
+    if isinstance(codegen, _PyTreeCodeGen):
+        in_spec = codegen.pytree_info.in_spec
+        out_spec = codegen.pytree_info.out_spec
+    else:
+        example_args = tuple(arg_inputs) if arg_inputs is not None else ()
+        example_kwargs = kwarg_inputs or {}
+        if not example_args and not example_kwargs and input_nodes:
+            # Reachable with no example inputs (save(retrace=False) passes
+            # arg_inputs=()); flattening them gives a 0-leaf spec that mismatches
+            # the placeholders and fails only later, so size it from them instead.
+            in_spec = pytree.tree_flatten((tuple(range(len(input_nodes))), {}))[1]
+        else:
+            in_spec = pytree.tree_flatten((example_args, example_kwargs))[1]
+        out_spec = pytree.tree_flatten(tuple(output_nodes))[1]
+        assert in_spec.num_leaves == len(input_nodes), (
+            f"create_trt_exp_program: in_spec has {in_spec.num_leaves} leaves but "
+            f"the graph has {len(input_nodes)} input placeholder(s)"
+        )
+
     module_call_graph = [
         ModuleCallEntry(
             "",
             ModuleCallSignature(
                 inputs=[],
                 outputs=[],
-                in_spec=gm.graph._codegen.pytree_info.in_spec,
-                out_spec=gm.graph._codegen.pytree_info.out_spec,
+                in_spec=in_spec,
+                out_spec=out_spec,
             ),
         )
     ]

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -399,6 +399,17 @@ def create_trt_exp_program(
             # the placeholders and fails only later, so size it from them instead.
             in_spec = pytree.tree_flatten((tuple(range(len(input_nodes))), {}))[1]
         else:
+            # pytree flattens kwargs in dict insertion order, but the graph
+            # consumes placeholders positionally, so kwargs passed out of
+            # signature order would silently bind to the wrong input. Each kwarg
+            # placeholder's target is its key, so when the trailing placeholder
+            # targets match the kwarg keys, reorder the kwargs into that order.
+            if example_kwargs:
+                kwarg_targets = [
+                    node.target for node in input_nodes[len(example_args) :]
+                ]
+                if set(kwarg_targets) == set(example_kwargs):
+                    example_kwargs = {key: example_kwargs[key] for key in kwarg_targets}
             in_spec = pytree.tree_flatten((example_args, example_kwargs))[1]
         out_spec = pytree.tree_flatten(tuple(output_nodes))[1]
         assert in_spec.num_leaves == len(input_nodes), (

--- a/tests/py/dynamo/models/test_exporter_inlining.py
+++ b/tests/py/dynamo/models/test_exporter_inlining.py
@@ -1,0 +1,127 @@
+"""Unit tests for the legacy dynamo exporter's submodule inlining
+(torch_tensorrt.dynamo._exporter). These run on plain fx graphs and need neither a
+GPU nor a TensorRT build."""
+
+import operator
+
+import pytest
+import torch
+from torch_tensorrt.dynamo._exporter import inline_torch_modules
+
+
+@pytest.mark.unit
+def test_inline_torch_modules_wires_inputs_by_position():
+    """inline_torch_modules must wire a _run_on_gpu submodule's inputs from the
+    call_module args by POSITION, not by matching placeholder names to graph nodes.
+
+    Regression: the old name-matching path bound a submodule input to a same-named
+    but unrelated graph node, rewiring a consumer to the wrong producer (and, for a
+    submodule mixing graph-input and computed-intermediate inputs, leaking the
+    latter as spurious graph placeholders). Here the submodule's first input
+    placeholder is named "y", colliding with the parent's second input "y" even
+    though the first *argument* is the parent's "x"; positional wiring must ignore
+    the collision. Subtraction makes the input order observable.
+    """
+    # Submodule: out = first - second. First placeholder deliberately named "y".
+    sub_graph = torch.fx.Graph()
+    first = sub_graph.placeholder("y")
+    second = sub_graph.placeholder("z")
+    sub_graph.output(sub_graph.call_function(torch.sub, (first, second)))
+    submodule = torch.fx.GraphModule(torch.nn.Module(), sub_graph)
+
+    # Parent: inputs (x, y); call _run_on_gpu_0(x, y) -> expected x - y.
+    parent_graph = torch.fx.Graph()
+    x = parent_graph.placeholder("x")
+    y = parent_graph.placeholder("y")
+    root = torch.nn.Module()
+    root.add_module("_run_on_gpu_0", submodule)
+    call = parent_graph.call_module("_run_on_gpu_0", (x, y))
+    parent_graph.output(call)
+    parent = torch.fx.GraphModule(root, parent_graph)
+
+    n_placeholders_before = sum(1 for n in parent.graph.nodes if n.op == "placeholder")
+
+    inline_torch_modules(parent)
+    parent.recompile()
+
+    # No spurious placeholders leaked by the inlining.
+    assert (
+        sum(1 for n in parent.graph.nodes if n.op == "placeholder")
+        == n_placeholders_before
+    )
+    # No call_module node survives (the submodule was inlined).
+    assert not any(n.op == "call_module" for n in parent.graph.nodes)
+    # Positional wiring: first input <- x, second input <- y, so out == x - y.
+    out = parent(torch.tensor(5.0), torch.tensor(3.0))
+    assert torch.allclose(out, torch.tensor(2.0))
+
+
+@pytest.mark.unit
+def test_inline_torch_modules_preserves_all_submodule_outputs():
+    """A multi-output _run_on_gpu submodule must keep every output wired to its
+    consumer after inlining. Regression: a mis-wired input orphaned one submodule
+    output, which dead-code elimination then pruned, leaving a downstream consumer
+    (or, in the hybrid case, a TensorRT engine) short an output at runtime.
+    """
+    # Submodule returns (a + b, a - b); both outputs are consumed downstream.
+    sub_graph = torch.fx.Graph()
+    a = sub_graph.placeholder("a")
+    b = sub_graph.placeholder("b")
+    add = sub_graph.call_function(torch.add, (a, b))
+    sub = sub_graph.call_function(torch.sub, (a, b))
+    sub_graph.output((add, sub))
+    submodule = torch.fx.GraphModule(torch.nn.Module(), sub_graph)
+
+    parent_graph = torch.fx.Graph()
+    x = parent_graph.placeholder("x")
+    y = parent_graph.placeholder("y")
+    root = torch.nn.Module()
+    root.add_module("_run_on_gpu_0", submodule)
+    call = parent_graph.call_module("_run_on_gpu_0", (x, y))
+    o0 = parent_graph.call_function(operator.getitem, (call, 0))
+    o1 = parent_graph.call_function(operator.getitem, (call, 1))
+    # Consume both outputs: (a+b) * (a-b).
+    parent_graph.output(parent_graph.call_function(torch.mul, (o0, o1)))
+    parent = torch.fx.GraphModule(root, parent_graph)
+
+    inline_torch_modules(parent)
+    parent.recompile()
+
+    # (x+y)*(x-y) == x^2 - y^2 ; with x=5, y=3 -> 25 - 9 = 16.
+    out = parent(torch.tensor(5.0), torch.tensor(3.0))
+    assert torch.allclose(out, torch.tensor(16.0))
+
+
+@pytest.mark.unit
+def test_inline_torch_modules_computed_intermediate_inputs():
+    """A _run_on_gpu submodule whose inputs are computed intermediates (not top-level
+    graph placeholders, and not name-matching any graph node) must inline correctly.
+    This is the case the old zero-duplicate path handled; positional wiring preserves
+    it (and it is the shape that leaked spurious placeholders in the mixed case).
+    """
+    # Submodule: out = m + n. Names don't collide with anything in the parent.
+    sub_graph = torch.fx.Graph()
+    m = sub_graph.placeholder("m")
+    n = sub_graph.placeholder("n")
+    sub_graph.output(sub_graph.call_function(torch.add, (m, n)))
+    submodule = torch.fx.GraphModule(torch.nn.Module(), sub_graph)
+
+    # Parent: x -> c0 = x*2, c1 = x+1; call _run_on_gpu_0(c0, c1) -> c0 + c1.
+    parent_graph = torch.fx.Graph()
+    x = parent_graph.placeholder("x")
+    c0 = parent_graph.call_function(torch.mul, (x, 2))
+    c1 = parent_graph.call_function(torch.add, (x, 1))
+    root = torch.nn.Module()
+    root.add_module("_run_on_gpu_0", submodule)
+    call = parent_graph.call_module("_run_on_gpu_0", (c0, c1))
+    parent_graph.output(call)
+    parent = torch.fx.GraphModule(root, parent_graph)
+
+    inline_torch_modules(parent)
+    parent.recompile()
+
+    # No spurious placeholders leaked; the computed intermediates stay in-graph.
+    assert sum(1 for node in parent.graph.nodes if node.op == "placeholder") == 1
+    # out = (x*2) + (x+1); x=5 -> 10 + 6 = 16.
+    out = parent(torch.tensor(5.0))
+    assert torch.allclose(out, torch.tensor(16.0))

--- a/tests/py/dynamo/models/test_exporter_inlining.py
+++ b/tests/py/dynamo/models/test_exporter_inlining.py
@@ -1,0 +1,175 @@
+"""Unit tests for the legacy dynamo exporter's submodule inlining
+(torch_tensorrt.dynamo._exporter). These run on plain fx graphs and need neither a
+GPU nor a TensorRT build."""
+
+import operator
+
+import pytest
+import torch
+from torch_tensorrt.dynamo._exporter import (
+    create_trt_exp_program,
+    inline_torch_modules,
+)
+
+
+@pytest.mark.unit
+def test_inline_torch_modules_wires_inputs_by_position():
+    """inline_torch_modules must wire a _run_on_gpu submodule's inputs from the
+    call_module args by POSITION, not by matching placeholder names to graph nodes.
+
+    Regression: the old name-matching path bound a submodule input to a same-named
+    but unrelated graph node, rewiring a consumer to the wrong producer (and, for a
+    submodule mixing graph-input and computed-intermediate inputs, leaking the
+    latter as spurious graph placeholders). Here the submodule's first input
+    placeholder is named "y", colliding with the parent's second input "y" even
+    though the first *argument* is the parent's "x"; positional wiring must ignore
+    the collision. Subtraction makes the input order observable.
+    """
+    # Submodule: out = first - second. First placeholder deliberately named "y".
+    sub_graph = torch.fx.Graph()
+    first = sub_graph.placeholder("y")
+    second = sub_graph.placeholder("z")
+    sub_graph.output(sub_graph.call_function(torch.sub, (first, second)))
+    submodule = torch.fx.GraphModule(torch.nn.Module(), sub_graph)
+
+    # Parent: inputs (x, y); call _run_on_gpu_0(x, y) -> expected x - y.
+    parent_graph = torch.fx.Graph()
+    x = parent_graph.placeholder("x")
+    y = parent_graph.placeholder("y")
+    root = torch.nn.Module()
+    root.add_module("_run_on_gpu_0", submodule)
+    call = parent_graph.call_module("_run_on_gpu_0", (x, y))
+    parent_graph.output(call)
+    parent = torch.fx.GraphModule(root, parent_graph)
+
+    n_placeholders_before = sum(1 for n in parent.graph.nodes if n.op == "placeholder")
+
+    inline_torch_modules(parent)
+    parent.recompile()
+
+    # No spurious placeholders leaked by the inlining.
+    assert (
+        sum(1 for n in parent.graph.nodes if n.op == "placeholder")
+        == n_placeholders_before
+    )
+    # No call_module node survives (the submodule was inlined).
+    assert not any(n.op == "call_module" for n in parent.graph.nodes)
+    # Positional wiring: first input <- x, second input <- y, so out == x - y.
+    out = parent(torch.tensor(5.0), torch.tensor(3.0))
+    assert torch.allclose(out, torch.tensor(2.0))
+
+
+@pytest.mark.unit
+def test_inline_torch_modules_preserves_all_submodule_outputs():
+    """A multi-output _run_on_gpu submodule must keep every output wired to its
+    consumer after inlining. Regression: a mis-wired input orphaned one submodule
+    output, which dead-code elimination then pruned, leaving a downstream consumer
+    (or, in the hybrid case, a TensorRT engine) short an output at runtime.
+    """
+    # Submodule returns (a + b, a - b); both outputs are consumed downstream.
+    sub_graph = torch.fx.Graph()
+    a = sub_graph.placeholder("a")
+    b = sub_graph.placeholder("b")
+    add = sub_graph.call_function(torch.add, (a, b))
+    sub = sub_graph.call_function(torch.sub, (a, b))
+    sub_graph.output((add, sub))
+    submodule = torch.fx.GraphModule(torch.nn.Module(), sub_graph)
+
+    parent_graph = torch.fx.Graph()
+    x = parent_graph.placeholder("x")
+    y = parent_graph.placeholder("y")
+    root = torch.nn.Module()
+    root.add_module("_run_on_gpu_0", submodule)
+    call = parent_graph.call_module("_run_on_gpu_0", (x, y))
+    o0 = parent_graph.call_function(operator.getitem, (call, 0))
+    o1 = parent_graph.call_function(operator.getitem, (call, 1))
+    # Consume both outputs: (a+b) * (a-b).
+    parent_graph.output(parent_graph.call_function(torch.mul, (o0, o1)))
+    parent = torch.fx.GraphModule(root, parent_graph)
+
+    inline_torch_modules(parent)
+    parent.recompile()
+
+    # (x+y)*(x-y) == x^2 - y^2 ; with x=5, y=3 -> 25 - 9 = 16.
+    out = parent(torch.tensor(5.0), torch.tensor(3.0))
+    assert torch.allclose(out, torch.tensor(16.0))
+
+
+@pytest.mark.unit
+def test_inline_torch_modules_computed_intermediate_inputs():
+    """A _run_on_gpu submodule whose inputs are computed intermediates (not top-level
+    graph placeholders, and not name-matching any graph node) must inline correctly.
+    This is the case the old zero-duplicate path handled; positional wiring preserves
+    it (and it is the shape that leaked spurious placeholders in the mixed case).
+    """
+    # Submodule: out = m + n. Names don't collide with anything in the parent.
+    sub_graph = torch.fx.Graph()
+    m = sub_graph.placeholder("m")
+    n = sub_graph.placeholder("n")
+    sub_graph.output(sub_graph.call_function(torch.add, (m, n)))
+    submodule = torch.fx.GraphModule(torch.nn.Module(), sub_graph)
+
+    # Parent: x -> c0 = x*2, c1 = x+1; call _run_on_gpu_0(c0, c1) -> c0 + c1.
+    parent_graph = torch.fx.Graph()
+    x = parent_graph.placeholder("x")
+    c0 = parent_graph.call_function(torch.mul, (x, 2))
+    c1 = parent_graph.call_function(torch.add, (x, 1))
+    root = torch.nn.Module()
+    root.add_module("_run_on_gpu_0", submodule)
+    call = parent_graph.call_module("_run_on_gpu_0", (c0, c1))
+    parent_graph.output(call)
+    parent = torch.fx.GraphModule(root, parent_graph)
+
+    inline_torch_modules(parent)
+    parent.recompile()
+
+    # No spurious placeholders leaked; the computed intermediates stay in-graph.
+    assert sum(1 for node in parent.graph.nodes if node.op == "placeholder") == 1
+    # out = (x*2) + (x+1); x=5 -> 10 + 6 = 16.
+    out = parent(torch.tensor(5.0))
+    assert torch.allclose(out, torch.tensor(16.0))
+
+
+@pytest.mark.unit
+def test_create_trt_exp_program_rebuilds_in_spec_without_inputs():
+    """create_trt_exp_program must rebuild a correct in_spec on the plain-CodeGen
+    fallback even when no example inputs are supplied.
+
+    Regression: torch_tensorrt.save(retrace=False) passes arg_inputs=() by
+    contract. Flattening an empty () produced a 0-leaf in_spec while the graph kept
+    its placeholders, so the ExportedProgram built and saved but failed later --
+    ep.module()(x) raised "Trying to flatten user inputs ..." and
+    output_format="executorch" failed inside to_edge. The no-input path must
+    instead rebuild the spec positionally from the placeholders. Reachable in the
+    normal flow because lift_mutated_buffers sets a plain CodeGen for any
+    mutated-buffer (KV-cache) model.
+    """
+
+    class M(torch.nn.Module):
+        def forward(self, x):
+            return x.relu()
+
+    # ExportedProgram.module() carries a _PyTreeCodeGen plus a _guards_fn node;
+    # lift_mutated_buffers strips both (replacing the codegen with a plain one) for
+    # mutated-buffer models. Replicate that so the fallback branch is exercised.
+    gm = torch.export.export(M().eval(), (torch.randn(3, 4),)).module()
+    for node in list(gm.graph.nodes):
+        if node.op == "call_module" and node.target == "_guards_fn":
+            gm.graph.erase_node(node)
+            break
+    gm.graph.set_codegen(torch.fx.graph.CodeGen())
+    gm.graph.lint()
+    gm.recompile()
+
+    # retrace=False passes arg_inputs=() -- the no-input path.
+    ep = create_trt_exp_program(gm, arg_inputs=())
+
+    n_user_inputs = sum(
+        1 for s in ep.graph_signature.input_specs if s.kind.name == "USER_INPUT"
+    )
+    assert n_user_inputs == 1
+
+    x = torch.randn(3, 4)
+    out = ep.module()(x)
+    out = out[0] if isinstance(out, (tuple, list)) else out
+    assert torch.allclose(out, x.relu())

--- a/tests/py/dynamo/models/test_exporter_inlining.py
+++ b/tests/py/dynamo/models/test_exporter_inlining.py
@@ -6,9 +6,18 @@ import operator
 
 import pytest
 import torch
+from torch.export.graph_signature import (
+    ExportGraphSignature,
+    InputKind,
+    InputSpec,
+    OutputKind,
+    OutputSpec,
+    TensorArgument,
+)
 from torch_tensorrt.dynamo._exporter import (
     create_trt_exp_program,
     inline_torch_modules,
+    lift,
 )
 
 
@@ -65,10 +74,18 @@ def test_inline_torch_modules_preserves_all_submodule_outputs():
     consumer after inlining. Regression: a mis-wired input orphaned one submodule
     output, which dead-code elimination then pruned, leaving a downstream consumer
     (or, in the hybrid case, a TensorRT engine) short an output at runtime.
+
+    The submodule's first placeholder is deliberately named "y" so it collides
+    with the parent's second input "y", even though the first *argument* passed is
+    the parent's "x". Wiring by position binds that first input to "x" and passes;
+    wiring by name would instead pre-seed "y" to the parent's "y", drop the "x"
+    binding, and fail with a missing positional argument. That collision is what
+    makes the test discriminate between the two.
     """
-    # Submodule returns (a + b, a - b); both outputs are consumed downstream.
+    # Submodule returns (y + b, y - b); both outputs are consumed downstream.
+    # First placeholder named "y" to collide with the parent's second input.
     sub_graph = torch.fx.Graph()
-    a = sub_graph.placeholder("a")
+    a = sub_graph.placeholder("y")
     b = sub_graph.placeholder("b")
     add = sub_graph.call_function(torch.add, (a, b))
     sub = sub_graph.call_function(torch.sub, (a, b))
@@ -173,3 +190,87 @@ def test_create_trt_exp_program_rebuilds_in_spec_without_inputs():
     out = ep.module()(x)
     out = out[0] if isinstance(out, (tuple, list)) else out
     assert torch.allclose(out, x.relu())
+
+
+@pytest.mark.unit
+def test_create_trt_exp_program_reorders_kwargs_to_placeholder_order():
+    """On the plain-CodeGen fallback, create_trt_exp_program must build in_spec in
+    placeholder order even when kwargs are supplied in a different order.
+
+    Regression: pytree flattens kwargs in dict insertion order while the graph
+    consumes placeholders positionally, so kwargs passed out of signature order
+    silently bound each value to the wrong input. a - b with reversed kwargs must
+    still compute a - b.
+    """
+
+    class Sub(torch.nn.Module):
+        def forward(self, a, b):
+            return a - b
+
+    gm = torch.export.export(
+        Sub().eval(), (), {"a": torch.tensor(10.0), "b": torch.tensor(3.0)}
+    ).module()
+    # Force the plain-CodeGen fallback branch (see the no-input test above).
+    for node in list(gm.graph.nodes):
+        if node.op == "call_module" and node.target == "_guards_fn":
+            gm.graph.erase_node(node)
+            break
+    gm.graph.set_codegen(torch.fx.graph.CodeGen())
+    gm.graph.lint()
+    gm.recompile()
+
+    # Kwargs supplied in reverse of the (a, b) placeholder order.
+    ep = create_trt_exp_program(
+        gm, kwarg_inputs={"b": torch.tensor(3.0), "a": torch.tensor(10.0)}
+    )
+    # in_spec must record the kwargs in placeholder order (a, b), not caller order.
+    assert ep.call_spec.in_spec.children()[1].context == ["a", "b"]
+
+    out = ep.module()(a=torch.tensor(10.0), b=torch.tensor(3.0))
+    out = out[0] if isinstance(out, (tuple, list)) else out
+    assert torch.allclose(out, torch.tensor(7.0))
+
+
+@pytest.mark.unit
+def test_lift_sets_persistent_true_on_buffer_spec():
+    """lift() must mark a lifted BUFFER InputSpec as persistent.
+
+    torch>=2.3 asserts an explicit persistent flag on BUFFER specs
+    ("Failed to specify persistent flag on BUFFER"); a registered buffer that
+    reaches lift() through the in-state_dict branch is persistent by construction
+    (non-persistent buffers are excluded from state_dict and lifted as constants).
+    This pins _exporter.py so a dropped persistent= would fail loudly here.
+    """
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    fake_mode = FakeTensorMode()
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    with fake_mode:
+        x.meta["val"] = torch.empty(3, 4)
+    buf_attr = graph.get_attr("my_buffer")
+    add = graph.call_function(torch.add, (x, buf_attr))
+    graph.output((add,))
+
+    root = torch.nn.Module()
+    root.register_buffer("my_buffer", torch.zeros(3, 4))
+    gm = torch.fx.GraphModule(root, graph)
+
+    graph_signature = ExportGraphSignature(
+        input_specs=[
+            InputSpec(InputKind.USER_INPUT, TensorArgument(name="x"), target=None)
+        ],
+        output_specs=[
+            OutputSpec(
+                OutputKind.USER_OUTPUT, TensorArgument(name=add.name), target=None
+            )
+        ],
+    )
+
+    _, lifted_signature, _, _ = lift(gm, graph_signature)
+
+    buffer_specs = [
+        spec for spec in lifted_signature.input_specs if spec.kind == InputKind.BUFFER
+    ]
+    assert len(buffer_specs) == 1
+    assert buffer_specs[0].persistent is True


### PR DESCRIPTION
## Description

`torch_tensorrt.save(..., retrace=False)` runs the legacy exporter, which calls `inline_torch_modules` to collapse submodules into the parent graph. That inlining wired submodule inputs **by placeholder name**. When a submodule input placeholder's name collides with an unrelated node in the parent graph, `graph_copy` maps the submodule body onto that node through a pre-seeded `val_map` — so the original producer is **consumed and disappears from the graph entirely**. This is silent: it surfaces only later as a delegate (or TensorRT engine) reporting the wrong argument count at runtime, or as a wrong numerical result rather than a crash.

A related failure hit multi-output submodules: a mis-wired input orphaned one submodule output, dead-code elimination then pruned it, and a downstream consumer (in the hybrid case, a TensorRT engine) was left short an output.

This path is on by default for composable hybrid TensorRT + CUDA `.pte` export (`retrace=False`), so it matters for that flow.

## Fix

- **Wire submodule inputs positionally** from the `call_module` node's `args` (the authoritative ordered list of what the node actually consumes) instead of matching by placeholder name, and remove the name-based `get_duplicate_nodes` matching. Names are incidental and can legally collide after graph surgery; there is no correct name-matching here.
- **`create_trt_exp_program` kwargs ordering:** `pytree` flattens kwargs in dict-insertion order while the graph consumes placeholders positionally, so kwargs passed out of signature order silently bound each value to the wrong input (the `num_leaves` assert only checks the count). Reorder kwargs into placeholder order before flattening.
- **`persistent=True` on lifted BUFFER specs:** torch >= 2.3 asserts an explicit `persistent` flag on `BUFFER`-kind `InputSpec`s. A buffer only reaches this branch when it is in `state_dict`, which excludes non-persistent buffers by construction, so `True` is always correct here.

> Note: the kwargs reorder handles flat, top-level kwargs passed out of signature order. An out-of-order *nested* kwarg (one whose value is itself a dict/list that flattens to multiple placeholders) falls through the `set(kwarg_targets) == set(example_kwargs)` guard unchanged — a pre-existing, narrower edge this PR doesn't address.

## Tests

`tests/py/dynamo/models/test_exporter_inlining.py` (all CPU-only, no GPU/TensorRT build required):

- `test_inline_torch_modules_preserves_all_submodule_outputs` — a submodule placeholder is deliberately named to collide with a parent input, so the test fails on the old name-matching path and passes with positional wiring.
- `test_inline_torch_modules_wires_inputs_by_position` — pins the positional-wiring behavior / no leaked placeholder.
- `test_create_trt_exp_program_reorders_kwargs_to_placeholder_order` — exports `a - b`, passes kwargs reversed, asserts `in_spec` records placeholder order and the result is `7.0` (not `-7.0`).
- `test_lift_sets_persistent_true_on_buffer_spec` — pins the `persistent=True` flag on lifted BUFFER specs.
- `test_create_trt_exp_program_rebuilds_in_spec_without_inputs` — the no-input `in_spec` path.
