### PR TITLE
fix: stop calling TensorRT 10.15 aliasing APIs unconditionally

### DIFF
--- a/core/runtime/TRTEngine.cpp
+++ b/core/runtime/TRTEngine.cpp
@@ -292,6 +292,10 @@ TRTEngine::TRTEngine(
   // engines built outside Torch-TensorRT). User-declared aliases (kind=kUser)
   // are preserved as-is since TRT doesn't know about them.
   this->aliased_io = aliased_io;
+// ICudaEngine::getAliasedInputTensor is not available before TRT 10.15 (e.g. Jetpack
+// L4T builds), where an engine cannot report its aliasing and the build-time map is
+// the only source of truth.
+#if NV_TENSORRT_MAJOR > 10 || (NV_TENSORRT_MAJOR == 10 && NV_TENSORRT_MINOR >= 15)
   for (const auto& out_name : this->out_binding_names) {
     // TRT returns nullptr / empty string for non-aliased outputs; any thrown
     // exception is a real error in the engine state and propagates.
@@ -315,6 +319,7 @@ TRTEngine::TRTEngine(
       it->second = AliasedIOSpec{std::string(aliased_in), AliasKind::kKVCacheUpdate};
     }
   }
+#endif
 
   // Precompute the set of input binding names that are the alias source of some
   // output (for the O(1) per-call membership test) and validate every aliased

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -9,6 +9,7 @@ import warnings
 from typing import Any, Collection, Dict, List, Optional, Sequence, Tuple, Union
 
 import sympy
+import tensorrt as trt
 import torch
 from torch.export import ExportedProgram
 from torch.export.graph_signature import InputKind
@@ -39,6 +40,9 @@ from torch_tensorrt.dynamo.conversion._ConverterRegistry import (
 )
 from torch_tensorrt.dynamo.debug._DebuggerConfig import DebuggerConfig
 from torch_tensorrt.dynamo.debug._supports_debugger import fn_supports_debugger
+from torch_tensorrt.dynamo.conversion.impl.slice_scatter import (
+    has_kv_cache_update,
+)
 from torch_tensorrt.dynamo.lowering import (
     get_decompositions,
     post_lowering,
@@ -419,6 +423,28 @@ def cross_compile_for_windows(
     return trt_gm
 
 
+def _refuse_lift_without_kv_cache_update(
+    lifted_buffers: Sequence[Tuple[str, str, torch.Tensor]],
+) -> None:
+    """Refuse a lifted mutable buffer when the engine cannot write it back.
+
+    Lifting drops the writeback copy because the engine is expected to write through
+    the aliased input. Without the KV-cache update layer that never happens, and the
+    mutation would be lost with no error at all.
+    """
+    if not lifted_buffers:
+        return
+    if has_kv_cache_update(trt.INetworkDefinition):
+        return
+    names = ", ".join(sorted(buffer_name for _, buffer_name, _ in lifted_buffers))
+    raise RuntimeError(
+        f"This model mutates module state ({names}), which needs the TensorRT "
+        "KV-cache update layer to preserve. That layer was added in TensorRT 10.15 "
+        "and this build does not have it. Use TensorRT 10.15 or newer, or keep the "
+        "stateful part of the model outside TensorRT."
+    )
+
+
 def compile(
     exported_program: ExportedProgram,
     inputs: Optional[Sequence[Sequence[Any]]] = None,
@@ -792,6 +818,7 @@ def compile(
     # module-held cache). Returns a fresh GraphModule whose forward signature
     # reflects the new placeholders.
     gm, lifted_buffers = lift_mutated_buffers(gm)
+    _refuse_lift_without_kv_cache_update(lifted_buffers)
     if lifted_buffers:
         # Append each lifted buffer as an engine input AFTER the user inputs.
         # Buffer tensors live on the gm's state; prepare an Input spec for
@@ -2005,6 +2032,7 @@ def convert_exported_program_to_serialized_trt_engine(
     lifted_buffers: List[Tuple[str, str, torch.Tensor]] = []
     if lift_mutable_buffers:
         gm, lifted_buffers = lift_mutated_buffers(gm)
+        _refuse_lift_without_kv_cache_update(lifted_buffers)
         if lifted_buffers:
             buffer_tensors = [t for _, _, t in lifted_buffers]
             buffer_inputs = prepare_inputs(buffer_tensors)

--- a/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
+++ b/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
@@ -515,8 +515,11 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
         # string for non-aliased outputs; any raised exception is a real
         # error in the engine and propagates.
         engine_aliased_io: Dict[str, Tuple[str, str]] = dict(self._aliased_io)
-        for out_name in self._output_names:
-            aliased_in = cuda_engine.get_aliased_input_tensor(out_name)
+        # TensorRT older than 10.15 has no getAliasedInputTensor, so an engine cannot
+        # report aliasing and the build-time records are the only source of truth.
+        report_aliasing = getattr(cuda_engine, "get_aliased_input_tensor", None)
+        for out_name in self._output_names if report_aliasing else ():
+            aliased_in = report_aliasing(out_name)
             if aliased_in:
                 # Engine-reported aliasing is always KV-cache-update origin
                 # (the only TRT-enforced aliasing API in 10.x).

--- a/py/torch_tensorrt/dynamo/conversion/impl/slice_scatter.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/slice_scatter.py
@@ -66,6 +66,15 @@ def _kv_eligible(
     return True, f"eligible (s_max={s_max}, write_start={start}, len={update_len})"
 
 
+def has_kv_cache_update(net: trt.INetworkDefinition) -> bool:
+    """Whether this TensorRT build can emit a KV-cache update layer.
+
+    The layer and its mode enum arrived together in TensorRT 10.15, and the write
+    through an aliased input depends on both, so probe them as one capability.
+    """
+    return hasattr(net, "add_kv_cache_update") and hasattr(trt, "KVCacheMode")
+
+
 def input_binding_name(ctx: ConversionContext, tensor: TRTTensor) -> Optional[str]:
     """If ``tensor`` is a direct network input, return its binding name, else None."""
     for i in range(ctx.net.num_inputs):
@@ -96,6 +105,18 @@ def emit_kv_cache_update_layer(
     if cache_input_name is None:
         logger.debug("KV cache update: skipped — input is not a direct network input")
         return None
+
+    # The cache is a network input being written in place, so falling back to the
+    # functional scatter would compute the right value and never write it back. That
+    # is worse than failing, so refuse instead of returning None here.
+    if not has_kv_cache_update(ctx.net):
+        raise RuntimeError(
+            f"Writing in place to the network input '{cache_input_name}' needs the "
+            "TensorRT KV-cache update layer, which was added in TensorRT 10.15. This "
+            "build does not have it, and without it the write would be computed and "
+            "then discarded. Use TensorRT 10.15 or newer, or return the updated "
+            "tensor instead of writing into an input."
+        )
 
     layer = ctx.net.add_kv_cache_update(
         cache, src, write_indices, trt.KVCacheMode.LINEAR

--- a/py/torch_tensorrt/dynamo/runtime/_TRTEngine.py
+++ b/py/torch_tensorrt/dynamo/runtime/_TRTEngine.py
@@ -665,9 +665,14 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
         Also enforces that aliased outputs are incompatible with the dynamic
         output allocator, and recomputes ``aliased_input_binding_names``.
         """
-        for out_name in self.out_binding_names:
+        # TensorRT older than 10.15 has no getAliasedInputTensor, so an engine cannot
+        # report aliasing and the deserialized map stands as-is. Only the loop below is
+        # engine-driven; everything after it must still run, because user-declared
+        # aliases exist independently of the API.
+        report_aliasing = getattr(self.cuda_engine, "get_aliased_input_tensor", None)
+        for out_name in self.out_binding_names if report_aliasing else ():
             # TRT returns None / empty string for non-aliased outputs.
-            aliased_in = self.cuda_engine.get_aliased_input_tensor(out_name)
+            aliased_in = report_aliasing(out_name)
             if not aliased_in:
                 continue
             existing = self.aliased_io.get(out_name)

--- a/tests/py/dynamo/runtime/test_aliased_io.py
+++ b/tests/py/dynamo/runtime/test_aliased_io.py
@@ -26,6 +26,7 @@ also honors aliasing by binding the aliased output to the source input's
 storage; :class:`TestPythonRuntimeAliasedIO` exercises that path directly.
 """
 
+import tensorrt as trt
 import torch
 import torch_tensorrt
 from torch.export import export
@@ -335,6 +336,95 @@ class TestPythonRuntimeAliasedIO(TestCase):
         self.assertAlmostEqual(cache.sum().item(), 64.0, places=3)
         engine.execute(self._ordered_inputs(engine, cache, torch.ones_like(upd) * 5.0))
         self.assertAlmostEqual(cache.sum().item(), 320.0, places=3)
+
+
+class TestMissingAliasingApi(TestCase):
+    """TensorRT older than 10.15 has no getAliasedInputTensor and no KV-cache
+    update layer. Reconciliation is the only consumer of the first, so a model
+    without aliasing must still work; a mutated buffer cannot be preserved
+    without the second, so it has to raise rather than lose the write."""
+
+    def test_model_without_aliasing_still_compiles(self):
+        original = getattr(trt.ICudaEngine, "get_aliased_input_tensor", None)
+        if original is not None:
+            del trt.ICudaEngine.get_aliased_input_tensor
+        try:
+
+            class Plain(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.fc = torch.nn.Linear(8, 8)
+
+                def forward(self, x):
+                    return torch.relu(self.fc(x))
+
+            inputs = (torch.randn(2, 8).cuda(),)
+            model = Plain().eval().cuda()
+            compiled = torch_tensorrt.dynamo.compile(
+                export(model, inputs),
+                inputs=list(inputs),
+                min_block_size=1,
+                truncate_double=True,
+            )
+            with torch.no_grad():
+                torch.testing.assert_close(compiled(*inputs), model(*inputs))
+        finally:
+            if original is not None:
+                trt.ICudaEngine.get_aliased_input_tensor = original
+
+    def test_mutated_buffer_is_refused(self):
+        original = getattr(trt.INetworkDefinition, "add_kv_cache_update", None)
+        if original is not None:
+            del trt.INetworkDefinition.add_kv_cache_update
+        try:
+
+            class Stateful(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.register_buffer("cache", torch.zeros(2, 8))
+
+                def forward(self, x):
+                    self.cache.copy_(x)
+                    return x + self.cache
+
+            inputs = (torch.randn(2, 8).cuda(),)
+            model = Stateful().eval().cuda()
+            with self.assertRaisesRegex(RuntimeError, "mutates module state"):
+                torch_tensorrt.dynamo.compile(
+                    export(model, inputs),
+                    inputs=list(inputs),
+                    min_block_size=1,
+                    truncate_double=True,
+                )
+        finally:
+            if original is not None:
+                trt.INetworkDefinition.add_kv_cache_update = original
+
+    def test_user_input_write_is_refused(self):
+        original = getattr(trt.INetworkDefinition, "add_kv_cache_update", None)
+        if original is not None:
+            del trt.INetworkDefinition.add_kv_cache_update
+        try:
+
+            class WritesItsInput(torch.nn.Module):
+                def forward(self, cache, update):
+                    cache[:, :, 3:4, :] = update
+                    return cache.sum()
+
+            cache = torch.zeros(1, 2, 8, 4).cuda()
+            update = torch.full((1, 2, 1, 4), 7.0).cuda()
+            model = WritesItsInput().eval().cuda()
+            with self.assertRaisesRegex(RuntimeError, "KV-cache update layer"):
+                torch_tensorrt.dynamo.compile(
+                    export(model, (cache, update)),
+                    inputs=[cache, update],
+                    min_block_size=1,
+                    truncate_double=True,
+                    use_python_runtime=True,
+                )
+        finally:
+            if original is not None:
+                trt.INetworkDefinition.add_kv_cache_update = original
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The problem

Three things Torch-TensorRT calls without checking were added in TensorRT 10.15:

- `ICudaEngine::getAliasedInputTensor` (C++)
- `ICudaEngine.get_aliased_input_tensor` (Python)
- the KV-cache update layer, with its `KVCacheMode` enum

Building against an older TensorRT fails outright:

```
core/runtime/TRTEngine.cpp: error: 'class nvinfer1::ICudaEngine'
    has no member named 'getAliasedInputTensor'
```

Once that is past, compiling any model fails, not only one with a cache:

```
File "py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py", line 519, in run
    aliased_in = cuda_engine.get_aliased_input_tensor(out_name)
AttributeError: 'ICudaEngine' object has no attribute 'get_aliased_input_tensor'
```

That loop runs after every engine build, over every output, so an ordinary model with no
aliasing at all hits it. The same call on the Python runtime fails the same way at engine
load.

## The fix

Reconciliation compares the build-time alias map against what an engine reports about
itself. A build without the API cannot report anything, so there is nothing to compare
and the build-time map already stands alone. Skip only that loop, and keep everything
after it, because user-declared aliases exist independently of the TensorRT API and their
binding names still need recomputing.

Writing through an alias is a different matter, because it cannot be emulated. Where the
code promises a write-through, it now refuses rather than quietly dropping it. Two paths
promise one:

- A cache passed in as a network input and written in place. Falling back to the
  functional scatter computed the correct return value and never touched the caller's
  tensor. That is worse than an error, because a test that only checks numbers passes
  while the cache silently stops updating.
- A mutated module buffer. Lifting removes the writeback copy, on the assumption the
  engine writes through the aliased input.

Both now raise, naming the input or the buffer and the version required:

```
Writing in place to the network input 'cache' needs the TensorRT KV-cache update
layer, which was added in TensorRT 10.15. This build does not have it, and without
it the write would be computed and then discarded. Use TensorRT 10.15 or newer, or
return the updated tensor instead of writing into an input.
```

One shared capability check backs both sites, so they cannot drift apart.

## Scope

This does not make Torch-TensorRT work on TensorRT older than 10.15. Other 10.15-only
symbols are still referenced unconditionally, including `trt.IAttention` in an annotation
that is evaluated at import time, so importing the package on 10.13 fails before any of
this runs. What this change does is take these three APIs off that list.

## Testing

```
ordinary model, aliasing API removed        compiles, matches eager
module buffer write, KV layer removed       raises, names the buffer
network input write, KV layer removed       raises, names the input
unmodified TensorRT 11.1.0.106              unchanged, matches eager
tests/py/dynamo/runtime/test_aliased_io.py  13 passed
black --check on all five changed files     clean
```

The three added tests fail without this change and pass with it. Also confirmed on an
aarch64 device with system TensorRT 10.13.3.9 that all three APIs are absent there, and
that the C++ version check evaluates false on it.
