### PR TITLE
feat(executorch): copy-back for non-KV mutable buffers in the TensorRT delegate

### DIFF
--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -1176,9 +1176,15 @@ def save(
                     _declare_aliased_kv_mutations_on_ep,
                 )
 
-                # The legacy exporter is the only thing that declares copy-back on this
-                # path, so this combination leaves it undeclared.
-                if not _use_legacy and module.meta.get("_copyback_mutation_buffers"):
+                # On this path the legacy exporter is what declares copy-back, except
+                # under output_format="executorch", where torch_tensorrt.executorch
+                # .export() declares it for whatever source shape it is handed. The
+                # remaining combination leaves it undeclared.
+                if (
+                    not _use_legacy
+                    and output_format != "executorch"
+                    and module.meta.get("_copyback_mutation_buffers")
+                ):
                     logger.warning(
                         "Module has non-KV mutable buffer(s) needing copy-back, but "
                         "retrace=False with use_legacy_exporter=False does not declare "

--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -1148,6 +1148,12 @@ def save(
             # whichever exporter produced the program. aot_inductor is left
             # undeclared: whether an aliased in-place mutation survives
             # functionalization under inductor is unverified.
+            #
+            # Copy-back buffers need the same declaration, but only the retrace=True
+            # branches pass them. Unlike the KV path the pass reclassifies the trailing
+            # copyback_buffers outputs unconditionally, so running it on a program the
+            # legacy exporter already declared would re-slice outputs that are no
+            # longer the trailing ones.
             if not retrace:
                 from torch_tensorrt.dynamo._exporter import export
 
@@ -1172,6 +1178,16 @@ def save(
                 from torch_tensorrt.dynamo._exporter import (
                     _declare_aliased_kv_mutations_on_ep,
                 )
+
+                # The legacy exporter is the only thing that declares copy-back on this
+                # path, so this combination leaves it undeclared.
+                if not _use_legacy and module.meta.get("_copyback_mutation_buffers"):
+                    logger.warning(
+                        "Module has non-KV mutable buffer(s) needing copy-back, but "
+                        "retrace=False with use_legacy_exporter=False does not declare "
+                        "them. The saved program's signature will not reflect those "
+                        "updates. Use the legacy exporter, or retrace=True."
+                    )
 
                 if output_format == "exported_program":
                     # Must precede normalization, which rewrites the engine constants
@@ -1283,6 +1299,8 @@ def save(
                     _declare_aliased_kv_mutations_on_ep,
                 )
 
+                _copyback_bufs = module.meta.get("_copyback_mutation_buffers", [])
+
                 if output_format == "aot_inductor" and any(
                     getattr(sub, "aliased_io", None)
                     for _sub_name, sub in module.named_modules()
@@ -1297,7 +1315,9 @@ def save(
                 if output_format == "exported_program":
                     # Must precede normalization, which rewrites the engine constants
                     # this pass reads aliased_io from.
-                    exp_program = _declare_aliased_kv_mutations_on_ep(exp_program)
+                    exp_program = _declare_aliased_kv_mutations_on_ep(
+                        exp_program, copyback_buffers=_copyback_bufs
+                    )
                     _normalize_engine_constants_to_python(exp_program)
                     function_overload_with_kwargs(
                         torch.export.save,
@@ -1318,7 +1338,6 @@ def save(
                         package_path=file_path,
                     )
                 elif output_format == "executorch":
-                    _copyback_bufs = module.meta.get("_copyback_mutation_buffers", [])
                     exp_program = _declare_aliased_kv_mutations_on_ep(
                         exp_program, copyback_buffers=_copyback_bufs
                     )

--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -1149,11 +1149,8 @@ def save(
             # undeclared: whether an aliased in-place mutation survives
             # functionalization under inductor is unverified.
             #
-            # Copy-back buffers need the same declaration, but only the retrace=True
-            # branches pass them. Unlike the KV path the pass reclassifies the trailing
-            # copyback_buffers outputs unconditionally, so running it on a program the
-            # legacy exporter already declared would re-slice outputs that are no
-            # longer the trailing ones.
+            # Copy-back is gated per-branch below: the legacy exporter declares it
+            # itself and consumes the trailing values while doing so.
             if not retrace:
                 from torch_tensorrt.dynamo._exporter import export
 
@@ -1251,6 +1248,7 @@ def save(
                     if node.op == "placeholder" and "val" in node.meta
                     for dim in getattr(node.meta["val"], "shape", [])
                 )
+                _use_legacy = False
                 if has_symbolic_metadata and dynamic_shapes is not None:
                     from torch_tensorrt.dynamo._exporter import export
 
@@ -1299,7 +1297,15 @@ def save(
                     _declare_aliased_kv_mutations_on_ep,
                 )
 
-                _copyback_bufs = module.meta.get("_copyback_mutation_buffers", [])
+                # create_trt_exp_program already declares the copy-back mutations and
+                # consumes their trailing outputs, so what trails the graph on that path
+                # is a genuine user output. Only the torch.export paths leave the values
+                # to be reclassified.
+                _copyback_bufs = (
+                    []
+                    if _use_legacy
+                    else module.meta.get("_copyback_mutation_buffers", [])
+                )
 
                 if output_format == "aot_inductor" and any(
                     getattr(sub, "aliased_io", None)

--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -1318,7 +1318,10 @@ def save(
                         package_path=file_path,
                     )
                 elif output_format == "executorch":
-                    exp_program = _declare_aliased_kv_mutations_on_ep(exp_program)
+                    _copyback_bufs = module.meta.get("_copyback_mutation_buffers", [])
+                    exp_program = _declare_aliased_kv_mutations_on_ep(
+                        exp_program, copyback_buffers=_copyback_bufs
+                    )
                     _save_as_executorch(
                         exp_program,
                         file_path,

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -2120,16 +2120,19 @@ def convert_exported_program_to_serialized_trt_engine(
         # Read before lowering: `gm` is replaced below and the meta does not follow it.
         predicted_kv_bindings = gm.meta.get("_predicted_kv_bindings", [])
         # A write the engine cannot alias in place is classified as copy-back: its
-        # new value is appended as an extra engine output and the buffer is updated
-        # afterwards. This entry point reports neither which output carries which
-        # buffer nor performs that update, so the caller has no way to complete it.
+        # new value is appended as an extra engine output, and whatever loads the
+        # serialized program copies that output into the buffer afterwards. This
+        # entry point returns engine bytes and no program, so it neither reports
+        # which output carries which buffer nor gives the copy anywhere to be
+        # declared, and the caller has no way to complete it.
         copyback_buffers = gm.meta.get("_copyback_mutation_buffers", [])
         if copyback_buffers:
             raise RuntimeError(
                 "convert_exported_program_to_serialized_trt_engine cannot express the "
                 f"write-back for mutable buffer(s) {copyback_buffers}: the engine "
                 "cannot alias them in place, so the buffers would never update. Use "
-                "torch_tensorrt.dynamo.compile, which performs the write-back itself."
+                "torch_tensorrt.dynamo.compile and save the result, which declares "
+                "the buffer mutation for the runtime to apply."
             )
         if lifted_buffers:
             buffer_tensors = [t for _, _, t in lifted_buffers]

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -864,12 +864,15 @@ def compile(
         trt_gm.meta["_copyback_mutation_buffers"] = _copyback_mutation_buffers
     # Ground-truth check: every write lift classified as KV (engine-aliased, so its
     # copy_ was dropped) must actually appear in a compiled engine's aliased_io,
-    # else its write-back would be silently lost -- fail loudly instead.
+    # else its write-back would be silently lost -- fail loudly instead. A dryrun
+    # returns before conversion, so there is no ground truth to check against.
     assert_predicted_kv_aliased(
         aliased_input_bindings(
             getattr(sub, "aliased_io", None) for _name, sub in trt_gm.named_children()
         ),
         _predicted_kv_bindings,
+        settings,
+        engines_built=not settings.dryrun,
     )
     if lifted_buffers:
         # Inline buffers into the compiled gm as get_attr nodes + registered
@@ -2220,6 +2223,7 @@ def convert_exported_program_to_serialized_trt_engine(
     assert_predicted_kv_aliased(
         aliased_input_bindings([interpreter_result.aliased_io]),
         predicted_kv_bindings,
+        settings,
     )
 
     serialized_engine: bytes = interpreter_result.serialized_engine

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -45,6 +45,7 @@ from torch_tensorrt.dynamo.lowering import (
     pre_export_lowering,
 )
 from torch_tensorrt.dynamo.lowering._buffer_lifting import (
+    assert_predicted_kv_aliased,
     inline_lifted_buffers_into_gm,
     lift_mutated_buffers,
 )
@@ -816,6 +817,8 @@ def compile(
     # module-held cache). Returns a fresh GraphModule whose forward signature
     # reflects the new placeholders.
     gm, lifted_buffers = lift_mutated_buffers(gm)
+    _copyback_mutation_buffers = gm.meta.get("_copyback_mutation_buffers", [])
+    _predicted_kv_bindings = gm.meta.get("_predicted_kv_bindings", [])
     if lifted_buffers:
         # Append each lifted buffer as an engine input AFTER the user inputs.
         # Buffer tensors live on the gm's state; prepare an Input spec for
@@ -856,6 +859,12 @@ def compile(
         engine_cache,
         graph_signature=exported_program.graph_signature,
     )
+    if _copyback_mutation_buffers:
+        trt_gm.meta["_copyback_mutation_buffers"] = _copyback_mutation_buffers
+    # Ground-truth check: every write lift classified as KV (engine-aliased, so its
+    # copy_ was dropped) must actually appear in a compiled engine's aliased_io,
+    # else its write-back would be silently lost -- fail loudly instead.
+    assert_predicted_kv_aliased(trt_gm, _predicted_kv_bindings)
     if lifted_buffers:
         # Inline buffers into the compiled gm as get_attr nodes + registered
         # buffers. The resulting gm's forward takes only user inputs; buffers

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -45,6 +45,7 @@ from torch_tensorrt.dynamo.lowering import (
     pre_export_lowering,
 )
 from torch_tensorrt.dynamo.lowering._buffer_lifting import (
+    aliased_input_bindings,
     assert_predicted_kv_aliased,
     inline_lifted_buffers_into_gm,
     lift_mutated_buffers,
@@ -864,7 +865,12 @@ def compile(
     # Ground-truth check: every write lift classified as KV (engine-aliased, so its
     # copy_ was dropped) must actually appear in a compiled engine's aliased_io,
     # else its write-back would be silently lost -- fail loudly instead.
-    assert_predicted_kv_aliased(trt_gm, _predicted_kv_bindings)
+    assert_predicted_kv_aliased(
+        aliased_input_bindings(
+            getattr(sub, "aliased_io", None) for _name, sub in trt_gm.named_children()
+        ),
+        _predicted_kv_bindings,
+    )
     if lifted_buffers:
         # Inline buffers into the compiled gm as get_attr nodes + registered
         # buffers. The resulting gm's forward takes only user inputs; buffers
@@ -1812,6 +1818,12 @@ def convert_exported_program_to_serialized_trt_engine(
     automatically; this lower-level entry point exposes the same machinery
     for callers that want to manage the bindings themselves.
 
+    Only writes the engine can alias in place are supported here. A mutation the
+    engine cannot alias needs its new value copied back into the buffer after the
+    call, and this entry point reports neither which output carries which buffer nor
+    performs the copy, so it raises rather than returning an engine whose buffer
+    would never update. Use :func:`torch_tensorrt.dynamo.compile` for those models.
+
     Arguments:
         exported_program (torch.export.ExportedProgram): Source module, running torch.export on a ``torch.nn.Module``
         inputs (Optional[Sequence[Sequence[Any]]]): List of specifications of input shape, dtype and memory layout for inputs to the module. This argument is required. Input Sizes can be specified as torch sizes, tuples or lists. dtypes can be specified using
@@ -1895,6 +1907,11 @@ def convert_exported_program_to_serialized_trt_engine(
         **kwargs: Any,
     Returns:
         bytes: Serialized TensorRT engine, can either be saved to a file or deserialized via TensorRT APIs
+    Raises:
+        RuntimeError: if ``lift_mutable_buffers=True`` and the model mutates a buffer
+            the engine cannot alias in place, or if a write predicted to be aliased is
+            absent from the built engine's ``aliased_io``. Either way the buffer would
+            silently never update.
     """
 
     if kwargs.get("debug", False):
@@ -2083,8 +2100,23 @@ def convert_exported_program_to_serialized_trt_engine(
     # resulting bindings at runtime — they are appended after the user inputs
     # in the order returned here.
     lifted_buffers: List[Tuple[str, str, torch.Tensor]] = []
+    predicted_kv_bindings: List[str] = []
     if lift_mutable_buffers:
         gm, lifted_buffers = lift_mutated_buffers(gm, settings)
+        # Read before lowering: `gm` is replaced below and the meta does not follow it.
+        predicted_kv_bindings = gm.meta.get("_predicted_kv_bindings", [])
+        # A write the engine cannot alias in place is classified as copy-back: its
+        # new value is appended as an extra engine output and the buffer is updated
+        # afterwards. This entry point reports neither which output carries which
+        # buffer nor performs that update, so the caller has no way to complete it.
+        copyback_buffers = gm.meta.get("_copyback_mutation_buffers", [])
+        if copyback_buffers:
+            raise RuntimeError(
+                "convert_exported_program_to_serialized_trt_engine cannot express the "
+                f"write-back for mutable buffer(s) {copyback_buffers}: the engine "
+                "cannot alias them in place, so the buffers would never update. Use "
+                "torch_tensorrt.dynamo.compile, which performs the write-back itself."
+            )
         if lifted_buffers:
             buffer_tensors = [t for _, _, t in lifted_buffers]
             buffer_inputs = prepare_inputs(buffer_tensors)
@@ -2184,6 +2216,11 @@ def convert_exported_program_to_serialized_trt_engine(
             exc_info=True,
         )
         raise RuntimeError(f"While interpreting the module got an error: {e}") from e
+
+    assert_predicted_kv_aliased(
+        aliased_input_bindings([interpreter_result.aliased_io]),
+        predicted_kv_bindings,
+    )
 
     serialized_engine: bytes = interpreter_result.serialized_engine
     return serialized_engine

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -820,6 +820,7 @@ def compile(
     # reflects the new placeholders.
     gm, lifted_buffers = lift_mutated_buffers(gm, settings)
     _copyback_mutation_buffers = gm.meta.get("_copyback_mutation_buffers", [])
+    _copyback_bindings = gm.meta.get("_copyback_bindings", [])
     _predicted_kv_bindings = gm.meta.get("_predicted_kv_bindings", [])
     if lifted_buffers:
         # Append each lifted buffer as an engine input AFTER the user inputs.
@@ -863,10 +864,12 @@ def compile(
     )
     if _copyback_mutation_buffers:
         trt_gm.meta["_copyback_mutation_buffers"] = _copyback_mutation_buffers
-    # Ground-truth check: every write lift classified as KV (engine-aliased, so its
-    # copy_ was dropped) must actually appear in a compiled engine's aliased_io,
-    # else its write-back would be silently lost -- fail loudly instead. A dryrun
-    # returns before conversion, so there is no ground truth to check against.
+    # Ground-truth check on both directions of the classification: every write lift
+    # called KV (engine-aliased, so its copy_ was dropped) must appear in a compiled
+    # engine's aliased_io or its write-back is silently lost, and no write lift
+    # called copy-back may appear there or the trailing output it added is one the
+    # runtime truncates while the graph still reads it. Fail loudly for either. A
+    # dryrun returns before conversion, so there is no ground truth to check against.
     assert_predicted_kv_aliased(
         aliased_input_bindings(
             getattr(sub, "aliased_io", None) for _name, sub in trt_gm.named_children()
@@ -874,6 +877,7 @@ def compile(
         _predicted_kv_bindings,
         settings,
         engines_built=not settings.dryrun,
+        copyback_bindings=_copyback_bindings,
     )
     if lifted_buffers:
         # Inline buffers into the compiled gm as get_attr nodes + registered

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -816,7 +816,7 @@ def compile(
     # prerequisite for IKVCacheUpdateLayer / aliased I/O to fire on a
     # module-held cache). Returns a fresh GraphModule whose forward signature
     # reflects the new placeholders.
-    gm, lifted_buffers = lift_mutated_buffers(gm)
+    gm, lifted_buffers = lift_mutated_buffers(gm, settings)
     _copyback_mutation_buffers = gm.meta.get("_copyback_mutation_buffers", [])
     _predicted_kv_bindings = gm.meta.get("_predicted_kv_bindings", [])
     if lifted_buffers:
@@ -2084,7 +2084,7 @@ def convert_exported_program_to_serialized_trt_engine(
     # in the order returned here.
     lifted_buffers: List[Tuple[str, str, torch.Tensor]] = []
     if lift_mutable_buffers:
-        gm, lifted_buffers = lift_mutated_buffers(gm)
+        gm, lifted_buffers = lift_mutated_buffers(gm, settings)
         if lifted_buffers:
             buffer_tensors = [t for _, _, t in lifted_buffers]
             buffer_inputs = prepare_inputs(buffer_tensors)

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -47,6 +47,7 @@ from torch_tensorrt.dynamo.lowering import (
 from torch_tensorrt.dynamo.lowering._buffer_lifting import (
     aliased_input_bindings,
     assert_predicted_kv_aliased,
+    hide_copyback_outputs,
     inline_lifted_buffers_into_gm,
     lift_mutated_buffers,
 )
@@ -882,6 +883,12 @@ def compile(
         # serializable by torch_tensorrt.save / torch.export (no external
         # Python wrapper that would be lost on a round-trip).
         trt_gm = inline_lifted_buffers_into_gm(trt_gm, lifted_buffers)
+    # A copy-back value stays on the output node, where the exporters read it and
+    # where dead-code elimination cannot reach it, but nothing between here and the
+    # ExecuTorch runtime writes it into the buffer. Returning it would report a
+    # mutation the caller cannot act on, so the compiled module keeps the arity of
+    # the model it was compiled from.
+    hide_copyback_outputs(trt_gm, len(_copyback_mutation_buffers))
     return trt_gm
 
 

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -46,6 +46,7 @@ from torch_tensorrt.dynamo.lowering import (
 )
 from torch_tensorrt.dynamo.lowering._buffer_lifting import (
     aliased_input_bindings,
+    assert_no_kv_alias_markers_survived,
     assert_predicted_kv_aliased,
     hide_copyback_outputs,
     inline_lifted_buffers_into_gm,
@@ -822,6 +823,7 @@ def compile(
     _copyback_mutation_buffers = gm.meta.get("_copyback_mutation_buffers", [])
     _copyback_bindings = gm.meta.get("_copyback_bindings", [])
     _predicted_kv_bindings = gm.meta.get("_predicted_kv_bindings", [])
+    _no_kv_alias_writes = gm.meta.get("_no_kv_alias_writes", [])
     if lifted_buffers:
         # Append each lifted buffer as an engine input AFTER the user inputs.
         # Buffer tensors live on the gm's state; prepare an Input spec for
@@ -840,6 +842,12 @@ def compile(
     gm = post_lowering(gm, settings)
     logger.debug(f"CPU memory usage after post_lowering: {get_cpu_memory_usage()} MB")
     logger.debug("Lowered Input graph: " + str(gm.graph))
+
+    # The marker is what keeps a re-routed write out of the engine's aliased_io, and
+    # it rides on node.meta through every pass above. Read it back before conversion
+    # so a pass that dropped it is named here rather than surfacing as a module that
+    # raises on every call.
+    assert_no_kv_alias_markers_survived(gm, _no_kv_alias_writes)
 
     # Move the weights in the state_dict to CPU
     if offload_module_to_cpu:

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -4,6 +4,7 @@ import operator
 from typing import Any, Dict, Optional, Sequence, Tuple
 
 import torch
+import torch.utils._pytree as pytree
 from torch._export.non_strict_utils import make_constraints
 from torch._guards import detect_fake_mode
 from torch._library.fake_class_registry import FakeScriptObject
@@ -19,6 +20,7 @@ from torch.export.exported_program import (
     OutputSpec,
     TensorArgument,
 )
+from torch.fx.graph import _PyTreeCodeGen
 from torch_tensorrt._features import ENABLED_FEATURES
 from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import ENGINE_IDX, NAME_IDX
 
@@ -230,6 +232,12 @@ def lift(
                         kind=input_kind,
                         arg=input_spec_arg,
                         target=node.target,
+                        # torch>=2.3 requires an explicit persistent flag on BUFFER
+                        # specs. state_dict() excludes non-persistent buffers by
+                        # construction, so any buffer reaching this in-state_dict
+                        # branch is persistent (non-persistent buffers take the
+                        # not-in-state_dict path above and are lifted as constants).
+                        persistent=(True if input_kind == InputKind.BUFFER else None),
                     ),
                 )
                 non_user_input_idx += 1
@@ -243,29 +251,6 @@ def lift(
     gm.graph.lint()
 
     return gm, graph_signature, state_dict, constants
-
-
-def get_duplicate_nodes(
-    gm: torch.fx.GraphModule, submodule: torch.fx.GraphModule
-) -> Tuple[Sequence[Any], Sequence[Any]]:
-    """
-    We check if there are duplicate nodes when we copy submodule graph into gm.
-    Handle the case where the subgraph input placeholders are same as
-    gm placeholders. This happens when the first submodule in the graph is
-    a pytorch submodule
-    """
-    submodule_placeholder_inputs = [
-        node for node in submodule.graph.nodes if node.op == "placeholder"
-    ]
-    submodule_input_node_names = [node.name for node in submodule_placeholder_inputs]
-    gm_node_names = [node.name for node in gm.graph.nodes]
-    submodule_duplicate_inputs = [
-        node for node in submodule_placeholder_inputs if node.name in gm_node_names
-    ]
-    gm_duplicate_inputs = [
-        node for node in gm.graph.nodes if node.name in submodule_input_node_names
-    ]
-    return submodule_duplicate_inputs, gm_duplicate_inputs
 
 
 def inline_torch_modules(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
@@ -285,43 +270,31 @@ def inline_torch_modules(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 # or a placeholder of the main graph
                 submodule_inputs = gm_node.args
 
-                submodule_duplicate_inputs, gm_duplicate_inputs = get_duplicate_nodes(
-                    gm, submodule
-                )
-                assert len(submodule_duplicate_inputs) == len(gm_duplicate_inputs)
-                # Avoid creating new copies of duplicate inputs by creating a mapping
-                val_map = {}
-                for i in range(len(submodule_duplicate_inputs)):
-                    val_map[submodule_duplicate_inputs[i]] = gm_duplicate_inputs[i]
-
-                # Copy all nodes in the submodule into gm and
-                # store the output node of this submodule which is now present in gm
+                # Copy the submodule's nodes into gm, then wire its inputs POSITIONALLY.
+                #
+                # We deliberately do NOT pre-seed val_map by matching submodule input
+                # placeholders to gm nodes by NAME. Name matching silently binds an
+                # input to the WRONG node when names collide (e.g. a _run_on_gpu input
+                # placeholder whose name matches a different engine's getitem), which
+                # rewires a consumer to the wrong producer and orphans the real one --
+                # the orphan is then pruned by dead-code elimination, leaving a delegate
+                # short an output at runtime. It also leaks a mixed submodule's
+                # computed-intermediate inputs as spurious graph inputs. gm_node.args is
+                # the authoritative, ordered list of the real inputs, so we let
+                # graph_copy create a fresh (auto-renamed on collision) placeholder for
+                # every submodule input and rewire each to submodule_inputs[i] by
+                # position, then erase it.
+                val_map: Dict[Any, Any] = {}
                 submodule_output = gm.graph.graph_copy(submodule.graph, val_map)
 
-                # Get their references (since we copied) in the parent graph (gm)
-                if len(submodule_duplicate_inputs) == 0:
-                    submodule_placeholder_input_names = [
-                        node.name
-                        for node in submodule.graph.nodes
-                        if node.op == "placeholder"
-                    ]
-                    gm_added_placeholder_inputs = [
-                        node
-                        for node in gm.graph.nodes
-                        if node.name in submodule_placeholder_input_names
-                    ]
-
-                    assert len(submodule_inputs) == len(gm_added_placeholder_inputs)
-
-                    # Replace the added placeholder inputs with original inputs to this submodule node
-                    for idx in range(len(gm_added_placeholder_inputs)):
-                        gm_added_placeholder_inputs[idx].replace_all_uses_with(
-                            submodule_inputs[idx]
-                        )
-
-                    # Erase the placeholder input nodes in the gm
-                    for idx in range(len(gm_added_placeholder_inputs)):
-                        gm.graph.erase_node(gm_added_placeholder_inputs[idx])
+                submodule_placeholders = [
+                    node for node in submodule.graph.nodes if node.op == "placeholder"
+                ]
+                assert len(submodule_placeholders) == len(submodule_inputs)
+                for idx, submodule_placeholder in enumerate(submodule_placeholders):
+                    copied_placeholder = val_map[submodule_placeholder]
+                    copied_placeholder.replace_all_uses_with(submodule_inputs[idx])
+                    gm.graph.erase_node(copied_placeholder)
 
                 # Replace the pytorch submodule node (call_module) with the inlined subgraph output
                 # Special handling when submodule returns multiple outputs (tuple)
@@ -403,14 +376,29 @@ def create_trt_exp_program(
         input_specs=input_specs, output_specs=output_specs
     )
 
+    # A hybrid TRT+CUDA GraphModule from dynamo.compile carries a plain fx.CodeGen
+    # (no pytree_info): the module already returns a flat tuple, so rebuild
+    # in_spec/out_spec from the example inputs and the flat graph outputs. This
+    # matches retrace=True, which traces the same flat module and likewise cannot
+    # re-nest -- so the fallback never diverges from it.
+    codegen = gm.graph._codegen
+    if isinstance(codegen, _PyTreeCodeGen):
+        in_spec = codegen.pytree_info.in_spec
+        out_spec = codegen.pytree_info.out_spec
+    else:
+        example_args = tuple(arg_inputs) if arg_inputs is not None else ()
+        example_kwargs = kwarg_inputs or {}
+        in_spec = pytree.tree_flatten((example_args, example_kwargs))[1]
+        out_spec = pytree.tree_flatten(tuple(output_nodes))[1]
+
     module_call_graph = [
         ModuleCallEntry(
             "",
             ModuleCallSignature(
                 inputs=[],
                 outputs=[],
-                in_spec=gm.graph._codegen.pytree_info.in_spec,
-                out_spec=gm.graph._codegen.pytree_info.out_spec,
+                in_spec=in_spec,
+                out_spec=out_spec,
             ),
         )
     ]

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -403,6 +403,9 @@ def create_trt_exp_program(
         for _n, _buf in zip(_outs[-len(_copyback) :], _copyback):
             if isinstance(_n, torch.fx.Node):
                 _n.meta["_kv_mutation_target"] = _buf
+        # Read by _declare_aliased_kv_mutations_on_ep, which must not consume these
+        # trailing values a second time.
+        gm.meta["_copyback_mutations_declared"] = True
 
         def _is_mut(_n: Any) -> bool:
             return isinstance(_n, torch.fx.Node) and "_kv_mutation_target" in _n.meta
@@ -578,10 +581,13 @@ def _declare_aliased_kv_mutations_on_ep(
     BUFFER_MUTATION of its caller-owned buffer input, and reclassify any copy-back
     outputs as BUFFER_MUTATIONs of their buffers.
 
-    Runs on both save() paths (retrace=True and retrace=False); it is idempotent
-    because it skips buffers that already carry a BUFFER_MUTATION spec (see
-    already_exposed below), so the legacy exporter's transform-time declaration is
-    not duplicated.
+    Safe to call more than once on the same program, by two separate mechanisms. The
+    KV half skips any buffer that already carries a BUFFER_MUTATION spec (see
+    already_exposed below), which is also how the legacy exporter's transform-time
+    declaration survives. The copy-back half cannot skip one buffer at a time, because
+    it detaches its outputs by position rather than by name; it skips the whole slice
+    instead, keyed on ``gm.meta['_copyback_mutations_declared']``, which every step
+    that consumes those trailing values sets.
 
     torch.export produces execute_engine nodes whose meta['val'] covers only the
     user outputs (the aliased KV outputs are network bindings excluded at the fx
@@ -603,9 +609,11 @@ def _declare_aliased_kv_mutations_on_ep(
             ``gm.meta['_copyback_mutation_buffers']`` by ``save()``; empty/None means
             KV-only (no copy-back).
 
-    Returns exp_program unchanged when there are no copy-back buffers and no engine
-    contributes an aliased KV output -- either because none has one, or because the
-    optional [executorch] extra is not importable and the engines cannot be read.
+    Returns exp_program unchanged when there is nothing to declare: no copy-back
+    buffers and no engine contributing an aliased KV output -- either because none has
+    one, or because the optional [executorch] extra is not importable and the engines
+    cannot be read -- or when the only candidate was a copy-back slice that a previous
+    run already consumed.
     """
     from torch_tensorrt.dynamo.runtime._serialized_engine_layout import (
         ALIASED_IO_IDX,
@@ -760,6 +768,20 @@ def _declare_aliased_kv_mutations_on_ep(
         for spec in orig_specs
         if spec.kind == OutputKind.BUFFER_MUTATION and isinstance(spec.target, str)
     }
+    # A BUFFER_MUTATION spec does not say whether the trailing value is still there:
+    # torch.export declares the mutation and leaves the value, while a previous run of
+    # this pass declares it and consumes the value, so it is the consuming step that
+    # records the marker.
+    # The marker is a property of the graph rather than of the buffer list handed in:
+    # it is set on the GraphModule by whichever step consumed the trailing values, and
+    # read back off the GraphModule this pass is later given. stage_exported_program
+    # copies gm.meta's entries into the staged module, so a staged copy sees what its
+    # source recorded before staging. The two mappings are separate objects, so what a
+    # staged copy records afterwards is not visible on the source.
+    if num_copyback and gm.meta.get("_copyback_mutations_declared"):
+        num_copyback = 0
+        if not mutation_outputs:
+            return exp_program
     if num_copyback:
         if len(out_args) < num_copyback:
             raise RuntimeError(
@@ -778,6 +800,7 @@ def _declare_aliased_kv_mutations_on_ep(
                     OutputKind.BUFFER_MUTATION, TensorArgument(name=value.name), buf
                 )
             )
+        gm.meta["_copyback_mutations_declared"] = True
 
     # BUFFER_MUTATIONs (KV + copy-back) must precede USER_OUTPUTs (verifier).
     output_node.args = (tuple(kv_getitems + copyback_getitems + out_args),)

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -751,13 +751,15 @@ def _declare_aliased_kv_mutations_on_ep(
     ]
 
     # Copy-back mutable buffers (non-KV, e.g. a convolution-state ring-buffer): lift
-    # appended each buffer's new-value as a trailing user output. torch.export usually
-    # leaves them as the last outputs, but when it recognises the mutation itself it
-    # declares them BUFFER_MUTATION and moves them to the front, because the verifier
-    # requires mutations to precede user outputs. Taking the tail unconditionally then
-    # reclassifies a real user output as a buffer mutation, and the runtime later fails
-    # copying that output into a buffer of a different shape. Reclassify only the buffers
-    # the program does not already declare as mutated.
+    # appended each buffer's new-value as a trailing user output, in copyback_buffers
+    # order. Those appended values are internal plumbing, so the whole run leaves the
+    # user outputs whether or not torch.export also recorded the mutation itself. It
+    # does record it when it recognises the write, and then places that BUFFER_MUTATION
+    # ahead of the user outputs because the verifier requires mutations to come first;
+    # re-declaring such a buffer here would describe one mutation twice. So detach the
+    # full run first and pair it positionally with the full buffer list, then keep only
+    # the buffers not already declared. Filtering before slicing would pair a value with
+    # the wrong buffer, and the runtime would copy it into a buffer of a different shape.
     copyback_getitems: List[torch.fx.Node] = []
     copyback_specs: List[OutputSpec] = []
     remaining_specs = orig_specs
@@ -766,18 +768,19 @@ def _declare_aliased_kv_mutations_on_ep(
         for spec in orig_specs
         if spec.kind == OutputKind.BUFFER_MUTATION and isinstance(spec.target, str)
     }
-    pending_copyback = [buf for buf in copyback_buffers if buf not in already_mutated]
-    if pending_copyback:
-        num_pending = len(pending_copyback)
-        copyback_getitems = list(out_args[-num_pending:])
-        remaining_args = out_args[:-num_pending]
-        remaining_specs = orig_specs[:-num_pending]
-        copyback_specs = [
-            OutputSpec(OutputKind.BUFFER_MUTATION, TensorArgument(name=g.name), buf)
-            for g, buf in zip(copyback_getitems, pending_copyback)
-            if isinstance(g, torch.fx.Node)
-        ]
-        out_args = remaining_args
+    if num_copyback:
+        trailing = list(out_args[-num_copyback:])
+        out_args = out_args[:-num_copyback]
+        remaining_specs = orig_specs[:-num_copyback]
+        for value, buf in zip(trailing, copyback_buffers):
+            if not isinstance(value, torch.fx.Node) or buf in already_mutated:
+                continue
+            copyback_getitems.append(value)
+            copyback_specs.append(
+                OutputSpec(
+                    OutputKind.BUFFER_MUTATION, TensorArgument(name=value.name), buf
+                )
+            )
 
     # BUFFER_MUTATIONs (KV + copy-back) must precede USER_OUTPUTs (verifier).
     output_node.args = (tuple(kv_getitems + copyback_getitems + out_args),)
@@ -790,11 +793,12 @@ def _declare_aliased_kv_mutations_on_ep(
     )
 
     # Copy-back outputs were user returns in the retraced program, so torch.export's
-    # out_spec counts them; after reclassifying them as BUFFER_MUTATION only the real
-    # user outputs remain. Rebuild the top-level out_spec (mirroring
-    # create_trt_exp_program) so to_edge's unflatten sees the right leaf count.
+    # out_spec counts them; after detaching them only the real user outputs remain.
+    # Rebuild the top-level out_spec (mirroring create_trt_exp_program) so to_edge's
+    # unflatten sees the right leaf count. Keyed on num_copyback, not on the specs we
+    # added, because an already-declared buffer still had its value detached above.
     module_call_graph = exp_program.module_call_graph
-    if copyback_specs and module_call_graph:
+    if num_copyback and module_call_graph:
         new_out_spec = pytree.tree_flatten(tuple(out_args))[1]
         _e0 = module_call_graph[0]
         _sig0 = _e0.signature

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -751,19 +751,30 @@ def _declare_aliased_kv_mutations_on_ep(
     ]
 
     # Copy-back mutable buffers (non-KV, e.g. a convolution-state ring-buffer): lift
-    # appended each buffer's new-value as a trailing user output; torch.export kept them as the
-    # last num_copyback outputs. Reclassify those from USER_OUTPUT to BUFFER_MUTATION
-    # so ET copies them back to the caller-owned buffers.
+    # appended each buffer's new-value as a trailing user output. torch.export usually
+    # leaves them as the last outputs, but when it recognises the mutation itself it
+    # declares them BUFFER_MUTATION and moves them to the front, because the verifier
+    # requires mutations to precede user outputs. Taking the tail unconditionally then
+    # reclassifies a real user output as a buffer mutation, and the runtime later fails
+    # copying that output into a buffer of a different shape. Reclassify only the buffers
+    # the program does not already declare as mutated.
     copyback_getitems: List[torch.fx.Node] = []
     copyback_specs: List[OutputSpec] = []
     remaining_specs = orig_specs
-    if num_copyback:
-        copyback_getitems = list(out_args[-num_copyback:])
-        remaining_args = out_args[:-num_copyback]
-        remaining_specs = orig_specs[:-num_copyback]
+    already_mutated = {
+        spec.target
+        for spec in orig_specs
+        if spec.kind == OutputKind.BUFFER_MUTATION and isinstance(spec.target, str)
+    }
+    pending_copyback = [buf for buf in copyback_buffers if buf not in already_mutated]
+    if pending_copyback:
+        num_pending = len(pending_copyback)
+        copyback_getitems = list(out_args[-num_pending:])
+        remaining_args = out_args[:-num_pending]
+        remaining_specs = orig_specs[:-num_pending]
         copyback_specs = [
             OutputSpec(OutputKind.BUFFER_MUTATION, TensorArgument(name=g.name), buf)
-            for g, buf in zip(copyback_getitems, copyback_buffers)
+            for g, buf in zip(copyback_getitems, pending_copyback)
             if isinstance(g, torch.fx.Node)
         ]
         out_args = remaining_args
@@ -783,7 +794,7 @@ def _declare_aliased_kv_mutations_on_ep(
     # user outputs remain. Rebuild the top-level out_spec (mirroring
     # create_trt_exp_program) so to_edge's unflatten sees the right leaf count.
     module_call_graph = exp_program.module_call_graph
-    if num_copyback and module_call_graph:
+    if copyback_specs and module_call_graph:
         new_out_spec = pytree.tree_flatten(tuple(out_args))[1]
         _e0 = module_call_graph[0]
         _sig0 = _e0.signature

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -2,7 +2,7 @@ import base64
 import copy
 import logging
 import operator
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
 
 import torch
 import torch.utils._pytree as pytree
@@ -410,11 +410,10 @@ def create_trt_exp_program(
         def _is_mut(_n: Any) -> bool:
             return isinstance(_n, torch.fx.Node) and "_kv_mutation_target" in _n.meta
 
-        output_nodes = tuple(
-            [_n for _n in _outs if _is_mut(_n)]
-            + [_n for _n in _outs if not _is_mut(_n)]
-        )
-        _output_node.args = (output_nodes,)
+        output_nodes = [_n for _n in _outs if _is_mut(_n)] + [
+            _n for _n in _outs if not _is_mut(_n)
+        ]
+        _output_node.args = (tuple(output_nodes),)
 
     # Outputs tagged by `_expose_aliased_buffer_mutations` become BUFFER_MUTATION
     # specs (their `_kv_mutation_target` meta names the backing buffer); the rest
@@ -626,10 +625,13 @@ def _declare_aliased_kv_mutations_on_ep(
     )
 
     # The [executorch] extra is optional, so this import can fail on a plain install.
+    read_engine_info: Optional[Callable[..., List[Any]]]
     try:
         from torch_tensorrt.executorch.backend import _get_engine_info_for_node
+
+        read_engine_info = _get_engine_info_for_node
     except ImportError:
-        _get_engine_info_for_node = None
+        read_engine_info = None
         logger.debug(
             "Could not import torch_tensorrt.executorch.backend; engine aliased-KV "
             "mutations will not be declared on this program."
@@ -660,12 +662,13 @@ def _declare_aliased_kv_mutations_on_ep(
     mutation_outputs: List[Tuple[torch.fx.Node, str]] = []
     # Reading an engine needs the [executorch] helper imported above; without it
     # there is nothing to scan.
-    nodes_to_scan = gm.graph.nodes if _get_engine_info_for_node is not None else ()
+    nodes_to_scan = gm.graph.nodes if read_engine_info is not None else ()
     for node in nodes_to_scan:
         if node.op != "call_function" or node.target is not exec_target:
             continue
+        assert read_engine_info is not None
         # Only the binding names and aliased_io are read, never the engine itself.
-        engine_info = _get_engine_info_for_node(exp_program, node, metadata_only=True)
+        engine_info = read_engine_info(exp_program, node, metadata_only=True)
         aliased_io = deserialize_aliased_io(_estr(engine_info, ALIASED_IO_IDX))
         if not aliased_io:
             continue

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -725,19 +725,6 @@ def _declare_aliased_kv_mutations_on_ep(
 
     copyback_buffers = copyback_buffers or []
     num_copyback = len(copyback_buffers)
-    # Unlike the KV path this reclassifies the trailing num_copyback outputs by
-    # position, so it cannot skip an already-declared buffer the way already_exposed
-    # does: after a first declaration the mutations sit at the front and the trailing
-    # outputs are the user's. Declaring twice would retarget those, dropping a user
-    # output and leaving the buffer with two mutation specs.
-    redeclared = sorted(set(copyback_buffers) & already_exposed)
-    if redeclared:
-        raise RuntimeError(
-            f"Copy-back buffer(s) {redeclared} already carry a BUFFER_MUTATION spec. "
-            "Declaring them again would reclassify the trailing outputs, which are no "
-            "longer the copy-back ones. Pass copyback_buffers only for a program whose "
-            "exporter has not already declared them."
-        )
     if not mutation_outputs and not num_copyback:
         return exp_program
 

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -664,7 +664,8 @@ def _declare_aliased_kv_mutations_on_ep(
     for node in nodes_to_scan:
         if node.op != "call_function" or node.target is not exec_target:
             continue
-        engine_info = _get_engine_info_for_node(exp_program, node)
+        # Only the binding names and aliased_io are read, never the engine itself.
+        engine_info = _get_engine_info_for_node(exp_program, node, metadata_only=True)
         aliased_io = deserialize_aliased_io(_estr(engine_info, ALIASED_IO_IDX))
         if not aliased_io:
             continue

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -603,8 +603,9 @@ def _declare_aliased_kv_mutations_on_ep(
             ``gm.meta['_copyback_mutation_buffers']`` by ``save()``; empty/None means
             KV-only (no copy-back).
 
-    Returns exp_program unchanged when no engine has aliased KV outputs and there are
-    no copy-back buffers.
+    Returns exp_program unchanged when there are no copy-back buffers and no engine
+    contributes an aliased KV output -- either because none has one, or because the
+    optional [executorch] extra is not importable and the engines cannot be read.
     """
     from torch_tensorrt.dynamo.runtime._serialized_engine_layout import (
         ALIASED_IO_IDX,
@@ -616,14 +617,15 @@ def _declare_aliased_kv_mutations_on_ep(
         deserialize_aliased_io,
     )
 
-    # Guard the import so a non-executorch save() (e.g. output_format=
-    # "exported_program" with no aliased KV outputs) doesn't hard-require the
-    # optional [executorch] extra: with no executorch there's no aliased_io to
-    # read and no declaration to make, so return unchanged.
+    # The [executorch] extra is optional, so this import can fail on a plain install.
     try:
         from torch_tensorrt.executorch.backend import _get_engine_info_for_node
     except ImportError:
-        return exp_program
+        _get_engine_info_for_node = None
+        logger.debug(
+            "Could not import torch_tensorrt.executorch.backend; engine aliased-KV "
+            "mutations will not be declared on this program."
+        )
 
     def _estr(engine_info: List[Any], idx: int) -> str:
         if idx < 0 or idx >= len(engine_info) or engine_info[idx] is None:
@@ -648,7 +650,10 @@ def _declare_aliased_kv_mutations_on_ep(
         if spec.kind == OutputKind.BUFFER_MUTATION and spec.target
     }
     mutation_outputs: List[Tuple[torch.fx.Node, str]] = []
-    for node in gm.graph.nodes:
+    # Reading an engine needs the [executorch] helper imported above; without it
+    # there is nothing to scan.
+    nodes_to_scan = gm.graph.nodes if _get_engine_info_for_node is not None else ()
+    for node in nodes_to_scan:
         if node.op != "call_function" or node.target is not exec_target:
             continue
         engine_info = _get_engine_info_for_node(exp_program, node)

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -371,7 +371,47 @@ def create_trt_exp_program(
     input_nodes = [node for node in gm.graph.nodes if node.op == "placeholder"]
     output_nodes = [node for node in gm.graph.nodes if node.op == "output"]
     assert output_nodes
-    output_nodes = output_nodes[0].args[0]
+    _output_node = output_nodes[0]
+    output_nodes = _output_node.args[0]
+
+    # Copy-back mutable buffers (non-KV, e.g. a convolution-state ring-buffer):
+    # lift_mutated_buffers appended each buffer's new-value as a trailing graph output. Tag it
+    # BUFFER_MUTATION (reusing the KV `_kv_mutation_target` path) so the runtime
+    # threads it and ExecuTorch copies it back to the caller-owned buffer, then move
+    # all mutation outputs before the user outputs (ExportedProgram verifier requires
+    # BUFFER_MUTATIONs to be contiguous at the front).
+    _copyback = gm.meta.get("_copyback_mutation_buffers", [])
+    if _copyback:
+        # A write-only buffer -- every reader served by the value being written
+        # -- has a dead get_attr, and `transform` already ran DCE. `lift` derives
+        # BUFFER input specs from get_attr nodes alone, so without one the
+        # BUFFER_MUTATION declared below names a buffer the signature never
+        # declares. An unused get_attr is enough: `lift` rewrites it to a
+        # placeholder, which fx's dead-code pass never removes. Must be a
+        # registered buffer, else `lift` makes it a parameter or constant.
+        _attrs = {n.target for n in gm.graph.nodes if n.op == "get_attr"}
+        _registered = dict(gm.named_buffers())
+        _first_node = next(iter(gm.graph.nodes))
+        for _buf in _copyback:
+            if _buf in _attrs or _buf not in _registered:
+                continue
+            with gm.graph.inserting_before(_first_node):
+                gm.graph.get_attr(_buf)
+            _attrs.add(_buf)
+
+        _outs = list(output_nodes)
+        for _n, _buf in zip(_outs[-len(_copyback) :], _copyback):
+            if isinstance(_n, torch.fx.Node):
+                _n.meta["_kv_mutation_target"] = _buf
+
+        def _is_mut(_n: Any) -> bool:
+            return isinstance(_n, torch.fx.Node) and "_kv_mutation_target" in _n.meta
+
+        output_nodes = tuple(
+            [_n for _n in _outs if _is_mut(_n)]
+            + [_n for _n in _outs if not _is_mut(_n)]
+        )
+        _output_node.args = (output_nodes,)
 
     # Outputs tagged by `_expose_aliased_buffer_mutations` become BUFFER_MUTATION
     # specs (their `_kv_mutation_target` meta names the backing buffer); the rest
@@ -532,9 +572,11 @@ def create_trt_exp_program(
 
 def _declare_aliased_kv_mutations_on_ep(
     exp_program: ExportedProgram,
+    copyback_buffers: Optional[List[str]] = None,
 ) -> ExportedProgram:
     """Post-export pass: declare each engine's aliased KV output as a
-    BUFFER_MUTATION of its caller-owned buffer input.
+    BUFFER_MUTATION of its caller-owned buffer input, and reclassify any copy-back
+    outputs as BUFFER_MUTATIONs of their buffers.
 
     Runs on both save() paths (retrace=True and retrace=False); it is idempotent
     because it skips buffers that already carry a BUFFER_MUTATION spec (see
@@ -546,8 +588,23 @@ def _declare_aliased_kv_mutations_on_ep(
     boundary), so the KV buffers -- though BUFFER inputs -- are never recorded as
     mutated and get frozen downstream. This surfaces each aliased output as a
     getitem and declares it a BUFFER_MUTATION of the aliased input's buffer,
-    mirroring create_trt_exp_program's handling on the retrace=False path. Returns
-    exp_program unchanged when no engine has aliased KV outputs.
+    mirroring create_trt_exp_program's handling on the retrace=False path.
+
+    Non-KV mutable buffers (e.g. a convolution-state ring-buffer) have no engine
+    aliasing: lift_mutated_buffers appended their new values as trailing user outputs, which
+    torch.export kept as the last ``len(copyback_buffers)`` outputs. Those are
+    reclassified from USER_OUTPUT to BUFFER_MUTATION here so ExecuTorch copies them
+    back to the caller-owned buffers after the delegate runs.
+
+    Args:
+        exp_program: the retraced ExportedProgram to rewrite.
+        copyback_buffers: buffer FQNs, in output order, for the trailing copy-back
+            outputs to reclassify as BUFFER_MUTATION. Threaded from
+            ``gm.meta['_copyback_mutation_buffers']`` by ``save()``; empty/None means
+            KV-only (no copy-back).
+
+    Returns exp_program unchanged when no engine has aliased KV outputs and there are
+    no copy-back buffers.
     """
     from torch_tensorrt.dynamo.runtime._serialized_engine_layout import (
         ALIASED_IO_IDX,
@@ -666,29 +723,89 @@ def _declare_aliased_kv_mutations_on_ep(
             mutation_outputs.append((getitem_node, buf_fqn))
         node.meta["val"] = tuple(val_list)
 
-    if not mutation_outputs:
+    copyback_buffers = copyback_buffers or []
+    num_copyback = len(copyback_buffers)
+    # Unlike the KV path this reclassifies the trailing num_copyback outputs by
+    # position, so it cannot skip an already-declared buffer the way already_exposed
+    # does: after a first declaration the mutations sit at the front and the trailing
+    # outputs are the user's. Declaring twice would retarget those, dropping a user
+    # output and leaving the buffer with two mutation specs.
+    redeclared = sorted(set(copyback_buffers) & already_exposed)
+    if redeclared:
+        raise RuntimeError(
+            f"Copy-back buffer(s) {redeclared} already carry a BUFFER_MUTATION spec. "
+            "Declaring them again would reclassify the trailing outputs, which are no "
+            "longer the copy-back ones. Pass copyback_buffers only for a program whose "
+            "exporter has not already declared them."
+        )
+    if not mutation_outputs and not num_copyback:
         return exp_program
 
-    # BUFFER_MUTATION outputs must precede USER_OUTPUTs (ExportedProgram verifier).
     out_args = list(output_node.args[0])
-    output_node.args = (tuple([g for g, _ in mutation_outputs] + out_args),)
+    orig_specs = list(sig.output_specs)
+
+    kv_getitems = [g for g, _ in mutation_outputs]
+    kv_specs = [
+        OutputSpec(OutputKind.BUFFER_MUTATION, TensorArgument(name=g.name), fqn)
+        for g, fqn in mutation_outputs
+    ]
+
+    # Copy-back mutable buffers (non-KV, e.g. a convolution-state ring-buffer): lift
+    # appended each buffer's new-value as a trailing user output; torch.export kept them as the
+    # last num_copyback outputs. Reclassify those from USER_OUTPUT to BUFFER_MUTATION
+    # so ET copies them back to the caller-owned buffers.
+    copyback_getitems: List[torch.fx.Node] = []
+    copyback_specs: List[OutputSpec] = []
+    remaining_specs = orig_specs
+    if num_copyback:
+        copyback_getitems = list(out_args[-num_copyback:])
+        remaining_args = out_args[:-num_copyback]
+        remaining_specs = orig_specs[:-num_copyback]
+        copyback_specs = [
+            OutputSpec(OutputKind.BUFFER_MUTATION, TensorArgument(name=g.name), buf)
+            for g, buf in zip(copyback_getitems, copyback_buffers)
+            if isinstance(g, torch.fx.Node)
+        ]
+        out_args = remaining_args
+
+    # BUFFER_MUTATIONs (KV + copy-back) must precede USER_OUTPUTs (verifier).
+    output_node.args = (tuple(kv_getitems + copyback_getitems + out_args),)
     gm.graph.lint()
     gm.recompile()
 
-    new_output_specs = [
-        OutputSpec(OutputKind.BUFFER_MUTATION, TensorArgument(name=g.name), fqn)
-        for g, fqn in mutation_outputs
-    ] + list(sig.output_specs)
+    new_output_specs = kv_specs + copyback_specs + list(remaining_specs)
     new_signature = ExportGraphSignature(
         input_specs=list(sig.input_specs), output_specs=new_output_specs
     )
+
+    # Copy-back outputs were user returns in the retraced program, so torch.export's
+    # out_spec counts them; after reclassifying them as BUFFER_MUTATION only the real
+    # user outputs remain. Rebuild the top-level out_spec (mirroring
+    # create_trt_exp_program) so to_edge's unflatten sees the right leaf count.
+    module_call_graph = exp_program.module_call_graph
+    if num_copyback and module_call_graph:
+        new_out_spec = pytree.tree_flatten(tuple(out_args))[1]
+        _e0 = module_call_graph[0]
+        _sig0 = _e0.signature
+        module_call_graph = [
+            ModuleCallEntry(
+                _e0.fqn,
+                ModuleCallSignature(
+                    inputs=_sig0.inputs if _sig0 is not None else [],
+                    outputs=[],
+                    in_spec=_sig0.in_spec if _sig0 is not None else None,
+                    out_spec=new_out_spec,
+                ),
+            )
+        ] + list(module_call_graph[1:])
+
     return ExportedProgram(
         root=gm,
         graph=gm.graph,
         graph_signature=new_signature,
         state_dict=exp_program.state_dict,
         range_constraints=exp_program.range_constraints,
-        module_call_graph=exp_program.module_call_graph,
+        module_call_graph=module_call_graph,
         example_inputs=exp_program.example_inputs,
         constants=exp_program.constants,
         verifiers=exp_program.verifiers,

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -756,6 +756,11 @@ def _declare_aliased_kv_mutations_on_ep(
         if spec.kind == OutputKind.BUFFER_MUTATION and isinstance(spec.target, str)
     }
     if num_copyback:
+        if len(out_args) < num_copyback:
+            raise RuntimeError(
+                f"Expected at least {num_copyback} trailing outputs to pair with "
+                f"copy-back buffers {copyback_buffers}, found only {len(out_args)}."
+            )
         trailing = list(out_args[-num_copyback:])
         out_args = out_args[:-num_copyback]
         remaining_specs = orig_specs[:-num_copyback]

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -1149,6 +1149,11 @@ def _index_copy_kv_eligible(
     ``lowering/_buffer_lifting.py`` runs before that and passes the node lowering
     will leave behind, which is not always ``node.args[0]``.
     """
+    # That same classifier marks a write it filed copy-back rather than KV, and its
+    # value is a graph output by now. Aliasing it as well would hand the runtime an
+    # output it keeps to itself while the graph still reads it.
+    if node.meta.get("_trt_no_kv_alias"):
+        return False
     if len(node.args) < 4:
         return False
     if input_node is None:

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -1121,7 +1121,10 @@ def aten_ops_gather(
 
 
 def _index_copy_kv_eligible(
-    node: Node, settings: Optional[CompilationSettings] = None
+    node: Node,
+    settings: Optional[CompilationSettings] = None,
+    *,
+    input_node: Optional[Node] = None,
 ) -> bool:
     """Validator for the KV-cache fast path of ``aten.index_copy.default``.
 
@@ -1139,10 +1142,18 @@ def _index_copy_kv_eligible(
 
     Cases that fail this validator fall through to
     ``aten_ops_index_copy_fallback``.
+
+    ``input_node`` overrides which node the input checks are applied to. The
+    partitioner never passes it: by the time this runs as a capability validator,
+    lowering has settled what the input is. The pre-conversion classifier in
+    ``lowering/_buffer_lifting.py`` runs before that and passes the node lowering
+    will leave behind, which is not always ``node.args[0]``.
     """
     if len(node.args) < 4:
         return False
-    input_node, dim, _index_node, src_node = node.args[:4]
+    if input_node is None:
+        input_node = node.args[0]  # type: ignore[assignment]
+    dim, _index_node, src_node = node.args[1:4]
 
     if not isinstance(input_node, Node) or input_node.op != "placeholder":
         return False

--- a/py/torch_tensorrt/dynamo/conversion/impl/slice_scatter.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/slice_scatter.py
@@ -19,7 +19,8 @@ table; this converter is the single place that handles it.
 from __future__ import annotations
 
 import logging
-from typing import Optional, Tuple
+from enum import Enum, auto
+from typing import Any, Optional, Tuple
 
 import numpy as np
 import tensorrt as trt
@@ -66,6 +67,92 @@ def _kv_eligible(
             f"write_start({start})+update_len({update_len}) > s_max({s_max})",
         )
     return True, f"eligible (s_max={s_max}, write_start={start}, len={update_len})"
+
+
+class KVWriteStatus(Enum):
+    """How ``resolve_slice_scatter_write`` resolved a write's slice bounds.
+
+    Anything but ``OK`` is one of the converter's early exits, reached before it
+    can emit an IKVCacheUpdateLayer.
+    """
+
+    OK = auto()
+    FULL_OVERWRITE = auto()
+    DYNAMIC_BOUNDS = auto()
+    BAD_DIM = auto()
+
+
+def resolve_slice_scatter_write(
+    cache_shape: Tuple[Any, ...],
+    dim: Any,
+    start: Any,
+    end: Any,
+    step: Any,
+) -> Tuple[Optional[int], Optional[int], Optional[int], KVWriteStatus]:
+    """Resolve ``slice_scatter``'s slice bounds into the form ``_kv_eligible`` takes.
+
+    Returns ``(start, end, step, status)``. Under ``OK`` and ``FULL_OVERWRITE`` the
+    three bounds are Python ``int``s, with the op's defaults filled in and negative
+    indices counted from the end; under ``DYNAMIC_BOUNDS`` and ``BAD_DIM`` all three
+    are ``None``, since nothing resolved. ``status`` is one of:
+
+    * ``OK`` — the bounds are concrete, and the caller goes on to
+      ``_kv_eligible(cache_shape, dim, start, end - start)``.
+    * ``FULL_OVERWRITE`` — the slice spans the whole dim with a step equal to 1, so
+      the converter returns ``src`` and emits no KV layer. ``step`` comes back as the
+      integer 1, which is all this branch establishes: the caller's own step may be a
+      symbolic object that merely compares equal to it, and no caller reads the value
+      under this status.
+    * ``DYNAMIC_BOUNDS`` — a bound is not a Python ``int``, so the converter
+      raises ``NotImplementedError``.
+    * ``BAD_DIM`` — ``dim`` is either not a Python ``int`` or does not index
+      ``cache_shape``; the converter raises ``IndexError`` for both. A
+      ``numpy.int64`` is rejected on the type check even when its value is in range.
+
+    Single source of truth for the arguments ``_kv_eligible`` is called with: the
+    converter below derives them from the TRT tensors, and the pre-conversion
+    predictor in ``lowering/_buffer_lifting.py`` derives them from the fx node. A
+    write is classified before conversion as engine-aliased and has its ``copy_``
+    dropped on the strength of that prediction, so if the two derivations disagree
+    the aliasing never materializes and the write-back is lost.
+
+    ``step`` is read only where the converter itself reads it — the full-overwrite
+    shortcut. ``_kv_eligible`` ignores ``step``, so a strided write with concrete
+    bounds takes the KV path; whether it should is a separate question this does
+    not settle.
+    """
+    if not isinstance(dim, int) or not -len(cache_shape) <= dim < len(cache_shape):
+        return None, None, None, KVWriteStatus.BAD_DIM
+    dim_size = cache_shape[dim]
+
+    if start is None:
+        start = 0
+    if isinstance(start, int) and start < 0 and isinstance(dim_size, int):
+        start = dim_size + start
+    if end is None:
+        end = dim_size
+    if isinstance(end, int) and end < 0 and isinstance(dim_size, int):
+        end = dim_size + end
+    if step is None:
+        step = 1
+
+    # A slice covering the whole dim is a plain copy of the source whatever `step` is
+    # made of, so it is settled before the bounds are required to be concrete: `step`
+    # only has to compare equal to 1, which a symbolic step can do.
+    if (
+        isinstance(start, int)
+        and isinstance(end, int)
+        and isinstance(dim_size, int)
+        and start == 0
+        and end == dim_size
+        and step == 1
+    ):
+        return start, end, 1, KVWriteStatus.FULL_OVERWRITE
+
+    if not (isinstance(start, int) and isinstance(end, int) and isinstance(step, int)):
+        return None, None, None, KVWriteStatus.DYNAMIC_BOUNDS
+
+    return start, end, step, KVWriteStatus.OK
 
 
 def input_binding_name(ctx: ConversionContext, tensor: TRTTensor) -> Optional[str]:
@@ -175,34 +262,27 @@ def slice_scatter(
 ) -> TRTTensor:
     """Emit either an IKVCacheUpdateLayer (with aliased I/O) or a scatter sequence."""
     rank = len(input.shape)
-    dim_size = input.shape[dim]
 
-    if start is None:
-        start = 0
-    if isinstance(start, int) and start < 0 and isinstance(dim_size, int):
-        start = dim_size + start
-    if end is None:
-        end = dim_size
-    if isinstance(end, int) and end < 0 and isinstance(dim_size, int):
-        end = dim_size + end
-    if step is None:
-        step = 1
+    start, end, step, status = resolve_slice_scatter_write(
+        tuple(input.shape), dim, start, end, step
+    )
+
+    if status is KVWriteStatus.BAD_DIM:
+        raise IndexError(
+            f"slice_scatter: {dim} of type {type(dim).__name__} is not a valid dim "
+            f"for a rank-{rank} input; dim must be a Python int in [-{rank}, {rank})"
+        )
 
     # Trivial: full overwrite.
-    if (
-        isinstance(start, int)
-        and isinstance(end, int)
-        and isinstance(dim_size, int)
-        and start == 0
-        and end == dim_size
-        and step == 1
-    ):
+    if status is KVWriteStatus.FULL_OVERWRITE:
         return src
 
-    if not (isinstance(start, int) and isinstance(end, int) and isinstance(step, int)):
+    if status is KVWriteStatus.DYNAMIC_BOUNDS:
         raise NotImplementedError(
             "slice_scatter with dynamic start/end/step is not yet supported"
         )
+    # OK is the only status left, and it resolves all three bounds to Python ints.
+    assert start is not None and end is not None and step is not None
 
     update_len = end - start
 

--- a/py/torch_tensorrt/dynamo/conversion/impl/slice_scatter.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/slice_scatter.py
@@ -290,8 +290,17 @@ def slice_scatter(
 
     update_len = end - start
 
-    # KV fast path.
-    kv_out = try_emit_kv_cache_update(ctx, name, input, src, dim, start, update_len)
+    # KV fast path, unless the write carries _trt_no_kv_alias: the classifier already
+    # filed it copy-back and re-attached its value as a graph output, and a buffer
+    # that is both copy-back and engine-aliased raises on every call.
+    kv_forbidden = ctx.current_node is not None and ctx.current_node.meta.get(
+        "_trt_no_kv_alias"
+    )
+    kv_out = (
+        None
+        if kv_forbidden
+        else try_emit_kv_cache_update(ctx, name, input, src, dim, start, update_len)
+    )
     if kv_out is not None:
         return kv_out
 

--- a/py/torch_tensorrt/dynamo/conversion/impl/slice_scatter.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/slice_scatter.py
@@ -116,10 +116,9 @@ def resolve_slice_scatter_write(
     dropped on the strength of that prediction, so if the two derivations disagree
     the aliasing never materializes and the write-back is lost.
 
-    ``step`` is read only where the converter itself reads it — the full-overwrite
-    shortcut. ``_kv_eligible`` ignores ``step``, so a strided write with concrete
-    bounds takes the KV path; whether it should is a separate question this does
-    not settle.
+    ``step`` is read here for the full-overwrite shortcut and, on the converter side,
+    only by the scatter fallback; the KV fast path never reads it. See the note on the
+    ``OK`` return for what that costs a strided write the KV path accepts.
     """
     if not isinstance(dim, int) or not -len(cache_shape) <= dim < len(cache_shape):
         return None, None, None, KVWriteStatus.BAD_DIM
@@ -152,6 +151,11 @@ def resolve_slice_scatter_write(
     if not (isinstance(start, int) and isinstance(end, int) and isinstance(step, int)):
         return None, None, None, KVWriteStatus.DYNAMIC_BOUNDS
 
+    # `step` is passed through untouched, and `try_emit_kv_cache_update` never reads
+    # it: a strided write the KV fast path accepts is classified and lowered as if it
+    # were contiguous, so `cache[:, :, 0:8:2, :]` lands in slots 0, 1, 2, 3 rather than
+    # 0, 2, 4, 6, silently. Known wrong and unfixed. The scatter fallback below does
+    # honour `step` (`test_fallback_step_two`), so only the KV path miscompiles.
     return start, end, step, KVWriteStatus.OK
 
 

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -327,6 +327,42 @@ def assert_predicted_kv_aliased(
         )
 
 
+def assert_no_kv_alias_markers_survived(
+    gm: torch.fx.GraphModule, marked_writes: Iterable[str]
+) -> None:
+    """Check that lowering carried each ``_trt_no_kv_alias`` marker through to
+    conversion.
+
+    The marker is the only thing stopping the converter from aliasing a write that
+    :func:`lift_mutated_buffers` deliberately filed copy-back, and it travels on
+    ``node.meta`` through every pass in ``post_lowering``. A pass that rebuilds the
+    node without its ``meta`` would drop it silently and the module would raise on
+    every call, so the markers are read back here, where the fault can still be named.
+
+    Called with the lowered graph and ``gm.meta['_no_kv_alias_writes']`` as recorded
+    before lowering. A marked write is a graph output by then, so it cannot be
+    eliminated; missing means rewritten.
+    """
+    marked = list(marked_writes)
+    if not marked:
+        return
+    by_name = {node.name: node for node in gm.graph.nodes}
+    lost = [
+        name
+        for name in marked
+        if name not in by_name or not by_name[name].meta.get("_trt_no_kv_alias")
+    ]
+    if lost:
+        raise RuntimeError(
+            "lift_mutated_buffers marked these buffer writes as copy-back-only "
+            "(node.meta['_trt_no_kv_alias']) so the converter would not alias them, "
+            f"but the marker did not survive lowering: {lost}. A pass in "
+            "post_lowering rebuilt or replaced the node without carrying its meta "
+            "over. Without the marker the engine aliases a buffer whose new value "
+            "is also a graph output, and the compiled module raises on every call."
+        )
+
+
 def lift_mutated_buffers(
     gm: torch.fx.GraphModule,
     settings: Optional[CompilationSettings] = None,
@@ -363,6 +399,20 @@ def lift_mutated_buffers(
     ``_declare_aliased_kv_mutations_on_ep``) read that list to reclassify those
     outputs as BUFFER_MUTATIONs. Copy-back is correct but not free; see the module
     docstring for what each such buffer costs per call.
+
+    One aliasable write is routed to copy-back anyway: one whose result nothing else
+    consumes. Erasing its ``copy_`` leaves it dead, and dead-code elimination takes it
+    before any engine can alias it. Copy-back makes it live again, so it needs the
+    converter to leave it alone -- ``node.meta['_trt_no_kv_alias']`` on the write node
+    says so, and :func:`assert_no_kv_alias_markers_survived` re-reads the markers after
+    lowering.
+
+    That marker goes on the write *node* while the classification is per *buffer*, so
+    one value node written back into two buffers would put the two in conflict: the
+    node marked on one buffer's behalf while the other buffer's write is predicted KV.
+    ``torch.export`` rejects that shape with ``SpecViolationError`` before the
+    classifier sees it, so it is a constraint on what can arrive here rather than a
+    case to guard against.
     """
     # Find all aten.copy_(get_attr_X, _) calls. The first arg's target is
     # the buffer name. Some EPs emit copy_.default, others copy_.
@@ -412,6 +462,9 @@ def lift_mutated_buffers(
     # (buf_*) is the stable key: it survives the buffer renaming inline does later,
     # and it is exactly what aliased_io records on the input side.
     predicted_kv_bindings: set[str] = set()
+    # Names of the write nodes marked _trt_no_kv_alias below. Read back after
+    # lowering by :func:`assert_no_kv_alias_markers_survived`.
+    no_kv_alias_writes: List[str] = []
 
     for copy_node, get_attr_node in mutation_pairs:
         buffer_name = get_attr_node.target
@@ -482,7 +535,24 @@ def lift_mutated_buffers(
         new_value = copy_node.args[1] if len(copy_node.args) > 1 else None
         gm.graph.erase_node(copy_node)
         if isinstance(new_value, torch.fx.Node):
-            if _kv_write_will_alias(new_value, tuple(buffer_tensor.shape), settings):
+            will_alias = _kv_write_will_alias(
+                new_value, tuple(buffer_tensor.shape), settings
+            )
+            if will_alias and not new_value.users:
+                # The copy_ was this write's only consumer, so it is now dead and
+                # dead-code elimination will take it before any engine sees it --
+                # leaving the prediction unfulfilled and the write-back lost. Copy-back
+                # revives it, because the value is re-attached as a graph output, but
+                # then the converter would alias a buffer that is also copy-back and
+                # the module would raise on every call. Marking the write forbids the
+                # aliasing, which is what makes the copy-back route available at all.
+                # Both eligibility checks read the marker: impl.slice_scatter off
+                # ctx.current_node, aten_ops_converters._index_copy_kv_eligible off
+                # the node it is handed.
+                new_value.meta["_trt_no_kv_alias"] = True
+                no_kv_alias_writes.append(new_value.name)
+                will_alias = False
+            if will_alias:
                 predicted_kv_bindings.add(replacement.name)
             else:
                 copyback.append((new_value, buffer_name, replacement.name))
@@ -511,6 +581,7 @@ def lift_mutated_buffers(
         gm.meta["_copyback_mutation_buffers"] = copyback_buffers
         gm.meta["_copyback_bindings"] = copyback_bindings
         gm.meta["_predicted_kv_bindings"] = sorted(predicted_kv_bindings)
+        gm.meta["_no_kv_alias_writes"] = no_kv_alias_writes
         return gm, []
 
     # ExportedProgram.module() produces a GraphModule whose forward is
@@ -544,6 +615,7 @@ def lift_mutated_buffers(
     new_gm.meta["_copyback_mutation_buffers"] = copyback_buffers
     new_gm.meta["_copyback_bindings"] = copyback_bindings
     new_gm.meta["_predicted_kv_bindings"] = sorted(predicted_kv_bindings)
+    new_gm.meta["_no_kv_alias_writes"] = no_kv_alias_writes
 
     logger.debug(
         "Lifted %d mutated buffer(s) to placeholders: %s; copy-back buffers: %s",

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -147,10 +147,14 @@ def _kv_write_will_alias(
     predicates -- and, for ``slice_scatter``, the converter's own derivation of
     the arguments those predicates take (:func:`resolve_slice_scatter_write`), since
     a divergence there mis-predicts just as effectively as a divergence in the
-    predicate. A ``slice_scatter`` / ``index_copy`` that is not eligible is
-    lowered to a non-aliasing scatter, so its write-back is kept as a
-    BUFFER_MUTATION output (copy-back) rather than dropped. Imports are local to
-    avoid a lowering<->conversion import cycle.
+    predicate. Returning ``False`` routes the write to copy-back, which is right
+    whatever the converter goes on to do with it: it lowers most ineligible writes
+    to a non-aliasing scatter, returns the source outright for a full overwrite, and
+    raises for the rest (a ``slice_scatter`` with dynamic bounds or a bad ``dim``, an
+    ``index_copy`` its fallback cannot express). The first two both have a write-back
+    to preserve -- for a full overwrite the source *is* the buffer's new contents --
+    and the ones that raise never get as far as needing one.
+    Imports are local to avoid a lowering<->conversion import cycle.
     """
     if not (isinstance(value_node, torch.fx.Node) and value_node.op == "call_function"):
         return False
@@ -187,10 +191,11 @@ def _kv_write_will_alias(
 
         # Any status other than OK is a case in which the converter returns or
         # raises before it reaches _kv_eligible, so nothing aliases the cache.
-        # Returning False keeps the copy_. A full overwrite needs that: it returns
-        # the source, emits no KV layer, and its write still has to be copied back.
-        # The other two statuses raise out of the converter, so the compile aborts
-        # and nothing is copied back at all.
+        # Returning False routes the write to copy-back -- the copy_ is erased
+        # either way, and the new value is re-attached as a graph output instead. A
+        # full overwrite needs that: it returns the source, emits no KV layer, and
+        # its write still has to be recorded. The other two statuses raise out of the
+        # converter, so the compile aborts and the output is never reached.
         dim = args[2] if len(args) > 2 else 0
         start, end, _step, status = resolve_slice_scatter_write(
             tuple(cache_shape),
@@ -342,10 +347,11 @@ def lift_mutated_buffers(
     I/O (an eligible ``slice_scatter`` / ``index_copy``, per
     :func:`_kv_write_will_alias`) relies on that engine aliasing for its
     write-back, so nothing further is added. Every other mutation -- a non-KV
-    buffer, or a ``slice_scatter`` / ``index_copy`` that fails eligibility and is
-    lowered to a non-aliasing scatter -- has no engine aliasing, so its new value
-    is re-appended as a graph output ("copy-back") and its buffer name recorded,
-    in output order, in ``gm.meta['_copyback_mutation_buffers']`` -- the
+    buffer, or a ``slice_scatter`` / ``index_copy`` that fails eligibility, whether
+    the converter then lowers it to a non-aliasing scatter, returns the source, or
+    raises -- has no engine aliasing, so its new value is re-appended as a graph
+    output ("copy-back") and its buffer name recorded, in output order, in
+    ``gm.meta['_copyback_mutation_buffers']`` -- the
     downstream exporters (``create_trt_exp_program`` /
     ``_declare_aliased_kv_mutations_on_ep``) read that list to reclassify those
     outputs as BUFFER_MUTATIONs. Copy-back is correct but not free; see the module

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -90,8 +90,9 @@ def _write_op_is_torch_executed(
     )
 
 
-def _reads_the_cache_as_a_network_input(cache_node: torch.fx.Node) -> bool:
-    """Whether the converter will see this write's cache argument as a network input.
+def _effective_cache_input(cache_node: torch.fx.Node) -> Optional[torch.fx.Node]:
+    """The node the converter will see as this write's cache argument, if it is a
+    network input, else ``None``.
 
     A lifted buffer is a placeholder, and ``emit_kv_cache_update_layer`` aliases the
     cache only when the argument it is handed is one -- anything else has no input
@@ -121,7 +122,7 @@ def _reads_the_cache_as_a_network_input(cache_node: torch.fx.Node) -> bool:
     ``min_block_size``, not only at ``min_block_size=1``.
     """
     if cache_node.op == "placeholder":
-        return True
+        return cache_node
     if not (
         cache_node.op == "call_function"
         and cache_node.target is torch.ops.aten.clone.default
@@ -129,9 +130,12 @@ def _reads_the_cache_as_a_network_input(cache_node: torch.fx.Node) -> bool:
         and isinstance(cache_node.args[0], torch.fx.Node)
         and cache_node.args[0].op == "placeholder"
     ):
-        return False
-    users = list(cache_node.args[0].users)
-    return len(users) == 1 and users[0] is cache_node
+        return None
+    placeholder = cache_node.args[0]
+    users = list(placeholder.users)
+    if len(users) == 1 and users[0] is cache_node:
+        return placeholder
+    return None
 
 
 def _kv_write_will_alias(
@@ -168,11 +172,10 @@ def _kv_write_will_alias(
         return False
     # The KV layer aliases the cache only if it is a direct network input; after
     # lifting, the mutated buffer is a placeholder the write op reads from.
-    if not (
-        args
-        and isinstance(args[0], torch.fx.Node)
-        and _reads_the_cache_as_a_network_input(args[0])
-    ):
+    if not (args and isinstance(args[0], torch.fx.Node)):
+        return False
+    cache_input = _effective_cache_input(args[0])
+    if cache_input is None:
         return False
 
     if value_node.target is torch.ops.aten.index_copy.default:
@@ -180,7 +183,11 @@ def _kv_write_will_alias(
             _index_copy_kv_eligible,
         )
 
-        return bool(_index_copy_kv_eligible(value_node))
+        # The validator applies its own placeholder check to args[0], and here that
+        # can still be the clone lowering is about to erase. Point it at what the
+        # converter will be handed instead; the partitioner, running after lowering,
+        # passes nothing and reads args[0] itself.
+        return bool(_index_copy_kv_eligible(value_node, input_node=cache_input))
 
     if value_node.target is torch.ops.aten.slice_scatter.default:
         from torch_tensorrt.dynamo.conversion.impl.slice_scatter import (

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -144,7 +144,11 @@ def aliased_input_bindings(aliased_io_maps: Iterable[Any]) -> Set[str]:
 
 
 def assert_predicted_kv_aliased(
-    aliased_in: Set[str], predicted_kv_bindings: List[str]
+    aliased_in: Set[str],
+    predicted_kv_bindings: List[str],
+    settings: Optional[CompilationSettings] = None,
+    *,
+    engines_built: bool = True,
 ) -> None:
     """Ground-truth check for the KV predictions :func:`_kv_write_will_alias` made.
 
@@ -159,16 +163,37 @@ def assert_predicted_kv_aliased(
     ``aliased_in`` is the ground truth, supplied by the caller because the two entry
     points hold it in different shapes: :func:`compile` reads it off the compiled
     submodules, while the engine converter has it on the interpreter result.
+
+    ``engines_built=False`` says the caller produced no engine, so ``aliased_in`` is
+    empty for reasons that say nothing about the predictions and every one of them
+    would look unfulfilled. The check is skipped there instead. :func:`compile` passes
+    ``not settings.dryrun``, because a dryrun returns before conversion; the engine
+    converter takes ``dryrun`` too but never acts on it and builds either way, so it
+    keeps the default.
     """
     if not predicted_kv_bindings:
         return
+    if not engines_built:
+        logger.debug(
+            "no engines were built, so the predicted-KV aliasing check for "
+            "%s has nothing to verify against and is skipped",
+            predicted_kv_bindings,
+        )
+        return
     missing = [b for b in predicted_kv_bindings if b not in aliased_in]
     if missing:
+        cause = "the write did not end up inside a TensorRT engine"
+        if settings is not None:
+            cause += (
+                f", most often because min_block_size ({settings.min_block_size}) "
+                "rejected the subgraph it landed in; min_block_size=1 rules that out"
+            )
         raise RuntimeError(
             "lift_mutated_buffers classified these buffer writes as KV-cache "
             "(engine-aliased) and dropped their copy_, but the compiled engine "
             f"did not alias them (absent from aliased_io): {missing}. Their "
-            "write-back would be silently dropped."
+            "write-back would be silently dropped. The classification runs before "
+            f"partitioning, so this means {cause}."
         )
 
 

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -275,16 +275,28 @@ def assert_predicted_kv_aliased(
     if missing:
         cause = "the write did not end up inside a TensorRT engine"
         if settings is not None:
-            cause += (
-                f", most often because min_block_size ({settings.min_block_size}) "
-                "rejected the subgraph it landed in; min_block_size=1 rules that out"
-            )
+            if settings.min_block_size > 1:
+                cause += (
+                    f", most often because min_block_size "
+                    f"({settings.min_block_size}) rejected the subgraph it landed "
+                    "in; min_block_size=1 rules that out"
+                )
+            else:
+                # The sibling branch's remedy is the value already in force here, so
+                # naming min_block_size at all would read as "1 rejected the
+                # subgraph; set it to 1" -- the value blamed and the value
+                # recommended being the same is no remedy the reader can act on.
+                # Name the cause instead.
+                cause += (
+                    ", most often because a converter or a capability validator "
+                    "rejected the op"
+                )
         raise RuntimeError(
             "lift_mutated_buffers classified these buffer writes as KV-cache "
             "(engine-aliased) and dropped their copy_, but the compiled engine "
             f"did not alias them (absent from aliased_io): {missing}. Their "
             "write-back would be silently dropped. The classification runs before "
-            f"partitioning, so this means {cause}."
+            f"lowering and partitioning, so: {cause}."
         )
 
     unexpected = [b for b in copyback_bindings if b in aliased_in]

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -340,27 +340,54 @@ def assert_no_kv_alias_markers_survived(
     every call, so the markers are read back here, where the fault can still be named.
 
     Called with the lowered graph and ``gm.meta['_no_kv_alias_writes']`` as recorded
-    before lowering. A marked write is a graph output by then, so it cannot be
-    eliminated; missing means rewritten.
+    before lowering, and the two sets must match exactly. They diverge three ways: a
+    recorded name keeps its node but loses the marker, so a pass rebuilt the node
+    without its meta; an unrecorded node gains a marker while every recorded one keeps
+    its own, so a pass copied the meta; or a recorded name goes missing and an
+    unrecorded node gains a marker, so a pass replaced the node and the meta travelled
+    with it. The third is the one the passes in ``post_lowering`` actually produce,
+    because each carries a node's meta onto that node's own replacement.
     """
-    marked = list(marked_writes)
-    if not marked:
-        return
+    expected = set(marked_writes)
     by_name = {node.name: node for node in gm.graph.nodes}
-    lost = [
+    lost = sorted(
         name
-        for name in marked
+        for name in expected
         if name not in by_name or not by_name[name].meta.get("_trt_no_kv_alias")
-    ]
-    if lost:
-        raise RuntimeError(
-            "lift_mutated_buffers marked these buffer writes as copy-back-only "
-            "(node.meta['_trt_no_kv_alias']) so the converter would not alias them, "
-            f"but the marker did not survive lowering: {lost}. A pass in "
-            "post_lowering rebuilt or replaced the node without carrying its meta "
-            "over. Without the marker the engine aliases a buffer whose new value "
-            "is also a graph output, and the compiled module raises on every call."
+    )
+    gained = sorted(
+        name
+        for name, node in by_name.items()
+        if name not in expected and node.meta.get("_trt_no_kv_alias")
+    )
+    if not lost and not gained:
+        return
+    if lost and gained:
+        detail = (
+            f"{lost} are gone and {gained} carry the marker instead, so a pass "
+            "replaced the node and the meta travelled with it"
         )
+    elif lost:
+        detail = (
+            f"the marker is gone from {lost} and no other node carries it, so a pass "
+            "rebuilt the node without its meta"
+        )
+    else:
+        detail = (
+            f"{gained} carry the marker but were never marked, so a pass copied the "
+            "meta onto another node"
+        )
+    # What raising here prevents: a marker rebuilt away lets the converter alias a
+    # write whose new value is also a graph output, and the module raises on every
+    # call; a marker copied onto a node the classifier chose to alias makes the
+    # converter refuse that aliasing, which the predicted-KV cross-check then reports
+    # as a partitioning failure that never happened; and a marker that travelled with
+    # a replacement cannot be shown from here to have landed on the write the
+    # classifier meant.
+    raise RuntimeError(
+        "lift_mutated_buffers set node.meta['_trt_no_kv_alias'] markers before "
+        f"lowering that no longer match the lowered graph: {detail}."
+    )
 
 
 def lift_mutated_buffers(

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -121,7 +121,7 @@ def _kv_write_will_alias(
             _index_copy_kv_eligible,
         )
 
-        return _index_copy_kv_eligible(value_node)
+        return bool(_index_copy_kv_eligible(value_node))
 
     if value_node.target is torch.ops.aten.slice_scatter.default:
         from torch_tensorrt.dynamo.conversion.impl.slice_scatter import (
@@ -149,7 +149,7 @@ def _kv_write_will_alias(
         # OK is the only status that resolves all three bounds to Python ints.
         assert start is not None and end is not None
         eligible, _reason = _kv_eligible(tuple(cache_shape), dim, start, end - start)
-        return eligible
+        return bool(eligible)
 
     return False
 

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -308,9 +308,7 @@ def lift_mutated_buffers(
         # BUFFER_MUTATION output below, then drop the (now input-target) copy_.
         new_value = copy_node.args[1] if len(copy_node.args) > 1 else None
         if isinstance(new_value, torch.fx.Node):
-            if _kv_write_will_alias(
-                new_value, tuple(buffer_tensor.shape), settings
-            ):
+            if _kv_write_will_alias(new_value, tuple(buffer_tensor.shape), settings):
                 predicted_kv_bindings.add(replacement.name)
             else:
                 copyback.append((new_value, buffer_name))

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -23,6 +23,25 @@ This module provides:
   threaded internally via the fx graph). Because everything is fx +
   module state, the result serializes naturally through
   ``torch_tensorrt.save`` / ``torch.export``.
+
+What copy-back costs: only an engine-aliased (KV) write is free. A write routed to
+copy-back re-attaches the *whole post-write buffer* as a graph output, because a
+BUFFER_MUTATION output is defined as the buffer's new contents rather than the slice
+that changed. Each call therefore pays, per copy-back buffer:
+
+* the graph materializing the full buffer as that output — whatever applied the
+  update produces the whole tensor rather than the changed slice, whether that is a
+  scatter inside an engine or an op the partitioner left in PyTorch — and
+* ExecuTorch's write-back pass copying that output into the caller-owned buffer
+  after the delegate returns.
+
+For a decode step writing one position into a multi-megabyte KV cache, that is a
+full-cache-sized materialization plus a full-cache-sized copy to record a
+single-slot update, per buffer, per call, and easily dominates the step. It is the
+right correctness tradeoff — the alternative is silently losing the write — but it
+is why the classifier routes a cache write to engine aliasing instead, and why a
+model that unexpectedly lands in copy-back comes out slow rather than wrong.
+``gm.meta['_copyback_mutation_buffers']`` lists which buffers are paying it.
 """
 
 from __future__ import annotations
@@ -237,7 +256,8 @@ def lift_mutated_buffers(
     in output order, in ``gm.meta['_copyback_mutation_buffers']`` -- the
     downstream exporters (``create_trt_exp_program`` /
     ``_declare_aliased_kv_mutations_on_ep``) read that list to reclassify those
-    outputs as BUFFER_MUTATIONs.
+    outputs as BUFFER_MUTATIONs. Copy-back is correct but not free; see the module
+    docstring for what each such buffer costs per call.
     """
     # Find all aten.copy_(get_attr_X, _) calls. The first arg's target is
     # the buffer name. Some EPs emit copy_.default, others copy_.

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -28,7 +28,7 @@ This module provides:
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import torch
 from torch_tensorrt.dynamo._settings import CompilationSettings
@@ -128,8 +128,23 @@ def _kv_write_will_alias(
     return False
 
 
+def aliased_input_bindings(aliased_io_maps: Iterable[Any]) -> Set[str]:
+    """Collect the input-binding side of one or more ``aliased_io`` maps.
+
+    Each map is ``output binding -> (input binding, kind)``, and a bare input binding
+    is tolerated in place of the pair.
+    """
+    bindings: Set[str] = set()
+    for amap in aliased_io_maps:
+        if not amap:
+            continue
+        for v in amap.values():
+            bindings.add(v[0] if isinstance(v, (tuple, list)) else v)
+    return bindings
+
+
 def assert_predicted_kv_aliased(
-    gm: torch.fx.GraphModule, predicted_kv_bindings: List[str]
+    aliased_in: Set[str], predicted_kv_bindings: List[str]
 ) -> None:
     """Ground-truth check for the KV predictions :func:`_kv_write_will_alias` made.
 
@@ -140,15 +155,13 @@ def assert_predicted_kv_aliased(
     appears in a compiled engine's ``aliased_io``, and raise loudly otherwise.
     Keyed on the ``buf_*`` binding name, which is stable across the later buffer
     rename and is what ``aliased_io`` records on the input side.
+
+    ``aliased_in`` is the ground truth, supplied by the caller because the two entry
+    points hold it in different shapes: :func:`compile` reads it off the compiled
+    submodules, while the engine converter has it on the interpreter result.
     """
     if not predicted_kv_bindings:
         return
-    aliased_in: set = set()
-    for _name, sub in gm.named_children():
-        amap = getattr(sub, "aliased_io", None)
-        if amap:
-            for v in amap.values():
-                aliased_in.add(v[0] if isinstance(v, (tuple, list)) else v)
     missing = [b for b in predicted_kv_bindings if b not in aliased_in]
     if missing:
         raise RuntimeError(

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -90,6 +90,50 @@ def _write_op_is_torch_executed(
     )
 
 
+def _reads_the_cache_as_a_network_input(cache_node: torch.fx.Node) -> bool:
+    """Whether the converter will see this write's cache argument as a network input.
+
+    A lifted buffer is a placeholder, and ``emit_kv_cache_update_layer`` aliases the
+    cache only when the argument it is handed is one -- anything else has no input
+    binding name and the converter falls back to a plain scatter.
+
+    One rewrite stands between this classification and the converter:
+    ``remove_input_alias_fixing_clones``, an ATEN lowering pass inside
+    ``post_lowering``, erases a ``clone`` whose placeholder has no other user, which
+    is the shape ``clone -> scatter -> copy_`` leaves behind once lifting has erased
+    the ``copy_``. The converter then does see a direct network input and does emit
+    the KV layer, so this has to predict what the converter will be handed rather
+    than what is in the graph now. Getting it wrong in that direction is worse than
+    a lost write-back: the write is filed copy-back, its value is re-attached as a
+    trailing graph output, and the engine aliases the cache anyway -- so the runtime
+    truncates that output as an engine side effect while the outer graph still reads
+    it, and every call raises ``IndexError``.
+
+    The pass's own condition is reproduced exactly, sole user and all: a placeholder
+    with another reader keeps its clone, the converter sees a ``call_function``, and
+    nothing aliases.
+
+    Predicting the peel is not free. A cloned cache write is classified KV, so if no
+    engine goes on to claim it -- at the *default* ``min_block_size=5`` a small
+    model's subgraph often does not -- ``assert_predicted_kv_aliased`` fails the
+    compile rather than leaving the buffer at its compile-time value. A loud failure
+    beats a silently stale buffer, and this failure is reachable at the default
+    ``min_block_size``, not only at ``min_block_size=1``.
+    """
+    if cache_node.op == "placeholder":
+        return True
+    if not (
+        cache_node.op == "call_function"
+        and cache_node.target is torch.ops.aten.clone.default
+        and cache_node.args
+        and isinstance(cache_node.args[0], torch.fx.Node)
+        and cache_node.args[0].op == "placeholder"
+    ):
+        return False
+    users = list(cache_node.args[0].users)
+    return len(users) == 1 and users[0] is cache_node
+
+
 def _kv_write_will_alias(
     value_node: object,
     cache_shape: Tuple[int, ...],
@@ -121,7 +165,9 @@ def _kv_write_will_alias(
     # The KV layer aliases the cache only if it is a direct network input; after
     # lifting, the mutated buffer is a placeholder the write op reads from.
     if not (
-        args and isinstance(args[0], torch.fx.Node) and args[0].op == "placeholder"
+        args
+        and isinstance(args[0], torch.fx.Node)
+        and _reads_the_cache_as_a_network_input(args[0])
     ):
         return False
 
@@ -184,8 +230,9 @@ def assert_predicted_kv_aliased(
     settings: Optional[CompilationSettings] = None,
     *,
     engines_built: bool = True,
+    copyback_bindings: Iterable[str] = (),
 ) -> None:
-    """Ground-truth check for the KV predictions :func:`_kv_write_will_alias` made.
+    """Ground-truth check on both directions of the classification.
 
     Each write ``lift_mutated_buffers`` classified as KV-aliased had its ``copy_``
     dropped in the expectation that the engine would alias it in place. If the
@@ -194,6 +241,13 @@ def assert_predicted_kv_aliased(
     appears in a compiled engine's ``aliased_io``, and raise loudly otherwise.
     Keyed on the ``buf_*`` binding name, which is stable across the later buffer
     rename and is what ``aliased_io`` records on the input side.
+
+    The other direction fails just as badly and is not the same check. A write filed
+    copy-back has its new value re-attached as a trailing graph output; if the engine
+    aliases that buffer anyway, the runtime truncates the aliased output as an engine
+    side effect while the outer graph still reads it, and the module raises on every
+    call. So ``copyback_bindings`` -- the input bindings of the writes filed
+    copy-back -- must be absent from ``aliased_io``.
 
     ``aliased_in`` is the ground truth, supplied by the caller because the two entry
     points hold it in different shapes: :func:`compile` reads it off the compiled
@@ -206,13 +260,15 @@ def assert_predicted_kv_aliased(
     converter takes ``dryrun`` too but never acts on it and builds either way, so it
     keeps the default.
     """
-    if not predicted_kv_bindings:
+    copyback_bindings = list(copyback_bindings)
+    if not predicted_kv_bindings and not copyback_bindings:
         return
     if not engines_built:
         logger.debug(
-            "no engines were built, so the predicted-KV aliasing check for "
-            "%s has nothing to verify against and is skipped",
+            "no engines were built, so the aliasing cross-check for predicted-KV "
+            "%s and copy-back %s has nothing to verify against and is skipped",
             predicted_kv_bindings,
+            copyback_bindings,
         )
         return
     missing = [b for b in predicted_kv_bindings if b not in aliased_in]
@@ -229,6 +285,21 @@ def assert_predicted_kv_aliased(
             f"did not alias them (absent from aliased_io): {missing}. Their "
             "write-back would be silently dropped. The classification runs before "
             f"partitioning, so this means {cause}."
+        )
+
+    unexpected = [b for b in copyback_bindings if b in aliased_in]
+    if unexpected:
+        # What raising here prevents: the runtime treats an aliased output as an
+        # engine side effect and does not return it, so the surrounding graph reads
+        # past the end of the results and the module raises on every call.
+        raise RuntimeError(
+            "lift_mutated_buffers classified these buffer writes as copy-back (not "
+            "engine-aliased) and re-attached their new values as trailing graph "
+            "outputs, but the compiled engine aliased them in place anyway (present "
+            f"in aliased_io): {unexpected}. The classification runs before lowering, "
+            "so a lowering pass rewrote the write into a form the converter could "
+            "alias after all -- remove_input_alias_fixing_clones erasing a clone of "
+            "the cache is the known case."
         )
 
 
@@ -307,12 +378,14 @@ def lift_mutated_buffers(
     # eligibility predicates (not the op target alone), so a non-aliasable
     # slice_scatter / index_copy falls to copy-back rather than being dropped.
     # index_put has no aliasing converter, so it always falls to copy-back too.
-    copyback: List[Tuple[torch.fx.Node, str]] = []  # (new_value_node, buffer_name)
+    # (new_value_node, buffer_name, input_binding_name)
+    copyback: List[Tuple[torch.fx.Node, str, str]] = []
     # Input-binding names of writes predicted to alias (KV). compile() asserts each
-    # actually appears in the engine's aliased_io, turning a mis-prediction into a
-    # loud error instead of a silently dropped write-back. The binding name (buf_*)
-    # is the stable key: it survives the buffer renaming inline does later, and it
-    # is exactly what aliased_io records on the input side.
+    # actually appears in the engine's aliased_io, and that no copy-back binding
+    # does, turning either mis-prediction into a loud error instead of a silently
+    # dropped write-back or a module that raises on every call. The binding name
+    # (buf_*) is the stable key: it survives the buffer renaming inline does later,
+    # and it is exactly what aliased_io records on the input side.
     predicted_kv_bindings: set[str] = set()
 
     for copy_node, get_attr_node in mutation_pairs:
@@ -374,14 +447,20 @@ def lift_mutated_buffers(
         # KV writes rely on engine-level aliasing, so the trailing copy_ is
         # redundant and dropped. Other (non-KV) mutations have no aliasing:
         # record their new value so we can re-attach it as a copy-back
-        # BUFFER_MUTATION output below, then drop the (now input-target) copy_.
+        # BUFFER_MUTATION output below.
+        #
+        # Drop the (now input-target) copy_ first, so the classification reads the
+        # graph the lowering passes and the partitioner will read. The copy_ is the
+        # last reader of the buffer placeholder in the ordinary write-only shape, and
+        # whether it is still there decides whether a clone of the cache survives
+        # into conversion.
         new_value = copy_node.args[1] if len(copy_node.args) > 1 else None
+        gm.graph.erase_node(copy_node)
         if isinstance(new_value, torch.fx.Node):
             if _kv_write_will_alias(new_value, tuple(buffer_tensor.shape), settings):
                 predicted_kv_bindings.add(replacement.name)
             else:
-                copyback.append((new_value, buffer_name))
-        gm.graph.erase_node(copy_node)
+                copyback.append((new_value, buffer_name, replacement.name))
 
         # Erase the now-unused get_attr.
         if not get_attr_node.users:
@@ -392,17 +471,20 @@ def lift_mutated_buffers(
     # Appended in order; recorded so create_trt_exp_program / _declare can tag the
     # corresponding engine outputs as BUFFER_MUTATION (copy-back) downstream.
     copyback_buffers: List[str] = []
+    copyback_bindings: List[str] = []
     if copyback:
         output_node = next(n for n in gm.graph.nodes if n.op == "output")
         out_args = list(output_node.args[0])
-        out_args.extend(nv for nv, _ in copyback)
+        out_args.extend(nv for nv, _, _ in copyback)
         output_node.args = (tuple(out_args),)
-        copyback_buffers = [buf for _, buf in copyback]
+        copyback_buffers = [buf for _, buf, _ in copyback]
+        copyback_bindings = sorted({binding for _, _, binding in copyback})
 
     gm.graph.lint()
 
     if not lifted:
         gm.meta["_copyback_mutation_buffers"] = copyback_buffers
+        gm.meta["_copyback_bindings"] = copyback_bindings
         gm.meta["_predicted_kv_bindings"] = sorted(predicted_kv_bindings)
         return gm, []
 
@@ -435,6 +517,7 @@ def lift_mutated_buffers(
                 pass
     new_gm.recompile()
     new_gm.meta["_copyback_mutation_buffers"] = copyback_buffers
+    new_gm.meta["_copyback_bindings"] = copyback_bindings
     new_gm.meta["_predicted_kv_bindings"] = sorted(predicted_kv_bindings)
 
     logger.debug(

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -72,7 +72,10 @@ def _kv_write_will_alias(
 
     Eligibility depends on the write dim, static shapes, and the cache being a
     direct network input, so this reuses the converters' own eligibility
-    predicates. A ``slice_scatter`` / ``index_copy`` that is not eligible is
+    predicates -- and, for ``slice_scatter``, the converter's own derivation of
+    the arguments those predicates take (:func:`resolve_slice_scatter_write`), since
+    a divergence there mis-predicts just as effectively as a divergence in the
+    predicate. A ``slice_scatter`` / ``index_copy`` that is not eligible is
     lowered to a non-aliasing scatter, so its write-back is kept as a
     BUFFER_MUTATION output (copy-back) rather than dropped. Imports are local to
     avoid a lowering<->conversion import cycle.
@@ -102,27 +105,31 @@ def _kv_write_will_alias(
         return _index_copy_kv_eligible(value_node)
 
     if value_node.target is torch.ops.aten.slice_scatter.default:
-        from torch_tensorrt.dynamo.conversion.impl.slice_scatter import _kv_eligible
+        from torch_tensorrt.dynamo.conversion.impl.slice_scatter import (
+            KVWriteStatus,
+            _kv_eligible,
+            resolve_slice_scatter_write,
+        )
 
-        dim = args[2] if len(args) > 2 and isinstance(args[2], int) else 0
-        start = args[3] if len(args) > 3 and isinstance(args[3], int) else 0
-        # Prefer the source's extent along `dim` for the write length; fall back
-        # to end-start from the slice bounds.
-        update_len = None
-        src = args[1] if len(args) > 1 else None
-        if isinstance(src, torch.fx.Node):
-            src_val = src.meta.get("val")
-            if src_val is not None and dim < len(src_val.shape):
-                s = src_val.shape[dim]
-                update_len = s if isinstance(s, int) else None
-        if update_len is None:
-            end = (
-                args[4]
-                if len(args) > 4 and isinstance(args[4], int)
-                else (cache_shape[dim] if dim < len(cache_shape) else 0)
-            )
-            update_len = max(end - start, 0)
-        eligible, _reason = _kv_eligible(tuple(cache_shape), dim, start, update_len)
+        # Any status other than OK is a case in which the converter returns or
+        # raises before it reaches _kv_eligible, so nothing aliases the cache.
+        # Returning False keeps the copy_. A full overwrite needs that: it returns
+        # the source, emits no KV layer, and its write still has to be copied back.
+        # The other two statuses raise out of the converter, so the compile aborts
+        # and nothing is copied back at all.
+        dim = args[2] if len(args) > 2 else 0
+        start, end, _step, status = resolve_slice_scatter_write(
+            tuple(cache_shape),
+            dim,
+            args[3] if len(args) > 3 else None,
+            args[4] if len(args) > 4 else None,
+            args[5] if len(args) > 5 else None,
+        )
+        if status is not KVWriteStatus.OK:
+            return False
+        # OK is the only status that resolves all three bounds to Python ints.
+        assert start is not None and end is not None
+        eligible, _reason = _kv_eligible(tuple(cache_shape), dim, start, end - start)
         return eligible
 
     return False

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -35,6 +35,92 @@ import torch
 logger = logging.getLogger(__name__)
 
 
+def _kv_write_will_alias(value_node: object, cache_shape: Tuple[int, ...]) -> bool:
+    """Whether the converter will emit an ``IKVCacheUpdateLayer`` (with in-place
+    aliased I/O) for this mutated buffer's new-value node.
+
+    Eligibility depends on the write dim, static shapes, and the cache being a
+    direct network input, so this reuses the converters' own eligibility
+    predicates. A ``slice_scatter`` / ``index_copy`` that is not eligible is
+    lowered to a non-aliasing scatter, so its write-back is kept as a
+    BUFFER_MUTATION output (copy-back) rather than dropped. Imports are local to
+    avoid a lowering<->conversion import cycle.
+    """
+    if not (isinstance(value_node, torch.fx.Node) and value_node.op == "call_function"):
+        return False
+    args = value_node.args
+    # The KV layer aliases the cache only if it is a direct network input; after
+    # lifting, the mutated buffer is a placeholder the write op reads from.
+    if not (
+        args and isinstance(args[0], torch.fx.Node) and args[0].op == "placeholder"
+    ):
+        return False
+
+    if value_node.target is torch.ops.aten.index_copy.default:
+        from torch_tensorrt.dynamo.conversion.aten_ops_converters import (
+            _index_copy_kv_eligible,
+        )
+
+        return _index_copy_kv_eligible(value_node)
+
+    if value_node.target is torch.ops.aten.slice_scatter.default:
+        from torch_tensorrt.dynamo.conversion.impl.slice_scatter import _kv_eligible
+
+        dim = args[2] if len(args) > 2 and isinstance(args[2], int) else 0
+        start = args[3] if len(args) > 3 and isinstance(args[3], int) else 0
+        # Prefer the source's extent along `dim` for the write length; fall back
+        # to end-start from the slice bounds.
+        update_len = None
+        src = args[1] if len(args) > 1 else None
+        if isinstance(src, torch.fx.Node):
+            src_val = src.meta.get("val")
+            if src_val is not None and dim < len(src_val.shape):
+                s = src_val.shape[dim]
+                update_len = s if isinstance(s, int) else None
+        if update_len is None:
+            end = (
+                args[4]
+                if len(args) > 4 and isinstance(args[4], int)
+                else (cache_shape[dim] if dim < len(cache_shape) else 0)
+            )
+            update_len = max(end - start, 0)
+        eligible, _reason = _kv_eligible(tuple(cache_shape), dim, start, update_len)
+        return eligible
+
+    return False
+
+
+def assert_predicted_kv_aliased(
+    gm: torch.fx.GraphModule, predicted_kv_bindings: List[str]
+) -> None:
+    """Ground-truth check for the KV predictions :func:`_kv_write_will_alias` made.
+
+    Each write ``lift_mutated_buffers`` classified as KV-aliased had its ``copy_``
+    dropped in the expectation that the engine would alias it in place. If the
+    converter did not actually emit an ``IKVCacheUpdateLayer`` for it, that
+    write-back is silently lost. So assert every predicted-KV input binding
+    appears in a compiled engine's ``aliased_io``, and raise loudly otherwise.
+    Keyed on the ``buf_*`` binding name, which is stable across the later buffer
+    rename and is what ``aliased_io`` records on the input side.
+    """
+    if not predicted_kv_bindings:
+        return
+    aliased_in: set = set()
+    for _name, sub in gm.named_children():
+        amap = getattr(sub, "aliased_io", None)
+        if amap:
+            for v in amap.values():
+                aliased_in.add(v[0] if isinstance(v, (tuple, list)) else v)
+    missing = [b for b in predicted_kv_bindings if b not in aliased_in]
+    if missing:
+        raise RuntimeError(
+            "lift_mutated_buffers classified these buffer writes as KV-cache "
+            "(engine-aliased) and dropped their copy_, but the compiled engine "
+            f"did not alias them (absent from aliased_io): {missing}. Their "
+            "write-back would be silently dropped."
+        )
+
+
 def lift_mutated_buffers(
     gm: torch.fx.GraphModule,
 ) -> Tuple[torch.fx.GraphModule, List[Tuple[str, str, torch.Tensor]]]:
@@ -55,6 +141,19 @@ def lift_mutated_buffers(
       tuples, in the order placeholders were appended (which matches the
       order they appear in the new gm's forward signature, after the
       original user inputs).
+
+    Side effects: the trailing ``copy_`` of each mutated buffer is erased. A write
+    the converter will lower to an ``IKVCacheUpdateLayer`` with in-place aliased
+    I/O (an eligible ``slice_scatter`` / ``index_copy``, per
+    :func:`_kv_write_will_alias`) relies on that engine aliasing for its
+    write-back, so nothing further is added. Every other mutation -- a non-KV
+    buffer, or a ``slice_scatter`` / ``index_copy`` that fails eligibility and is
+    lowered to a non-aliasing scatter -- has no engine aliasing, so its new value
+    is re-appended as a graph output ("copy-back") and its buffer name recorded,
+    in output order, in ``gm.meta['_copyback_mutation_buffers']`` -- the
+    downstream exporters (``create_trt_exp_program`` /
+    ``_declare_aliased_kv_mutations_on_ep``) read that list to reclassify those
+    outputs as BUFFER_MUTATIONs.
     """
     # Find all aten.copy_(get_attr_X, _) calls. The first arg's target is
     # the buffer name. Some EPs emit copy_.default, others copy_.
@@ -81,6 +180,27 @@ def lift_mutated_buffers(
 
     lifted: List[Tuple[str, str, torch.Tensor]] = []
     seen_buffers: Dict[str, torch.fx.Node] = {}  # buffer name -> new placeholder node
+
+    # Each mutated buffer's write-back is handled one of two ways downstream:
+    #   - Engine-level aliasing (zero-copy): the slice_scatter / index_copy
+    #     converters emit an IKVCacheUpdateLayer whose output is aliased in-place
+    #     to the cache input. We drop the copy_ and rely on that aliasing.
+    #   - Copy-back: any other mutation (a non-KV buffer such as a convolution-
+    #     state ring-buffer, OR a slice_scatter / index_copy the converter cannot
+    #     turn into an IKVCacheUpdateLayer) has no aliasing, so its new value is
+    #     re-attached as an ordinary BUFFER_MUTATION output that ExecuTorch copies
+    #     back after the delegate runs.
+    # `_kv_write_will_alias` decides between them by reusing the converters' own
+    # eligibility predicates (not the op target alone), so a non-aliasable
+    # slice_scatter / index_copy falls to copy-back rather than being dropped.
+    # index_put has no aliasing converter, so it always falls to copy-back too.
+    copyback: List[Tuple[torch.fx.Node, str]] = []  # (new_value_node, buffer_name)
+    # Input-binding names of writes predicted to alias (KV). compile() asserts each
+    # actually appears in the engine's aliased_io, turning a mis-prediction into a
+    # loud error instead of a silently dropped write-back. The binding name (buf_*)
+    # is the stable key: it survives the buffer renaming inline does later, and it
+    # is exactly what aliased_io records on the input side.
+    predicted_kv_bindings: set[str] = set()
 
     for copy_node, get_attr_node in mutation_pairs:
         buffer_name = get_attr_node.target
@@ -138,17 +258,39 @@ def lift_mutated_buffers(
         # to the new placeholder.
         get_attr_node.replace_all_uses_with(replacement)
 
-        # Drop the trailing copy_ (it's now redundant — the mutation lands on the
-        # placeholder's storage via engine-level aliasing).
+        # KV writes rely on engine-level aliasing, so the trailing copy_ is
+        # redundant and dropped. Other (non-KV) mutations have no aliasing:
+        # record their new value so we can re-attach it as a copy-back
+        # BUFFER_MUTATION output below, then drop the (now input-target) copy_.
+        new_value = copy_node.args[1] if len(copy_node.args) > 1 else None
+        if isinstance(new_value, torch.fx.Node):
+            if _kv_write_will_alias(new_value, tuple(buffer_tensor.shape)):
+                predicted_kv_bindings.add(replacement.name)
+            else:
+                copyback.append((new_value, buffer_name))
         gm.graph.erase_node(copy_node)
 
         # Erase the now-unused get_attr.
         if not get_attr_node.users:
             gm.graph.erase_node(get_attr_node)
 
+    # Re-attach non-KV mutation new-values as graph outputs so they survive
+    # compilation (otherwise, with the copy_ gone, they are dead and eliminated).
+    # Appended in order; recorded so create_trt_exp_program / _declare can tag the
+    # corresponding engine outputs as BUFFER_MUTATION (copy-back) downstream.
+    copyback_buffers: List[str] = []
+    if copyback:
+        output_node = next(n for n in gm.graph.nodes if n.op == "output")
+        out_args = list(output_node.args[0])
+        out_args.extend(nv for nv, _ in copyback)
+        output_node.args = (tuple(out_args),)
+        copyback_buffers = [buf for _, buf in copyback]
+
     gm.graph.lint()
 
     if not lifted:
+        gm.meta["_copyback_mutation_buffers"] = copyback_buffers
+        gm.meta["_predicted_kv_bindings"] = sorted(predicted_kv_bindings)
         return gm, []
 
     # ExportedProgram.module() produces a GraphModule whose forward is
@@ -179,11 +321,14 @@ def lift_mutated_buffers(
             except AttributeError:
                 pass
     new_gm.recompile()
+    new_gm.meta["_copyback_mutation_buffers"] = copyback_buffers
+    new_gm.meta["_predicted_kv_bindings"] = sorted(predicted_kv_bindings)
 
     logger.debug(
-        "Lifted %d mutated buffer(s) to placeholders: %s",
+        "Lifted %d mutated buffer(s) to placeholders: %s; copy-back buffers: %s",
         len(lifted),
         [(p, b) for p, b, _ in lifted],
+        copyback_buffers,
     )
 
     return new_gm, lifted
@@ -244,6 +389,18 @@ def inline_lifted_buffers_into_gm(
         if not hasattr(gm, attr_name):
             gm.register_buffer(attr_name, tensor.clone())
         buf_to_attr[buf_name] = attr_name
+
+    # Copy-back mutation targets were recorded (in gm.meta) under the buffers'
+    # original names; nested ones were just flattened to lifted_buf_* above. Remap
+    # the recorded targets through the same mapping so the downstream exporter
+    # names a buffer that still exists -- otherwise the ExportedProgram verifier
+    # rejects the BUFFER_MUTATION ("output ... does not point to a buffer that
+    # exists").
+    copyback = gm.meta.get("_copyback_mutation_buffers")
+    if copyback:
+        gm.meta["_copyback_mutation_buffers"] = [
+            buf_to_attr.get(name, name) for name in copyback
+        ]
 
     # Find placeholders we need to replace. Insert get_attr nodes BEFORE
     # removing the placeholders so the graph remains valid throughout.

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -36,15 +36,17 @@ from torch_tensorrt.dynamo._settings import CompilationSettings
 logger = logging.getLogger(__name__)
 
 
-def _write_is_excluded_from_tensorrt(
+def _write_op_is_torch_executed(
     value_node: object,
     settings: Optional[CompilationSettings] = None,
 ) -> bool:
-    """Whether the caller kept this buffer write out of TensorRT.
+    """Whether this write's op is in ``settings.torch_executed_ops``.
 
-    An excluded write stays in PyTorch and is claimed by whichever other backend
-    partitions the graph, so TensorRT must leave the buffer alone. Lifting it would
-    move the mutation across a delegate boundary, which ExecuTorch cannot express.
+    Matched the way the partitioners match it, so the two agree about the op. This is
+    only one of the reasons a node can end up in PyTorch (a missing converter, a failed
+    capability validator, ``min_block_size`` and others do the same), so it is a
+    sufficient reason to rule engine aliasing out, never a proof that aliasing happens.
+    ``assert_predicted_kv_aliased`` remains the ground-truth check for the rest.
     """
     if settings is None or not settings.torch_executed_ops:
         return False
@@ -81,8 +83,9 @@ def _kv_write_will_alias(
     # An op the caller excluded from TensorRT never reaches a converter, so it
     # cannot emit an IKVCacheUpdateLayer and the engine will not alias it. Without
     # this the write is classified as engine-aliased, its copy_ is dropped, and
-    # compile() later fails its own aliased_io cross-check.
-    if _write_is_excluded_from_tensorrt(value_node, settings):
+    # compile() later fails its own aliased_io cross-check. It still gets lifted and
+    # copied back like any other non-aliasing write.
+    if _write_op_is_torch_executed(value_node, settings):
         return False
     # The KV layer aliases the cache only if it is a direct network input; after
     # lifting, the mutated buffer is a placeholder the write op reads from.
@@ -240,14 +243,6 @@ def lift_mutated_buffers(
 
     for copy_node, get_attr_node in mutation_pairs:
         buffer_name = get_attr_node.target
-        new_value_probe = copy_node.args[1] if len(copy_node.args) > 1 else None
-        if _write_is_excluded_from_tensorrt(new_value_probe, settings):
-            logger.debug(
-                "lift_mutated_buffers: %s is written by an op excluded from "
-                "TensorRT; leaving it to the other backend",
-                buffer_name,
-            )
-            continue
         # A get_attr target is fully qualified, so a buffer owned by a submodule
         # arrives as "layers.0.self_attn.kv_cache.k_cache". getattr does not walk a
         # dotted path, so it reports every nested buffer as missing; get_buffer

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -28,14 +28,43 @@ This module provides:
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import torch
+from torch_tensorrt.dynamo._settings import CompilationSettings
 
 logger = logging.getLogger(__name__)
 
 
-def _kv_write_will_alias(value_node: object, cache_shape: Tuple[int, ...]) -> bool:
+def _write_is_excluded_from_tensorrt(
+    value_node: object,
+    settings: Optional[CompilationSettings] = None,
+) -> bool:
+    """Whether the caller kept this buffer write out of TensorRT.
+
+    An excluded write stays in PyTorch and is claimed by whichever other backend
+    partitions the graph, so TensorRT must leave the buffer alone. Lifting it would
+    move the mutation across a delegate boundary, which ExecuTorch cannot express.
+    """
+    if settings is None or not settings.torch_executed_ops:
+        return False
+    if not (isinstance(value_node, torch.fx.Node) and value_node.op == "call_function"):
+        return False
+    from torch_tensorrt.dynamo.conversion._ConverterRegistry import ConverterRegistry
+
+    excluded = set(settings.torch_executed_ops)
+    target = value_node.target
+    return (
+        ConverterRegistry.qualified_name_or_str(target) in excluded
+        or target in excluded
+    )
+
+
+def _kv_write_will_alias(
+    value_node: object,
+    cache_shape: Tuple[int, ...],
+    settings: Optional[CompilationSettings] = None,
+) -> bool:
     """Whether the converter will emit an ``IKVCacheUpdateLayer`` (with in-place
     aliased I/O) for this mutated buffer's new-value node.
 
@@ -49,6 +78,12 @@ def _kv_write_will_alias(value_node: object, cache_shape: Tuple[int, ...]) -> bo
     if not (isinstance(value_node, torch.fx.Node) and value_node.op == "call_function"):
         return False
     args = value_node.args
+    # An op the caller excluded from TensorRT never reaches a converter, so it
+    # cannot emit an IKVCacheUpdateLayer and the engine will not alias it. Without
+    # this the write is classified as engine-aliased, its copy_ is dropped, and
+    # compile() later fails its own aliased_io cross-check.
+    if _write_is_excluded_from_tensorrt(value_node, settings):
+        return False
     # The KV layer aliases the cache only if it is a direct network input; after
     # lifting, the mutated buffer is a placeholder the write op reads from.
     if not (
@@ -123,6 +158,7 @@ def assert_predicted_kv_aliased(
 
 def lift_mutated_buffers(
     gm: torch.fx.GraphModule,
+    settings: Optional[CompilationSettings] = None,
 ) -> Tuple[torch.fx.GraphModule, List[Tuple[str, str, torch.Tensor]]]:
     """Lift each mutated buffer from a ``get_attr`` to a ``placeholder``.
 
@@ -204,6 +240,14 @@ def lift_mutated_buffers(
 
     for copy_node, get_attr_node in mutation_pairs:
         buffer_name = get_attr_node.target
+        new_value_probe = copy_node.args[1] if len(copy_node.args) > 1 else None
+        if _write_is_excluded_from_tensorrt(new_value_probe, settings):
+            logger.debug(
+                "lift_mutated_buffers: %s is written by an op excluded from "
+                "TensorRT; leaving it to the other backend",
+                buffer_name,
+            )
+            continue
         # A get_attr target is fully qualified, so a buffer owned by a submodule
         # arrives as "layers.0.self_attn.kv_cache.k_cache". getattr does not walk a
         # dotted path, so it reports every nested buffer as missing; get_buffer
@@ -264,7 +308,9 @@ def lift_mutated_buffers(
         # BUFFER_MUTATION output below, then drop the (now input-target) copy_.
         new_value = copy_node.args[1] if len(copy_node.args) > 1 else None
         if isinstance(new_value, torch.fx.Node):
-            if _kv_write_will_alias(new_value, tuple(buffer_tensor.shape)):
+            if _kv_write_will_alias(
+                new_value, tuple(buffer_tensor.shape), settings
+            ):
                 predicted_kv_bindings.add(replacement.name)
             else:
                 copyback.append((new_value, buffer_name))

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -42,6 +42,15 @@ right correctness tradeoff — the alternative is silently losing the write — 
 is why the classifier routes a cache write to engine aliasing instead, and why a
 model that unexpectedly lands in copy-back comes out slow rather than wrong.
 ``gm.meta['_copyback_mutation_buffers']`` lists which buffers are paying it.
+
+What copy-back does *not* do: update the buffer in process. The value re-attached as
+a graph output is only carried to whatever serializes the module, which declares it a
+BUFFER_MUTATION for the ExecuTorch runtime to apply after the delegate returns. Nothing
+between ``compile()`` and that runtime writes it anywhere, so a compiled module called
+directly from PyTorch leaves its buffer at the value it was compiled with. The
+re-attached value is therefore hidden from the compiled module's return
+(:func:`hide_copyback_outputs`) rather than handed back as an extra output that would
+read like a mutation the caller can rely on.
 """
 
 from __future__ import annotations
@@ -436,6 +445,47 @@ def lift_mutated_buffers(
     )
 
     return new_gm, lifted
+
+
+class _HiddenCopybackOutputs(torch.fx.graph.CodeGen):  # type: ignore[misc]
+    """Generate a ``forward`` that stops short of the trailing copy-back values.
+
+    The values stay on the graph's output node; only the generated ``forward`` stops
+    early. Everything that reads the graph rather than calling the module still sees
+    them -- the exporters, dead-code elimination, and the ``torch.fx.Interpreter``
+    that a *non-strict* ``torch.export`` runs a GraphModule through, so a retrace
+    keeps them too. Non-strict is what both retrace paths get: ``_compile.save``
+    passes ``strict=False`` and ``dynamo._exporter.export`` takes the default, which
+    is ``False``. A caller who exports the compiled module themselves with
+    ``strict=True`` gets the module called rather than interpreted, and the hidden
+    values do not reach the program. ``_TorchTensorRTModule.forward`` does the same
+    with the aliased outputs the interpreter appends: the engine produces them, the
+    caller never sees them.
+    """
+
+    def __init__(self, num_hidden: int) -> None:
+        super().__init__()
+        self.num_hidden = num_hidden
+
+    def generate_output(self, output_args: Any, *args: Any, **kwargs: Any) -> str:
+        if self.num_hidden and isinstance(output_args, (list, tuple)):
+            output_args = output_args[: len(output_args) - self.num_hidden]
+            # descs, when the caller passes it, is one entry per untruncated output.
+            kwargs.pop("descs", None)
+        return str(super().generate_output(output_args, *args, **kwargs))
+
+
+def hide_copyback_outputs(gm: torch.fx.GraphModule, num_hidden: int) -> None:
+    """Drop the last ``num_hidden`` graph outputs from what ``gm`` returns.
+
+    They remain outputs of the graph, so the exporters still find them and declare
+    them BUFFER_MUTATIONs; see the module docstring for why they are not the
+    caller's to see.
+    """
+    if num_hidden <= 0:
+        return
+    gm.graph.set_codegen(_HiddenCopybackOutputs(num_hidden))
+    gm.recompile()
 
 
 def inline_lifted_buffers_into_gm(

--- a/py/torch_tensorrt/dynamo/lowering/passes/remove_input_alias_fixing_clones.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/remove_input_alias_fixing_clones.py
@@ -17,7 +17,7 @@ def remove_input_alias_fixing_clones(
 
     See: https://github.com/pytorch/pytorch/issues/108079
 
-    ``lowering._buffer_lifting._reads_the_cache_as_a_network_input`` runs before this
+    ``lowering._buffer_lifting._effective_cache_input`` runs before this
     pass and reproduces the condition below to predict whether a mutated buffer's
     write will reach the converter reading a direct network input. Loosening the
     condition -- or deleting the pass, as the TODO above invites -- invalidates that

--- a/py/torch_tensorrt/dynamo/lowering/passes/remove_input_alias_fixing_clones.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/remove_input_alias_fixing_clones.py
@@ -16,6 +16,17 @@ def remove_input_alias_fixing_clones(
     """Remove the auxiliary clone nodes inserted to fix input aliasing
 
     See: https://github.com/pytorch/pytorch/issues/108079
+
+    ``lowering._buffer_lifting._reads_the_cache_as_a_network_input`` runs before this
+    pass and reproduces the condition below to predict whether a mutated buffer's
+    write will reach the converter reading a direct network input. Loosening the
+    condition -- or deleting the pass, as the TODO above invites -- invalidates that
+    prediction, and a mis-prediction is not a lost optimization: the write is filed
+    copy-back, its value re-attached as a graph output, the engine aliases the buffer
+    anyway, and the compiled module raises on every call. Keep the two in step, or
+    update the classifier in the same change. ``compile()`` cross-checks the
+    prediction against the built engine either way, so the failure surfaces as an
+    error rather than as a broken module.
     """
     modified_graph = False
 

--- a/py/torch_tensorrt/executorch/_export.py
+++ b/py/torch_tensorrt/executorch/_export.py
@@ -473,6 +473,29 @@ def export(
     )
     program_map = {"forward": programs} if not isinstance(programs, dict) else programs
     copyback_by_method = _copyback_buffers_by_method(source, method_names)
+    copyback_names = sorted({n for ns in copyback_by_method.values() for n in ns})
+    if copyback_names:
+        # Engine-aliased KV buffers are declared mutated as well, so ExecuTorch
+        # serializes only their shape and dtype too; they are left out of the warning
+        # below on purpose. An aliased write is a cache-position write on the sequence
+        # axis -- the only form IKVCacheUpdateLayer expresses -- and such a model is
+        # assumed to read the cache under that same position, through a bounded slice
+        # or a position mask, so slots no step has written should not reach the
+        # output. Nothing here verifies that; it is a property of the model. On that
+        # assumption initializing a cache buys nothing, and it would cost what is
+        # typically the model's largest tensor, written whole into the .pte.
+        logger.warning(
+            "Copy-back mutable buffer(s) %s are declared mutated, so ExecuTorch "
+            "serializes only their shape and dtype, not their value, unless a pass "
+            'marks them meta["et_init_buffer"]; without that, a buffer read before '
+            "it is written starts from whatever the allocation held. ExecuTorch's "
+            "own warning names InitializedMutableBufferPass for this. That pass "
+            "reads the buffer host-side to serialize it, so it works while the "
+            "buffer is on CPU and segfaults the export, rather than raising, once "
+            "the buffer is CUDA-resident -- which is what exporting the model on "
+            "CUDA leaves behind.",
+            copyback_names,
+        )
     extra_partitioners = _per_method_values(partitioners, method_names, "partitioners")
     _reject_misnamed_partitioners(extra_partitioners)
     method_compile_specs = _per_method_values(

--- a/py/torch_tensorrt/executorch/_export.py
+++ b/py/torch_tensorrt/executorch/_export.py
@@ -122,6 +122,29 @@ def _prepare_graph_module(
     )
 
 
+def _copyback_buffers_by_method(
+    source: Any, method_names: tuple[str, ...]
+) -> dict[str, list[str]]:
+    """Per-method copy-back buffer names, read from the source's ``meta``.
+
+    ``compile()`` records the flattened names of the non-KV mutable buffers that
+    need a write-back copy in ``gm.meta["_copyback_mutation_buffers"]``.
+    """
+
+    def _names(obj: Any) -> list[str]:
+        gm = (
+            obj
+            if isinstance(obj, torch.fx.GraphModule)
+            else getattr(obj, "graph_module", None)
+        )
+        meta = getattr(gm, "meta", {}) or {}
+        return list(meta.get("_copyback_mutation_buffers", []) or [])
+
+    if isinstance(source, Mapping):
+        return {name: _names(source[name]) for name in method_names}
+    return {method_names[0]: _names(source)}
+
+
 def _prepare_programs(
     source: ExportedProgram | torch.fx.GraphModule | Mapping[str, ExportedProgram],
     *,
@@ -433,6 +456,7 @@ def export(
 
     import torch_tensorrt.dynamo.runtime.meta_ops.register_meta_ops  # noqa: F401
     from executorch.exir import to_edge_transform_and_lower
+    from torch_tensorrt.dynamo._exporter import _declare_aliased_kv_mutations_on_ep
     from torch_tensorrt.executorch import TensorRTPartitioner, get_edge_compile_config
     from torch_tensorrt.executorch._export_utils import (
         replace_execute_engine,
@@ -448,6 +472,7 @@ def export(
         retrace=retrace,
     )
     program_map = {"forward": programs} if not isinstance(programs, dict) else programs
+    copyback_by_method = _copyback_buffers_by_method(source, method_names)
     extra_partitioners = _per_method_values(partitioners, method_names, "partitioners")
     _reject_misnamed_partitioners(extra_partitioners)
     method_compile_specs = _per_method_values(
@@ -500,8 +525,25 @@ def export(
     }
     # Zero-engine methods are allowed: later partitioners may claim their ops,
     # or portable operators may remain undelegated.
+
+    # An undeclared copy-back mutation reaches ExecuTorch as a trailing user output that
+    # nothing copies back, and an undeclared engine-aliased KV write does not reach it
+    # at all, since torch.export drops those outputs at the fx boundary. Either way the
+    # buffer loads frozen at its serialized value and never updates. Only the
+    # legacy exporter declares them while building the program, so a retraced program
+    # always needs the declaration and a caller's pre-exported one may or may not; the
+    # pass is idempotent, so every source shape can go through it. It rewrites the
+    # graph's output node in place while returning the rewritten signature on a new
+    # ExportedProgram, so it runs on the staged copy: given the caller's own program it
+    # would leave that program's graph and signature describing different outputs, which
+    # only the ExportedProgram verifier -- reached through save() -- reports. Staging
+    # holds engines and weights by reference, so declaring here costs no extra copy.
     staged_programs = {
-        name: stage_exported_program(program) for name, program in program_map.items()
+        name: _declare_aliased_kv_mutations_on_ep(
+            stage_exported_program(program),
+            copyback_buffers=copyback_by_method.get(name, []),
+        )
+        for name, program in program_map.items()
     }
     rewritten: dict[str, ExportedProgram] = {}
     method_partitioners: dict[str, list[Partitioner]] = {}

--- a/py/torch_tensorrt/executorch/backend.py
+++ b/py/torch_tensorrt/executorch/backend.py
@@ -79,8 +79,8 @@ def _get_engine_info_from_edge_program(edge_program: ExportedProgram) -> List[An
     - no_op_placeholder_for_execute_engine: engine info is embedded directly as
       string args (args[1:]) — used when _replace_execute_engine_for_executorch
       converted the graph before to_edge_transform_and_lower.
-    - execute_engine: engine info is extracted from the ScriptObject via
-      __getstate__() — fallback for graphs not yet converted.
+    - execute_engine: engine info is read off the ScriptObject through
+      :func:`get_engine_info_from_state` — fallback for graphs not yet converted.
 
     Uses schema name comparison (not object identity) so it works for both
     OpOverload and EdgeOpOverload targets.
@@ -91,11 +91,14 @@ def _get_engine_info_from_edge_program(edge_program: ExportedProgram) -> List[An
 
 
 def _get_engine_info_for_node(
-    edge_program: ExportedProgram, node: torch.fx.Node
+    edge_program: ExportedProgram, node: torch.fx.Node, *, metadata_only: bool = False
 ) -> List[Any]:
     # Engine-info extraction for a single TRT node; callable per-partition so a
     # coalesced multi-engine graph can resolve each engine without the
     # whole-program "exactly 1 engine" assumption.
+    #
+    # metadata_only is forwarded verbatim to get_engine_info_from_state; its docstring
+    # states what that flag costs and which slot it leaves unreadable.
     gm = edge_program.graph_module
     name = _schema_name(node.target)
 
@@ -174,8 +177,12 @@ def _get_engine_info_for_node(
             f"'{engine_node.op}'"
         )
 
-    state = engine_obj.__getstate__()
-    return list(state[0] if isinstance(state, tuple) else state)
+    from torch_tensorrt.executorch._export_utils import get_engine_info_from_state
+
+    state: List[Any] = get_engine_info_from_state(
+        engine_obj, metadata_only=metadata_only
+    )
+    return state
 
 
 def _validate_engine_info(engine_info: List[Any]) -> None:

--- a/py/torch_tensorrt/executorch/partitioner.py
+++ b/py/torch_tensorrt/executorch/partitioner.py
@@ -158,7 +158,10 @@ class TensorRTPartitioner(Partitioner):  # type: ignore[misc]
                     f"expected exactly 1 engine node in partition "
                     f"{getattr(partition, 'id', '?')}, found {len(engine_nodes)}"
                 )
-            engine_info = _get_engine_info_for_node(exported_program, engine_nodes[0])
+            # Only DEVICE_IDX is read, never the engine itself.
+            engine_info = _get_engine_info_for_node(
+                exported_program, engine_nodes[0], metadata_only=True
+            )
             return f"cuda:{_parse_device_id(engine_info[DEVICE_IDX])}".encode()
         except Exception as e:
             # Broad by design: any extraction failure must fall back, not abort

--- a/tests/py/dynamo/conversion/test_slice_scatter_aten.py
+++ b/tests/py/dynamo/conversion/test_slice_scatter_aten.py
@@ -18,10 +18,17 @@ network input — the converter's "input is a placeholder" check fails and
 falls through to scatter.
 """
 
+import unittest
+from types import SimpleNamespace
+
+import numpy as np
 import torch
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
 from torch_tensorrt import Input
+from torch_tensorrt.dynamo.conversion.impl.slice_scatter import (
+    slice_scatter as slice_scatter_impl,
+)
 
 from .harness import DispatchTestCase
 
@@ -111,6 +118,66 @@ class TestSliceScatterFallback(DispatchTestCase):
         cache = torch.randn(2, 4, 16, 8)
         update = torch.randn(2, 4, 16, 8)
         self.run_test(M(), [cache, update])
+
+
+class TestSliceScatterEarlyExits(unittest.TestCase):
+    """The converter's two raising exits, driven through the converter itself.
+
+    Both are reached before the converter touches anything but ``input.shape``, so
+    ``_call`` passes ``None`` for ``ctx``, ``target``, ``source_ir`` and ``src``, and
+    an object carrying only a shape for the cache. Those five stand-ins are what
+    breaks if either exit is ever moved below a line that reads one of them.
+
+    ``run_test`` reaches neither exit, for a different reason per test. A bound that
+    is not a Python int has no concrete ``aten.slice_scatter`` to be traced into. An
+    out-of-range ``dim`` does trace, but running the traced module raises torch's own
+    "Dimension out of range" ``IndexError`` before any engine is built, so the
+    assertion would be pinning torch's message rather than the converter's. A
+    ``numpy.int64`` ``dim`` never reaches a converter at all: the tracer either
+    refuses the argument type or records a plain ``int``.
+    """
+
+    _CACHE_SHAPE = (2, 4, 16, 8)
+
+    def _call(self, dim, start, end, step):
+        cache = SimpleNamespace(shape=self._CACHE_SHAPE)
+        return slice_scatter_impl(
+            None, None, None, "test_slice_scatter", cache, None, dim, start, end, step
+        )
+
+    def test_dynamic_bound_is_not_implemented(self):
+        # A bound that is not a Python int is what the converter cannot lower; a
+        # bare object stands in for the symbolic value that carries one in a real
+        # dynamic-shape graph, since the resolver discriminates only on int-ness.
+        symbolic_end = object()
+        with self.assertRaisesRegex(
+            NotImplementedError, "dynamic start/end/step is not yet supported"
+        ):
+            self._call(2, 0, symbolic_end, 1)
+
+    def test_out_of_range_dim_is_an_index_error(self):
+        """A Python int outside the rank is rejected on range, not on type, and the
+        message has to say which: the type it prints is the required one, so the range
+        is the only thing that explains the error."""
+        with self.assertRaisesRegex(
+            IndexError,
+            r"^slice_scatter: 9 of type int is not a valid dim for a rank-4 input; "
+            r"dim must be a Python int in \[-4, 4\)$",
+        ):
+            self._call(9, 0, 4, 1)
+
+    def test_non_int_dim_is_an_index_error(self):
+        """An in-range numpy.int64 dim is rejected on type, not on range, and the
+        message has to say which: the value it prints is in range, so the type is the
+        only thing that explains the error. Matching the type name rather than the
+        rendered value keeps this independent of how numpy formats a scalar, which
+        changed in numpy 2.0."""
+        with self.assertRaisesRegex(
+            IndexError,
+            r"^slice_scatter: 2 of type int64 is not a valid dim for a rank-4 input; "
+            r"dim must be a Python int in \[-4, 4\)$",
+        ):
+            self._call(np.int64(2), 0, 4, 1)
 
 
 if __name__ == "__main__":

--- a/tests/py/dynamo/executorch/test_api.py
+++ b/tests/py/dynamo/executorch/test_api.py
@@ -333,6 +333,12 @@ def test_resolve_lifted_custom_obj_unwraps_fake_script_object():
 
 @pytest.mark.unit
 def test_resolve_target_device_uses_partition_engine(monkeypatch):
+    """The device comes from the partition's own engine node, read as metadata only.
+
+    DEVICE_IDX is the only slot wanted, and this runs once per partition on every
+    export that does not pin ``target_device`` -- the default -- so reading the full
+    record would re-serialize each engine to look at one string.
+    """
     pytest.importorskip("executorch.exir")
     from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import DEVICE_IDX
     from torch_tensorrt.executorch import partitioner as P
@@ -342,10 +348,17 @@ def test_resolve_target_device_uses_partition_engine(monkeypatch):
     monkeypatch.setattr(P, "_get_engine_nodes_in", lambda nodes: [engine_node])
     info = ["0"] * (DEVICE_IDX + 1)
     info[DEVICE_IDX] = "2"
-    monkeypatch.setattr(P, "_get_engine_info_for_node", lambda ep, n: info)
+    calls = []
+
+    def _spy(ep, n, **kwargs):
+        calls.append(kwargs)
+        return info
+
+    monkeypatch.setattr(P, "_get_engine_info_for_node", _spy)
 
     partition = types.SimpleNamespace(id=0, nodes=[engine_node])
     assert part._resolve_target_device_for_partition(object(), partition) == b"cuda:2"
+    assert calls == [{"metadata_only": True}]
 
 
 @pytest.mark.unit
@@ -373,7 +386,7 @@ def test_per_partition_distinct_target_devices(monkeypatch):
     # Each partition's engine node carries its own device id as its value.
     monkeypatch.setattr(P, "_get_engine_nodes_in", lambda nodes: [nodes[0]])
 
-    def fake_info(ep, node):
+    def fake_info(ep, node, **kwargs):
         info = ["0"] * (DEVICE_IDX + 1)
         info[DEVICE_IDX] = str(node)
         return info

--- a/tests/py/dynamo/executorch/test_export.py
+++ b/tests/py/dynamo/executorch/test_export.py
@@ -42,6 +42,10 @@ ENGINE_BYTES = b"engine-bytes"
 # _TRTEngine.__getstate__ base64-encodes the engine into a str, so that is the shape
 # the rewrite sees in production; raw bytes only come from an in-memory engine info.
 ENGINE_BASE64 = base64.b64encode(ENGINE_BYTES).decode("utf-8")
+# The two copy-back warning tests -- one that the warning fires, one that it stays
+# silent -- both key on this phrase, so a reworded warning cannot leave one of them
+# keyed on text that no message contains.
+COPYBACK_WARNING_ANCHOR = "are declared mutated, so ExecuTorch serializes"
 
 
 class FakeExportedProgram:
@@ -1561,6 +1565,66 @@ def test_export_warns_for_multiple_engines(monkeypatch, caplog):
 
     export_module.export(program)
     assert "contains 2 TRT engine calls" in caplog.text
+
+
+@pytest.mark.unit
+def test_export_warns_that_copyback_buffers_load_uninitialized(monkeypatch, caplog):
+    """Declaring a copy-back buffer mutated costs it its serialized initial value, and a
+    model that reads the buffer before writing it needs to know. The warning has to be
+    readable from a terminal with no source in view, so it names the buffers and says
+    what ExecuTorch keeps of them. ExecuTorch's own emitter tells the same user, in the
+    same export, that a pass puts the value back; the warning carries that name only
+    together with the one thing upstream does not say about it -- see below.
+
+    The declaration itself is stubbed out; it has its own coverage in
+    ``test_executorch_export_declares_copyback_for_every_source_shape``, and running it
+    over this stub program would only exercise the stub.
+    """
+    import torch_tensorrt.dynamo._exporter as dynamo_exporter
+
+    program = FakeExportedProgram()
+    program.graph_module.meta["_copyback_mutation_buffers"] = ["conv_state"]
+    export_module, _ = _patch_lowering(monkeypatch)
+    monkeypatch.setattr(
+        dynamo_exporter, "_declare_aliased_kv_mutations_on_ep", lambda ep, **kw: ep
+    )
+
+    export_module.export(program)
+
+    assert "conv_state" in caplog.text
+    assert COPYBACK_WARNING_ANCHOR in caplog.text
+    # The rule is conditional, and saying it unconditionally would be wrong for a
+    # caller who has already supplied the pass: with et_init_buffer set the value is
+    # in the .pte.
+    assert 'unless a pass marks them meta["et_init_buffer"]' in caplog.text
+    assert "starts from whatever the allocation held" in caplog.text
+    # InitializedMutableBufferPass is ExecuTorch's own way to put a mutated buffer's
+    # initial value back, and its emitter names the pass to this same user later in
+    # this same export, saying nothing about where the buffer has to live. The pass
+    # sets et_init_buffer, which makes the emitter serialize the buffer by reading it
+    # host-side through ctypes.cast(spec.storage.data_ptr(), ...); that read segfaults
+    # the process, rather than raising, whenever the buffer is CUDA-resident, which is
+    # what exporting a model on CUDA leaves behind. Withholding the name withholds the
+    # caveat and not the advice, so the name is allowed here -- but only in a message
+    # that carries the caveat with it.
+    naming = [
+        record
+        for record in caplog.records
+        if "InitializedMutableBufferPass" in record.getMessage()
+    ]
+    assert naming
+    for record in naming:
+        assert "segfaults the export" in record.getMessage()
+
+
+@pytest.mark.unit
+def test_export_is_quiet_without_copyback_buffers(monkeypatch, caplog):
+    """Every export would otherwise carry a caveat about a situation it is not in."""
+    export_module, _ = _patch_lowering(monkeypatch)
+
+    export_module.export(FakeExportedProgram())
+
+    assert COPYBACK_WARNING_ANCHOR not in caplog.text
 
 
 @pytest.mark.unit

--- a/tests/py/dynamo/executorch/test_export.py
+++ b/tests/py/dynamo/executorch/test_export.py
@@ -45,7 +45,18 @@ ENGINE_BASE64 = base64.b64encode(ENGINE_BYTES).decode("utf-8")
 
 
 class FakeExportedProgram:
-    pass
+    """A program stand-in carrying the graph module and signature ``export()`` reads.
+
+    ``export()`` runs the mutation-declaration pass over every program it is handed, and
+    that pass reads both members. Nothing here is mutated, so the pass finds nothing to
+    declare and hands back the same object.
+    """
+
+    def __init__(self):
+        graph = torch.fx.Graph()
+        graph.output((graph.placeholder("x"),))
+        self.graph_module = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self.graph_signature = SimpleNamespace(inputs_to_buffers={}, output_specs=[])
 
 
 class FakeTensorRTPartitioner:

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -382,7 +382,11 @@ def test_declare_aliased_kv_mutations_skips_already_declared_copyback(monkeypatc
     torch.export moves a mutation it recognises to the front of the outputs. The
     trailing value lift appended for that same buffer is internal plumbing, so it must
     be detached either way, otherwise it stays a user output and the saved model gains
-    a return it never had."""
+    a return it never had.
+
+    The legacy exporter's shape -- mutation declared *and* the trailing value already
+    consumed -- never reaches here: ``save()`` passes no ``copyback_buffers`` on that
+    path (see ``test_saved_copyback_program_reloads_and_keeps_its_user_output``)."""
     pytest.importorskip("executorch.exir")
 
     g = torch.fx.Graph()
@@ -430,18 +434,19 @@ def test_declare_aliased_kv_mutations_skips_already_declared_copyback(monkeypatc
 
     class _CapturingEP:
         def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
             captured.update(kwargs)
 
     monkeypatch.setattr(E, "ExportedProgram", _CapturingEP)
 
-    E._declare_aliased_kv_mutations_on_ep(ep, copyback_buffers=["state_0"])
+    result = E._declare_aliased_kv_mutations_on_ep(ep, copyback_buffers=["state_0"])
 
-    new_specs = captured["graph_signature"].output_specs
+    specs = result.graph_signature.output_specs
     # state_0 keeps its single existing mutation spec; no second one is added.
-    mutations = [s for s in new_specs if s.kind == OutputKind.BUFFER_MUTATION]
+    mutations = [s for s in specs if s.kind == OutputKind.BUFFER_MUTATION]
     assert [s.target for s in mutations] == ["state_0"]
     # The trailing copy-back value is gone from the user outputs.
-    user_outputs = [s for s in new_specs if s.kind == OutputKind.USER_OUTPUT]
+    user_outputs = [s for s in specs if s.kind == OutputKind.USER_OUTPUT]
     assert [s.arg.name for s in user_outputs] == ["user_out"]
 
     out_node = next(n for n in gm.graph.nodes if n.op == "output")
@@ -680,3 +685,64 @@ def test_save_warns_when_copyback_cannot_be_declared(
 
     warned = any("copy-back" in r.message for r in caplog.records)
     assert warned is expect_warning
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("use_legacy", [True, False])
+def test_saved_copyback_program_reloads_and_keeps_its_user_output(tmp_path, use_legacy):
+    """A saved copy-back program declares the mutation, returns exactly the outputs the
+    source module returned, and updates the buffer when run after a reload.
+
+    ``create_trt_exp_program`` declares the mutation itself and consumes the trailing
+    value while doing so, so re-declaring it slices a genuine user output and relabels
+    it as the buffer's new contents; the saved program then fails to load."""
+    pytest.importorskip("executorch.exir")
+
+    import torch_tensorrt
+    from torch_tensorrt.dynamo.lowering._buffer_lifting import (
+        inline_lifted_buffers_into_gm,
+        lift_mutated_buffers,
+    )
+
+    class _CopyBackModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.register_buffer("state", torch.zeros(4))
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            self.state.copy_(self.state + x.sum())
+            return x * 3.0
+
+    dim = torch.export.Dim("d", min=2, max=64)
+    ep = torch.export.export(
+        _CopyBackModel(), (torch.ones(8),), dynamic_shapes={"x": {0: dim}}
+    )
+    gm, lifted = lift_mutated_buffers(ep.module())
+    gm = inline_lifted_buffers_into_gm(gm, lifted)
+    assert gm.meta["_copyback_mutation_buffers"] == ["state"]
+
+    path = str(tmp_path / "out.pt2")
+    torch_tensorrt.save(
+        gm,
+        path,
+        output_format="exported_program",
+        retrace=True,
+        use_legacy_exporter=use_legacy,
+        dynamic_shapes={"x": {0: dim}},
+        arg_inputs=(torch.ones(8),),
+    )
+
+    loaded = torch.export.load(path)
+    mutations = [
+        s.target
+        for s in loaded.graph_signature.output_specs
+        if s.kind == OutputKind.BUFFER_MUTATION
+    ]
+    assert mutations == ["state"]
+
+    module = loaded.module()
+    before = dict(module.named_buffers())["state"].clone()
+    outputs = torch.utils._pytree.tree_leaves(module(torch.ones(8)))
+    assert len(outputs) == 1
+    torch.testing.assert_close(outputs[0], torch.full((8,), 3.0))
+    assert not torch.allclose(dict(module.named_buffers())["state"], before)

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -422,6 +422,8 @@ def test_declare_aliased_kv_mutations_skips_already_declared_copyback(monkeypatc
         range_constraints={},
         module_call_graph=[],
         constants={},
+        example_inputs=_EXAMPLE_INPUTS,
+        verifiers=[Verifier],
     )
 
     captured = {}
@@ -499,6 +501,8 @@ def test_declare_aliased_kv_mutations_pairs_copyback_by_position(monkeypatch):
         range_constraints={},
         module_call_graph=[],
         constants={},
+        example_inputs=_EXAMPLE_INPUTS,
+        verifiers=[Verifier],
     )
 
     captured = {}
@@ -640,57 +644,6 @@ def test_create_trt_exp_program_does_not_duplicate_copyback_get_attr(monkeypatch
 
     targets = sorted(n.target for n in gm.graph.nodes if n.op == "get_attr")
     assert targets == ["state_0"]
-
-
-@pytest.mark.unit
-def test_declare_aliased_kv_mutations_rejects_redeclared_copyback():
-    """Declaring copy-back twice must fail rather than corrupt the signature.
-
-    The copy-back path reclassifies the trailing outputs by position, so on a
-    program whose exporter already declared them the trailing outputs are the
-    user's: a second pass would retarget those, dropping a user output and giving
-    the buffer two mutation specs.
-    """
-    pytest.importorskip("executorch.exir")
-
-    g = torch.fx.Graph()
-    x = g.placeholder("x")
-    state_in = g.placeholder("state_in")
-    user_out = g.call_function(torch.add, (x, x))
-    state_new = g.call_function(torch.add, (state_in, x))
-    g.output((state_new, user_out))
-    gm = torch.fx.GraphModule(torch.nn.Module(), g)
-
-    # state_0 already declared -- what the legacy exporter leaves behind.
-    sig = SimpleNamespace(
-        inputs_to_buffers={"state_in": "state_0"},
-        input_specs=[
-            InputSpec(
-                InputKind.BUFFER, TensorArgument(name="state_in"), "state_0", True
-            )
-        ],
-        output_specs=[
-            OutputSpec(
-                OutputKind.BUFFER_MUTATION,
-                TensorArgument(name=state_new.name),
-                "state_0",
-            ),
-            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name="user_out"), None),
-        ],
-    )
-    ep = SimpleNamespace(
-        graph_module=gm,
-        graph_signature=sig,
-        state_dict={},
-        range_constraints={},
-        module_call_graph=[],
-        constants={},
-        example_inputs=_EXAMPLE_INPUTS,
-        verifiers=[Verifier],
-    )
-
-    with pytest.raises(RuntimeError, match="already carry a BUFFER_MUTATION"):
-        E._declare_aliased_kv_mutations_on_ep(ep, copyback_buffers=["state_0"])
 
 
 @pytest.mark.unit

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -375,6 +375,155 @@ def test_declare_aliased_kv_mutations_declares_copyback(monkeypatch):
 
 
 @pytest.mark.unit
+def test_declare_aliased_kv_mutations_skips_already_declared_copyback(monkeypatch):
+    """A buffer torch.export already declared BUFFER_MUTATION is not declared twice,
+    and its trailing value still leaves the user outputs.
+
+    torch.export moves a mutation it recognises to the front of the outputs. The
+    trailing value lift appended for that same buffer is internal plumbing, so it must
+    be detached either way, otherwise it stays a user output and the saved model gains
+    a return it never had."""
+    pytest.importorskip("executorch.exir")
+
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    state_in = g.placeholder("state_in")
+    state_new = g.call_function(torch.add, (state_in, x))
+    user_out = g.call_function(torch.add, (x, x))
+    # torch.export's own mutation output first, then the user output, then the
+    # trailing copy-back value lift appended for the same buffer.
+    g.output((state_new, user_out, state_new))
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+    sig = SimpleNamespace(
+        inputs_to_buffers={"state_in": "state_0"},
+        input_specs=[
+            InputSpec(
+                InputKind.BUFFER, TensorArgument(name="state_in"), "state_0", True
+            ),
+            InputSpec(InputKind.USER_INPUT, TensorArgument(name="x"), None),
+        ],
+        output_specs=[
+            OutputSpec(
+                OutputKind.BUFFER_MUTATION,
+                TensorArgument(name=state_new.name),
+                "state_0",
+            ),
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name="user_out"), None),
+            OutputSpec(
+                OutputKind.USER_OUTPUT, TensorArgument(name=state_new.name), None
+            ),
+        ],
+    )
+    ep = SimpleNamespace(
+        graph_module=gm,
+        graph_signature=sig,
+        state_dict={},
+        range_constraints={},
+        module_call_graph=[],
+        constants={},
+    )
+
+    captured = {}
+
+    class _CapturingEP:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(E, "ExportedProgram", _CapturingEP)
+
+    E._declare_aliased_kv_mutations_on_ep(ep, copyback_buffers=["state_0"])
+
+    new_specs = captured["graph_signature"].output_specs
+    # state_0 keeps its single existing mutation spec; no second one is added.
+    mutations = [s for s in new_specs if s.kind == OutputKind.BUFFER_MUTATION]
+    assert [s.target for s in mutations] == ["state_0"]
+    # The trailing copy-back value is gone from the user outputs.
+    user_outputs = [s for s in new_specs if s.kind == OutputKind.USER_OUTPUT]
+    assert [s.arg.name for s in user_outputs] == ["user_out"]
+
+    out_node = next(n for n in gm.graph.nodes if n.op == "output")
+    assert list(out_node.args[0]) == [state_new, user_out]
+
+
+@pytest.mark.unit
+def test_declare_aliased_kv_mutations_pairs_copyback_by_position(monkeypatch):
+    """With a mix of declared and undeclared buffers, each remaining copy-back value
+    is paired with the buffer lift appended it for.
+
+    lift appends the values in copyback_buffers order, so the pairing has to come from
+    that full run. Dropping the declared buffers before slicing shifts the run and
+    declares one buffer's value as another's mutation, which the runtime then copies
+    into a buffer of a different shape."""
+    pytest.importorskip("executorch.exir")
+
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    a_in = g.placeholder("a_in")
+    b_in = g.placeholder("b_in")
+    c_in = g.placeholder("c_in")
+    a_new = g.call_function(torch.add, (a_in, x))
+    b_new = g.call_function(torch.add, (b_in, x))
+    c_new = g.call_function(torch.add, (c_in, x))
+    user_out = g.call_function(torch.add, (x, x))
+    # Only b is recognised by torch.export, so its mutation leads. The trailing run
+    # is a_new, b_new, c_new, matching copyback_buffers order.
+    g.output((b_new, user_out, a_new, b_new, c_new))
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+    def buf_spec(name, target):
+        return InputSpec(InputKind.BUFFER, TensorArgument(name=name), target, True)
+
+    sig = SimpleNamespace(
+        inputs_to_buffers={"a_in": "a", "b_in": "b", "c_in": "c"},
+        input_specs=[
+            buf_spec("a_in", "a"),
+            buf_spec("b_in", "b"),
+            buf_spec("c_in", "c"),
+            InputSpec(InputKind.USER_INPUT, TensorArgument(name="x"), None),
+        ],
+        output_specs=[
+            OutputSpec(
+                OutputKind.BUFFER_MUTATION, TensorArgument(name=b_new.name), "b"
+            ),
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name="user_out"), None),
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name=a_new.name), None),
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name=b_new.name), None),
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name=c_new.name), None),
+        ],
+    )
+    ep = SimpleNamespace(
+        graph_module=gm,
+        graph_signature=sig,
+        state_dict={},
+        range_constraints={},
+        module_call_graph=[],
+        constants={},
+    )
+
+    captured = {}
+
+    class _CapturingEP:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(E, "ExportedProgram", _CapturingEP)
+
+    E._declare_aliased_kv_mutations_on_ep(ep, copyback_buffers=["a", "b", "c"])
+
+    new_specs = captured["graph_signature"].output_specs
+    mutations = [s for s in new_specs if s.kind == OutputKind.BUFFER_MUTATION]
+    # Each buffer appears once, paired with the value appended for it.
+    assert [(s.target, s.arg.name) for s in mutations] == [
+        ("a", a_new.name),
+        ("c", c_new.name),
+        ("b", b_new.name),
+    ]
+    user_outputs = [s for s in new_specs if s.kind == OutputKind.USER_OUTPUT]
+    assert [s.arg.name for s in user_outputs] == ["user_out"]
+
+
+@pytest.mark.unit
 def test_create_trt_exp_program_declares_copyback(monkeypatch):
     """retrace=False: create_trt_exp_program reads
     gm.meta['_copyback_mutation_buffers'], tags the trailing outputs with their

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -817,3 +817,33 @@ def test_saved_copyback_program_reloads_and_keeps_its_user_output(tmp_path, use_
     assert len(outputs) == 1
     torch.testing.assert_close(outputs[0], torch.full((8,), 3.0))
     assert not torch.allclose(dict(module.named_buffers())["state"], before)
+
+
+@pytest.mark.unit
+def test_serialized_engine_rejects_copyback_buffers():
+    """``lift_mutable_buffers=True`` on a buffer whose write the engine cannot alias
+    raises, instead of returning an engine whose buffer never updates."""
+    from torch_tensorrt.dynamo._compiler import (
+        convert_exported_program_to_serialized_trt_engine,
+    )
+
+    class M(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("state", torch.zeros(4))
+
+        def forward(self, x):
+            self.state.add_(x)
+            return self.state.sum()
+
+    exp_program = torch.export.export(M(), (torch.ones(4),))
+
+    with pytest.raises(RuntimeError, match="cannot express the write-back") as excinfo:
+        convert_exported_program_to_serialized_trt_engine(
+            exp_program,
+            arg_inputs=[torch.ones(4)],
+            lift_mutable_buffers=True,
+            min_block_size=1,
+        )
+    # The offending buffer has to be named, or the user cannot act on the error.
+    assert "state" in str(excinfo.value)

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -847,13 +847,31 @@ def test_create_trt_exp_program_does_not_duplicate_copyback_get_attr(monkeypatch
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("use_legacy, expect_warning", [(True, False), (False, True)])
+@pytest.mark.parametrize(
+    "use_legacy, output_format, expect_warning",
+    [
+        (True, "exported_program", False),
+        (False, "exported_program", True),
+        (True, "executorch", False),
+        (False, "executorch", False),
+    ],
+)
 def test_save_warns_when_copyback_cannot_be_declared(
-    monkeypatch, tmp_path, caplog, use_legacy, expect_warning
+    monkeypatch, tmp_path, caplog, use_legacy, output_format, expect_warning
 ):
-    """retrace=False only declares copy-back through the legacy exporter, so the
-    non-legacy combination drops it. Say so rather than saving a signature that
-    omits the update."""
+    """One combination of ``retrace=False`` leaves copy-back undeclared, and only it
+    warns.
+
+    Under ``exported_program`` the legacy exporter is what declares copy-back, so the
+    non-legacy pairing drops it and the saved signature would omit the update
+    silently. Under ``executorch`` the program goes on to
+    ``torch_tensorrt.executorch.export``, which declares copy-back for every source
+    shape it accepts, so neither pairing drops it -- warning there would contradict
+    what the branch does.
+
+    The two formats reach the warning through the same block, so pinning them
+    together is what keeps them from drifting apart.
+    """
     pytest.importorskip("executorch.exir")
     import torch_tensorrt
     from torch_tensorrt import _compile as C
@@ -862,6 +880,7 @@ def test_save_warns_when_copyback_cannot_be_declared(
     monkeypatch.setattr(E, "export", lambda *a, **k: object())
     monkeypatch.setattr(E, "_declare_aliased_kv_mutations_on_ep", lambda ep, **k: ep)
     monkeypatch.setattr(C, "_normalize_engine_constants_to_python", lambda ep: None)
+    monkeypatch.setattr(C, "_save_as_executorch", lambda *a, **k: None)
     monkeypatch.setattr(torch.export, "save", lambda *a, **k: None)
 
     g = torch.fx.Graph()
@@ -869,11 +888,12 @@ def test_save_warns_when_copyback_cannot_be_declared(
     gm = torch.fx.GraphModule(torch.nn.Module(), g)
     gm.meta["_copyback_mutation_buffers"] = ["state_0"]
 
+    suffix = "pte" if output_format == "executorch" else "pt2"
     with caplog.at_level("WARNING"):
         torch_tensorrt.save(
             gm,
-            str(tmp_path / "out.pt2"),
-            output_format="exported_program",
+            str(tmp_path / f"out.{suffix}"),
+            output_format=output_format,
             retrace=False,
             use_legacy_exporter=use_legacy,
         )
@@ -971,3 +991,154 @@ def test_serialized_engine_rejects_copyback_buffers():
         )
     # The offending buffer has to be named, or the user cannot act on the error.
     assert "state" in str(excinfo.value)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "source_shape",
+    ["graph_module", "graph_module_no_retrace", "exported_program", "mapping"],
+)
+def test_executorch_export_declares_copyback_for_every_source_shape(
+    monkeypatch, source_shape
+):
+    """Every source shape ``torch_tensorrt.executorch.export`` accepts reaches the Edge
+    program with its copy-back buffer declared as a BUFFER_MUTATION, on every method,
+    and with the module's own output still there.
+
+    Undeclared, the buffer's new value stays a trailing user output that nothing copies
+    back and the buffer loads frozen. Only the legacy exporter declares the mutation
+    while building the program, so some of these sources arrive already declared and
+    have to come through a second declaration attempt unharmed.
+    """
+    pytest.importorskip("executorch.exir")
+    from torch_tensorrt.dynamo.lowering._buffer_lifting import (
+        inline_lifted_buffers_into_gm,
+        lift_mutated_buffers,
+    )
+    from torch_tensorrt.executorch import export as executorch_export
+
+    class _CopyBackModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.register_buffer("state", torch.zeros(4))
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            self.state.copy_(self.state + x)
+            return x * 3.0
+
+    def _graph_module() -> torch.fx.GraphModule:
+        """The shape ``compile()`` hands on: the mutated buffer lifted to an input, its
+        new value appended as a trailing output, and its name left in the meta."""
+        program = torch.export.export(_CopyBackModel(), (torch.ones(4),))
+        gm, lifted = lift_mutated_buffers(program.module())
+        gm = inline_lifted_buffers_into_gm(gm, lifted)
+        assert gm.meta["_copyback_mutation_buffers"] == ["state"]
+        return gm
+
+    def _exported(use_legacy_exporter: bool) -> torch.export.ExportedProgram:
+        return E.export(
+            _graph_module(),
+            arg_inputs=(torch.ones(4),),
+            use_legacy_exporter=use_legacy_exporter,
+        )
+
+    # A GraphModule source is retraced against example inputs placed on the default
+    # device, and this model's buffer is on the host.
+    monkeypatch.setattr(
+        "torch_tensorrt.dynamo._defaults.default_device", lambda: torch.device("cpu")
+    )
+
+    if source_shape == "graph_module":
+        source = _graph_module()
+        options = {"arg_inputs": (torch.ones(4),), "retrace": True}
+        methods = ("forward",)
+    elif source_shape == "graph_module_no_retrace":
+        # Retracing is off by default, which routes through the legacy exporter and
+        # its transform-time declaration.
+        source = _graph_module()
+        options = {"arg_inputs": (torch.ones(4),)}
+        methods = ("forward",)
+    elif source_shape == "exported_program":
+        source, options, methods = _exported(False), {}, ("forward",)
+    else:
+        # decode comes from the legacy exporter, which declared its mutation already:
+        # it is the method that must not end up describing that mutation twice.
+        source = {"prefill": _exported(False), "decode": _exported(True)}
+        options, methods = {}, ("prefill", "decode")
+
+    edge_program = executorch_export(source, **options)
+
+    for method in methods:
+        specs = edge_program.exported_program(method).graph_signature.output_specs
+        assert [(spec.kind, spec.target) for spec in specs] == [
+            (OutputKind.BUFFER_MUTATION, "state"),
+            (OutputKind.USER_OUTPUT, None),
+        ]
+
+
+@pytest.mark.unit
+def test_executorch_export_leaves_the_source_program_intact(tmp_path):
+    """A caller who hands ``torch_tensorrt.executorch.export`` their own
+    ExportedProgram keeps it usable afterwards.
+
+    The declaration pass rewrites the graph's output node in place and returns the
+    matching signature on a new program, so running it on the caller's object leaves
+    that object's graph and signature describing different outputs. Nothing on the
+    program raises for that -- ``module()`` and calling it still work -- until the
+    ExportedProgram verifier runs, so the check below saves the program as well as
+    comparing it.
+    """
+    pytest.importorskip("executorch.exir")
+    from torch_tensorrt.dynamo.lowering._buffer_lifting import (
+        inline_lifted_buffers_into_gm,
+        lift_mutated_buffers,
+    )
+    from torch_tensorrt.executorch import export as executorch_export
+
+    class _CopyBackModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.register_buffer("state", torch.zeros(4))
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            self.state.copy_(self.state + x)
+            return x * 3.0
+
+    program = torch.export.export(_CopyBackModel(), (torch.ones(4),))
+    gm, lifted = lift_mutated_buffers(program.module())
+    source = E.export(
+        inline_lifted_buffers_into_gm(gm, lifted),
+        arg_inputs=(torch.ones(4),),
+        use_legacy_exporter=False,
+    )
+
+    def _outputs(exported_program):
+        output_node = next(
+            node
+            for node in exported_program.graph_module.graph.nodes
+            if node.op == "output"
+        )
+        return (
+            [getattr(arg, "name", arg) for arg in output_node.args[0]],
+            [
+                (spec.kind, spec.target)
+                for spec in exported_program.graph_signature.output_specs
+            ],
+        )
+
+    before = _outputs(source)
+
+    def _edge_output_specs(edge_program):
+        specs = edge_program.exported_program("forward").graph_signature.output_specs
+        return [(spec.kind, spec.target) for spec in specs]
+
+    declared = [
+        (OutputKind.BUFFER_MUTATION, "state"),
+        (OutputKind.USER_OUTPUT, None),
+    ]
+    assert _edge_output_specs(executorch_export(source)) == declared
+    assert _outputs(source) == before
+    torch.export.save(source, str(tmp_path / "source.pt2"))
+    # Exporting the same program twice has to give the same Edge program, which it
+    # cannot if the first export consumed something from it.
+    assert _edge_output_specs(executorch_export(source)) == declared

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -75,6 +75,62 @@ def test_declare_aliased_kv_mutations_is_noop_without_engines():
 
 
 @pytest.mark.unit
+def test_declare_aliased_kv_mutations_reads_engine_metadata_only(monkeypatch):
+    """The pass reads binding names and aliased_io and never the engine payload, so
+    it must ask for the metadata-only record. Reading the full record re-serializes
+    the ICudaEngine -- 0.4 s and a 67 MB transient string for a ~50 MB engine -- and
+    the loop runs before the pass can tell whether any engine has aliased I/O at all,
+    so a program with no aliased KV pays that per engine and then returns unchanged.
+    """
+    pytest.importorskip("executorch.exir")
+    import torch_tensorrt.dynamo.runtime._serialized_engine_layout as L
+    import torch_tensorrt.dynamo.runtime._TorchTensorRTModule as M
+    import torch_tensorrt.executorch.backend as B
+
+    exec_target = torch.ops.tensorrt.execute_engine.default
+
+    g = torch.fx.Graph()
+    tokens = g.placeholder("tokens")
+    engine = g.placeholder("engine")
+    eng = g.call_function(exec_target, ([tokens], engine))
+    user_out = g.call_function(operator.getitem, (eng, 0))
+    g.output((user_out,))
+
+    out_val = torch.zeros(1)
+    tokens.meta["val"] = torch.zeros(1)
+    engine.meta["val"] = None
+    eng.meta["val"] = [out_val]
+    user_out.meta["val"] = out_val
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+    ep = SimpleNamespace(
+        graph_module=gm,
+        graph_signature=SimpleNamespace(
+            inputs_to_buffers={},
+            input_specs=[],
+            output_specs=[
+                OutputSpec(
+                    OutputKind.USER_OUTPUT, TensorArgument(name=user_out.name), None
+                )
+            ],
+        ),
+    )
+
+    calls = []
+    info = ["x"] * (L.ALIASED_IO_IDX + 1)
+
+    def _spy(ep_, node, **kwargs):
+        calls.append(kwargs)
+        return info
+
+    monkeypatch.setattr(B, "_get_engine_info_for_node", _spy)
+    monkeypatch.setattr(M, "deserialize_aliased_io", lambda s: {})
+
+    assert E._declare_aliased_kv_mutations_on_ep(ep) is ep
+    assert calls == [{"metadata_only": True}]
+
+
+@pytest.mark.unit
 def test_declare_aliased_kv_mutations_is_idempotent(monkeypatch):
     """Running on a program whose mutation is already declared must be a no-op.
 
@@ -136,7 +192,7 @@ def test_declare_aliased_kv_mutations_is_idempotent(monkeypatch):
     info = ["x"] * (L.ALIASED_IO_IDX + 1)
     info[L.INPUT_BINDING_NAMES_IDX] = "IN"
     info[L.OUTPUT_BINDING_NAMES_IDX] = "OUT"
-    monkeypatch.setattr(B, "_get_engine_info_for_node", lambda ep_, n: info)
+    monkeypatch.setattr(B, "_get_engine_info_for_node", lambda ep_, n, **kw: info)
     monkeypatch.setattr(
         M, "deserialize_aliased_io", lambda s: {"out_k": ("k_in", "kv_cache_update")}
     )
@@ -214,7 +270,7 @@ def test_declare_aliased_kv_mutations_declares_buffer_mutation(monkeypatch):
     info = ["x"] * (L.ALIASED_IO_IDX + 1)
     info[L.INPUT_BINDING_NAMES_IDX] = "IN"
     info[L.OUTPUT_BINDING_NAMES_IDX] = "OUT"
-    monkeypatch.setattr(B, "_get_engine_info_for_node", lambda ep_, n: info)
+    monkeypatch.setattr(B, "_get_engine_info_for_node", lambda ep_, n, **kw: info)
     monkeypatch.setattr(
         M, "deserialize_aliased_io", lambda s: {"out_k": ("k_in", "kv_cache_update")}
     )

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -454,6 +454,74 @@ def test_declare_aliased_kv_mutations_skips_already_declared_copyback(monkeypatc
 
 
 @pytest.mark.unit
+def test_declare_copyback_is_idempotent(monkeypatch):
+    """A second run is a no-op. The copy-back slice is positional over the trailing
+    outputs, so slicing twice detaches a genuine user output and the saved program then
+    fails to load."""
+    pytest.importorskip("executorch.exir")
+
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    state_in = g.placeholder("state_in")
+    state_new = g.call_function(torch.add, (state_in, x))
+    user_out = g.call_function(torch.mul, (x, x))
+    g.output((user_out, state_new))
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+    sig = SimpleNamespace(
+        inputs_to_buffers={"state_in": "state_0"},
+        input_specs=[
+            InputSpec(
+                InputKind.BUFFER, TensorArgument(name="state_in"), "state_0", True
+            ),
+            InputSpec(InputKind.USER_INPUT, TensorArgument(name="x"), None),
+        ],
+        output_specs=[
+            OutputSpec(
+                OutputKind.USER_OUTPUT, TensorArgument(name=user_out.name), None
+            ),
+            OutputSpec(
+                OutputKind.USER_OUTPUT, TensorArgument(name=state_new.name), None
+            ),
+        ],
+    )
+    ep = SimpleNamespace(
+        graph_module=gm,
+        graph_signature=sig,
+        state_dict={},
+        range_constraints={},
+        module_call_graph=[],
+        constants={},
+        example_inputs=_EXAMPLE_INPUTS,
+        verifiers=[Verifier],
+    )
+
+    class _CapturingEP:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+            # A real ExportedProgram builds a *new* GraphModule and shallow-copies
+            # root.meta into it, so the marker the pass sets on root before
+            # construction is readable off the resulting program's graph_module --
+            # which is what lets a program the pass produced be fed back through it.
+            # Exposing root directly reproduces that readback. The mechanism the real
+            # class relies on is the meta copy, and it is the part a torch upgrade
+            # could take away.
+            self.graph_module = kwargs["root"]
+
+    monkeypatch.setattr(E, "ExportedProgram", _CapturingEP)
+
+    first = E._declare_aliased_kv_mutations_on_ep(ep, copyback_buffers=["state_0"])
+    second = E._declare_aliased_kv_mutations_on_ep(first, copyback_buffers=["state_0"])
+
+    assert second is first
+    specs = second.graph_signature.output_specs
+    mutations = [s for s in specs if s.kind == OutputKind.BUFFER_MUTATION]
+    assert [s.target for s in mutations] == ["state_0"]
+    user_outputs = [s for s in specs if s.kind == OutputKind.USER_OUTPUT]
+    assert [s.arg.name for s in user_outputs] == [user_out.name]
+
+
+@pytest.mark.unit
 def test_declare_copyback_runs_without_executorch_extra(monkeypatch):
     """Pins that an unimportable ``torch_tensorrt.executorch.backend`` does not suppress
     copy-back declaration: the trailing copy-back value is still reclassified as a

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -319,6 +319,70 @@ def test_declare_aliased_kv_mutations_declares_buffer_mutation(monkeypatch):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("module_type", ["ep", "fx_retrace", "fx_no_retrace"])
+@pytest.mark.parametrize("output_format", ["exported_program", "executorch"])
+def test_save_declares_aliased_mutations_on_every_serializing_branch(
+    monkeypatch, tmp_path, module_type, output_format
+):
+    """Every ``save()`` branch that serializes a signature runs the declaration pass.
+
+    torch.export drops an engine's aliased KV outputs at the fx boundary, so a branch
+    that serializes without declaring writes a program whose delegate carries fewer
+    outputs than the engine has output bindings, and whose copy-back buffers load
+    frozen. The declaration is reached two different ways -- ``save()`` calls the pass
+    itself before ``torch.export.save``, while the ``executorch`` branches get it from
+    ``_save_as_executorch`` handing the program to ``torch_tensorrt.executorch.export``
+    -- and neither route is visible from the other, so all six combinations are swept
+    here. aot_inductor is excluded on purpose: it warns instead of declaring.
+
+    Sweeping is not the same as constraining. ``save()``'s own call sites already
+    reach the pass on five of the six; only ``[executorch-ep]`` fails if
+    ``torch_tensorrt.executorch.export`` stops calling it. The other five are here so
+    that a branch losing its declaration is caught wherever the loss happens, not
+    because each one pins a caller of its own.
+
+    The pass itself runs for real, so this stays a test of which branch reaches it.
+    """
+    pytest.importorskip("executorch.exir")
+    import torch_tensorrt
+
+    calls = []
+    declare = E._declare_aliased_kv_mutations_on_ep
+
+    def _spy(exp_program, **kwargs):
+        calls.append(exp_program)
+        return declare(exp_program, **kwargs)
+
+    monkeypatch.setattr(E, "_declare_aliased_kv_mutations_on_ep", _spy)
+
+    class _Model(torch.nn.Module):
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return x * 3.0
+
+    program = torch.export.export(_Model(), (torch.ones(4),))
+    if module_type == "ep":
+        source, save_kwargs = program, {}
+    else:
+        source = program.module()
+        save_kwargs = {
+            "arg_inputs": (torch.ones(4),),
+            "retrace": module_type == "fx_retrace",
+        }
+
+    suffix = "pte" if output_format == "executorch" else "pt2"
+    torch_tensorrt.save(
+        source,
+        str(tmp_path / f"out.{suffix}"),
+        output_format=output_format,
+        **save_kwargs,
+    )
+
+    # Not an exact count: an fx source saved as executorch is declared in save() and
+    # again inside export(), which is what the pass's idempotency is for.
+    assert calls
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("output_format", ["exported_program", "executorch"])
 @pytest.mark.parametrize("use_legacy", [True, False])
 def test_save_declares_aliased_mutations_without_retrace(

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -454,6 +454,77 @@ def test_declare_aliased_kv_mutations_skips_already_declared_copyback(monkeypatc
 
 
 @pytest.mark.unit
+def test_declare_copyback_runs_without_executorch_extra(monkeypatch):
+    """Pins that an unimportable ``torch_tensorrt.executorch.backend`` does not suppress
+    copy-back declaration: the trailing copy-back value is still reclassified as a
+    BUFFER_MUTATION of its buffer.
+
+    The graph carries an ``execute_engine`` node so the engine loop is reachable. Without
+    one the loop filters every node on target anyway and the skip goes untested."""
+    import sys
+
+    # Make `from torch_tensorrt.executorch.backend import ...` raise ImportError,
+    # simulating a plain install without the [executorch] extra.
+    monkeypatch.setitem(sys.modules, "torch_tensorrt.executorch.backend", None)
+
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    state_in = g.placeholder("state_in")
+    engine = g.placeholder("engine")
+    eng = g.call_function(torch.ops.tensorrt.execute_engine.default, ([x], engine))
+    eng.meta["val"] = [torch.zeros(1)]
+    state_new = g.call_function(torch.add, (state_in, x))
+    user_out = g.call_function(torch.mul, (x, x))
+    # lift appended the copy-back value (state_new) as the trailing user output; the
+    # mutation is not yet declared.
+    g.output((user_out, state_new))
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+    sig = SimpleNamespace(
+        inputs_to_buffers={"state_in": "state_0"},
+        input_specs=[
+            InputSpec(
+                InputKind.BUFFER, TensorArgument(name="state_in"), "state_0", True
+            ),
+            InputSpec(InputKind.USER_INPUT, TensorArgument(name="x"), None),
+            InputSpec(InputKind.USER_INPUT, TensorArgument(name="engine"), None),
+        ],
+        output_specs=[
+            OutputSpec(
+                OutputKind.USER_OUTPUT, TensorArgument(name=user_out.name), None
+            ),
+            OutputSpec(
+                OutputKind.USER_OUTPUT, TensorArgument(name=state_new.name), None
+            ),
+        ],
+    )
+    ep = SimpleNamespace(
+        graph_module=gm,
+        graph_signature=sig,
+        state_dict={},
+        range_constraints={},
+        module_call_graph=[],
+        constants={},
+        example_inputs=_EXAMPLE_INPUTS,
+        verifiers=[Verifier],
+    )
+
+    class _CapturingEP:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    monkeypatch.setattr(E, "ExportedProgram", _CapturingEP)
+
+    result = E._declare_aliased_kv_mutations_on_ep(ep, copyback_buffers=["state_0"])
+
+    specs = result.graph_signature.output_specs
+    mutations = [s for s in specs if s.kind == OutputKind.BUFFER_MUTATION]
+    assert [s.target for s in mutations] == ["state_0"]
+    user_outputs = [s for s in specs if s.kind == OutputKind.USER_OUTPUT]
+    assert [s.arg.name for s in user_outputs] == [user_out.name]
+
+
+@pytest.mark.unit
 def test_declare_aliased_kv_mutations_pairs_copyback_by_position(monkeypatch):
     """With a mix of declared and undeclared buffers, each remaining copy-back value
     is paired with the buffer lift appended it for.

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -1054,7 +1054,19 @@ def test_serialized_engine_rejects_copyback_buffers():
             min_block_size=1,
         )
     # The offending buffer has to be named, or the user cannot act on the error.
-    assert "state" in str(excinfo.value)
+    # Matched in its rendered form: a bare "state" also matches "stateless",
+    # "state_dict" and "statement".
+    assert "['state']" in str(excinfo.value)
+    # The remedy the message gives is deliberately not asserted here. `compile()`
+    # alone does not perform the write-back -- it leaves the value on the graph for
+    # an exporter to reclassify -- so the advice has to be "compile *and save*", and
+    # whether that works is what makes the wording true or false. Pinning the words
+    # would break on a correct reword and pass on a differently wrong one. What holds
+    # the advice to account is following it end to end:
+    # `test_executorch_export_declares_copyback_for_every_source_shape` below, and
+    # `test_buffer_lifting.py::TestCompileSeam`'s
+    # `test_saved_program_declares_the_hidden_copyback_mutation`, which compiles,
+    # saves, and asserts the BUFFER_MUTATION arrives.
 
 
 @pytest.mark.unit

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -306,3 +306,239 @@ def test_save_declares_aliased_mutations_without_retrace(
     )
 
     assert declared == [sentinel]
+
+
+@pytest.mark.unit
+def test_declare_aliased_kv_mutations_declares_copyback(monkeypatch):
+    """retrace=True: a trailing copy-back output (a non-KV mutable buffer with no
+    engine aliasing) is reclassified from USER_OUTPUT to BUFFER_MUTATION of its
+    buffer and ordered ahead of the user outputs."""
+    pytest.importorskip("executorch.exir")
+
+    # No execute_engine node -> the pure copy-back case (num_copyback drives the
+    # pass). ``user_out`` is a real return; ``state_new`` is the copy-back new value
+    # that lift_mutated_buffers appended as the trailing output.
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    state_in = g.placeholder("state_in")
+    user_out = g.call_function(torch.add, (x, x))
+    state_new = g.call_function(torch.add, (state_in, x))
+    g.output((user_out, state_new))
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+    sig = SimpleNamespace(
+        inputs_to_buffers={"state_in": "state_0"},
+        input_specs=[
+            InputSpec(
+                InputKind.BUFFER, TensorArgument(name="state_in"), "state_0", True
+            ),
+            InputSpec(InputKind.USER_INPUT, TensorArgument(name="x"), None),
+        ],
+        output_specs=[
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name="user_out"), None),
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name="state_new"), None),
+        ],
+    )
+    ep = SimpleNamespace(
+        graph_module=gm,
+        graph_signature=sig,
+        state_dict={},
+        range_constraints={},
+        module_call_graph=[],
+        constants={},
+        example_inputs=_EXAMPLE_INPUTS,
+        verifiers=[Verifier],
+    )
+
+    captured = {}
+
+    class _CapturingEP:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(E, "ExportedProgram", _CapturingEP)
+
+    E._declare_aliased_kv_mutations_on_ep(ep, copyback_buffers=["state_0"])
+
+    new_specs = captured["graph_signature"].output_specs
+    # The trailing copy-back output becomes a BUFFER_MUTATION of state_0, first.
+    assert len(new_specs) == 2
+    assert new_specs[0].kind == OutputKind.BUFFER_MUTATION
+    assert new_specs[0].target == "state_0"
+    assert new_specs[0].arg.name == state_new.name
+    assert new_specs[1].kind == OutputKind.USER_OUTPUT
+
+    # Mutation is prepended to the graph output; the user output follows.
+    out_node = next(n for n in gm.graph.nodes if n.op == "output")
+    assert out_node.args[0][0] is state_new
+    assert out_node.args[0][1] is user_out
+
+
+@pytest.mark.unit
+def test_create_trt_exp_program_declares_copyback(monkeypatch):
+    """retrace=False: create_trt_exp_program reads
+    gm.meta['_copyback_mutation_buffers'], tags the trailing outputs with their
+    buffer target, and emits them as BUFFER_MUTATION specs ahead of the user
+    outputs."""
+    pytest.importorskip("executorch.exir")
+
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    state_in = g.placeholder("state_in")
+    user_out = g.call_function(torch.add, (x, x))
+    state_new = g.call_function(torch.add, (state_in, x))
+    g.output((user_out, state_new))
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+    gm.recompile()
+    gm.meta["_copyback_mutation_buffers"] = ["state_0"]
+
+    captured = {}
+
+    class _CapturingEP:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    # Stub the heavy tail: lift() (param/buffer lifting) and the real EP ctor.
+    monkeypatch.setattr(E, "ExportedProgram", _CapturingEP)
+    monkeypatch.setattr(E, "lift", lambda gm_, sig_: (gm_, sig_, {}, {}))
+
+    E.create_trt_exp_program(gm)
+
+    specs = captured["graph_signature"].output_specs
+    assert len(specs) == 2
+    assert specs[0].kind == OutputKind.BUFFER_MUTATION
+    assert specs[0].target == "state_0"
+    assert specs[0].arg.name == state_new.name
+    assert specs[1].kind == OutputKind.USER_OUTPUT
+
+    # The trailing output is tagged with its buffer and reordered mutation-first.
+    assert state_new.meta["_kv_mutation_target"] == "state_0"
+    out_node = next(n for n in gm.graph.nodes if n.op == "output")
+    assert out_node.args[0][0] is state_new
+    assert out_node.args[0][1] is user_out
+
+
+@pytest.mark.unit
+def test_create_trt_exp_program_declares_write_only_copyback_buffer():
+    """A copy-back buffer with no reader must still reach ``lift`` as a get_attr.
+
+    ``transform``'s dead-code pass drops the get_attr of a buffer nothing reads,
+    and ``lift`` derives BUFFER input specs from get_attr nodes alone, so the
+    BUFFER_MUTATION declared here would name a buffer the signature never
+    declares. Drives the real ``lift``/``ExportedProgram`` constructor so a
+    regression reproduces the verifier error instead of passing vacuously.
+    """
+    pytest.importorskip("executorch.exir")
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    fake_mode = FakeTensorMode()
+    with fake_mode:
+        fake_x = torch.randn(2)
+
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    x.meta["val"] = fake_x
+    # Neither output reads the buffer -- the write-only shape.
+    user_out = g.call_function(torch.ops.aten.mul.Tensor, (x, x))
+    user_out.meta["val"] = fake_x
+    state_new = g.call_function(torch.ops.aten.add.Tensor, (x, x))
+    state_new.meta["val"] = fake_x
+    g.output((user_out, state_new))
+
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+    gm.register_buffer("state_0", torch.zeros(2))
+    gm.recompile()
+    gm.meta["_copyback_mutation_buffers"] = ["state_0"]
+
+    ep = E.create_trt_exp_program(gm, arg_inputs=(torch.randn(2),))
+
+    buffer_inputs = [
+        s.target for s in ep.graph_signature.input_specs if s.kind == InputKind.BUFFER
+    ]
+    mutations = [
+        (s.target, s.kind)
+        for s in ep.graph_signature.output_specs
+        if s.kind == OutputKind.BUFFER_MUTATION
+    ]
+    assert buffer_inputs == ["state_0"]
+    assert mutations == [("state_0", OutputKind.BUFFER_MUTATION)]
+
+
+@pytest.mark.unit
+def test_create_trt_exp_program_does_not_duplicate_copyback_get_attr(monkeypatch):
+    """The re-add is keyed on the existing get_attr targets, so a copy-back buffer
+    that still has a live reader keeps its single get_attr, and a name that is not
+    registered on the module is left alone rather than producing a dangling one."""
+    pytest.importorskip("executorch.exir")
+
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    state_in = g.get_attr("state_0")
+    user_out = g.call_function(torch.add, (x, x))
+    state_new = g.call_function(torch.add, (state_in, x))
+    g.output((user_out, state_new))
+    root = torch.nn.Module()
+    root.register_buffer("state_0", torch.zeros(2))
+    gm = torch.fx.GraphModule(root, g)
+    gm.recompile()
+    # "ghost" is not registered on the module, so it cannot be re-added.
+    gm.meta["_copyback_mutation_buffers"] = ["state_0", "ghost"]
+
+    monkeypatch.setattr(E, "ExportedProgram", lambda **kwargs: None)
+    monkeypatch.setattr(E, "lift", lambda gm_, sig_: (gm_, sig_, {}, {}))
+
+    E.create_trt_exp_program(gm)
+
+    targets = sorted(n.target for n in gm.graph.nodes if n.op == "get_attr")
+    assert targets == ["state_0"]
+
+
+@pytest.mark.unit
+def test_declare_aliased_kv_mutations_rejects_redeclared_copyback():
+    """Declaring copy-back twice must fail rather than corrupt the signature.
+
+    The copy-back path reclassifies the trailing outputs by position, so on a
+    program whose exporter already declared them the trailing outputs are the
+    user's: a second pass would retarget those, dropping a user output and giving
+    the buffer two mutation specs.
+    """
+    pytest.importorskip("executorch.exir")
+
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    state_in = g.placeholder("state_in")
+    user_out = g.call_function(torch.add, (x, x))
+    state_new = g.call_function(torch.add, (state_in, x))
+    g.output((state_new, user_out))
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+    # state_0 already declared -- what the legacy exporter leaves behind.
+    sig = SimpleNamespace(
+        inputs_to_buffers={"state_in": "state_0"},
+        input_specs=[
+            InputSpec(
+                InputKind.BUFFER, TensorArgument(name="state_in"), "state_0", True
+            )
+        ],
+        output_specs=[
+            OutputSpec(
+                OutputKind.BUFFER_MUTATION,
+                TensorArgument(name=state_new.name),
+                "state_0",
+            ),
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name="user_out"), None),
+        ],
+    )
+    ep = SimpleNamespace(
+        graph_module=gm,
+        graph_signature=sig,
+        state_dict={},
+        range_constraints={},
+        module_call_graph=[],
+        constants={},
+        example_inputs=_EXAMPLE_INPUTS,
+        verifiers=[Verifier],
+    )
+
+    with pytest.raises(RuntimeError, match="already carry a BUFFER_MUTATION"):
+        E._declare_aliased_kv_mutations_on_ep(ep, copyback_buffers=["state_0"])

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -542,3 +542,39 @@ def test_declare_aliased_kv_mutations_rejects_redeclared_copyback():
 
     with pytest.raises(RuntimeError, match="already carry a BUFFER_MUTATION"):
         E._declare_aliased_kv_mutations_on_ep(ep, copyback_buffers=["state_0"])
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("use_legacy, expect_warning", [(True, False), (False, True)])
+def test_save_warns_when_copyback_cannot_be_declared(
+    monkeypatch, tmp_path, caplog, use_legacy, expect_warning
+):
+    """retrace=False only declares copy-back through the legacy exporter, so the
+    non-legacy combination drops it. Say so rather than saving a signature that
+    omits the update."""
+    pytest.importorskip("executorch.exir")
+    import torch_tensorrt
+    from torch_tensorrt import _compile as C
+    from torch_tensorrt.dynamo import _exporter as E
+
+    monkeypatch.setattr(E, "export", lambda *a, **k: object())
+    monkeypatch.setattr(E, "_declare_aliased_kv_mutations_on_ep", lambda ep, **k: ep)
+    monkeypatch.setattr(C, "_normalize_engine_constants_to_python", lambda ep: None)
+    monkeypatch.setattr(torch.export, "save", lambda *a, **k: None)
+
+    g = torch.fx.Graph()
+    g.output((g.placeholder("x"),))
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+    gm.meta["_copyback_mutation_buffers"] = ["state_0"]
+
+    with caplog.at_level("WARNING"):
+        torch_tensorrt.save(
+            gm,
+            str(tmp_path / "out.pt2"),
+            output_format="exported_program",
+            retrace=False,
+            use_legacy_exporter=use_legacy,
+        )
+
+    warned = any("copy-back" in r.message for r in caplog.records)
+    assert warned is expect_warning

--- a/tests/py/dynamo/executorch/test_weight_streaming_budget.py
+++ b/tests/py/dynamo/executorch/test_weight_streaming_budget.py
@@ -7,6 +7,7 @@ at load time, so it is not covered here.
 
 import importlib
 import logging
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -25,7 +26,18 @@ _KEY = WEIGHT_STREAMING_BUDGET_COMPILE_SPEC_KEY
 
 
 class FakeExportedProgram:
-    pass
+    """A program stand-in carrying the graph module and signature ``export()`` reads.
+
+    ``export()`` runs the mutation-declaration pass over every program it is handed, and
+    that pass reads both members. Nothing here is mutated, so the pass finds nothing to
+    declare and hands back the same object.
+    """
+
+    def __init__(self):
+        graph = torch.fx.Graph()
+        graph.output((graph.placeholder("x"),))
+        self.graph_module = torch.fx.GraphModule(torch.nn.Module(), graph)
+        self.graph_signature = SimpleNamespace(inputs_to_buffers={}, output_specs=[])
 
 
 class FakeTensorRTPartitioner:

--- a/tests/py/dynamo/lowering/test_buffer_lifting.py
+++ b/tests/py/dynamo/lowering/test_buffer_lifting.py
@@ -31,6 +31,7 @@ from torch.export import export
 from torch.testing._internal.common_utils import TestCase, run_tests
 from torch_tensorrt.dynamo._settings import CompilationSettings
 from torch_tensorrt.dynamo.lowering._buffer_lifting import (
+    aliased_input_bindings,
     assert_predicted_kv_aliased,
     inline_lifted_buffers_into_gm,
     lift_mutated_buffers,
@@ -570,6 +571,14 @@ class TestPredictedKvAssertion(TestCase):
     appear in a compiled engine's `aliased_io`, else its write-back would be
     silently dropped."""
 
+    @staticmethod
+    def _aliased_in(gm):
+        """Ground truth the way ``compile()`` assembles it, off the compiled
+        submodules."""
+        return aliased_input_bindings(
+            getattr(sub, "aliased_io", None) for _name, sub in gm.named_children()
+        )
+
     def test_passes_when_predicted_kv_is_aliased(self):
         gm = _FakeGM(
             {
@@ -579,7 +588,7 @@ class TestPredictedKvAssertion(TestCase):
             }
         )
         # buf_k_cache is aliased -> no error.
-        assert_predicted_kv_aliased(gm, ["buf_k_cache"])
+        assert_predicted_kv_aliased(self._aliased_in(gm), ["buf_k_cache"])
 
     def test_raises_when_predicted_kv_not_aliased(self):
         # Predicted KV for buf_conv_state, but the engine aliased only buf_k_cache
@@ -593,7 +602,7 @@ class TestPredictedKvAssertion(TestCase):
             }
         )
         with self.assertRaises(RuntimeError):
-            assert_predicted_kv_aliased(gm, ["buf_conv_state"])
+            assert_predicted_kv_aliased(self._aliased_in(gm), ["buf_conv_state"])
 
     def test_aggregates_aliased_io_across_engines(self):
         gm = _FakeGM(
@@ -607,10 +616,12 @@ class TestPredictedKvAssertion(TestCase):
             }
         )
         # Both predicted-KV bindings are aliased across the two engines -> no error.
-        assert_predicted_kv_aliased(gm, ["buf_k_cache", "buf_v_cache"])
+        assert_predicted_kv_aliased(
+            self._aliased_in(gm), ["buf_k_cache", "buf_v_cache"]
+        )
 
     def test_noop_when_no_prediction(self):
-        assert_predicted_kv_aliased(_FakeGM({}), [])
+        assert_predicted_kv_aliased(self._aliased_in(_FakeGM({})), [])
 
 
 if __name__ == "__main__":

--- a/tests/py/dynamo/lowering/test_buffer_lifting.py
+++ b/tests/py/dynamo/lowering/test_buffer_lifting.py
@@ -25,6 +25,8 @@ These tests verify:
 """
 
 import inspect
+import unittest
+from unittest import mock
 
 import torch
 from torch.export import export
@@ -658,6 +660,121 @@ class TestPredictedKvAssertion(TestCase):
         message = str(caught.exception)
         self.assertIn("min_block_size (5)", message)
         self.assertIn("min_block_size=1", message)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA required")
+class TestCompileSeam(TestCase):
+    """End-to-end coverage of the wire between the two halves of the design.
+
+    ``lift_mutated_buffers`` classifies each write before partitioning and
+    ``assert_predicted_kv_aliased`` re-checks that classification after conversion.
+    Every other test in this file drives one half directly, so the two could be
+    disconnected in ``_compiler.py`` -- the copy-back list never reaching
+    ``trt_gm.meta``, or the cross-check never being called -- without a single
+    failure. These go through ``compile()`` so that wiring is observed.
+    """
+
+    @staticmethod
+    def _compile(model, args, **kwargs):
+        import torch_tensorrt
+
+        ep = torch.export.export(model, args, strict=False)
+        return torch_tensorrt.dynamo.compile(
+            ep,
+            inputs=list(args),
+            cache_built_engines=False,
+            reuse_cached_engines=False,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _kv_model(batch):
+        """A model and inputs whose single-position cache write lift classifies as
+        engine-aliased, so it drops the ``copy_`` and the cross-check has something
+        to be right or wrong about."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(batch, 4, 16, 8).cuda())
+
+            def forward(self, x):
+                self.cache[:, :, 3:4, :] = x
+                return self.cache.sum()
+
+        return M().cuda().eval(), (torch.ones(batch, 4, 1, 8).cuda(),)
+
+    def test_compile_threads_copyback_buffers_into_trt_gm_meta(self):
+        """The copy-back list ``lift_mutated_buffers`` records has to survive
+        ``compile_module`` and land on the compiled module's meta -- that is the only
+        channel by which ``save()`` learns which trailing outputs to reclassify as
+        BUFFER_MUTATIONs."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("state", torch.zeros(8).cuda())
+
+            def forward(self, x):
+                self.state.add_(x)
+                return self.state.sum()
+
+        x = torch.arange(8, dtype=torch.float32).cuda()
+        trt_gm = self._compile(M().cuda().eval(), (x,), min_block_size=1)
+
+        self.assertEqual(trt_gm.meta.get("_copyback_mutation_buffers"), ["state"])
+        # The recorded name must resolve to a buffer that still exists, else the
+        # ExportedProgram verifier rejects the BUFFER_MUTATION downstream.
+        self.assertIn("state", dict(trt_gm.named_buffers()))
+
+        # The copy-back value is a real trailing output carrying the post-write
+        # buffer, not a stale read.
+        outs = trt_gm(x)
+        self.assertIsInstance(outs, (tuple, list))
+        self.assertEqual(len(outs), 2)
+        self.assertTrue(torch.allclose(outs[-1].float().cpu(), x.cpu()))
+
+    def test_compile_runs_the_predicted_kv_cross_check(self):
+        """``compile()`` must actually call ``assert_predicted_kv_aliased`` with the
+        predictions lift made; without that call a mis-classified write silently
+        loses its write-back."""
+        from torch_tensorrt.dynamo import _compiler as C
+
+        model, args = self._kv_model(1)
+        calls = []
+        original = C.assert_predicted_kv_aliased
+
+        def _spy(aliased_in, bindings, settings=None, **kwargs):
+            calls.append(list(bindings))
+            return original(aliased_in, bindings, settings, **kwargs)
+
+        with mock.patch.object(C, "assert_predicted_kv_aliased", _spy):
+            self._compile(model, args, min_block_size=1)
+
+        self.assertEqual(calls, [["buf_cache"]])
+
+    def test_compile_raises_when_a_predicted_kv_write_is_not_aliased(self):
+        """The cross-check is load-bearing, not decorative: a write predicted to alias
+        whose node the partitioner then leaves out of every engine (here via the
+        default ``min_block_size``) fails the compile instead of returning a module
+        whose buffer never updates."""
+        model, args = self._kv_model(2)
+
+        with self.assertRaisesRegex(RuntimeError, "did not alias them"):
+            self._compile(model, args, min_block_size=5)
+
+    def test_compile_does_not_cross_check_a_dryrun(self):
+        """A dryrun returns before any engine is built, so every prediction is absent
+        from ``aliased_io`` for a reason that says nothing about the prediction.
+
+        ``compile()`` is the only caller that knows this, so it is the only one that
+        tells the check -- the check itself cannot read it off ``dryrun``, which the
+        engine converter accepts while building anyway. Nothing else observes that
+        ``compile()`` says so, and a run whose only job is to report would otherwise
+        fail outright."""
+        model, args = self._kv_model(1)
+
+        self._compile(model, args, dryrun=True, min_block_size=1)
 
 
 if __name__ == "__main__":

--- a/tests/py/dynamo/lowering/test_buffer_lifting.py
+++ b/tests/py/dynamo/lowering/test_buffer_lifting.py
@@ -30,6 +30,7 @@ import torch
 from torch.export import export
 from torch.testing._internal.common_utils import TestCase, run_tests
 from torch_tensorrt.dynamo.lowering._buffer_lifting import (
+    assert_predicted_kv_aliased,
     inline_lifted_buffers_into_gm,
     lift_mutated_buffers,
 )
@@ -282,6 +283,288 @@ class TestInlineLiftedBuffers(TestCase):
         if isinstance(out, tuple):
             out = out[0]
         self.assertEqual(out.item(), 33.0)
+
+    def test_inline_remaps_copyback_targets_for_nested_buffers(self):
+        """A nested (dotted) buffer is registered under a flattened
+        ``lifted_buf_*`` name (``register_buffer`` rejects "."), so the recorded
+        copy-back targets -- which still use the original dotted name -- must be
+        remapped through the same mapping. Otherwise the ``BUFFER_MUTATION``
+        OutputSpec names a buffer that no longer exists and the ExportedProgram
+        verifier rejects the program. A flat name maps to itself and is unchanged.
+        """
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        b_state = graph.placeholder("buf_state")
+        b_nested = graph.placeholder("buf_nested")
+        s = graph.call_function(torch.add, args=(x, b_state))
+        out = graph.call_function(torch.add, args=(s, b_nested))
+        graph.output(out)
+        gm = torch.fx.GraphModule({}, graph)
+        gm.recompile()
+        # lift_mutated_buffers records copy-back targets under the buffers'
+        # original names (dotted for a submodule-owned cache).
+        gm.meta["_copyback_mutation_buffers"] = ["state", "layers.0.attn.k_cache"]
+
+        new_gm = inline_lifted_buffers_into_gm(
+            gm,
+            lifted_buffers=[
+                ("buf_state", "state", torch.zeros(4)),
+                ("buf_nested", "layers.0.attn.k_cache", torch.zeros(4)),
+            ],
+        )
+
+        registered = dict(new_gm.named_buffers())
+        # Flat name kept; nested name flattened to a valid attribute.
+        self.assertIn("state", registered)
+        self.assertIn("lifted_buf_layers_0_attn_k_cache", registered)
+        # Copy-back targets remapped: flat unchanged, nested -> flattened name.
+        self.assertEqual(
+            new_gm.meta["_copyback_mutation_buffers"],
+            ["state", "lifted_buf_layers_0_attn_k_cache"],
+        )
+        # Every recorded target now names a buffer that actually exists.
+        for name in new_gm.meta["_copyback_mutation_buffers"]:
+            self.assertIn(name, registered)
+
+
+class TestCopyBackClassification(TestCase):
+    """``lift_mutated_buffers`` splits mutated buffers into two kinds.
+
+    An *eligible* ``slice_scatter`` / ``index_copy`` KV write (one the converter
+    lowers to an ``IKVCacheUpdateLayer`` with in-place aliased I/O) relies on that
+    engine aliasing and is NOT recorded for copy-back. Every other mutation --
+    including a ``slice_scatter`` / ``index_copy`` that fails the converter's
+    eligibility (wrong rank/dim/shape) and is lowered to a non-aliasing scatter --
+    has no engine aliasing, so its new value is re-appended as a trailing graph
+    output and its buffer name recorded in
+    ``gm.meta['_copyback_mutation_buffers']`` for the exporters to reclassify as
+    a BUFFER_MUTATION.
+    """
+
+    def test_kv_slice_scatter_write_no_copyback(self):
+        """A slice-assignment KV write is aliased downstream, not copied back."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(2, 4, 16, 8))
+
+            def forward(self, x):
+                self.cache[:, :, 3:4, :] = x
+                return self.cache.sum()
+
+        gm = _ep_module_decomposed(M(), (torch.ones(2, 4, 1, 8),))
+        new_gm, lifted = lift_mutated_buffers(gm)
+        self.assertEqual(len(lifted), 1)
+        self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], [])
+        # Predicted-KV binding recorded so compile() can assert it actually aliases.
+        self.assertEqual(new_gm.meta["_predicted_kv_bindings"], ["buf_cache"])
+
+    def test_kv_index_copy_write_no_copyback(self):
+        """An eligible ``index_copy`` KV write (4-D static cache, dim=2, batch 1,
+        single-position source) is aliased by the KV converter, so it is not
+        copied back."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(1, 4, 16, 8))
+
+            def forward(self, x):
+                self.cache.index_copy_(2, torch.tensor([3]), x)
+                return self.cache.sum()
+
+        gm = _ep_module_decomposed(M(), (torch.ones(1, 4, 1, 8),))
+        new_gm, lifted = lift_mutated_buffers(gm)
+        self.assertEqual(len(lifted), 1)
+        self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], [])
+
+    def test_non_kv_mutation_recorded_for_copyback(self):
+        """A non-KV in-place mutation is recorded for copy-back by buffer name."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("state", torch.zeros(4))
+
+            def forward(self, x):
+                self.state.add_(x)
+                return self.state.sum()
+
+        gm = _ep_module_decomposed(M(), (torch.ones(4),))
+        new_gm, lifted = lift_mutated_buffers(gm)
+        self.assertEqual(len(lifted), 1)
+        self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], ["state"])
+        # A non-KV mutation is not predicted to alias, so nothing to assert later.
+        self.assertEqual(new_gm.meta["_predicted_kv_bindings"], [])
+
+    def test_copyback_value_appended_as_last_output(self):
+        """The non-KV new value is re-attached as a trailing graph output so it
+        survives DCE; at the lift stage it is the LAST output and equals the
+        updated buffer."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("state", torch.zeros(4))
+
+            def forward(self, x):
+                self.state.add_(x)
+                return self.state.sum()
+
+        x = torch.arange(4, dtype=torch.float32)
+        gm = _ep_module_decomposed(M(), (x.clone(),))
+        new_gm, lifted = lift_mutated_buffers(gm)
+        _, buf_name, buf_tensor = lifted[0]
+        self.assertEqual(buf_name, "state")
+
+        out = new_gm(x.clone(), buf_tensor.clone())
+        self.assertIsInstance(out, tuple)
+        # Last output is the copy-back value == state + x.
+        self.assertTrue(torch.allclose(out[-1], buf_tensor + x))
+
+    def test_index_put_is_copyback_not_kv(self):
+        """Regression: ``index_put`` has no aliasing converter, so it must fall
+        into copy-back rather than being dropped in expectation of aliasing."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("state", torch.zeros(4, 8))
+
+            def forward(self, x):
+                self.state[torch.tensor([1, 3])] = x
+                return self.state.sum()
+
+        gm = _ep_module_decomposed(M(), (torch.ones(2, 8),))
+        new_gm, lifted = lift_mutated_buffers(gm)
+        self.assertEqual(len(lifted), 1)
+        self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], ["state"])
+
+    def test_mixed_kv_and_copyback(self):
+        """One KV buffer + one non-KV buffer: only the non-KV one is recorded."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(2, 4, 16, 8))
+                self.register_buffer("state", torch.zeros(4))
+
+            def forward(self, x_kv, x_state):
+                self.cache[:, :, 3:4, :] = x_kv
+                self.state.add_(x_state)
+                return self.cache.sum() + self.state.sum()
+
+        gm = _ep_module_decomposed(M(), (torch.ones(2, 4, 1, 8), torch.ones(4)))
+        new_gm, lifted = lift_mutated_buffers(gm)
+        self.assertEqual(len(lifted), 2)
+        self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], ["state"])
+
+    def test_ineligible_index_copy_is_copyback(self):
+        """Regression: an ``index_copy`` the KV converter cannot alias (here a 2-D
+        cache / dim 0, not the 4-D dim=2 layout ``IKVCacheUpdateLayer`` requires)
+        is lowered to a non-aliasing scatter, so its write-back must be preserved
+        as copy-back rather than dropped."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(4, 8))
+
+            def forward(self, x):
+                self.cache.index_copy_(0, torch.tensor([2]), x)
+                return self.cache.sum()
+
+        gm = _ep_module_decomposed(M(), (torch.ones(1, 8),))
+        new_gm, lifted = lift_mutated_buffers(gm)
+        self.assertEqual(len(lifted), 1)
+        self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], ["cache"])
+
+    def test_ineligible_slice_scatter_is_copyback(self):
+        """Regression: a ``slice_scatter`` on a KV-shaped 4-D cache but the wrong
+        axis (dim 1, not dim 2) is not IKVCacheUpdateLayer-eligible, so it is
+        lowered to a non-aliasing scatter and must fall to copy-back rather than
+        being dropped."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(2, 16, 4, 8))
+
+            def forward(self, x):
+                self.cache[:, 3:4, :, :] = x  # write on dim 1, not the seq dim 2
+                return self.cache.sum()
+
+        gm = _ep_module_decomposed(M(), (torch.ones(2, 1, 4, 8),))
+        new_gm, lifted = lift_mutated_buffers(gm)
+        self.assertEqual(len(lifted), 1)
+        self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], ["cache"])
+
+
+class _FakeEngine:
+    """Stand-in for a compiled TRT submodule exposing an ``aliased_io`` map."""
+
+    def __init__(self, aliased_io):
+        self.aliased_io = aliased_io
+
+
+class _FakeGM:
+    """Stand-in for a compiled GraphModule whose children are TRT engines."""
+
+    def __init__(self, children):
+        self._children = children
+
+    def named_children(self):
+        return list(self._children.items())
+
+
+class TestPredictedKvAssertion(TestCase):
+    """`assert_predicted_kv_aliased` is the ground-truth backstop for the
+    pre-conversion KV prediction: every write predicted to alias must actually
+    appear in a compiled engine's `aliased_io`, else its write-back would be
+    silently dropped."""
+
+    def test_passes_when_predicted_kv_is_aliased(self):
+        gm = _FakeGM(
+            {
+                "_run_on_acc_0": _FakeEngine(
+                    {"out_k": ("buf_k_cache", "kv_cache_update")}
+                )
+            }
+        )
+        # buf_k_cache is aliased -> no error.
+        assert_predicted_kv_aliased(gm, ["buf_k_cache"])
+
+    def test_raises_when_predicted_kv_not_aliased(self):
+        # Predicted KV for buf_conv_state, but the engine aliased only buf_k_cache
+        # (the converter emitted no IKVCacheUpdateLayer for conv_state) -> must
+        # raise rather than silently drop the write-back.
+        gm = _FakeGM(
+            {
+                "_run_on_acc_0": _FakeEngine(
+                    {"out_k": ("buf_k_cache", "kv_cache_update")}
+                )
+            }
+        )
+        with self.assertRaises(RuntimeError):
+            assert_predicted_kv_aliased(gm, ["buf_conv_state"])
+
+    def test_aggregates_aliased_io_across_engines(self):
+        gm = _FakeGM(
+            {
+                "_run_on_acc_0": _FakeEngine(
+                    {"out_k": ("buf_k_cache", "kv_cache_update")}
+                ),
+                "_run_on_acc_1": _FakeEngine(
+                    {"out_v": ("buf_v_cache", "kv_cache_update")}
+                ),
+            }
+        )
+        # Both predicted-KV bindings are aliased across the two engines -> no error.
+        assert_predicted_kv_aliased(gm, ["buf_k_cache", "buf_v_cache"])
+
+    def test_noop_when_no_prediction(self):
+        assert_predicted_kv_aliased(_FakeGM({}), [])
 
 
 if __name__ == "__main__":

--- a/tests/py/dynamo/lowering/test_buffer_lifting.py
+++ b/tests/py/dynamo/lowering/test_buffer_lifting.py
@@ -550,6 +550,118 @@ class TestCopyBackClassification(TestCase):
         self.assertEqual(erasable, [])
 
 
+class TestSliceScatterDerivationIsShared(TestCase):
+    """The predictor and the converter must derive ``_kv_eligible``'s arguments
+    the same way.
+
+    ``_kv_write_will_alias`` reuses the converter's eligibility predicate, but a
+    predicate is only as good as what it is handed: computing ``start`` /
+    ``update_len`` differently on the two sides mis-predicts just as effectively
+    as a different predicate would. ``resolve_slice_scatter_write`` is the single
+    derivation both sides call, and these pin the corners where an independent
+    derivation would part company with the converter.
+    """
+
+    @staticmethod
+    def _classify(cache_shape, src_shape, *slice_args):
+        """Route a hand-built ``slice_scatter`` through the predictor."""
+        from torch_tensorrt.dynamo.lowering._buffer_lifting import _kv_write_will_alias
+
+        graph = torch.fx.Graph()
+        cache = graph.placeholder("cache")
+        cache.meta["val"] = torch.empty(cache_shape, device="meta")
+        src = graph.placeholder("src")
+        src.meta["val"] = torch.empty(src_shape, device="meta")
+        node = graph.call_function(
+            torch.ops.aten.slice_scatter.default, args=(cache, src, *slice_args)
+        )
+        return _kv_write_will_alias(node, tuple(cache_shape))
+
+    def test_full_overwrite_is_not_kv(self):
+        """The converter short-circuits a full overwrite by returning the source,
+        so it emits no KV layer and nothing aliases the cache."""
+        self.assertFalse(self._classify((2, 4, 16, 8), (2, 4, 16, 8), 2, 0, 16))
+        # Same slice written implicitly (no start/end args).
+        self.assertFalse(self._classify((2, 4, 16, 8), (2, 4, 16, 8), 2))
+
+    def test_open_ended_slice_is_not_kv(self):
+        """``cache[:, :, 3:, :]`` lowers with ``end == INT64_MAX``. The converter
+        takes its write length from ``end - start``, which fails the ``start +
+        update_len <= s_max`` bound, so the predictor has to read the length the
+        same way rather than from the source's extent along the dim."""
+        self.assertFalse(
+            self._classify((2, 4, 16, 8), (2, 4, 13, 8), 2, 3, 9223372036854775807)
+        )
+
+    def test_negative_start_is_normalised(self):
+        """A negative ``start`` counts from the end for the converter, so the
+        predictor must normalise it before applying the ``start + update_len <=
+        s_max`` bound rather than passing the raw negative through."""
+        # -4 normalises to 12; 12 + 4 == s_max, so this is eligible.
+        self.assertTrue(self._classify((2, 4, 16, 8), (2, 4, 4, 8), 2, -4, 16))
+        # -4 normalises to 12 but the write runs past s_max, so it is not.
+        self.assertFalse(self._classify((2, 4, 16, 8), (2, 4, 8, 8), 2, -4, 20))
+
+    def test_non_int_start_is_not_kv(self):
+        """A non-constant bound makes the converter raise rather than emit a KV
+        layer, so it cannot be predicted to alias. Reading it as ``start = 0``
+        would predict aliasing for a write that never gets converted at all."""
+        graph = torch.fx.Graph()
+        pos = graph.placeholder("pos")
+        self.assertFalse(self._classify((2, 4, 16, 8), (2, 4, 1, 8), 2, pos, 4))
+
+    def test_strided_write_still_takes_the_kv_path(self):
+        """Guard against the shared derivation quietly changing ``step``
+        handling: ``_kv_eligible`` does not look at ``step``, so a strided write
+        with concrete bounds is classified as KV-eligible. Whether it should be
+        is a separate question this test deliberately does not settle -- it only
+        pins the answer against accidental change."""
+        self.assertTrue(self._classify((2, 4, 16, 8), (2, 4, 4, 8), 2, 0, 8, 2))
+
+    def test_resolve_reports_the_converter_early_exits(self):
+        """Each status comes back with the bounds its contract promises, since a
+        caller reads the bounds on the strength of the status alone."""
+        from torch_tensorrt.dynamo.conversion.impl.slice_scatter import (
+            KVWriteStatus,
+            resolve_slice_scatter_write,
+        )
+
+        shape = (2, 4, 16, 8)
+        self.assertEqual(
+            resolve_slice_scatter_write(shape, 2, 3, 4, 1), (3, 4, 1, KVWriteStatus.OK)
+        )
+        # Defaults filled in and negative indices counted from the end.
+        self.assertEqual(
+            resolve_slice_scatter_write(shape, 2, -4, None, None),
+            (12, 16, 1, KVWriteStatus.OK),
+        )
+        self.assertEqual(
+            resolve_slice_scatter_write(shape, 2, None, None, None),
+            (0, 16, 1, KVWriteStatus.FULL_OVERWRITE),
+        )
+
+        class _StepEqualToOne:
+            """A step that is not an ``int`` but compares equal to 1, which is what a
+            symbolic step out of a dynamic-shape trace can be."""
+
+            def __eq__(self, other):
+                return other == 1
+
+        self.assertEqual(
+            resolve_slice_scatter_write(shape, 2, 0, 16, _StepEqualToOne()),
+            (0, 16, 1, KVWriteStatus.FULL_OVERWRITE),
+        )
+        # Nothing resolved, so nothing is reported as resolved.
+        self.assertEqual(
+            resolve_slice_scatter_write(shape, 2, "sym", 4, 1),
+            (None, None, None, KVWriteStatus.DYNAMIC_BOUNDS),
+        )
+        self.assertEqual(
+            resolve_slice_scatter_write(shape, 9, 0, 4, 1),
+            (None, None, None, KVWriteStatus.BAD_DIM),
+        )
+
+
 class _FakeEngine:
     """Stand-in for a compiled TRT submodule exposing an ``aliased_io`` map."""
 

--- a/tests/py/dynamo/lowering/test_buffer_lifting.py
+++ b/tests/py/dynamo/lowering/test_buffer_lifting.py
@@ -623,6 +623,42 @@ class TestPredictedKvAssertion(TestCase):
     def test_noop_when_no_prediction(self):
         assert_predicted_kv_aliased(self._aliased_in(_FakeGM({})), [])
 
+    def test_no_engines_built_does_not_raise(self):
+        """With no engine built, aliased_io is empty for every prediction whatever
+        the predictions were worth, so there is nothing to check and raising would
+        fail a run on the strength of its own absence of evidence."""
+        assert_predicted_kv_aliased(
+            self._aliased_in(_FakeGM({})),
+            ["buf_k_cache"],
+            engines_built=False,
+        )
+
+    def test_dryrun_alone_does_not_skip(self):
+        """``dryrun`` is not what the skip keys on. The engine converter accepts it,
+        never acts on it and builds an engine regardless, so treating it as "no
+        engines" there would turn a check the converter deliberately has no opt-out
+        for into one with an opt-out kwarg."""
+        with self.assertRaises(RuntimeError):
+            assert_predicted_kv_aliased(
+                self._aliased_in(_FakeGM({})),
+                ["buf_k_cache"],
+                CompilationSettings(dryrun=True),
+            )
+
+    def test_message_names_min_block_size(self):
+        """The classification runs before partitioning, so the usual cause is the
+        partitioner rejecting the subgraph the write landed in. Without the value in
+        force and the remedy, there is nothing in the error to act on."""
+        with self.assertRaises(RuntimeError) as caught:
+            assert_predicted_kv_aliased(
+                self._aliased_in(_FakeGM({})),
+                ["buf_k_cache"],
+                CompilationSettings(min_block_size=5),
+            )
+        message = str(caught.exception)
+        self.assertIn("min_block_size (5)", message)
+        self.assertIn("min_block_size=1", message)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/tests/py/dynamo/lowering/test_buffer_lifting.py
+++ b/tests/py/dynamo/lowering/test_buffer_lifting.py
@@ -35,6 +35,7 @@ from torch_tensorrt.dynamo._settings import CompilationSettings
 from torch_tensorrt.dynamo.lowering._buffer_lifting import (
     aliased_input_bindings,
     assert_predicted_kv_aliased,
+    hide_copyback_outputs,
     inline_lifted_buffers_into_gm,
     lift_mutated_buffers,
 )
@@ -774,6 +775,54 @@ class TestPredictedKvAssertion(TestCase):
         self.assertIn("min_block_size=1", message)
 
 
+class TestHiddenCopybackOutputs(TestCase):
+    """``hide_copyback_outputs`` splits what the graph returns from what ``forward``
+    returns: the trailing copy-back values stay on the output node so the exporters
+    keep finding them and dead-code elimination cannot reach them, while the caller
+    sees the arity of the model that was compiled."""
+
+    @staticmethod
+    def _two_output_gm():
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        doubled = graph.call_function(torch.mul, args=(x, 2))
+        graph.output((x, doubled))
+        return torch.fx.GraphModule(torch.nn.Module(), graph)
+
+    def test_hidden_output_leaves_the_graph_untouched(self):
+        gm = self._two_output_gm()
+        hide_copyback_outputs(gm, 1)
+
+        x = torch.arange(3, dtype=torch.float32)
+        self.assertEqual(gm(x), (x,))
+        output_node = next(n for n in gm.graph.nodes if n.op == "output")
+        self.assertEqual(len(output_node.args[0]), 2)
+        # Nothing is dead, so eliminate_dead_code cannot take the hidden value.
+        gm.graph.eliminate_dead_code()
+        self.assertEqual(len(output_node.args[0]), 2)
+
+    def test_hiding_nothing_is_a_no_op(self):
+        gm = self._two_output_gm()
+        hide_copyback_outputs(gm, 0)
+        x = torch.arange(3, dtype=torch.float32)
+        self.assertEqual(len(gm(x)), 2)
+
+    def test_graph_consumers_still_see_the_hidden_value(self):
+        """Only the call boundary is narrowed. A non-strict ``torch.export`` runs a
+        GraphModule through ``fx.Interpreter``, which reads the output node, so a
+        retrace carries the copy-back value into the program even though the module
+        stopped returning it -- and the exporter downstream has something to
+        reclassify. Both retrace paths are non-strict; a caller who exports the
+        compiled module with ``strict=True`` gets the module called instead and loses
+        the hidden values."""
+        gm = self._two_output_gm()
+        hide_copyback_outputs(gm, 1)
+
+        x = torch.arange(3, dtype=torch.float32)
+        self.assertEqual(len(gm(x)), 1)
+        self.assertEqual(len(torch.fx.Interpreter(gm).run(x)), 2)
+
+
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA required")
 class TestCompileSeam(TestCase):
     """End-to-end coverage of the wire between the two halves of the design.
@@ -839,9 +888,10 @@ class TestCompileSeam(TestCase):
         # ExportedProgram verifier rejects the BUFFER_MUTATION downstream.
         self.assertIn("state", dict(trt_gm.named_buffers()))
 
-        # The copy-back value is a real trailing output carrying the post-write
-        # buffer, not a stale read.
-        outs = trt_gm(x)
+        # The copy-back value is a real trailing graph output carrying the post-write
+        # buffer, not a stale read. It is hidden from the module's return, so read it
+        # the way anything that walks the graph does.
+        outs = torch.fx.Interpreter(trt_gm).run(x)
         self.assertIsInstance(outs, (tuple, list))
         self.assertEqual(len(outs), 2)
         self.assertTrue(torch.allclose(outs[-1].float().cpu(), x.cpu()))
@@ -874,6 +924,170 @@ class TestCompileSeam(TestCase):
 
         with self.assertRaisesRegex(RuntimeError, "did not alias them"):
             self._compile(model, args, min_block_size=5)
+
+    def test_compile_hides_the_copyback_value_from_the_return(self):
+        """A copy-back value is carried on the graph output for the exporters, and
+        nothing between ``compile()`` and the ExecuTorch runtime writes it into the
+        buffer. Returning it would report an in-process mutation that did not
+        happen, so the compiled module keeps the arity of the model it came from
+        while the graph keeps the value."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("state", torch.zeros(8).cuda())
+
+            def forward(self, x):
+                self.state.add_(x)
+                return self.state.sum()
+
+        x = torch.arange(8, dtype=torch.float32).cuda()
+        model = M().cuda().eval()
+        trt_gm = self._compile(model, (x,), min_block_size=1)
+
+        self.assertEqual(trt_gm.meta.get("_copyback_mutation_buffers"), ["state"])
+        eager = model(x.clone())
+        out = trt_gm(x)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].shape, eager.shape)
+
+        # Still on the output node, where the exporters read it and dead-code
+        # elimination cannot reach it.
+        output_node = next(n for n in trt_gm.graph.nodes if n.op == "output")
+        self.assertEqual(len(output_node.args[0]), 2)
+
+    def test_compile_hides_copyback_beside_an_engine_aliased_kv_buffer(self):
+        """One module holding both kinds of mutated buffer at once.
+
+        ``hide_copyback_outputs`` truncates the last *N* values of the return, so it
+        is right only while the copy-back values really are the trailing ones. Two
+        mechanisms append outputs: lift appends the copy-back values last, and the
+        interpreter appends an aliased output per KV write inside each submodule.
+        The second is truncated at the submodule boundary and must never reach the
+        outer graph, else the *N* counted here would take a KV output and leave a
+        copy-back value in the return. Each mechanism is covered alone; this is the
+        intersection."""
+
+        def _model():
+            class M(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.register_buffer("k", torch.zeros(1, 4, 16, 8).cuda())
+                    self.register_buffer("state", torch.zeros(8).cuda())
+
+                def forward(self, x_kv, x_state):
+                    self.k[:, :, 3:4, :] = x_kv
+                    self.state.add_(x_state)
+                    return self.k.sum() + self.state.sum()
+
+            return M().cuda().eval()
+
+        args = (
+            torch.full((1, 4, 1, 8), 2.0).cuda(),
+            torch.arange(8, dtype=torch.float32).cuda(),
+        )
+        eager = _model()
+        with torch.no_grad():
+            expected = eager(*args).clone()
+            expected_k = eager.k.clone()
+            expected_state = eager.state.clone()
+
+        trt_gm = self._compile(_model(), args, min_block_size=1)
+
+        # The KV write is aliased in the engine; only the other buffer is copy-back.
+        self.assertEqual(trt_gm.meta.get("_copyback_mutation_buffers"), ["state"])
+        aliased = aliased_input_bindings(
+            getattr(sub, "aliased_io", None) for _name, sub in trt_gm.named_children()
+        )
+        self.assertEqual(aliased, {"buf_k"})
+
+        out = trt_gm(*args)
+        self.assertEqual(len(out), 1)
+        self.assertTrue(torch.allclose(out[0].cpu(), expected.cpu(), atol=1e-3))
+        # Aliased, so the engine wrote the cache in place.
+        self.assertTrue(torch.allclose(trt_gm.k.cpu(), expected_k.cpu(), atol=1e-3))
+
+        # The graph keeps exactly one more value than the return, and it is the
+        # copy-back buffer's new contents rather than a KV output.
+        output_node = next(n for n in trt_gm.graph.nodes if n.op == "output")
+        self.assertEqual(len(output_node.args[0]), 2)
+        outs = torch.fx.Interpreter(trt_gm).run(*args)
+        self.assertEqual(len(outs), 2)
+        self.assertTrue(
+            torch.allclose(outs[-1].float().cpu(), expected_state.cpu(), atol=1e-3)
+        )
+
+    def test_saved_program_declares_the_hidden_copyback_mutation(self):
+        """Hiding the value from the return must not hide it from the exporter: the
+        saved program still has to carry the BUFFER_MUTATION that tells the
+        ExecuTorch runtime to write the buffer back."""
+        import tempfile
+
+        import torch_tensorrt
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("state", torch.zeros(8).cuda())
+
+            def forward(self, x):
+                self.state.add_(x)
+                return self.state.sum()
+
+        x = torch.arange(8, dtype=torch.float32).cuda()
+        trt_gm = self._compile(M().cuda().eval(), (x,), min_block_size=1)
+
+        with tempfile.TemporaryDirectory() as directory:
+            # Both exporters have to see the value the module stopped returning.
+            for retrace in (False, True):
+                path = f"{directory}/program_{retrace}.ep"
+                torch_tensorrt.save(
+                    trt_gm,
+                    path,
+                    output_format="exported_program",
+                    retrace=retrace,
+                    arg_inputs=(x,) if retrace else None,
+                )
+                loaded = torch.export.load(path)
+                # The user output has to survive alongside the declaration. An
+                # exporter that never saw the hidden value declares the buffer
+                # mutation out of the user output instead, which passes a check for
+                # the mutation alone and leaves the program returning nothing.
+                self.assertEqual(
+                    [
+                        (spec.kind.name, spec.target)
+                        for spec in loaded.graph_signature.output_specs
+                    ],
+                    [("BUFFER_MUTATION", "state"), ("USER_OUTPUT", None)],
+                    f"retrace={retrace}",
+                )
+                # And the module the caller still holds returns what it did before.
+                self.assertEqual(len(trt_gm(x)), 1, f"retrace={retrace}")
+
+    def test_retracing_exporter_sees_the_hidden_copyback_value(self):
+        """``dynamo._exporter.export`` without the legacy exporter re-traces, and it
+        is the retrace, not the module's return, that has to carry the hidden value.
+        It does: the export is non-strict, so the GraphModule is interpreted off its
+        output node and the value enters the program with nothing exposing it first.
+        The declaration pass downstream then reclassifies it as the mutation."""
+        from torch_tensorrt.dynamo._exporter import export as exporter_export
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("state", torch.zeros(8).cuda())
+
+            def forward(self, x):
+                self.state.add_(x)
+                return self.state.sum()
+
+        x = torch.arange(8, dtype=torch.float32).cuda()
+        trt_gm = self._compile(M().cuda().eval(), (x,), min_block_size=1)
+
+        exported = exporter_export(trt_gm, arg_inputs=(x,), use_legacy_exporter=False)
+        # Undeclared at this layer -- the copy-back value is still a user output --
+        # but it must be there for the declaration pass to reclassify.
+        self.assertEqual(len(exported.graph_signature.output_specs), 2)
 
     def test_compile_does_not_cross_check_a_dryrun(self):
         """A dryrun returns before any engine is built, so every prediction is absent

--- a/tests/py/dynamo/lowering/test_buffer_lifting.py
+++ b/tests/py/dynamo/lowering/test_buffer_lifting.py
@@ -1117,15 +1117,38 @@ class TestNoKvAliasMarkerSurvival(TestCase):
     def test_stripped_marker_raises(self):
         gm, name = self._marked_gm()
         next(n for n in gm.graph.nodes if n.name == name).meta.pop("_trt_no_kv_alias")
-        with self.assertRaisesRegex(RuntimeError, "did not survive lowering"):
+        with self.assertRaisesRegex(RuntimeError, "no other node carries it"):
             assert_no_kv_alias_markers_survived(gm, [name])
 
-    def test_replaced_node_raises(self):
-        """A marked write is a graph output by then, so it cannot be eliminated;
-        gone means some pass rewrote it, and the rewrite carried no marker."""
+    def test_replacement_carrying_the_marker_raises(self):
+        """The reachable shape. Every pass in ``post_lowering`` that carries a node's
+        meta onto a replacement erases the original in the same block, so the recorded
+        name goes missing *and* an unrecorded node gains the marker. Reporting only
+        the missing half would say the meta was dropped when it was in fact carried,
+        and predict aliasing when the marker's presence prevents it."""
         gm, name = self._marked_gm()
-        with self.assertRaisesRegex(RuntimeError, "did not survive lowering"):
-            assert_no_kv_alias_markers_survived(gm, [name + "_rewritten"])
+        with self.assertRaisesRegex(RuntimeError, "carry the marker instead"):
+            assert_no_kv_alias_markers_survived(gm, [name + "_original"])
+
+    def test_marker_on_an_unmarked_node_raises(self):
+        """A marker on a node that was never marked, with every recorded marker still
+        in place: a pass copied the meta rather than moving it. The converter then
+        refuses to alias a write the classifier chose to alias, which the predicted-KV
+        cross-check reports as a partitioning failure -- the wrong cause."""
+        gm, name = self._marked_gm()
+        other = next(n for n in gm.graph.nodes if n.op == "placeholder")
+        other.meta["_trt_no_kv_alias"] = True
+        with self.assertRaisesRegex(RuntimeError, "were never marked"):
+            assert_no_kv_alias_markers_survived(gm, [name])
+
+    def test_marker_appearing_where_none_was_recorded_raises(self):
+        """The empty-expected case is checked too. Nothing recorded before lowering and
+        a marker present after it is the copied-meta fault with no recorded marker to
+        compare against; returning early on an empty set would skip it in the case
+        that occurs most, since most graphs mark nothing."""
+        gm, _name = self._marked_gm()
+        with self.assertRaisesRegex(RuntimeError, "were never marked"):
+            assert_no_kv_alias_markers_survived(gm, [])
 
 
 class TestHiddenCopybackOutputs(TestCase):

--- a/tests/py/dynamo/lowering/test_buffer_lifting.py
+++ b/tests/py/dynamo/lowering/test_buffer_lifting.py
@@ -663,6 +663,104 @@ class TestSliceScatterDerivationIsShared(TestCase):
         )
 
 
+class TestCacheMustReachTheConverterAsANetworkInput(TestCase):
+    """``emit_kv_cache_update_layer`` aliases the cache only when it is handed a
+    network input, so the classifier has to predict what the converter will be handed
+    -- after ``post_lowering``, not what the graph holds at classification time.
+
+    Both directions are damaging. Reading the cache through an op that survives means
+    no KV layer, so a write called KV loses its write-back. A ``clone`` that
+    ``remove_input_alias_fixing_clones`` then erases means the KV layer *is* emitted,
+    so a write called copy-back adds a trailing output the runtime truncates as an
+    engine side effect while the outer graph still reads it.
+    """
+
+    CACHE = (2, 4, 16, 8)
+    SRC = (2, 4, 1, 8)
+
+    @classmethod
+    def _classify(cls, build_cache_arg, extra_reader=False):
+        """Route a KV-eligible ``slice_scatter`` whose cache argument is whatever
+        ``build_cache_arg`` returns through the predictor."""
+        from torch_tensorrt.dynamo.lowering._buffer_lifting import _kv_write_will_alias
+
+        graph = torch.fx.Graph()
+        buffer = graph.placeholder("buf_cache")
+        buffer.meta["val"] = torch.empty(cls.CACHE, device="meta")
+        cache_arg = build_cache_arg(graph, buffer)
+        if extra_reader:
+            graph.call_function(torch.ops.aten.sum.default, args=(buffer,))
+        src = graph.placeholder("src")
+        src.meta["val"] = torch.empty(cls.SRC, device="meta")
+        node = graph.call_function(
+            torch.ops.aten.slice_scatter.default, args=(cache_arg, src, 2, 3, 4)
+        )
+        return _kv_write_will_alias(node, cls.CACHE)
+
+    def test_direct_placeholder_is_kv(self):
+        self.assertTrue(self._classify(lambda _graph, buffer: buffer))
+
+    def test_clone_of_a_sole_use_placeholder_is_kv(self):
+        """``clone -> scatter -> copy_`` is the ordinary shape when the post-write
+        cache is read in the same forward. Lifting erases the ``copy_``, leaving the
+        clone as the placeholder's only user, which is exactly the condition
+        ``remove_input_alias_fixing_clones`` erases it under -- so the converter does
+        see a network input and does alias."""
+        self.assertTrue(
+            self._classify(
+                lambda graph, buffer: graph.call_function(
+                    torch.ops.aten.clone.default, args=(buffer,)
+                )
+            )
+        )
+
+    def test_clone_of_a_shared_placeholder_is_not_kv(self):
+        """``remove_input_alias_fixing_clones`` only erases a clone that is its
+        placeholder's sole user, so a cache something else also reads keeps its clone
+        and the converter never sees a network input."""
+        self.assertFalse(
+            self._classify(
+                lambda graph, buffer: graph.call_function(
+                    torch.ops.aten.clone.default, args=(buffer,)
+                ),
+                extra_reader=True,
+            )
+        )
+
+    def test_clone_of_a_non_placeholder_is_not_kv(self):
+        self.assertFalse(
+            self._classify(
+                lambda graph, buffer: graph.call_function(
+                    torch.ops.aten.clone.default,
+                    args=(
+                        graph.call_function(
+                            torch.ops.aten.mul.Tensor, args=(buffer, 1.0)
+                        ),
+                    ),
+                )
+            )
+        )
+
+    def test_cache_read_through_another_op_is_not_kv(self):
+        """Nothing erases an arbitrary op between the placeholder and the write, so
+        the converter is handed a ``call_function`` with no input binding name, falls
+        back to a plain scatter, and aliases nothing. Without this the shape and dim
+        alone say KV-eligible and the write-back is dropped for an aliasing that never
+        happens."""
+        self.assertFalse(
+            self._classify(
+                lambda graph, buffer: graph.call_function(
+                    torch.ops.aten.mul.Tensor, args=(buffer, 1.0)
+                )
+            )
+        )
+
+    def test_cache_read_from_a_get_attr_is_not_kv(self):
+        """An unlifted buffer is a ``get_attr``, which constant-folds into the engine
+        rather than becoming an input binding."""
+        self.assertFalse(self._classify(lambda graph, _buffer: graph.get_attr("cache")))
+
+
 class _FakeEngine:
     """Stand-in for a compiled TRT submodule exposing an ``aliased_io`` map."""
 
@@ -759,6 +857,36 @@ class TestPredictedKvAssertion(TestCase):
                 ["buf_k_cache"],
                 CompilationSettings(dryrun=True),
             )
+
+    def test_raises_when_a_copyback_write_is_aliased(self):
+        """The other direction. A copy-back write carries its new value as a trailing
+        graph output; if the engine aliases that buffer anyway the runtime truncates
+        the output as a side effect while the outer graph still reads it, and the
+        module raises on every call. ``predicted_kv_bindings`` is empty in that case,
+        so the KV direction returns at its early exit and sees nothing."""
+        gm = _FakeGM(
+            {"_run_on_acc_0": _FakeEngine({"output1": ("buf_k", "kv_cache_update")})}
+        )
+        with self.assertRaisesRegex(RuntimeError, "aliased them in place anyway"):
+            assert_predicted_kv_aliased(
+                self._aliased_in(gm), [], copyback_bindings=["buf_k"]
+            )
+
+    def test_passes_when_a_copyback_write_is_not_aliased(self):
+        gm = _FakeGM(
+            {"_run_on_acc_0": _FakeEngine({"output1": ("buf_k", "kv_cache_update")})}
+        )
+        assert_predicted_kv_aliased(
+            self._aliased_in(gm), ["buf_k"], copyback_bindings=["buf_state"]
+        )
+
+    def test_no_engines_built_does_not_raise_for_copyback_either(self):
+        assert_predicted_kv_aliased(
+            self._aliased_in(_FakeGM({})),
+            [],
+            copyback_bindings=["buf_k"],
+            engines_built=False,
+        )
 
     def test_message_names_min_block_size(self):
         """The classification runs before partitioning, so the usual cause is the
@@ -1088,6 +1216,63 @@ class TestCompileSeam(TestCase):
         # Undeclared at this layer -- the copy-back value is still a user output --
         # but it must be there for the declaration pass to reclassify.
         self.assertEqual(len(exported.graph_signature.output_specs), 2)
+
+    @staticmethod
+    def _cloned_cache_model():
+        """Clone, scatter, write back -- the ordinary shape when the post-write cache
+        is also read in the same forward."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("k", torch.zeros(1, 2, 16, 4).cuda())
+
+            def forward(self, x):
+                k = self.k.clone()
+                k[:, :, 3:4, :] = x
+                self.k.copy_(k)
+                return k.sum(dim=-1)
+
+        return M().cuda().eval(), (torch.full((1, 2, 1, 4), 3.0).cuda(),)
+
+    def test_compile_runs_a_cloned_cache_write_and_writes_it_back(self):
+        """``remove_input_alias_fixing_clones`` erases the clone after
+        classification, so the converter emits the KV layer whatever the classifier
+        decided. Classified copy-back, the module raised ``IndexError`` on every call
+        -- the trailing output the runtime truncates as an engine side effect while
+        the outer graph still reads it."""
+        model, args = self._cloned_cache_model()
+        with torch.no_grad():
+            expected = model(*args).clone()
+            expected_cache = model.k.clone()
+
+        trt_gm = self._compile(*self._cloned_cache_model(), min_block_size=1)
+
+        self.assertEqual(trt_gm.meta.get("_copyback_mutation_buffers", []), [])
+        aliased = aliased_input_bindings(
+            getattr(sub, "aliased_io", None) for _name, sub in trt_gm.named_children()
+        )
+        self.assertEqual(aliased, {"buf_k"})
+
+        out = trt_gm(*args)
+        self.assertEqual(len(out), 1)
+        self.assertTrue(torch.allclose(out[0].cpu(), expected.cpu(), atol=1e-3))
+        self.assertTrue(torch.allclose(trt_gm.k.cpu(), expected_cache.cpu(), atol=1e-3))
+
+    def test_compile_raises_when_a_copyback_write_is_aliased(self):
+        """The backstop for the next divergence between what the classifier predicts
+        and what the converter emits, whatever that turns out to be. Standing in for
+        it by making the classifier file everything copy-back: the engine aliases the
+        cache anyway, and the compile has to say so rather than hand back a module
+        that raises ``IndexError`` on every call."""
+        from torch_tensorrt.dynamo.lowering import _buffer_lifting
+
+        model, args = self._cloned_cache_model()
+        with mock.patch.object(
+            _buffer_lifting, "_kv_write_will_alias", lambda *a, **k: False
+        ):
+            with self.assertRaisesRegex(RuntimeError, "aliased them in place anyway"):
+                self._compile(model, args, min_block_size=1)
 
     def test_compile_does_not_cross_check_a_dryrun(self):
         """A dryrun returns before any engine is built, so every prediction is absent

--- a/tests/py/dynamo/lowering/test_buffer_lifting.py
+++ b/tests/py/dynamo/lowering/test_buffer_lifting.py
@@ -34,6 +34,7 @@ from torch.testing._internal.common_utils import TestCase, run_tests
 from torch_tensorrt.dynamo._settings import CompilationSettings
 from torch_tensorrt.dynamo.lowering._buffer_lifting import (
     aliased_input_bindings,
+    assert_no_kv_alias_markers_survived,
     assert_predicted_kv_aliased,
     hide_copyback_outputs,
     inline_lifted_buffers_into_gm,
@@ -994,6 +995,139 @@ class TestPredictedKvAssertion(TestCase):
         self.assertNotIn("min_block_size", message)
 
 
+class TestDeadKvWriteRouting(TestCase):
+    """A KV write nothing else consumes is routed to copy-back instead of aliased.
+
+    Erasing its ``copy_`` leaves such a write dead, so it is eliminated before any
+    engine can alias it and the prediction can never be fulfilled. Copy-back makes it
+    live again by re-attaching its value as a graph output, which is only safe because
+    ``_trt_no_kv_alias`` stops the converter aliasing the same buffer as well: a
+    buffer that is both raises on every call.
+    """
+
+    @staticmethod
+    def _dead_write_gm():
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(2, 4, 16, 8))
+
+            def forward(self, x):
+                self.cache[:, :, 3:4, :] = x
+                return x.sum() * 2.0
+
+        return _ep_module_decomposed(M(), (torch.ones(2, 4, 1, 8),))
+
+    @staticmethod
+    def _live_index_copy_gm():
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(1, 4, 16, 8))
+
+            def forward(self, x):
+                self.cache.index_copy_(2, torch.tensor([3]), x)
+                return self.cache.sum()
+
+        return _ep_module_decomposed(M(), (torch.ones(1, 4, 1, 8),))
+
+    def test_dead_write_is_copyback_rather_than_predicted_kv(self):
+        """The same write with a reader is predicted KV (see
+        ``test_kv_slice_scatter_write_no_copyback``); without one it goes to
+        copy-back, which is what stops the cross-check failing a compile the merge
+        base ran."""
+        gm, lifted = lift_mutated_buffers(self._dead_write_gm())
+        self.assertEqual(len(lifted), 1)
+        self.assertEqual(gm.meta["_copyback_mutation_buffers"], ["cache"])
+        self.assertEqual(gm.meta["_predicted_kv_bindings"], [])
+
+    def test_the_rerouted_write_is_marked(self):
+        gm, _lifted = lift_mutated_buffers(self._dead_write_gm())
+        marked = gm.meta["_no_kv_alias_writes"]
+        self.assertEqual(len(marked), 1)
+        node = next(n for n in gm.graph.nodes if n.name == marked[0])
+        self.assertIs(node.target, torch.ops.aten.slice_scatter.default)
+        self.assertTrue(node.meta["_trt_no_kv_alias"])
+
+    def test_a_live_kv_write_is_not_marked(self):
+        """Only a write the classifier re-routed is marked. Marking a live KV write
+        would cost it its aliasing and hand it copy-back's per-call full-cache copy,
+        which is the cost the fast path exists to avoid."""
+        gm, _lifted = lift_mutated_buffers(self._live_index_copy_gm())
+        self.assertEqual(gm.meta["_no_kv_alias_writes"], [])
+        self.assertEqual(gm.meta["_predicted_kv_bindings"], ["buf_cache"])
+
+    def test_a_non_kv_write_is_not_marked(self):
+        """Nothing would alias it anyway, so the marker would say nothing. Keeping it
+        to writes the converter really would have aliased is what leaves
+        ``assert_predicted_kv_aliased``'s copy-back direction something to catch."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("state", torch.zeros(4))
+
+            def forward(self, x):
+                self.state.add_(x)
+                return x.sum()
+
+        gm, _lifted = lift_mutated_buffers(_ep_module_decomposed(M(), (torch.ones(4),)))
+        self.assertEqual(gm.meta["_copyback_mutation_buffers"], ["state"])
+        self.assertEqual(gm.meta["_no_kv_alias_writes"], [])
+
+    def test_the_marker_blocks_index_copy_eligibility(self):
+        """``index_copy`` applies its own eligibility check rather than
+        ``slice_scatter``'s, so the marker has to be honoured in both places or the
+        decode write aliases while its value is also a copy-back output."""
+        from torch_tensorrt.dynamo.conversion.aten_ops_converters import (
+            _index_copy_kv_eligible,
+        )
+
+        gm, _lifted = lift_mutated_buffers(self._live_index_copy_gm())
+        node = next(
+            n for n in gm.graph.nodes if n.target is torch.ops.aten.index_copy.default
+        )
+        self.assertTrue(_index_copy_kv_eligible(node))
+        node.meta["_trt_no_kv_alias"] = True
+        self.assertFalse(_index_copy_kv_eligible(node))
+
+
+class TestNoKvAliasMarkerSurvival(TestCase):
+    """``assert_no_kv_alias_markers_survived`` re-reads the markers after lowering.
+
+    The marker is the only thing keeping a copy-back write out of ``aliased_io``, and
+    it rides on ``node.meta`` through every pass in ``post_lowering``. A pass that
+    rebuilt the node without its meta would drop it silently, so it is checked where
+    the cause can still be named rather than left to surface as a module that raises.
+    """
+
+    @staticmethod
+    def _marked_gm():
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        write = graph.call_function(torch.ops.aten.mul.Tensor, (x, 2.0))
+        write.meta["_trt_no_kv_alias"] = True
+        graph.output((write,))
+        return torch.fx.GraphModule(torch.nn.Module(), graph), write.name
+
+    def test_surviving_marker_passes(self):
+        gm, name = self._marked_gm()
+        assert_no_kv_alias_markers_survived(gm, [name])
+
+    def test_stripped_marker_raises(self):
+        gm, name = self._marked_gm()
+        next(n for n in gm.graph.nodes if n.name == name).meta.pop("_trt_no_kv_alias")
+        with self.assertRaisesRegex(RuntimeError, "did not survive lowering"):
+            assert_no_kv_alias_markers_survived(gm, [name])
+
+    def test_replaced_node_raises(self):
+        """A marked write is a graph output by then, so it cannot be eliminated;
+        gone means some pass rewrote it, and the rewrite carried no marker."""
+        gm, name = self._marked_gm()
+        with self.assertRaisesRegex(RuntimeError, "did not survive lowering"):
+            assert_no_kv_alias_markers_survived(gm, [name + "_rewritten"])
+
+
 class TestHiddenCopybackOutputs(TestCase):
     """``hide_copyback_outputs`` splits what the graph returns from what ``forward``
     returns: the trailing copy-back values stay on the output node so the exporters
@@ -1398,6 +1532,184 @@ class TestCompileSeam(TestCase):
         ):
             with self.assertRaisesRegex(RuntimeError, "aliased them in place anyway"):
                 self._compile(model, args, min_block_size=1)
+
+    @staticmethod
+    def _dead_slice_scatter_model():
+        """A KV-shaped write whose result nothing else consumes."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = torch.nn.Linear(4, 4, bias=False).cuda()
+                self.register_buffer("cache", torch.zeros(2, 4, 16, 4).cuda())
+
+            def forward(self, x):
+                self.cache[:, :, 3:4, :] = self.lin(x)
+                return x.sum() * 2.0
+
+        return M().cuda().eval(), (torch.ones(2, 4, 1, 4).cuda(),)
+
+    def _assert_copyback_and_unaliased(self, trt_gm, model, args, buffers):
+        """The compile produced a module that runs, and the buffer it could not alias
+        is declared copy-back rather than both."""
+        self.assertEqual(trt_gm.meta.get("_copyback_mutation_buffers"), buffers)
+        for _name, sub in trt_gm.named_children():
+            self.assertFalse(getattr(sub, "aliased_io", None))
+        out = trt_gm(*args)
+        self.assertEqual(len(out), 1)
+        eager = model(*args)
+        # These models return a 0-d sum, which comes back from the engine as rank-1.
+        # Only the value is under test here.
+        torch.testing.assert_close(
+            out[0].reshape(eager.shape), eager, rtol=1e-3, atol=1e-3
+        )
+
+    def test_compile_routes_a_dead_slice_scatter_write_to_copyback(self):
+        """Erasing the ``copy_`` leaves the write dead, so no engine could ever alias
+        it and the predicted-KV cross-check would fail the compile. It is filed
+        copy-back instead, and the marker on the write is what keeps the engine from
+        aliasing it once the copy-back output makes it live again."""
+        model, args = self._dead_slice_scatter_model()
+        for min_block_size in (1, 5):
+            trt_gm = self._compile(model, args, min_block_size=min_block_size)
+            self._assert_copyback_and_unaliased(trt_gm, model, args, ["cache"])
+
+    def test_compile_routes_a_dead_cloned_cache_write_to_copyback(self):
+        """The two mechanisms meet here: the write reads its cache through a clone
+        *and* nothing consumes its result. The clone peel is what classifies it KV in
+        the first place, and the dead-write routing is what stops that classification
+        failing the cross-check -- so a write that is both is the case each mechanism
+        can only handle with the other. Without the peel it is filed copy-back
+        unmarked, ``remove_input_alias_fixing_clones`` erases the clone, and the
+        engine aliases a buffer that is also copy-back; without the routing it is
+        predicted KV, dies with its ``copy_``, and no engine claims it."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(1, 2, 16, 4).cuda())
+
+            def forward(self, x):
+                k = self.cache.clone()
+                k[:, :, 3:4, :] = x
+                self.cache.copy_(k)
+                return x.sum() * 2.0
+
+        model, args = M().cuda().eval(), (torch.full((1, 2, 1, 4), 3.0).cuda(),)
+        for min_block_size in (1, 5):
+            trt_gm = self._compile(model, args, min_block_size=min_block_size)
+            self._assert_copyback_and_unaliased(trt_gm, model, args, ["cache"])
+
+    def test_compile_routes_a_dead_write_whose_buffer_has_another_reader(self):
+        """The buffer is read before the write, so the *placeholder* still has a
+        reader in the lowered graph while the *write* is dead. Keyed on the
+        placeholder this looked like a write the partitioner had rejected."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = torch.nn.Linear(4, 4, bias=False).cuda()
+                self.register_buffer("cache", torch.zeros(2, 4, 16, 4).cuda())
+
+            def forward(self, x):
+                prev = self.cache.sum()
+                self.cache[:, :, 3:4, :] = self.lin(x)
+                return prev * 2.0 + x.sum()
+
+        model, args = M().cuda().eval(), (torch.ones(2, 4, 1, 4).cuda(),)
+        trt_gm = self._compile(model, args, min_block_size=1)
+        self._assert_copyback_and_unaliased(trt_gm, model, args, ["cache"])
+
+    def test_compile_routes_a_dead_index_copy_write_to_copyback(self):
+        """``index_copy``'s eligibility check is a different function from
+        ``slice_scatter``'s, so honouring the marker in one does not honour it in the
+        other -- and the decode write is the ``index_copy`` one."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("k", torch.zeros(1, 2, 16, 4).cuda())
+
+            def forward(self, x, pos):
+                self.k.index_copy_(2, pos, x)
+                return x.sum() * 2.0
+
+        model = M().cuda().eval()
+        args = (torch.ones(1, 2, 1, 4).cuda(), torch.tensor([3]).cuda())
+        trt_gm = self._compile(model, args, min_block_size=1)
+        self._assert_copyback_and_unaliased(trt_gm, model, args, ["k"])
+
+    def test_saved_program_declares_the_dead_write_mutation(self):
+        """Compiling is not the point -- the write has to reach the runtime. A
+        compile that succeeded without declaring the mutation would leave the buffer
+        at its compile-time value; the saved program declares it for the runtime to
+        apply."""
+        import tempfile
+
+        import torch_tensorrt
+
+        model, args = self._dead_slice_scatter_model()
+        trt_gm = self._compile(model, args, min_block_size=1)
+        with tempfile.TemporaryDirectory() as directory:
+            path = f"{directory}/program.ep"
+            torch_tensorrt.save(
+                trt_gm, path, output_format="exported_program", arg_inputs=args
+            )
+            loaded = torch.export.load(path)
+        self.assertIn(
+            ("BUFFER_MUTATION", "cache"),
+            [
+                (spec.kind.name, spec.target)
+                for spec in loaded.graph_signature.output_specs
+            ],
+        )
+
+    def test_compile_reads_the_markers_back_after_lowering(self):
+        """``compile()`` must call ``assert_no_kv_alias_markers_survived`` on the
+        *lowered* graph with the names lift recorded. Nothing else observes that
+        call: every pass in ``post_lowering`` carries the marks today, so dropping
+        the read-back changes no result until the day a pass stops carrying one,
+        which is exactly when it is needed.
+
+        Where the call sits is the whole of its value -- run above ``post_lowering``
+        it would only ever see the graph the marks were just written into, and could
+        not fail -- so the position is pinned as well as the call. It is pinned by
+        order rather than by comparing graphs: ``post_lowering`` rewrites the module
+        in place and returns the same object, so the graph handed to the read-back is
+        the same object either way and only *when* the call happens distinguishes
+        them."""
+        from torch_tensorrt.dynamo import _compiler as C
+
+        model, args = self._dead_slice_scatter_model()
+        events = []
+        original = C.assert_no_kv_alias_markers_survived
+        original_lowering = C.post_lowering
+
+        def _spy_lowering(gm, *a, **kw):
+            lowered = original_lowering(gm, *a, **kw)
+            events.append(("lowered", None))
+            return lowered
+
+        def _spy(gm, marked):
+            marked = list(marked)
+            events.append(("read_back", marked))
+            return original(gm, marked)
+
+        with mock.patch.object(C, "post_lowering", _spy_lowering):
+            with mock.patch.object(C, "assert_no_kv_alias_markers_survived", _spy):
+                self._compile(model, args, min_block_size=1)
+
+        reads = [e for e in events if e[0] == "read_back"]
+        self.assertEqual(len(reads), 1)
+        self.assertEqual(len(reads[0][1]), 1)
+
+        kinds = [kind for kind, _payload in events]
+        self.assertIn(
+            "lowered",
+            kinds[: kinds.index("read_back")],
+            "the read-back ran before lowering, so it can only ever see the graph "
+            "the markers were just written into",
+        )
 
     def test_compile_does_not_cross_check_a_dryrun(self):
         """A dryrun returns before any engine is built, so every prediction is absent

--- a/tests/py/dynamo/lowering/test_buffer_lifting.py
+++ b/tests/py/dynamo/lowering/test_buffer_lifting.py
@@ -714,8 +714,68 @@ class TestCacheMustReachTheConverterAsANetworkInput(TestCase):
         )
         return _kv_write_will_alias(node, cls.CACHE)
 
+    @staticmethod
+    def _classify_index_copy(through_clone, extra_reader=False):
+        """Same, for ``index_copy``, whose converter applies its own placeholder
+        check to ``args[0]`` rather than relying on the binding name."""
+        from torch_tensorrt.dynamo.lowering._buffer_lifting import _kv_write_will_alias
+
+        cache_shape, src_shape = (1, 4, 16, 8), (1, 4, 1, 8)
+        graph = torch.fx.Graph()
+        buffer = graph.placeholder("buf_cache")
+        buffer.meta["val"] = torch.empty(cache_shape, device="meta")
+        cache_arg = buffer
+        if through_clone:
+            cache_arg = graph.call_function(
+                torch.ops.aten.clone.default, args=(buffer,)
+            )
+        if extra_reader:
+            graph.call_function(torch.ops.aten.sum.default, args=(buffer,))
+        index = graph.placeholder("index")
+        index.meta["val"] = torch.empty((1,), dtype=torch.int64, device="meta")
+        src = graph.placeholder("src")
+        src.meta["val"] = torch.empty(src_shape, device="meta")
+        node = graph.call_function(
+            torch.ops.aten.index_copy.default, args=(cache_arg, 2, index, src)
+        )
+        return _kv_write_will_alias(node, cache_shape)
+
     def test_direct_placeholder_is_kv(self):
         self.assertTrue(self._classify(lambda _graph, buffer: buffer))
+
+    def test_index_copy_through_a_sole_use_clone_is_kv(self):
+        """``_index_copy_kv_eligible`` checks ``args[0]`` itself, so peeling the
+        clone for the binding-name question is not enough -- the validator has to be
+        pointed at the same node, or an ``index_copy`` decode write through a clone
+        is filed copy-back and the engine aliases it anyway."""
+        self.assertTrue(self._classify_index_copy(through_clone=False))
+        self.assertTrue(self._classify_index_copy(through_clone=True))
+
+    def test_index_copy_through_a_shared_clone_is_not_kv(self):
+        self.assertFalse(
+            self._classify_index_copy(through_clone=True, extra_reader=True)
+        )
+
+    def test_index_copy_validator_still_reads_args0_by_default(self):
+        """The partitioner passes no override and must go on seeing the node's own
+        input: by the time it runs, lowering has settled what that is."""
+        from torch_tensorrt.dynamo.conversion.aten_ops_converters import (
+            _index_copy_kv_eligible,
+        )
+
+        graph = torch.fx.Graph()
+        buffer = graph.placeholder("buf_cache")
+        buffer.meta["val"] = torch.empty((1, 4, 16, 8), device="meta")
+        clone = graph.call_function(torch.ops.aten.clone.default, args=(buffer,))
+        clone.meta["val"] = torch.empty((1, 4, 16, 8), device="meta")
+        index = graph.placeholder("index")
+        src = graph.placeholder("src")
+        src.meta["val"] = torch.empty((1, 4, 1, 8), device="meta")
+        node = graph.call_function(
+            torch.ops.aten.index_copy.default, args=(clone, 2, index, src)
+        )
+        self.assertFalse(_index_copy_kv_eligible(node))
+        self.assertTrue(_index_copy_kv_eligible(node, input_node=buffer))
 
     def test_clone_of_a_sole_use_placeholder_is_kv(self):
         """``clone -> scatter -> copy_`` is the ordinary shape when the post-write
@@ -1285,6 +1345,40 @@ class TestCompileSeam(TestCase):
         )
         self.assertEqual(aliased, {"buf_k"})
 
+        out = trt_gm(*args)
+        self.assertEqual(len(out), 1)
+        self.assertTrue(torch.allclose(out[0].cpu(), expected.cpu(), atol=1e-3))
+        self.assertTrue(torch.allclose(trt_gm.k.cpu(), expected_cache.cpu(), atol=1e-3))
+
+    def test_compile_runs_a_cloned_index_copy_write_and_writes_it_back(self):
+        """The `index_copy` decode shape of the same case: a per-step cache-position
+        write through a clone. Its validator checks `args[0]` on its own account, so
+        this fails for a different reason than the `slice_scatter` one even though
+        the model shape and the symptom are the same."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("k", torch.zeros(1, 2, 16, 4).cuda())
+
+            def forward(self, x, pos):
+                k = self.k.clone()
+                k = k.index_copy(2, pos, x)
+                self.k.copy_(k)
+                return k.sum(dim=-1)
+
+        args = (
+            torch.full((1, 2, 1, 4), 3.0).cuda(),
+            torch.tensor([3], dtype=torch.int64).cuda(),
+        )
+        model = M().cuda().eval()
+        with torch.no_grad():
+            expected = model(*args).clone()
+            expected_cache = model.k.clone()
+
+        trt_gm = self._compile(M().cuda().eval(), args, min_block_size=1)
+
+        self.assertEqual(trt_gm.meta.get("_copyback_mutation_buffers", []), [])
         out = trt_gm(*args)
         self.assertEqual(len(out), 1)
         self.assertTrue(torch.allclose(out[0].cpu(), expected.cpu(), atol=1e-3))

--- a/tests/py/dynamo/lowering/test_buffer_lifting.py
+++ b/tests/py/dynamo/lowering/test_buffer_lifting.py
@@ -611,13 +611,29 @@ class TestSliceScatterDerivationIsShared(TestCase):
         pos = graph.placeholder("pos")
         self.assertFalse(self._classify((2, 4, 16, 8), (2, 4, 1, 8), 2, pos, 4))
 
-    def test_strided_write_still_takes_the_kv_path(self):
-        """Guard against the shared derivation quietly changing ``step``
-        handling: ``_kv_eligible`` does not look at ``step``, so a strided write
-        with concrete bounds is classified as KV-eligible. Whether it should be
-        is a separate question this test deliberately does not settle -- it only
-        pins the answer against accidental change."""
-        self.assertTrue(self._classify((2, 4, 16, 8), (2, 4, 4, 8), 2, 0, 8, 2))
+    def test_step_is_returned_unchanged(self):
+        """``step`` passes through the shared derivation untouched, which is what
+        both sides need: the derivation reads it for the full-overwrite shortcut, and
+        on the converter side only the scatter fallback reads it.
+
+        This deliberately says nothing about how a strided write is *classified*. One
+        the KV fast path accepts is lowered wrong, because that path ignores ``step``
+        -- ``cache[:, :, 0:8:2, :]`` writes slots 0, 1, 2, 3 rather than 0, 2, 4, 6 --
+        and that is a known, unfixed bug. One that falls through to the scatter
+        fallback is lowered correctly (``test_fallback_step_two``). Asserting the
+        current classification would make the eventual fix arrive looking like a
+        regression and force whoever lands it to delete a passing test."""
+        from torch_tensorrt.dynamo.conversion.impl.slice_scatter import (
+            KVWriteStatus,
+            resolve_slice_scatter_write,
+        )
+
+        shape = (2, 4, 16, 8)
+        for step in (1, 2, 3):
+            self.assertEqual(
+                resolve_slice_scatter_write(shape, 2, 0, 8, step),
+                (0, 8, step, KVWriteStatus.OK),
+            )
 
     def test_resolve_reports_the_converter_early_exits(self):
         """Each status comes back with the bounds its contract promises, since a

--- a/tests/py/dynamo/lowering/test_buffer_lifting.py
+++ b/tests/py/dynamo/lowering/test_buffer_lifting.py
@@ -902,6 +902,20 @@ class TestPredictedKvAssertion(TestCase):
         self.assertIn("min_block_size (5)", message)
         self.assertIn("min_block_size=1", message)
 
+    def test_message_does_not_offer_min_block_size_1_when_it_is_already_1(self):
+        """The remedy has to be one the reader can act on, and at ``min_block_size=1``
+        blaming the value and recommending it are the same sentence. So this branch
+        names the cause and mentions ``min_block_size`` nowhere."""
+        with self.assertRaises(RuntimeError) as caught:
+            assert_predicted_kv_aliased(
+                self._aliased_in(_FakeGM({})),
+                ["buf_k_cache"],
+                CompilationSettings(min_block_size=1),
+            )
+        message = str(caught.exception)
+        self.assertIn("a converter or a capability validator rejected the op", message)
+        self.assertNotIn("min_block_size", message)
+
 
 class TestHiddenCopybackOutputs(TestCase):
     """``hide_copyback_outputs`` splits what the graph returns from what ``forward``

--- a/tests/py/dynamo/lowering/test_buffer_lifting.py
+++ b/tests/py/dynamo/lowering/test_buffer_lifting.py
@@ -29,6 +29,7 @@ import inspect
 import torch
 from torch.export import export
 from torch.testing._internal.common_utils import TestCase, run_tests
+from torch_tensorrt.dynamo._settings import CompilationSettings
 from torch_tensorrt.dynamo.lowering._buffer_lifting import (
     assert_predicted_kv_aliased,
     inline_lifted_buffers_into_gm,
@@ -499,6 +500,51 @@ class TestCopyBackClassification(TestCase):
         new_gm, lifted = lift_mutated_buffers(gm)
         self.assertEqual(len(lifted), 1)
         self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], ["cache"])
+
+    def test_torch_executed_write_is_copyback_not_kv(self):
+        """A KV-shaped write whose op the caller excluded from TensorRT cannot reach a
+        converter, so no IKVCacheUpdateLayer can alias it.
+
+        It must still be lifted and copied back. Dropping the buffer instead would
+        leave the copy_ with no users, and post_lowering's dead-node pass would erase
+        it, silently losing the write."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(2, 4, 16, 8))
+
+            def forward(self, x):
+                self.cache[:, :, 3:4, :] = x
+                return self.cache.sum()
+
+        args = (torch.ones(2, 4, 1, 8),)
+        # Without the exclusion the same write is predicted to alias inside the engine.
+        gm = _ep_module_decomposed(M(), args)
+        baseline_gm, baseline_lifted = lift_mutated_buffers(gm)
+        self.assertEqual(len(baseline_lifted), 1)
+        self.assertEqual(baseline_gm.meta["_copyback_mutation_buffers"], [])
+        self.assertEqual(len(baseline_gm.meta["_predicted_kv_bindings"]), 1)
+
+        gm = _ep_module_decomposed(M(), args)
+        settings = CompilationSettings(
+            torch_executed_ops={"torch.ops.aten.slice_scatter.default"}
+        )
+        new_gm, lifted = lift_mutated_buffers(gm, settings)
+        self.assertEqual(len(lifted), 1)
+        self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], ["cache"])
+        self.assertEqual(new_gm.meta["_predicted_kv_bindings"], [])
+
+        # The write survives as a real graph output, so it cannot be dead-code
+        # eliminated the way an orphaned copy_ would be.
+        out_node = next(n for n in new_gm.graph.nodes if n.op == "output")
+        self.assertEqual(len(out_node.args[0]), 2)
+        erasable = [
+            n
+            for n in new_gm.graph.nodes
+            if n is not out_node and not n.users and n.all_input_nodes
+        ]
+        self.assertEqual(erasable, [])
 
 
 class _FakeEngine:

--- a/tests/py/dynamo/lowering/test_buffer_lifting.py
+++ b/tests/py/dynamo/lowering/test_buffer_lifting.py
@@ -339,8 +339,9 @@ class TestCopyBackClassification(TestCase):
     lowers to an ``IKVCacheUpdateLayer`` with in-place aliased I/O) relies on that
     engine aliasing and is NOT recorded for copy-back. Every other mutation --
     including a ``slice_scatter`` / ``index_copy`` that fails the converter's
-    eligibility (wrong rank/dim/shape) and is lowered to a non-aliasing scatter --
-    has no engine aliasing, so its new value is re-appended as a trailing graph
+    eligibility (wrong rank/dim/shape), whichever of the converter's ineligible
+    paths it then takes -- a non-aliasing scatter, an outright return of the source,
+    or a raise -- has no engine aliasing, so its new value is re-appended as a trailing graph
     output and its buffer name recorded in
     ``gm.meta['_copyback_mutation_buffers']`` for the exporters to reclassify as
     a BUFFER_MUTATION.

--- a/tests/py/dynamo/models/test_exporter_inlining.py
+++ b/tests/py/dynamo/models/test_exporter_inlining.py
@@ -1,0 +1,127 @@
+"""Unit tests for the legacy dynamo exporter's submodule inlining
+(torch_tensorrt.dynamo._exporter). These run on plain fx graphs and need neither a
+GPU nor a TensorRT build."""
+
+import operator
+
+import pytest
+import torch
+from torch_tensorrt.dynamo._exporter import inline_torch_modules
+
+
+@pytest.mark.unit
+def test_inline_torch_modules_wires_inputs_by_position():
+    """inline_torch_modules must wire a _run_on_gpu submodule's inputs from the
+    call_module args by POSITION, not by matching placeholder names to graph nodes.
+
+    Regression: the old name-matching path bound a submodule input to a same-named
+    but unrelated graph node, rewiring a consumer to the wrong producer (and, for a
+    submodule mixing graph-input and computed-intermediate inputs, leaking the
+    latter as spurious graph placeholders). Here the submodule's first input
+    placeholder is named "y", colliding with the parent's second input "y" even
+    though the first *argument* is the parent's "x"; positional wiring must ignore
+    the collision. Subtraction makes the input order observable.
+    """
+    # Submodule: out = first - second. First placeholder deliberately named "y".
+    sub_graph = torch.fx.Graph()
+    first = sub_graph.placeholder("y")
+    second = sub_graph.placeholder("z")
+    sub_graph.output(sub_graph.call_function(torch.sub, (first, second)))
+    submodule = torch.fx.GraphModule(torch.nn.Module(), sub_graph)
+
+    # Parent: inputs (x, y); call _run_on_gpu_0(x, y) -> expected x - y.
+    parent_graph = torch.fx.Graph()
+    x = parent_graph.placeholder("x")
+    y = parent_graph.placeholder("y")
+    root = torch.nn.Module()
+    root.add_module("_run_on_gpu_0", submodule)
+    call = parent_graph.call_module("_run_on_gpu_0", (x, y))
+    parent_graph.output(call)
+    parent = torch.fx.GraphModule(root, parent_graph)
+
+    n_placeholders_before = sum(1 for n in parent.graph.nodes if n.op == "placeholder")
+
+    inline_torch_modules(parent)
+    parent.recompile()
+
+    # No spurious placeholders leaked by the inlining.
+    assert (
+        sum(1 for n in parent.graph.nodes if n.op == "placeholder")
+        == n_placeholders_before
+    )
+    # No call_module node survives (the submodule was inlined).
+    assert not any(n.op == "call_module" for n in parent.graph.nodes)
+    # Positional wiring: first input <- x, second input <- y, so out == x - y.
+    out = parent(torch.tensor(5.0), torch.tensor(3.0))
+    assert torch.allclose(out, torch.tensor(2.0))
+
+
+@pytest.mark.unit
+def test_inline_torch_modules_preserves_all_submodule_outputs():
+    """A multi-output _run_on_gpu submodule must keep every output wired to its
+    consumer after inlining. Regression: a mis-wired input orphaned one submodule
+    output, which dead-code elimination then pruned, leaving a downstream consumer
+    (or, in the hybrid case, a TensorRT engine) short an output at runtime.
+    """
+    # Submodule returns (a + b, a - b); both outputs are consumed downstream.
+    sub_graph = torch.fx.Graph()
+    a = sub_graph.placeholder("a")
+    b = sub_graph.placeholder("b")
+    add = sub_graph.call_function(torch.add, (a, b))
+    sub = sub_graph.call_function(torch.sub, (a, b))
+    sub_graph.output((add, sub))
+    submodule = torch.fx.GraphModule(torch.nn.Module(), sub_graph)
+
+    parent_graph = torch.fx.Graph()
+    x = parent_graph.placeholder("x")
+    y = parent_graph.placeholder("y")
+    root = torch.nn.Module()
+    root.add_module("_run_on_gpu_0", submodule)
+    call = parent_graph.call_module("_run_on_gpu_0", (x, y))
+    o0 = parent_graph.call_function(operator.getitem, (call, 0))
+    o1 = parent_graph.call_function(operator.getitem, (call, 1))
+    # Consume both outputs: (a+b) * (a-b).
+    parent_graph.output(parent_graph.call_function(torch.mul, (o0, o1)))
+    parent = torch.fx.GraphModule(root, parent_graph)
+
+    inline_torch_modules(parent)
+    parent.recompile()
+
+    # (x+y)*(x-y) == x^2 - y^2 ; with x=5, y=3 -> 25 - 9 = 16.
+    out = parent(torch.tensor(5.0), torch.tensor(3.0))
+    assert torch.allclose(out, torch.tensor(16.0))
+
+
+@pytest.mark.unit
+def test_inline_torch_modules_computed_intermediate_inputs():
+    """A _run_on_gpu submodule whose inputs are computed intermediates (not top-level
+    graph placeholders, and not name-matching any graph node) must inline correctly.
+    This is the case the old zero-duplicate path handled; positional wiring preserves
+    it (and it is the shape that leaked spurious placeholders in the mixed case).
+    """
+    # Submodule: out = m + n. Names don't collide with anything in the parent.
+    sub_graph = torch.fx.Graph()
+    m = sub_graph.placeholder("m")
+    n = sub_graph.placeholder("n")
+    sub_graph.output(sub_graph.call_function(torch.add, (m, n)))
+    submodule = torch.fx.GraphModule(torch.nn.Module(), sub_graph)
+
+    # Parent: x -> c0 = x*2, c1 = x+1; call _run_on_gpu_0(c0, c1) -> c0 + c1.
+    parent_graph = torch.fx.Graph()
+    x = parent_graph.placeholder("x")
+    c0 = parent_graph.call_function(torch.mul, (x, 2))
+    c1 = parent_graph.call_function(torch.add, (x, 1))
+    root = torch.nn.Module()
+    root.add_module("_run_on_gpu_0", submodule)
+    call = parent_graph.call_module("_run_on_gpu_0", (c0, c1))
+    parent_graph.output(call)
+    parent = torch.fx.GraphModule(root, parent_graph)
+
+    inline_torch_modules(parent)
+    parent.recompile()
+
+    # No spurious placeholders leaked; the computed intermediates stay in-graph.
+    assert sum(1 for node in parent.graph.nodes if node.op == "placeholder") == 1
+    # out = (x*2) + (x+1); x=5 -> 10 + 6 = 16.
+    out = parent(torch.tensor(5.0))
+    assert torch.allclose(out, torch.tensor(16.0))


### PR DESCRIPTION
## Why this PR is needed

Caller-owned KV cache support (#4445) lets a mutable buffer live above the delegate and be updated in place by the engine. It handles this by lifting each mutated buffer to a delegate input and **erasing the trailing `copy_`**, relying on TensorRT's `IKVCacheUpdateLayer` aliasing to write the new value back to the caller-owned storage (zero-copy).

That assumption only holds for **KV-cache writes**. The `slice_scatter` and `index_copy` converters have a fast path that emits an `IKVCacheUpdateLayer` whose output is aliased in-place to the cache input. **Any other in-place mutable buffer has no such aliasing** — for example the `conv_state` / `recurrent_state` ring-buffers of a Gated DeltaNet (GDN) layer. For those, erasing the `copy_` dropped the write-back entirely: the update became dead code and was eliminated, so the engine received fewer args than expected at runtime and the buffer never updated (silently wrong output).

## The fix

Distinguish the two kinds of mutation in `lift_mutated_buffers`:

- **KV writes** (`slice_scatter` / `index_copy`) keep the existing zero-copy aliasing path — the `copy_` is erased and the write-back is handled by the engine's `IKVCacheUpdateLayer`.
- **Any other ("copy-back") mutation** has its new value re-attached as an ordinary graph output and recorded as a `BUFFER_MUTATION` of its caller-owned buffer, so ExecuTorch copies it back after the delegate runs.

This uses the standard mutable-buffer representation rather than the engine-enforced aliased-I/O path (which is reserved for zero-copy KV aliasing).

Classification reuses the converters' own eligibility predicates rather than the op target alone, so a `slice_scatter` / `index_copy` the converter cannot turn into an `IKVCacheUpdateLayer` falls to copy-back instead of being dropped. `assert_predicted_kv_aliased` then cross-checks the classification against the engines that were actually built, in both directions: every write predicted as KV must appear in an engine's `aliased_io`, and no write filed copy-back may appear there. The first direction catches a silently lost write-back. The second catches a module that raises on every call, because the runtime treats an aliased output as an engine side effect and does not return it, while the surrounding graph still reads the trailing output copy-back added.

## One derivation for `slice_scatter` eligibility

A predicate is only as good as its arguments: deriving `_kv_eligible`'s inputs independently on the two sides mis-predicts as effectively as a different predicate would. `resolve_slice_scatter_write` in `dynamo/conversion/impl/slice_scatter.py` is the single derivation both sides call — the converter derives its arguments from the TRT tensors, the predictor from the fx node, and both go through this helper. It fills in the op's defaults, counts negative indices from the end, and reports which of the converter's early exits a write hits through a `KVWriteStatus`: `FULL_OVERWRITE` (the converter returns the source and emits no KV layer), `DYNAMIC_BOUNDS` (a non-`int` bound, which the converter raises `NotImplementedError` on), `BAD_DIM` (a `dim` that is not a Python `int` or does not index the cache, which raises `IndexError`), or `OK`. Only `OK` reaches `_kv_eligible`, with `update_len` taken as `end - start`. Every other status is a case in which the converter returns or raises before it can emit an aliasing layer, so none of them can be predicted to alias: a full overwrite keeps its copy-back, and the two raising statuses abort the compile, so nothing is copied back at all.

`_kv_eligible` itself does not take `step`. The shared derivation reads `step` for the full-overwrite shortcut, which requires `step == 1`, and otherwise passes it through untouched. On the converter side only the scatter fallback reads it: `try_emit_kv_cache_update` takes no `step` at all and writes `update_len` slots consecutively from `start`. So a strided write the KV fast path accepts is lowered as if it were contiguous — `cache[:, :, 0:8:2, :]` lands in slots 0, 1, 2, 3 rather than 0, 2, 4, 6, silently. That is confined to the KV fast path: a strided write that falls through to the scatter fallback is lowered correctly, because the fallback builds its scatter indices with `step` in hand, and `test_fallback_step_two` drives exactly that shape and compares against eager. The KV-path miscompile behaves the same way on `main`, and this change neither introduces nor fixes it; the `OK` return carries a comment recording it as known and unfixed and scoping it to the KV path, so the next reader is not sent at a fallback that is correct. `test_step_is_returned_unchanged` pins only what the shared derivation owes its two callers — that `step` comes back as it went in — so freezing the derivation does not freeze the routing built on top of it.

Two converter behaviours differ from `main`, because the `dim` check moved into the shared helper so that predictor and converter apply one rule to `dim`: an out-of-range `dim` raises `IndexError` from the converter instead of surfacing as a TensorRT message out of `input.shape[dim]`, and `dim` must be a Python `int`, so a `numpy.int64` `dim` is read as a bad dim where on `main` it works.

## The cache has to reach the converter as a network input

`emit_kv_cache_update_layer` aliases the cache only when the argument it is handed is a direct network input — anything else has no input binding name, and the converter falls back to a plain scatter. After lifting, a mutated buffer is a placeholder, so the ordinary write-only shape satisfies that directly. A `clone` in between does not, and that is the shape a forward takes when it also reads the post-write cache: the write's cache argument is a `call_function`, but `remove_input_alias_fixing_clones` — an ATEN lowering pass inside `post_lowering` — then erases the clone, and the converter does see a network input after all.

`_effective_cache_input` therefore predicts what the converter will be handed rather than reading what is in the graph at classification time, reproducing that pass's own condition exactly: the clone is peeled only when its input is a placeholder and that placeholder's sole user is the clone. A placeholder some other node also reads keeps its clone, the converter sees a `call_function`, and nothing aliases. For the same reason classification runs after the trailing `copy_` is erased — the `copy_` is the last reader of the buffer placeholder in the write-only shape, so whether it is still there decides whether the clone survives. The peel has to reach both write ops: `_index_copy_kv_eligible` applies a placeholder check of its own, so it takes an `input_node` keyword the classifier passes and the partitioner does not; running as a capability validator, after lowering has settled what the input is, it reads `node.args[0]` itself.

Predicting this wrong in the copy-back direction is worse than a lost write-back: the write is filed copy-back, its new value re-attached as a trailing graph output, the engine aliases the cache anyway, and every call raises. That is what the second direction of the cross-check exists for. `remove_input_alias_fixing_clones` carries a note back to the classifier, so that loosening the pass's condition, or deleting the pass as its own TODO invites, is done knowing a prediction depends on it.

## A KV write nothing else reads

Erasing the trailing `copy_` can leave a KV-eligible write with no consumer at all — a forward that updates a cache and returns something unrelated. Dead-code elimination then takes the write before any engine can see it, so a prediction of engine aliasing could never be fulfilled. Such a write is routed to copy-back instead: re-attaching its new value as a graph output makes it live again, so the model compiles at the default `min_block_size` and the ExecuTorch runtime applies the buffer, rather than the compile failing on a prediction nothing could fulfil.

Copy-back and engine aliasing are mutually exclusive for one buffer, so a re-routed write also has to be kept out of `aliased_io`. It carries `node.meta["_trt_no_kv_alias"]`, and both eligibility checks honour it: `impl.slice_scatter` reads it off `ctx.current_node`, and `_index_copy_kv_eligible` off the node it is handed. The key is a bare string literal at every site, which is how every other custom meta key in `dynamo/` is written — `_fp8_softmax_scale`, set by a lowering pass and read off `ctx.current_node` in a converter, is the same shape — and it keeps `_buffer_lifting.py` free of a module-level import from `conversion/`.

The marker is deliberately narrow. It goes only on a write the classifier knows the converter would otherwise have aliased and whose result nothing consumes, never on copy-back writes at large: marking every copy-back write would leave the copy-back direction of the cross-check nothing to catch, and catching a genuine mis-prediction there is the whole point of it. The marker rides on `node.meta` through every pass in `post_lowering`, where a pass that rebuilds a node without its meta would drop it silently, so `assert_no_kv_alias_markers_survived` reconciles the names recorded before lowering against the lowered graph before conversion. That reconciliation runs in both directions and reports which of three faults it found: a recorded name that kept its node but lost the marker, an unrecorded node that gained one, or a recorded name gone with an unrecorded node carrying the marker instead.

The marker sits on the write *node* while the classification is per *buffer*, so one value node written back into two buffers would put the two in conflict. `torch.export` rejects that shape with `SpecViolationError` before the classifier sees it, which makes it a constraint on what can arrive rather than a case to guard against.

## Two further cases

- **Submodule-owned buffers.** A `get_attr` target is fully qualified (`layers.0.self_attn.kv_cache.k_cache`), and `hasattr`/`getattr` do not walk a dotted path, so nested caches were silently skipped and frozen as constants. `lift_mutated_buffers` resolves through submodules with `get_buffer`; `register_buffer` rejects dots, so the buffer is renamed to a flat attribute (`lifted_buf_*`) and the recorded copy-back targets are remapped through the same renaming (otherwise the verifier rejects the program).
- **Writes excluded from TensorRT.** An op in `settings.torch_executed_ops` never reaches a converter, so it cannot emit an `IKVCacheUpdateLayer` and the engine will not alias that buffer. The classifier honours the exclusion list (matched the way the partitioner matches it, so the two cannot disagree) and leaves such a write on the copy-back path — which is what lets a program split across the TensorRT and CUDA delegates export.

## How it works

The classification happens once, in `lift_mutated_buffers`, and is threaded to both save paths:

1. **`dynamo/lowering/_buffer_lifting.py`** — for each lifted buffer, a KV write is left to aliasing and its input-binding name recorded in `gm.meta["_predicted_kv_bindings"]`; a non-KV write has its new value appended as a trailing graph output (so it survives DCE now that the `copy_` is gone), its buffer name recorded in output order in `gm.meta["_copyback_mutation_buffers"]`, and its input-binding name recorded in `gm.meta["_copyback_bindings"]` for the other direction of the cross-check. A KV-eligible write re-routed for want of a consumer is marked, and the marked node names recorded in `gm.meta["_no_kv_alias_writes"]`. Nested buffers are resolved through `get_buffer` and renamed; excluded writes are left on the copy-back path.
2. **`dynamo/_compiler.py`** — reads the markers back against the lowered graph (`assert_no_kv_alias_markers_survived`) after `post_lowering` and before conversion, forwards the copy-back list onto the compiled module's meta so it reaches the exporters, runs `assert_predicted_kv_aliased` against the `aliased_io` of the compiled submodules with both binding sets, and hides the copy-back values from what the compiled module returns (`hide_copyback_outputs`).
3. **`dynamo/_exporter.py`**
   - `create_trt_exp_program` (retrace=False, legacy exporter): tags the trailing outputs with their buffer target and moves all mutation outputs ahead of the user outputs (verifier requirement). A write-only buffer has no surviving `get_attr` after DCE and `lift` derives BUFFER input specs from `get_attr` nodes alone, so an unused one is re-added for it.
   - `_declare_aliased_kv_mutations_on_ep` (run on the resulting `ExportedProgram` by every `save()` branch that serializes a signature, and by `torch_tensorrt.executorch.export()` for every source shape it accepts): detaches the full trailing run of copy-back values, pairs each positionally with its buffer (in `copyback_buffers` order), and declares as `BUFFER_MUTATION` only the buffers `torch.export` did not already declare itself — skipping the rest — then rebuilds the top-level `out_spec` so `to_edge`'s unflatten sees the right leaf count. Pairing across the full run before filtering is deliberate: dropping already-declared buffers first would shift the run and pair a value with the wrong buffer, which the runtime would then copy into a buffer of a different shape.
4. **`executorch/_export.py`** — `torch_tensorrt.executorch.export()` runs the declaration pass over `program_map` once `_prepare_programs` has normalized all three accepted source shapes into it, threading each method's `_copyback_mutation_buffers` from the source that method came from. It runs on the staged copy rather than the caller's program, so a caller who hands in their own `ExportedProgram` keeps it usable afterwards.

The KV half of `_declare_aliased_kv_mutations_on_ep` needs the optional `[executorch]` extra to read an engine's binding names; on a plain install that import fails, the engine scan is skipped, and the copy-back half still runs.

## What `compile()` returns

A copy-back value is only ever consumed by whatever serializes the module. Nothing between `compile()` and the ExecuTorch runtime writes it anywhere, so a compiled module called directly from PyTorch leaves its buffer at the value it was compiled with, exactly as on `main`. Handing that value back as an extra return value would report a mutation the caller cannot act on, so `hide_copyback_outputs` installs a `CodeGen` whose generated `forward` stops short of the trailing copy-back values. The compiled module keeps the arity of the model it was compiled from: a non-KV mutable buffer does not turn one return value into two.

Only the generated `forward` stops early. The values stay on the graph's output node, so everything that reads the graph rather than calling the module still finds them — the exporters, dead-code elimination, and the `torch.fx.Interpreter` that a non-strict `torch.export` runs a GraphModule through, which is why a retrace keeps them too. Non-strict is what both retrace paths get: `_compile.save` passes `strict=False` and `dynamo._exporter.export` takes the default. A caller who exports the compiled module themselves with `strict=True` gets the module called rather than interpreted, and the hidden values do not reach the program; the `_HiddenCopybackOutputs` docstring records that at the point of decision. `_TorchTensorRTModule.forward` does the same with the aliased outputs the interpreter appends: the engine produces them, the caller never sees them.

## Where copy-back is declared

| source | exporter | `exported_program` | `executorch` | `aot_inductor` |
|---|---|---|---|---|
| `ExportedProgram` | n/a | KV only | KV + copy-back | not declared |
| `GraphModule`, `retrace=True` | either | KV + copy-back | KV + copy-back | not declared |
| `GraphModule`, `retrace=False` | legacy (default) | KV + copy-back, at transform time | KV + copy-back, at transform time | KV + copy-back, at transform time |
| `GraphModule`, `retrace=False` | `use_legacy_exporter=False` | KV only, **warns** | KV + copy-back | not declared, **warns** |

`torch_tensorrt.executorch.export()` declares for every source shape it accepts, and `save(output_format="executorch")` reaches it on every branch, so that column is uniform. `save(output_format="exported_program")` declares only the KV half of an already-exported program, since no copy-back buffer list is threaded on that branch; `save()` is therefore not uniform across its two serializing formats.

`aot_inductor` is left undeclared on the `torch.export` paths — whether an aliased in-place mutation survives functionalization under inductor is unverified — matching #4445's KV scoping. It warns when the module carries engines with aliased I/O, and, under `retrace=False` with `use_legacy_exporter=False`, when a copy-back buffer would go undeclared.

Among the `GraphModule` paths, `retrace=False` with `use_legacy_exporter=False` and `output_format="exported_program"` is the one combination that leaves a copy-back mutation undeclared: on the `retrace=False` branch the legacy exporter is what declares copy-back, and `torch_tensorrt.executorch.export()` covers the `executorch` format, so this combination falls between the two. It warns rather than silently saving a signature that omits the update.

## Idempotency

The declaration pass is safe to call more than once, by two separate mechanisms. The KV half skips any buffer already carrying a `BUFFER_MUTATION` spec, which is also how the legacy exporter's transform-time declaration survives a later run. The copy-back half cannot skip one buffer at a time, because it detaches its outputs by position rather than by name, and per-buffer state cannot tell the two "already declared" cases apart: `torch.export` declares a mutation it recognises and *leaves* the trailing value, while a previous run of this pass declares it and *consumes* the value. So the consuming step records `gm.meta["_copyback_mutations_declared"]` on the GraphModule and the slice is skipped when it is set. `create_trt_exp_program` sets the same marker, since it declares copy-back itself at transform time. Without the marker a second run slices whatever trails the graph — by then a genuine user output — and the saved program fails to load with `treespec.unflatten ... leaves has length 0`.

## Uninitialized copy-back buffers

Declaring a write as an ExecuTorch `BUFFER_MUTATION` puts the buffer under ExecuTorch's rule that a mutated buffer has a meaningless initial state: only its shape and dtype are serialized. A buffer read before it is written — a GDN `conv_state` or `recurrent_state`, an EMA, a running statistic — therefore starts from whatever the allocation held. ExecuTorch warns about this itself, but generically, naming no buffer. `torch_tensorrt.executorch.export()` names the copy-back buffers and states the rule they fall under, with the condition attached rather than stated flat, since a caller who has already supplied the pass below does have the value in the `.pte`: they *"are declared mutated, so ExecuTorch serializes only their shape and dtype, not their value, unless a pass marks them meta["et_init_buffer"]; without that, a buffer read before it is written starts from whatever the allocation held."*

The remedy is named, but only together with the one thing upstream does not say about it. ExecuTorch's own way to put an initial value back is `InitializedMutableBufferPass`, which sets `et_init_buffer` on the placeholders its patterns match; the emitter then marks the spec const and serializes the buffer by reading its storage host-side through `ctypes.cast(spec.storage.data_ptr(), ...)`. Whether that read is safe is decided by where the buffer lives: it works while the buffer is on CPU, and it takes the export down with a segfault, rather than raising, once the buffer is CUDA-resident — which is what exporting a model on CUDA leaves behind, and exporting on CUDA is the ordinary way to reach a TensorRT engine. ExecuTorch's emitter names the pass to the same user later in the same export and says nothing about where the buffer has to live, so withholding the name here would withhold the caveat and not the advice. The warning carries both, and the test that covers it requires the two to travel together.

Engine-aliased KV buffers lose their serialized initial value the same way and are deliberately excluded from the warning. An aliased write is a cache-position write on the sequence axis — the only form `IKVCacheUpdateLayer` expresses — and such a model is assumed to read the cache under that same position, through a bounded slice or a position mask, so slots no step has written should not reach the output. Nothing verifies that; it is a property of the model. On that assumption initializing a cache buys nothing and would cost what is typically the model's largest tensor, written whole into the `.pte`.

## What copy-back costs

Only an engine-aliased (KV) write is free. A `BUFFER_MUTATION` output is defined as the buffer's new contents rather than the slice that changed, so a copy-back write re-attaches the **whole post-write buffer** as a graph output. Each call therefore pays, per copy-back buffer, a full-buffer materialization of that output plus a full-buffer copy from ExecuTorch's own write-back pass after the delegate returns. For a decode step writing one position into a multi-megabyte KV cache, that easily dominates the step. It is the right correctness tradeoff — the alternative is silently losing the write — but it is why the classifier routes a cache write to engine aliasing instead, and why a model that unexpectedly lands in copy-back comes out slow rather than wrong. This is recorded in the `_buffer_lifting.py` module docstring, with `gm.meta['_copyback_mutation_buffers']` named as the way to find out which buffers are paying it.

## The engine-converter entry point

`convert_exported_program_to_serialized_trt_engine(..., lift_mutable_buffers=True)` hands the caller raw engine bindings and performs no write-back of its own. A copy-back write there would append an extra engine output that the entry point reports nothing about, so the buffer would come back stale; it is rejected right after lifting, with the offending buffers named and the working route pointed at: `torch_tensorrt.dynamo.compile` *and* saving the result, since it is the save that declares the buffer mutation for the runtime to apply — `compile()` on its own performs no write-back either. The cross-check runs there too, against `interpreter_result.aliased_io`.

## Diagnosing a failed cross-check

`assert_predicted_kv_aliased` takes the aliased-input binding set rather than a module, because the two callers hold ground truth in different shapes — `compile()` reads it off the compiled submodules, the engine converter off the interpreter result — and `aliased_input_bindings` assembles it for both. Both directions are keyed on the `buf_*` input-binding name, which is stable across the buffer rename that inlining does later and is exactly what `aliased_io` records on the input side.

Classification runs before lowering and partitioning, so an unfulfilled KV prediction means something in between kept the write out of the engine it was predicted into. The error names the buffers and then names a likely cause, citing `min_block_size` only where that setting can be the reason: above 1 it reports the value in force and that `min_block_size=1` rules the setting out, and at 1 it points at a converter or a capability validator rejecting the op instead, since naming the setting there would blame the value it would have to recommend.

Under `compile(dryrun=True)` no engine is built, so `aliased_io` is empty for reasons that say nothing about the predictions and every one of them would look unfulfilled. The skip is keyed on an explicit `engines_built` keyword rather than on `settings.dryrun`, because the two entry points do not mean the same thing by that flag: `convert_exported_program_to_serialized_trt_engine` accepts `dryrun`, puts it in `CompilationSettings` and then never consults it, so an engine comes out regardless. Reading `dryrun` inside the shared helper would hand that entry point an opt-out kwarg for a check it is meant to have none for. Only `compile()` passes `engines_built=False`, and only where it returns before conversion.

## Reading engine metadata without re-serializing the engine

`__getstate__` on a TensorRT engine is the pickling hook, not a metadata accessor: it re-serializes the whole `ICudaEngine` and base64-encodes it. `get_engine_info_from_state(..., metadata_only=True)` takes the record from `serialize_metadata_only` instead, and `_get_engine_info_for_node` forwards the flag. Two callers read metadata only and opt in. The aliased-mutation declaration pass reads `ALIASED_IO`, `INPUT_BINDING_NAMES` and `OUTPUT_BINDING_NAMES` and runs its engine loop before it can know whether any engine has aliased I/O at all, so a program with no aliased KV paid a full serialization per engine node and then returned unchanged — measured at 0.4 s and a 67 MB transient string for one ~50 MB engine. `TensorRTPartitioner._resolve_target_device_for_partition` reads a single field, `DEVICE_IDX`, once per partition, on every export that does not pin `target_device`, which is the default: 967.6 ms against 3.1 ms on a ~100 MB engine, plus a 134 MB base64 string built and dropped. The accessor's caveat that `ENGINE_IDX` is unreliable under `metadata_only` applies to neither, since neither reads that slot.

## Scope

The classification is a no-op for any model with no non-KV in-place mutable buffer and no KV write whose result nothing consumes — including all standard models, and any KV-cache model whose writes the converter turns into `IKVCacheUpdateLayer`s. The `dim` handling above is the one converter behaviour that differs for programs with no mutable buffer at all.

## Testing

Unit tests, CPU-only unless noted, and gated on `executorch.exir` where they touch it:

- **`tests/py/dynamo/lowering/test_buffer_lifting.py`** — classification: KV `slice_scatter` / `index_copy` writes stay aliased with no copy-back; a non-KV mutation is recorded and its new value re-attached as the trailing output (verified numerically equal to the updated buffer); `index_put` falls to copy-back; a mixed KV + non-KV graph records only the non-KV buffer; an ineligible `index_copy` (2-D cache) and an ineligible `slice_scatter` (wrong dim) fall to copy-back rather than being dropped; a write excluded through `torch_executed_ops` is left on the copy-back path; nested buffers are lifted, and inlining remaps the recorded copy-back targets to their flattened attribute names. `TestSliceScatterDerivationIsShared` pins the corners where an independent derivation would part company with the converter — full overwrite, open-ended `end == INT64_MAX`, negative `start`, non-`int` `start` — plus each `KVWriteStatus`, the bounds its contract promises, and `step` coming back as it went in. `TestCacheMustReachTheConverterAsANetworkInput` covers what the converter will be handed: a direct placeholder and a sole-use clone of one classify as KV, for `slice_scatter` and for `index_copy`, while a shared clone, a clone of a non-placeholder, a cache read through another op and a cache still read from a `get_attr` do not — and the `index_copy` validator still reads `node.args[0]` when nobody overrides it, so the partitioner's view of the same node is unchanged. `TestDeadKvWriteRouting` covers the write nothing else reads: it is filed copy-back rather than predicted KV, the re-routed write carries the marker, a live KV write and a non-KV write do not, and the marker turns `_index_copy_kv_eligible` from true to false on the same node. `TestNoKvAliasMarkerSurvival` drives the reconciliation: a surviving marker passes, while a stripped marker, a marker copied onto an unmarked node, a marker appearing where none was recorded, and a marked node replaced by another carrying the marker each raise. `TestPredictedKvAssertion` covers the backstop in both directions: it passes when a predicted-KV write is aliased and raises when it is not, raises when a copy-back write is aliased and passes when it is not, aggregates `aliased_io` across multiple engines, no-ops with no prediction, skips under `engines_built=False` for either direction, does *not* skip on `dryrun` alone, and names `min_block_size` only where that setting can be the cause. `TestHiddenCopybackOutputs` pins that hiding a value leaves the graph's output node untouched, that hiding nothing is a no-op, and that a graph consumer still sees the hidden value. `TestCompileSeam` (CUDA) drives `compile()` end to end and pins the wire between the two halves: the copy-back list reaching `trt_gm.meta` and still resolving to a live buffer, the cross-check being called with the predictions lifting made, each direction of it failing a compile, `compile()` telling the check that a dryrun built no engines, a cloned `slice_scatter` and a cloned `index_copy` cache write each compiling and writing back, a dead `slice_scatter` write compiling with an empty `aliased_io` at `min_block_size` 1 and at the default 5 and its mutation arriving in a saved program, the same for a dead `index_copy` write, for a dead cloned write where both mechanisms meet, and for a dead write whose buffer still has another reader, the marker read-back running on the lowered graph rather than before lowering, and the copy-back value staying out of the compiled module's return — beside an engine-aliased KV buffer in the same module, and while a retrace and a saved program still find it.
- **`tests/py/dynamo/executorch/test_kv_cache_export.py`** — both exporter passes reclassify a trailing copy-back output to `BUFFER_MUTATION` ahead of the user outputs; a buffer `torch.export` already declared is skipped rather than declared twice, and with a mix of declared and undeclared buffers each remaining copy-back value is paired with the buffer it was appended for; a second run of the pass is a no-op; the copy-back half still runs when the `[executorch]` extra is unimportable; the declaration pass reads engine metadata only; a write-only copy-back buffer still reaches `lift` as a `get_attr` (driving the real `lift` and `ExportedProgram` constructor so a regression reproduces the verifier error rather than passing vacuously), and the re-added `get_attr` neither duplicates an existing one nor invents a dangling one; a saved copy-back program reloads, returns exactly the outputs the source module returned, and updates its buffer; `torch_tensorrt.executorch.export()` declares copy-back for each source shape it accepts (both GraphModule retrace modes, an ExportedProgram, and a method mapping) and leaves the caller's own program intact; every `save()` branch that serializes a signature reaches the declaration pass, swept over module type by serializing format; `save()` warns on exactly the one combination that cannot declare; and the engine-converter entry point rejects a copy-back buffer by name, matched in its rendered form so a substring of an unrelated word cannot satisfy the assertion.
- **`tests/py/dynamo/executorch/test_export.py`** — the uninitialized-buffer warning names the buffer, states what ExecuTorch keeps of it and under what condition, and names `InitializedMutableBufferPass` only in a message that also carries the CUDA caveat; an export with nothing to copy back stays silent.
- **`tests/py/dynamo/conversion/test_slice_scatter_aten.py`** — `TestSliceScatterFallback` drives the scatter fallback against eager across ranks and dims, including a `step=2` write and a dynamic-shape case; `TestSliceScatterEarlyExits` drives the converter's raising exits: dynamic bounds, and both forms of bad `dim`.
- **`tests/py/dynamo/executorch/test_api.py`** — the partitioner asks for the engine record with `metadata_only=True`.

The copy-back path was also exercised outside the test suite, by running `.pte`s on a real ExecuTorch runner: a synthetic copy-back model; an L=2 Gemma4 MoE with an added non-KV buffer, which puts copy-back and engine-aliased KV in one hybrid TensorRT + CUDA model; a Qwen3.5 GDN decode whose four per-layer `conv_*` / `rec_*` state buffers are all copy-back and whose recurrent state has no KV aliasing anywhere; and a clone / cache-position-write / write-back decode step. In each, a step observes the previous step's write. Those runs are not part of this PR's automated tests.

## Stacking

Not stacked. **#4446** (retrace=False legacy-exporter fix) and **#4445** (caller-owned KV cache) have both landed, and this branch is based on `main` above them.

## Follow-ups

- **#4440 (composable Edge export API)** has **landed**, and the declaration for `output_format="executorch"` now lives in `torch_tensorrt.executorch.export()`, where it runs per method. The `output_format="exported_program"` branches still declare from `save()` in `_compile.py`, and `save(exported_program, output_format="exported_program")` still declares only the KV half; making `save()` uniform across its two serializing formats is a follow-up.
- **#4454 (shared caller stream)** has **landed**. A copy-back is an ExecuTorch-level write performed after the delegate; on the shared caller stream it is naturally ordered before the next delegate reads the buffer, so cross-delegate copy-back is correct without additional code. A cross-delegate prefill/decode acceptance test is now unblocked and will be added as a follow-up.
- `_write_op_is_torch_executed` and the dead-write re-route are the two reasons a write can miss an engine that the classifier can see coming, and both file the write as copy-back up front. The others — `min_block_size`, a missing converter, a failed capability validator — are not knowable before partitioning, so the cross-check catches them after it instead. Making the prediction non-destructive, by always keeping the copy-back output and dropping it after conversion once `aliased_io` has settled which buffers the engine aliased, would remove the need for the cross-check entirely; that is a larger change and belongs in its own PR.
