### PR TITLE
fix: stabilize engine cache keys for unordered settings

### DIFF
--- a/py/torch_tensorrt/dynamo/_engine_cache.py
+++ b/py/torch_tensorrt/dynamo/_engine_cache.py
@@ -29,6 +29,19 @@ UnpackedCacheHit = Tuple[
 ]
 
 
+def _canonicalize_setting_value(value: Any) -> str:
+    """Stringify a setting so the result does not depend on iteration order.
+
+    ``str()`` of a set lays elements out in hash order, and Python randomizes
+    string hashing per process unless PYTHONHASHSEED is pinned. Hashing that
+    directly would give the same compilation settings a different cache key on
+    every run, so unordered collections are sorted first.
+    """
+    if isinstance(value, (set, frozenset)):
+        return str(sorted(str(element) for element in value))
+    return str(value)
+
+
 class BaseEngineCache(ABC):
     @abstractmethod
     def __init__(
@@ -88,7 +101,7 @@ class BaseEngineCache(ABC):
         input_specs_hash = sha256_hash(input_specs_data)
 
         invariant_engine_specs = [
-            str(getattr(settings, field))
+            _canonicalize_setting_value(getattr(settings, field))
             for field in sorted(_SETTINGS_TO_BE_ENGINE_INVARIANT)
         ]
         with io.BytesIO() as stream:

--- a/tests/py/dynamo/models/test_engine_cache.py
+++ b/tests/py/dynamo/models/test_engine_cache.py
@@ -10,7 +10,10 @@ import torch
 import torch_tensorrt as torch_trt
 from torch.testing._internal.common_utils import TestCase
 from torch_tensorrt.dynamo._defaults import TIMING_CACHE_PATH
-from torch_tensorrt.dynamo._engine_cache import BaseEngineCache
+from torch_tensorrt.dynamo._engine_cache import (
+    BaseEngineCache,
+    _canonicalize_setting_value,
+)
 from torch_tensorrt.dynamo._settings import CompilationSettings
 from torch_tensorrt.dynamo.utils import COSINE_THRESHOLD, cosine_similarity
 
@@ -60,6 +63,22 @@ class MyEngineCache(BaseEngineCache):
 
 
 class TestHashFunction(TestCase):
+    def test_unordered_settings_are_hashed_in_a_stable_order(self):
+        """Engine-invariant settings that are sets must not depend on hash order.
+
+        str() of a set lays elements out by hash, and string hashing is
+        randomized per process, so hashing one directly would give the same
+        settings a different cache key on every run.
+        """
+        self.assertEqual(
+            _canonicalize_setting_value({"b", "a", "c"}), "['a', 'b', 'c']"
+        )
+        self.assertEqual(
+            _canonicalize_setting_value(frozenset({"b", "a"})),
+            _canonicalize_setting_value({"a", "b"}),
+        )
+        self.assertEqual(_canonicalize_setting_value(True), "True")
+
     @unittest.skipIf(
         not importlib.util.find_spec("torchvision"), "torchvision not installed"
     )


### PR DESCRIPTION
# Description

Stabilizes engine cache keys for unordered compilation settings. Set and frozenset values are canonicalized before hashing, preventing identical settings from producing different cache keys across Python processes. Includes focused test coverage.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
