### PR TITLE
fix(tests): correct TensorRT-RTX deconv version gate and guard plugin-backed converter tests

### DIFF
--- a/core/conversion/converters/impl/conv_deconv.cpp
+++ b/core/conversion/converters/impl/conv_deconv.cpp
@@ -294,7 +294,9 @@ bool add_conv_deconv(ConversionCtx* ctx, const torch::jit::Node* n, args& args) 
     deconv->setStrideNd(stride);
     deconv->setPrePadding(begPadding);
     deconv->setPostPadding(padding);
-#if NV_TENSORRT_MAJOR > 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR >= 1)
+// TensorRT-RTX reports NV_TENSORRT_MAJOR == 1, so the plain version comparison below would
+// select the pre-7.1 fallback and reject grouped or dilated deconvolutions that RTX supports.
+#if defined(TRT_MAJOR_RTX) || NV_TENSORRT_MAJOR > 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR >= 1)
     deconv->setDilationNd(dilation);
     deconv->setNbGroups(groups);
 #else

--- a/tests/core/conversion/converters/test_instance_norm.cpp
+++ b/tests/core/conversion/converters/test_instance_norm.cpp
@@ -28,6 +28,13 @@ constexpr auto graph = R"IR(
         return (%4)
 )IR";
 
+// The aten::instance_norm converter is implemented with a TensorRT plugin, which TensorRT-RTX
+// does not provide, so aten::instance_norm is left unregistered for RTX builds (see
+// core/conversion/converters/impl/batch_norm.cpp). All three tests below share the same
+// aten::instance_norm graph, so all three are guarded -- the first two additionally carry an
+// unconditional GTEST_SKIP() that is unrelated to RTX.
+#ifndef TRT_MAJOR_RTX
+
 TEST(Converters, ATenInstanceNormConvertsCorrectly) {
   GTEST_SKIP();
   auto g = std::make_shared<torch::jit::Graph>();
@@ -103,3 +110,5 @@ TEST(Converters, ATenInstanceNormRunningStatsConvertsCorrectly) {
   auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in});
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0])));
 }
+
+#endif // TRT_MAJOR_RTX

--- a/tests/core/conversion/converters/test_normalize.cpp
+++ b/tests/core/conversion/converters/test_normalize.cpp
@@ -43,6 +43,11 @@
     ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt));                 \
   }
 
+// The aten::norm converter is implemented with a TensorRT plugin, which TensorRT-RTX does not
+// provide, so it is compiled out for RTX builds (see
+// core/conversion/converters/impl/normalize.cpp). The aten::frobenius_norm and
+// aten::linalg_norm tests below do not use that converter and are left enabled.
+#ifndef TRT_MAJOR_RTX
 ATEN_INTERPOLATE_TESTS(
     ATenNormOrder1RemoveDims,
     R"IR(
@@ -75,6 +80,7 @@ ATEN_INTERPOLATE_TESTS(
               %5 : Tensor = aten::norm(%x.1, %3, %2, %4)
               return (%5))IR",
     std::vector<int64_t>({3, 4, 3}));
+#endif // TRT_MAJOR_RTX
 
 TEST(Converters, ATenFrobeniusNorm) {
   const auto graph = R"IR(

--- a/tests/core/conversion/converters/test_pooling.cpp
+++ b/tests/core/conversion/converters/test_pooling.cpp
@@ -410,6 +410,12 @@ TEST(Converters, ATenAvgPool3DNoCountPadConvertsCorrectly) {
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0]));
 }
 
+// The adaptive pooling converters are implemented with TensorRT plugins, which TensorRT-RTX
+// does not provide, so they are compiled out for RTX builds (see
+// core/conversion/converters/impl/pooling.cpp). Without this guard every test below fails
+// conversion with "Expected converter to be true but got false".
+#ifndef TRT_MAJOR_RTX
+
 TEST(Converters, ATenAdaptiveAvgPool2DConvertsCorrectly) {
   const auto graph = R"IR(
       graph(%0 : Tensor):
@@ -781,3 +787,5 @@ TEST(Converters, ATenAdaptiveMaxPool3DUsingPluginConvertsCorrectly) {
 
   ASSERT_TRUE(torch_tensorrt::tests::util::almostEqual(jit_results[0], trt_results[0]));
 }
+
+#endif // TRT_MAJOR_RTX


### PR DESCRIPTION
# Description

Fixes 4 failing converter test targets on TensorRT-RTX builds. Two independent causes.

**1. `conv_deconv.cpp` takes the pre-TensorRT-7.1 fallback on RTX.** TensorRT-RTX defines `NV_TENSORRT_MAJOR` as `TRT_MAJOR_RTX` (`== 1`), so the version check guarding `setDilationNd()` / `setNbGroups()` is false on every RTX build. Deconvolutions with `groups > 1` or `dilation > 1` are then rejected citing TensorRT 7.1, although RTX supports both. Adds the `defined(TRT_MAJOR_RTX)` escape already used for this in `ConversionCtx.cpp` and `quantization.cpp`.

Reached only by the TorchScript frontend — the dynamo converter gates strided *and* dilated deconv on RTX, not groups.

**2. Plugin-backed converters have no RTX implementation.** Adaptive pooling, `aten::norm` and `aten::instance_norm` are built on TensorRT plugins that TensorRT-RTX does not provide, and are already compiled out for RTX. Their gtests therefore fail with `Expected converter to be true but got false`. Guarded with `#ifndef TRT_MAJOR_RTX`, which is already visible via `tests/util/util.h` → `core/ir/ir.h` → `NvInfer.h` (no new includes or build deps). Non-RTX builds keep full coverage.

- `test_pooling.cpp` — 14 adaptive tests guarded; max/avg pooling left enabled
- `test_normalize.cpp` — 6 `aten::norm` tests guarded; `frobenius_norm` / `linalg_norm` left enabled
- `test_instance_norm.cpp` — all 3 guarded (they share one `aten::instance_norm` graph)

Verified on TensorRT-RTX 1.6.1.120: `//tests/core/conversion:conversion_tests` passes 49/49 targets, including `ATenConvTransposeWithGroupConvertsCorrectly`, which covers cause 1 and is deliberately left unguarded.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
