### PR TITLE
fix(executorch): lift nested and partitioner-excluded mutable buffers

### DIFF
--- a/.github/scripts/verify-executorch-reference-runner.sh
+++ b/.github/scripts/verify-executorch-reference-runner.sh
@@ -14,6 +14,10 @@ set +x
 #   First argument: path to an existing .pte model.
 #   EXECUTORCH_SOURCE_DIR=/path/to/executorch
 #
+# Optional second argument: path to a caller-owned KV-cache decode .pte (see
+#   examples/torchtrt_executorch_example/export_kv_cache_decode.py). When given,
+#   kv_cache_decode_check is built and run against it as well.
+#
 # Optional:
 #   TensorRT_ROOT=/path/to/extracted/TensorRT
 #     If unset, the script reuses Bazel's fetched TensorRT SDK when available
@@ -29,13 +33,18 @@ set +x
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${repo_root}"
 
-if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 PATH_TO_MODEL.pte" >&2
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 PATH_TO_MODEL.pte [PATH_TO_KV_CACHE_DECODE.pte]" >&2
   exit 1
 fi
 model_path="$1"
 if [[ ! -f "${model_path}" ]]; then
   echo "ExecuTorch model not found: ${model_path}" >&2
+  exit 1
+fi
+kv_model_path="${2:-}"
+if [[ -n "${kv_model_path}" && ! -f "${kv_model_path}" ]]; then
+  echo "KV-cache decode model not found: ${kv_model_path}" >&2
   exit 1
 fi
 
@@ -274,6 +283,7 @@ require_tar_entry "torch_tensorrt/src/torch_tensorrt/executorch/CMakeLists.txt"
 require_tar_entry "torch_tensorrt/examples/executorch_reference_runner/CMakeLists.txt"
 require_tar_entry "torch_tensorrt/bin/example_executorch_runner"
 require_tar_entry "torch_tensorrt/lib/libextension_cuda.so"
+require_tar_entry "torch_tensorrt/examples/executorch_reference_runner/kv_cache_decode_check.cpp"
 require_tar_entry "torch_tensorrt/BUILD"
 
 export TORCH_TENSORRT_ROOT="${verify_root}/torch_tensorrt"
@@ -295,8 +305,13 @@ fi
 
 cmake "${cmake_args[@]}"
 
+build_targets=(example_executorch_runner)
+if [[ -n "${kv_model_path}" ]]; then
+  build_targets+=(kv_cache_decode_check)
+fi
+
 cmake --build "${verify_root}/build-executorch-reference-runner" \
-  --target example_executorch_runner \
+  --target "${build_targets[@]}" \
   -j"${MAX_JOBS:-$(nproc)}"
 
 runner_log="${verify_root}/my_runner.log"
@@ -452,3 +467,20 @@ for _log in "${runner_log}" "${packaged_runner_log}"; do
     fi
   done
 done
+
+if [[ -n "${kv_model_path}" ]]; then
+  # kv_cache_decode_check exits non-zero when a decode step does not observe the KV
+  # the previous step wrote; the grep additionally pins the assertion itself, so
+  # weakening the check inside the binary cannot quietly turn this into a no-op.
+  kv_check_log="${verify_root}/kv_cache_decode_check.log"
+  kv_check_path="${verify_root}/build-executorch-reference-runner/kv_cache_decode_check"
+  if command -v ldd >/dev/null 2>&1 &&
+    ldd "${kv_check_path}" |
+      grep -E "libtorch|libtorch_cpu|libtorch_cuda|libc10" >&2; then
+    echo "kv_cache_decode_check links PyTorch/libtorch shared libraries" >&2
+    exit 1
+  fi
+
+  "${kv_check_path}" --model_path="${kv_model_path}" 2>&1 | tee "${kv_check_log}"
+  grep -q "PASS: decode at pos=1 observed the KV written at pos=0" "${kv_check_log}"
+fi

--- a/.github/workflows/executorch-test-linux.yml
+++ b/.github/workflows/executorch-test-linux.yml
@@ -82,7 +82,10 @@ jobs:
         export EXECUTORCH_ROOT="${EXECUTORCH_SOURCE_DIR}"
         python examples/torchtrt_executorch_example/export_static_shape.py \
           --model_path="${RUNNER_TEMP}/torchtrt-python.pte"
+        python examples/torchtrt_executorch_example/export_kv_cache_decode.py \
+          --model_path="${RUNNER_TEMP}/torchtrt-kv-cache-decode.pte"
         .github/scripts/verify-executorch-reference-runner.sh \
-          "${RUNNER_TEMP}/torchtrt-python.pte"
+          "${RUNNER_TEMP}/torchtrt-python.pte" \
+          "${RUNNER_TEMP}/torchtrt-kv-cache-decode.pte"
         python examples/executorch_reference_runner/load_model.py \
           --model_path="${RUNNER_TEMP}/torchtrt-python.pte" --num_runs=1

--- a/cpp/include/torch_tensorrt/executorch/TensorRTBackend.h
+++ b/cpp/include/torch_tensorrt/executorch/TensorRTBackend.h
@@ -59,6 +59,21 @@ struct EngineHandle {
   std::vector<size_t> cached_output_sizes;
   size_t num_inputs = 0;
   size_t num_outputs = 0;
+  // Per output binding [0..num_outputs): index into input_binding_names of the
+  // input it aliases (in-place KV-cache / user alias), or -1 for a normal output.
+  // Built at init from the blob's aliased_io. The KV buffers are threaded by
+  // ExecuTorch as caller-owned mutable-buffer delegate args (input AND aliased
+  // output): execute() binds each aliased TRT output binding to its aliased
+  // input's caller-provided pointer (in-place) and reflects the result into the
+  // delegate output EValue (a no-op when the memory planner already aliased the
+  // two -> zero-copy).
+  std::vector<int> output_aliased_input_idx;
+  // Per input binding [0..num_inputs): true if any output aliases this input, so
+  // its in-place (KV/user) update must land in the caller-owned storage. Built at
+  // init from aliased_io; execute() uses it to reject a non-device-resident
+  // aliased input instead of silently staging its update into delegate scratch.
+  std::vector<bool> input_is_alias_target;
+  size_t num_aliased_outputs = 0;
   int device_id = 0;
   bool unified_memory = false;
   std::mutex mu;

--- a/cpp/include/torch_tensorrt/executorch/TensorRTBackend.h
+++ b/cpp/include/torch_tensorrt/executorch/TensorRTBackend.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * ExecuTorch backend delegate that runs TensorRT engines serialized by
- * torch_tensorrt. The processed blob uses the standalone TR01 wire format from
+ * torch_tensorrt. The processed blob uses the standalone wire format from
  * py/torch_tensorrt/executorch/serialization.py and is parsed directly here.
  * This runtime path intentionally does not depend on the legacy
  * Torch-TensorRT C++ runtime or libtorch.

--- a/cpp/include/torch_tensorrt/executorch/TensorRTBackend.h
+++ b/cpp/include/torch_tensorrt/executorch/TensorRTBackend.h
@@ -65,8 +65,7 @@ struct EngineHandle {
   // ExecuTorch as caller-owned mutable-buffer delegate args (input AND aliased
   // output): execute() binds each aliased TRT output binding to its aliased
   // input's caller-provided pointer (in-place) and reflects the result into the
-  // delegate output EValue (a no-op when the memory planner already aliased the
-  // two -> zero-copy).
+  // delegate output EValue, which ExecuTorch's write-back copy_ then reads.
   std::vector<int> output_aliased_input_idx;
   // Per input binding [0..num_inputs): true if any output aliases this input, so
   // its in-place (KV/user) update must land in the caller-owned storage. Built at

--- a/cpp/include/torch_tensorrt/executorch/TensorRTBlobHeader.h
+++ b/cpp/include/torch_tensorrt/executorch/TensorRTBlobHeader.h
@@ -8,6 +8,16 @@
 namespace torch_tensorrt {
 namespace executorch_backend {
 
+// One aliased output->input binding pair (KV-cache in-place update, or a
+// user-declared alias). The engine's output binding shares device memory with
+// the named input binding; the runtime binds the output to the input's tensor
+// so the update lands in-place in the caller-owned buffer.
+struct AliasedBinding {
+  std::string output; // output binding name
+  std::string input; // input binding name it aliases
+  std::string kind; // "kv_cache_update" (TRT-enforced) or "user"
+};
+
 struct TensorRTBlobHeader {
   uint32_t metadata_offset = 0;
   uint32_t metadata_size = 0;
@@ -15,6 +25,7 @@ struct TensorRTBlobHeader {
   uint64_t engine_size = 0;
   std::vector<std::string> input_binding_names;
   std::vector<std::string> output_binding_names;
+  std::vector<AliasedBinding> aliased_io;
   bool hardware_compatible = false;
   int device_id = 0;
 

--- a/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
+++ b/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
@@ -781,7 +781,7 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
   // Caller-owned KV: (dst = delegate output EValue ptr, src = aliased input ptr,
   // nbytes). The engine updates the aliased input in place; reflect that into the
   // delegate output EValue after enqueue so ExecuTorch's write-back copy_ sees the
-  // updated cache. Skipped when dst == src (memory planner aliased them: zero-copy).
+  // updated cache.
   std::vector<std::tuple<void*, void*, size_t>> aliased_reflects;
   for (size_t o = 0; o < num_outputs; ++o) {
     const std::string& name = engine->output_binding_names[o];
@@ -820,6 +820,9 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
         (void)executorch::runtime::resize_tensor(et_alias_out, {a_sizes, static_cast<size_t>(a_dims.nbDims)});
       }
       void* dst = et_alias_out.nbytes() > 0 ? et_alias_out.mutable_data_ptr() : nullptr;
+      // dst != bind_ptr guards against issuing a self-copy. The memory planner does
+      // not currently place the delegate's output slot on the aliased input -- the
+      // two are live at the same time -- so this holds for every aliased output.
       if (dst != nullptr && dst != bind_ptr) {
         aliased_reflects.emplace_back(dst, bind_ptr, et_alias_out.nbytes());
       }
@@ -911,8 +914,7 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
   }
 
   // Caller-owned KV: reflect each engine in-place update into its delegate output
-  // EValue (D2D on the same stream, after the engine work). No-op list under
-  // zero-copy (dst == src filtered out at bind time).
+  // EValue (D2D on the same stream, after the engine work).
   for (const auto& r : aliased_reflects) {
     cuda_err = cudaMemcpyAsync(std::get<0>(r), std::get<1>(r), std::get<2>(r), cudaMemcpyDeviceToDevice, stream);
     if (cuda_err != cudaSuccess) {
@@ -938,11 +940,10 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
   // next execute() and the destructor wait before reusing/freeing exec_ctx. The D2H
   // copies live in the must_sync branch: an output staged to host always sets
   // output_staged_to_host, so outputs_needing_copy is empty on the skip path.
-  // A non-zero-copy aliased reflect enqueues the engine's in-place update into
-  // the delegate output EValue on `stream`; ExecuTorch's buffer-mutation copy_
-  // reads that EValue after execute() returns, so the reflect must complete
-  // first. Zero-copy aliases (dst == src) record no reflect, so the common
-  // caller-owned KV fast path is untouched.
+  // An aliased reflect enqueues the engine's in-place update into the delegate
+  // output EValue on `stream`; ExecuTorch's buffer-mutation copy_ reads that EValue
+  // after execute() returns, so the reflect must complete first. A model with
+  // aliased outputs therefore always syncs here.
   const bool aliased_reflect_pending = !aliased_reflects.empty();
   const bool must_sync =
       output_staged_to_host || input_staged_from_host || aliased_reflect_pending || !caller_stream_set;

--- a/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
+++ b/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
@@ -811,13 +811,22 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
         return Error::InvalidArgument;
       }
       exec_aten::Tensor et_alias_out = out_arg->toTensor();
+      // nbytes() below sizes both the reflect copy and ExecuTorch's write-back, so
+      // the tensor has to carry the shape TRT inferred before either of them reads it.
       nvinfer1::Dims a_dims = ctx->getTensorShape(name.c_str());
-      if (a_dims.nbDims >= 0 && a_dims.nbDims <= nvinfer1::Dims::MAX_DIMS) {
-        SizesType a_sizes[nvinfer1::Dims::MAX_DIMS];
-        for (int d = 0; d < a_dims.nbDims; ++d) {
-          a_sizes[d] = static_cast<SizesType>(a_dims.d[d]);
-        }
-        (void)executorch::runtime::resize_tensor(et_alias_out, {a_sizes, static_cast<size_t>(a_dims.nbDims)});
+      if (a_dims.nbDims < 0 || a_dims.nbDims > nvinfer1::Dims::MAX_DIMS) {
+        ET_LOG(Error, "TensorRTBackend::execute: invalid rank for aliased output '%s'", name.c_str());
+        return Error::InvalidState;
+      }
+      SizesType a_sizes[nvinfer1::Dims::MAX_DIMS];
+      for (int d = 0; d < a_dims.nbDims; ++d) {
+        a_sizes[d] = static_cast<SizesType>(a_dims.d[d]);
+      }
+      Error a_resize_err =
+          executorch::runtime::resize_tensor(et_alias_out, {a_sizes, static_cast<size_t>(a_dims.nbDims)});
+      if (a_resize_err != Error::Ok) {
+        ET_LOG(Error, "TensorRTBackend::execute: resize_tensor failed for aliased output '%s'", name.c_str());
+        return a_resize_err;
       }
       void* dst = et_alias_out.nbytes() > 0 ? et_alias_out.mutable_data_ptr() : nullptr;
       // dst != bind_ptr guards against issuing a self-copy. The memory planner does

--- a/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
+++ b/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
@@ -242,7 +242,7 @@ Result<DelegateHandle*> TensorRTBackend::init(
 
   TensorRTBlobHeader header;
   if (!TensorRTBlobHeader::parse(processed->data(), processed->size(), header)) {
-    ET_LOG(Error, "TensorRTBackend::init: failed to parse TR01 TensorRT blob");
+    ET_LOG(Error, "TensorRTBackend::init: failed to parse TensorRT blob");
     return Error::InvalidProgram;
   }
 

--- a/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
+++ b/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -436,6 +437,98 @@ Result<DelegateHandle*> TensorRTBackend::init(
     return err;
   }
 
+  // Map each aliased output binding to the index of the input it aliases so
+  // execute() can bind it to that input's device pointer (in-place).
+  // Non-aliased models have an empty header.aliased_io -> all -1, unchanged path.
+  handle->output_aliased_input_idx.assign(handle->num_outputs, -1);
+  handle->input_is_alias_target.assign(handle->num_inputs, false);
+  for (const auto& ab : header.aliased_io) {
+    int oi = -1;
+    for (size_t k = 0; k < handle->output_binding_names.size(); ++k) {
+      if (handle->output_binding_names[k] == ab.output) {
+        oi = static_cast<int>(k);
+        break;
+      }
+    }
+    int ii = -1;
+    for (size_t k = 0; k < handle->input_binding_names.size(); ++k) {
+      if (handle->input_binding_names[k] == ab.input) {
+        ii = static_cast<int>(k);
+        break;
+      }
+    }
+    if (oi < 0 || ii < 0) {
+      ET_LOG(
+          Error,
+          "TensorRTBackend::init: aliased_io names not found (output='%s', input='%s')",
+          ab.output.c_str(),
+          ab.input.c_str());
+      return Error::InvalidProgram;
+    }
+    // Validate the alias kind against the two we understand. The blob parser
+    // defaults a missing "kind" to "kv_cache_update"; any other value is a
+    // corrupt or newer-than-us wire format we can't safely bind, so fail loudly
+    // rather than fall through and treat it as a KV alias (which would bind two
+    // tensors to the same storage). Mirrors the Python _reconcile_aliased_io.
+    if (ab.kind != "kv_cache_update" && ab.kind != "user") {
+      ET_LOG(
+          Error,
+          "TensorRTBackend::init: aliased_io entry (output='%s') has unknown kind '%s'",
+          ab.output.c_str(),
+          ab.kind.c_str());
+      return Error::InvalidProgram;
+    }
+    if (ab.kind == "kv_cache_update") {
+      // TensorRT's IKVCacheUpdateLayer aliasing is the source of truth for
+      // kv_cache_update; the persisted map must agree with what the engine
+      // reports, else the blob is inconsistent with its own engine.
+      // ICudaEngine::getAliasedInputTensor is TensorRT 10.15+; on older TRT (e.g.
+      // Jetson's 10.13) skip the cross-check and trust the persisted aliased_io
+      // from the blob (recorded by Torch-TensorRT at export).
+#if NV_TENSORRT_MAJOR > 10 || (NV_TENSORRT_MAJOR == 10 && NV_TENSORRT_MINOR >= 15)
+      const char* trt_alias = handle->engine->getAliasedInputTensor(ab.output.c_str());
+      if (trt_alias == nullptr || ab.input != trt_alias) {
+        ET_LOG(
+            Error,
+            "TensorRTBackend::init: kv_cache_update alias for output '%s' disagrees with the "
+            "engine (persisted input='%s', engine input='%s')",
+            ab.output.c_str(),
+            ab.input.c_str(),
+            trt_alias == nullptr ? "<none>" : trt_alias);
+        return Error::InvalidProgram;
+      }
+#endif
+    } else {
+      // AliasKind::USER aliases are declared by Torch-TensorRT and not tracked
+      // by TensorRT, so it can't validate them; confirm the aliased output and
+      // input share a shape before binding them to the same storage.
+      const nvinfer1::Dims od = handle->engine->getTensorShape(ab.output.c_str());
+      const nvinfer1::Dims id = handle->engine->getTensorShape(ab.input.c_str());
+      bool compatible = od.nbDims == id.nbDims;
+      for (int d = 0; compatible && d < od.nbDims; ++d) {
+        compatible = od.d[d] == id.d[d];
+      }
+      if (!compatible) {
+        ET_LOG(
+            Error,
+            "TensorRTBackend::init: user alias output '%s' shape is incompatible with input '%s'",
+            ab.output.c_str(),
+            ab.input.c_str());
+        return Error::InvalidProgram;
+      }
+    }
+    handle->output_aliased_input_idx[static_cast<size_t>(oi)] = ii;
+    handle->input_is_alias_target[static_cast<size_t>(ii)] = true;
+    ++handle->num_aliased_outputs;
+  }
+
+  if (handle->num_aliased_outputs > 0) {
+    ET_LOG(
+        Info,
+        "TensorRTBackend::init: %zu aliased output(s) bound in-place to caller-owned inputs",
+        handle->num_aliased_outputs);
+  }
+
   err = initialize_input_profiles(*handle);
   if (err != Error::Ok) {
     return err;
@@ -472,9 +565,17 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
 
   const size_t num_inputs = engine->num_inputs;
   const size_t num_outputs = engine->num_outputs;
-  if (args.size() < num_inputs + num_outputs) {
+  // Caller-owned KV: every input is a delegate arg, and each aliased output is
+  // threaded as a delegate output arg (the caller-owned mutable buffer's mutation
+  // slot), so all engine bindings map 1:1 to delegate args.
+  const size_t num_delegate_outputs = num_outputs;
+  const size_t num_delegate_inputs = num_inputs;
+  if (args.size() < num_delegate_inputs + num_delegate_outputs) {
     ET_LOG(
-        Error, "TensorRTBackend::execute: expected at least %zu args, got %zu", num_inputs + num_outputs, args.size());
+        Error,
+        "TensorRTBackend::execute: expected at least %zu args, got %zu",
+        num_delegate_inputs + num_delegate_outputs,
+        args.size());
     return Error::InvalidArgument;
   }
 
@@ -544,16 +645,22 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
   // ------------------------------------------------------------------
   // 1. Bind input shapes and addresses
   // ------------------------------------------------------------------
+  // Device pointer each input binding was bound to; aliased outputs reuse the
+  // pointer of the input they alias so their update lands in-place.
+  std::vector<void*> input_bind_ptrs(num_inputs, nullptr);
+  size_t arg_idx = 0; // running index into delegate args
   for (size_t i = 0; i < num_inputs; ++i) {
-    EValue* arg = args[i];
-    TORCHTRT_ET_CHECK_NOT_NULL(arg, Error::InvalidArgument, "TensorRTBackend::execute: input %zu is not a tensor", i);
+    const std::string& name = engine->input_binding_names[i];
+
+    EValue* arg = args[arg_idx++];
+    TORCHTRT_ET_CHECK_NOT_NULL(
+        arg, Error::InvalidArgument, "TensorRTBackend::execute: input arg %zu is not a tensor", i);
     if (!arg->isTensor()) {
       ET_LOG(Error, "TensorRTBackend::execute: input %zu is not a tensor", i);
       return Error::InvalidArgument;
     }
 
     exec_aten::Tensor et_in = arg->toTensor();
-    const std::string& name = engine->input_binding_names[i];
     nvinfer1::Dims dims = to_trt_dims(et_in);
     if (dims.nbDims > nvinfer1::Dims::MAX_DIMS) {
       ET_LOG(Error, "TensorRTBackend::execute: input '%s' rank exceeds TensorRT limit", name.c_str());
@@ -580,6 +687,26 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
     if (!ctx->setInputShape(name.c_str(), dims)) {
       ET_LOG(Error, "TensorRTBackend::execute: setInputShape failed for '%s'", name.c_str());
       return Error::InvalidState;
+    }
+
+    // Caller-owned aliased input: an aliased output binds in-place to this
+    // input's device pointer, so its update must land in the caller's storage.
+    // If it isn't device-resident the branches below would stage it through
+    // delegate scratch, and the in-place update (bound to that scratch) would be
+    // silently lost on the next execute() when the staging copy re-reads the
+    // caller's unchanged buffer. Fail loudly instead.
+    if (engine->input_is_alias_target[i]) {
+      const bool device_resident =
+          et_in.nbytes() > 0 && (engine->unified_memory || is_cuda_accessible_ptr(et_in.const_data_ptr()));
+      if (!device_resident) {
+        ET_LOG(
+            Error,
+            "TensorRTBackend::execute: aliased input '%s' must be device-resident (non-empty and "
+            "CUDA-accessible or unified memory); its caller-owned in-place update cannot be staged "
+            "through host scratch",
+            name.c_str());
+        return Error::InvalidArgument;
+      }
     }
 
     void* bind_ptr = nullptr;
@@ -621,6 +748,7 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
       }
     }
 
+    input_bind_ptrs[i] = bind_ptr;
     if (!ctx->setTensorAddress(name.c_str(), bind_ptr)) {
       ET_LOG(Error, "TensorRTBackend::execute: setTensorAddress failed for input '%s'", name.c_str());
       return Error::InvalidState;
@@ -648,9 +776,58 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
   // nbytes() and before the Python binding reads back the shape.
   // If the buffer is CPU, stage through a temporary CUDA allocation.
   // ------------------------------------------------------------------
+  // (arg index, device_src ptr) for outputs staged through a device buffer.
   std::vector<std::pair<size_t, void*>> outputs_needing_copy;
+  // Caller-owned KV: (dst = delegate output EValue ptr, src = aliased input ptr,
+  // nbytes). The engine updates the aliased input in place; reflect that into the
+  // delegate output EValue after enqueue so ExecuTorch's write-back copy_ sees the
+  // updated cache. Skipped when dst == src (memory planner aliased them: zero-copy).
+  std::vector<std::tuple<void*, void*, size_t>> aliased_reflects;
   for (size_t o = 0; o < num_outputs; ++o) {
-    EValue* arg = args[num_inputs + o];
+    const std::string& name = engine->output_binding_names[o];
+
+    // Aliased output (KV-cache / user): the engine updates the aliased input in
+    // place, so bind this output binding to the aliased input's device pointer.
+    const int alias_in = engine->output_aliased_input_idx[o];
+    if (alias_in >= 0) {
+      void* bind_ptr = input_bind_ptrs[static_cast<size_t>(alias_in)];
+      if (bind_ptr == nullptr) {
+        ET_LOG(Error, "TensorRTBackend::execute: aliased output '%s' has no bound input pointer", name.c_str());
+        return Error::InvalidState;
+      }
+      if (!ctx->setTensorAddress(name.c_str(), bind_ptr)) {
+        ET_LOG(Error, "TensorRTBackend::execute: setTensorAddress failed for aliased output '%s'", name.c_str());
+        return Error::InvalidState;
+      }
+      // The aliased output IS a delegate output arg (the caller-owned mutable
+      // buffer's mutation slot). Consume it and record a reflect so ExecuTorch's
+      // write-back copy_ sees the engine's in-place update.
+      const size_t arg_i = arg_idx++;
+      EValue* out_arg = args[arg_i];
+      TORCHTRT_ET_CHECK_NOT_NULL(
+          out_arg, Error::InvalidArgument, "TensorRTBackend::execute: aliased output %zu is not a tensor", o);
+      if (!out_arg->isTensor()) {
+        ET_LOG(Error, "TensorRTBackend::execute: aliased output %zu is not a tensor", o);
+        return Error::InvalidArgument;
+      }
+      exec_aten::Tensor et_alias_out = out_arg->toTensor();
+      nvinfer1::Dims a_dims = ctx->getTensorShape(name.c_str());
+      if (a_dims.nbDims >= 0 && a_dims.nbDims <= nvinfer1::Dims::MAX_DIMS) {
+        SizesType a_sizes[nvinfer1::Dims::MAX_DIMS];
+        for (int d = 0; d < a_dims.nbDims; ++d) {
+          a_sizes[d] = static_cast<SizesType>(a_dims.d[d]);
+        }
+        (void)executorch::runtime::resize_tensor(et_alias_out, {a_sizes, static_cast<size_t>(a_dims.nbDims)});
+      }
+      void* dst = et_alias_out.nbytes() > 0 ? et_alias_out.mutable_data_ptr() : nullptr;
+      if (dst != nullptr && dst != bind_ptr) {
+        aliased_reflects.emplace_back(dst, bind_ptr, et_alias_out.nbytes());
+      }
+      continue;
+    }
+
+    const size_t arg_i = arg_idx++; // continue the shared running arg index after the inputs
+    EValue* arg = args[arg_i];
     TORCHTRT_ET_CHECK_NOT_NULL(arg, Error::InvalidArgument, "TensorRTBackend::execute: output %zu is not a tensor", o);
     if (!arg->isTensor()) {
       ET_LOG(Error, "TensorRTBackend::execute: output %zu is not a tensor", o);
@@ -658,7 +835,6 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
     }
 
     exec_aten::Tensor et_out = arg->toTensor();
-    const std::string& name = engine->output_binding_names[o];
 
     // Update the ExecuTorch tensor shape to the actual TRT output shape.
     // getTensorShape() is valid after inferShapes() has been called.
@@ -712,7 +888,7 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
       }
       bind_ptr = engine->cached_output_ptrs[o];
       output_staged_to_host = true;
-      outputs_needing_copy.push_back({o, bind_ptr});
+      outputs_needing_copy.push_back({arg_i, bind_ptr});
     }
 
     if (!ctx->setTensorAddress(name.c_str(), bind_ptr)) {
@@ -734,6 +910,24 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
     return Error::InvalidState;
   }
 
+  // Caller-owned KV: reflect each engine in-place update into its delegate output
+  // EValue (D2D on the same stream, after the engine work). No-op list under
+  // zero-copy (dst == src filtered out at bind time).
+  for (const auto& r : aliased_reflects) {
+    cuda_err = cudaMemcpyAsync(std::get<0>(r), std::get<1>(r), std::get<2>(r), cudaMemcpyDeviceToDevice, stream);
+    if (cuda_err != cudaSuccess) {
+      ET_LOG(
+          Error, "TensorRTBackend::execute: aliased-output reflect D2D copy failed: %s", cudaGetErrorString(cuda_err));
+      // enqueueV3 already submitted engine work to `stream`, and inflight_pending
+      // is not armed until the end of the happy path -- drain now so a later
+      // execute() or the destructor never reconfigures/frees exec_ctx while this
+      // enqueue is still running.
+      (void)cudaStreamSynchronize(stream);
+      engine->inflight_pending = false;
+      return Error::InvalidProgram;
+    }
+  }
+
   // The engine work is now in flight on `stream`. Decide whether to wait for it:
   //   must_sync = an output is staged to host (the caller reads the D2H result on
   //   return), an input was staged from host (its async H2D read the caller's host
@@ -744,11 +938,18 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
   // next execute() and the destructor wait before reusing/freeing exec_ctx. The D2H
   // copies live in the must_sync branch: an output staged to host always sets
   // output_staged_to_host, so outputs_needing_copy is empty on the skip path.
-  const bool must_sync = output_staged_to_host || input_staged_from_host || !caller_stream_set;
+  // A non-zero-copy aliased reflect enqueues the engine's in-place update into
+  // the delegate output EValue on `stream`; ExecuTorch's buffer-mutation copy_
+  // reads that EValue after execute() returns, so the reflect must complete
+  // first. Zero-copy aliases (dst == src) record no reflect, so the common
+  // caller-owned KV fast path is untouched.
+  const bool aliased_reflect_pending = !aliased_reflects.empty();
+  const bool must_sync =
+      output_staged_to_host || input_staged_from_host || aliased_reflect_pending || !caller_stream_set;
   if (must_sync) {
     Error copy_err = Error::Ok;
     for (auto& output : outputs_needing_copy) {
-      exec_aten::Tensor et_out = args[num_inputs + output.first]->toTensor();
+      exec_aten::Tensor et_out = args[output.first]->toTensor();
       cuda_err =
           cudaMemcpyAsync(et_out.mutable_data_ptr(), output.second, et_out.nbytes(), cudaMemcpyDeviceToHost, stream);
       if (cuda_err != cudaSuccess) {

--- a/cpp/src/torch_tensorrt/executorch/TensorRTBlobHeader.cpp
+++ b/cpp/src/torch_tensorrt/executorch/TensorRTBlobHeader.cpp
@@ -136,6 +136,7 @@ bool parse_int_after_key(const std::string& json, std::size_t search_from, const
 bool parse_metadata_json(const std::string& json, TensorRTBlobHeader& out) {
   out.input_binding_names.clear();
   out.output_binding_names.clear();
+  out.aliased_io.clear();
   out.hardware_compatible = false;
   out.device_id = 0;
 
@@ -225,6 +226,84 @@ bool parse_metadata_json(const std::string& json, TensorRTBlobHeader& out) {
         out.input_binding_names.push_back(name);
       } else {
         out.output_binding_names.push_back(name);
+      }
+    }
+  }
+
+  // Optional aliased_io array: [{"output":..,"input":..,"kind":..}, ...].
+  // Absent in older blobs -> leave empty (backward compatible). Mirrors the
+  // io_bindings walk above using the same string helpers.
+  const std::size_t alias_key = json.find("\"aliased_io\"");
+  if (alias_key != std::string::npos) {
+    std::size_t apos = json.find('[', alias_key);
+    if (apos == std::string::npos) {
+      return false;
+    }
+    ++apos;
+    while (true) {
+      apos = skip_ws(json, apos);
+      if (apos >= json.size()) {
+        return false;
+      }
+      if (json[apos] == ']') {
+        ++apos;
+        break;
+      }
+      if (json[apos] == ',') {
+        ++apos;
+        continue;
+      }
+      if (json[apos] != '{') {
+        return false;
+      }
+      ++apos;
+
+      AliasedBinding ab;
+      while (true) {
+        apos = skip_ws(json, apos);
+        if (apos >= json.size()) {
+          return false;
+        }
+        if (json[apos] == '}') {
+          ++apos;
+          break;
+        }
+        if (json[apos] == ',') {
+          ++apos;
+          continue;
+        }
+        std::string key;
+        apos = parse_string(json, apos, key);
+        if (apos == std::string::npos) {
+          return false;
+        }
+        apos = skip_ws(json, apos);
+        if (apos >= json.size() || json[apos] != ':') {
+          return false;
+        }
+        apos = skip_ws(json, apos + 1);
+        if (key == "output") {
+          apos = parse_string(json, apos, ab.output);
+        } else if (key == "input") {
+          apos = parse_string(json, apos, ab.input);
+        } else if (key == "kind") {
+          apos = parse_string(json, apos, ab.kind);
+        } else {
+          apos = skip_value(json, apos);
+        }
+        if (apos == std::string::npos) {
+          return false;
+        }
+      }
+      if (!ab.output.empty() && !ab.input.empty()) {
+        // A missing "kind" key means an older blob (the Python serializer omits
+        // it for KV aliases); default to the TRT-enforced kind so init()'s kind
+        // validation treats an absent key the same as the Python runtime rather
+        // than rejecting it as unknown.
+        if (ab.kind.empty()) {
+          ab.kind = "kv_cache_update";
+        }
+        out.aliased_io.push_back(std::move(ab));
       }
     }
   }

--- a/cpp/src/torch_tensorrt/executorch/TensorRTBlobHeader.cpp
+++ b/cpp/src/torch_tensorrt/executorch/TensorRTBlobHeader.cpp
@@ -9,7 +9,10 @@ namespace torch_tensorrt {
 namespace executorch_backend {
 namespace {
 
+// TR02 marks a blob whose metadata carries aliased_io; TR01 is one without. This
+// parser handles aliased_io, so it accepts either.
 constexpr char TENSORRT_MAGIC[4] = {'T', 'R', '0', '1'};
+constexpr char TENSORRT_MAGIC_ALIASED_IO[4] = {'T', 'R', '0', '2'};
 constexpr uint32_t METADATA_OFFSET_FIELD_OFFSET = 4;
 constexpr uint32_t METADATA_SIZE_FIELD_OFFSET = 8;
 constexpr uint32_t ENGINE_OFFSET_FIELD_OFFSET = 12;
@@ -324,7 +327,8 @@ bool TensorRTBlobHeader::parse(const void* data, std::size_t size, TensorRTBlobH
   }
 
   const auto* bytes = static_cast<const uint8_t*>(data);
-  if (std::memcmp(bytes, TENSORRT_MAGIC, sizeof(TENSORRT_MAGIC)) != 0) {
+  if (std::memcmp(bytes, TENSORRT_MAGIC, sizeof(TENSORRT_MAGIC)) != 0 &&
+      std::memcmp(bytes, TENSORRT_MAGIC_ALIASED_IO, sizeof(TENSORRT_MAGIC_ALIASED_IO)) != 0) {
     return false;
   }
 

--- a/examples/executorch_reference_runner/BUILD
+++ b/examples/executorch_reference_runner/BUILD
@@ -7,6 +7,7 @@ filegroup(
     srcs = [
         "CMakeLists.txt",
         "README.md",
+        "kv_cache_decode_check.cpp",
         "load_model.py",
         "main.cpp",
     ],
@@ -27,5 +28,16 @@ cc_binary(
         "@executorch//:executorch_core",
         "@executorch//:executorch_file_data_loader",
         "@executorch//:extension_cuda",
+    ],
+)
+
+cc_binary(
+    name = "kv_cache_decode_check",
+    srcs = ["kv_cache_decode_check.cpp"],
+    deps = [
+        "//cpp:tensorrt_executorch_backend",
+        "@cuda//:cudart",
+        "@executorch//:executorch_core",
+        "@executorch//:executorch_file_data_loader",
     ],
 )

--- a/examples/executorch_reference_runner/CMakeLists.txt
+++ b/examples/executorch_reference_runner/CMakeLists.txt
@@ -66,3 +66,18 @@ target_link_libraries(
     executorch::extensions
     executorch::kernels
     torchtrt::executorch_backend)
+
+# Caller-owned KV-cache persistence check (see kv_cache_decode_check.cpp). It
+# cudaMalloc's the device-tagged planned arenas that hold the KV buffers and
+# copies the logits back to host, so it links the CUDA runtime directly.
+find_package(CUDAToolkit REQUIRED)
+add_executable(kv_cache_decode_check kv_cache_decode_check.cpp)
+target_link_libraries(
+  kv_cache_decode_check
+  PRIVATE
+    executorch
+    executorch::backends
+    executorch::extensions
+    executorch::kernels
+    torchtrt::executorch_backend
+    CUDA::cudart)

--- a/examples/executorch_reference_runner/README.md
+++ b/examples/executorch_reference_runner/README.md
@@ -178,3 +178,30 @@ result links no libtorch and no libc10.
 This path is verified by hand, not in CI: the CI configuration builds the runner
 without the CUDA delegate. It also takes the synchronized path, because the method
 inputs and outputs are host-backed.
+
+## Caller-Owned KV-Cache Persistence Check
+
+`kv_cache_decode_check` is a small self-asserting runner for a caller-owned
+KV-cache decode `.pte` (its aliased KV output is bound in place to the caller's
+mutable buffer, which persists across `execute()` calls).
+
+Export a minimal single-layer decode model:
+
+```bash
+python examples/torchtrt_executorch_example/export_kv_cache_decode.py \
+  --model_path=kv_cache_decode.pte
+```
+
+The same CMake build produces the check runner (`kv_cache_decode_check`
+target). Run it:
+
+```bash
+./build-executorch-reference-runner/kv_cache_decode_check --model_path=kv_cache_decode.pte
+```
+
+It loads the method twice (each starting from a zeroed cache) and runs a decode
+at `input_pos=1` once with no prior step and once after a step at `input_pos=0`.
+Because the causal attention at position 1 covers positions 0..1, the two logits
+differ only if the KV written at position 0 persisted across `execute()` calls.
+The runner prints `[kv-check] PASS` and returns 0 on success, or fails if the
+two are identical (the update did not persist). It requires a CUDA device.

--- a/examples/executorch_reference_runner/kv_cache_decode_check.cpp
+++ b/examples/executorch_reference_runner/kv_cache_decode_check.cpp
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Caller-owned KV-cache persistence check for a Torch-TensorRT ExecuTorch .pte.
+ *
+ * Exercises the caller-owned KV contract: the engine's aliased KV output is
+ * bound in place to the caller's mutable buffer, which persists across
+ * execute() calls. Given a single-layer decode .pte (see
+ * examples/torchtrt_executorch_example/export_kv_cache_decode.py) with signature
+ * forward(tokens[1,1], input_pos[1]) -> logits, this runs two scenarios on
+ * FRESH method loads (each starts from a zeroed cache):
+ *
+ *   A) one decode at input_pos=1                  (no prior write at pos 0)
+ *   B) a decode at input_pos=0, then at input_pos=1
+ *
+ * At input_pos=1 the causal attention covers positions 0..1. If the cache is
+ * shared across execute() calls, scenario B's second step sees the key/value
+ * step 0 wrote at position 0, so its logits differ from scenario A (whose
+ * position-0 slot is still zero). Equal logits mean the update did not persist
+ * (cache reset per call, or the aliased output bound to scratch), so we fail.
+ *
+ * Usage:
+ *   kv_cache_decode_check --model_path=kv_cache_decode.pte [--tol=1e-3]
+ */
+
+#include <cinttypes>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include <executorch/extension/data_loader/file_data_loader.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/evalue.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/executor/method.h>
+#include <executorch/runtime/executor/method_meta.h>
+#include <executorch/runtime/executor/program.h>
+#include <executorch/runtime/platform/log.h>
+#include <executorch/runtime/platform/runtime.h>
+
+using executorch::extension::FileDataLoader;
+using executorch::runtime::Error;
+using executorch::runtime::EValue;
+using executorch::runtime::HierarchicalAllocator;
+using executorch::runtime::MemoryAllocator;
+using executorch::runtime::MemoryManager;
+using executorch::runtime::Method;
+using executorch::runtime::MethodMeta;
+using executorch::runtime::Program;
+using executorch::runtime::Result;
+using executorch::runtime::Span;
+using executorch::runtime::TensorInfo;
+
+static const char* get_flag(int argc, char** argv, const char* flag, const char* def) {
+  const size_t n = strlen(flag);
+  for (int i = 1; i < argc; ++i) {
+    if (strncmp(argv[i], flag, n) == 0 && argv[i][n] == '=') {
+      return argv[i] + n + 1;
+    }
+  }
+  return def;
+}
+
+// Load a FRESH method (zeroed caller-owned buffers), run one decode step per
+// entry in `positions` (token id fixed to 1, input_pos = the position), and
+// return the final step's first output as host floats.
+static std::vector<float> run_decode(Program& program, const char* method_name, const std::vector<int64_t>& positions) {
+  Result<MethodMeta> method_meta = program.method_meta(method_name);
+  ET_CHECK_MSG(method_meta.ok(), "method_meta failed: 0x%" PRIx32, static_cast<uint32_t>(method_meta.error()));
+
+  auto method_pool = std::make_unique<uint8_t[]>(4 * 1024U * 1024U);
+  auto temp_pool = std::make_unique<uint8_t[]>(1 * 1024U * 1024U);
+  MemoryAllocator method_allocator{4 * 1024U * 1024U, method_pool.get()};
+  MemoryAllocator temp_allocator{1 * 1024U * 1024U, temp_pool.get()};
+
+  // Caller-owned KV buffers live in the memory-planned arenas. Arenas tagged
+  // CUDA (by PropagateDevicePass, for device tensors a delegate reads/writes)
+  // must be backed by real device memory -- otherwise the aliased KV input is
+  // not device-resident and the backend rejects it.
+  std::vector<std::unique_ptr<uint8_t[]>> host_arenas;
+  std::vector<void*> cuda_arenas;
+  std::vector<Span<uint8_t>> planned_spans;
+  const size_t num_planned = method_meta->num_memory_planned_buffers();
+  for (size_t i = 0; i < num_planned; ++i) {
+    const size_t sz = static_cast<size_t>(method_meta->memory_planned_buffer_size(i).get());
+    auto dev = method_meta->memory_planned_buffer_device(i);
+    if (dev.ok() && dev.get().type() == executorch::runtime::etensor::DeviceType::CUDA) {
+      void* p = nullptr;
+      ET_CHECK_MSG(cudaMalloc(&p, sz) == cudaSuccess, "cudaMalloc planned buffer %zu failed", i);
+      cuda_arenas.push_back(p);
+      planned_spans.push_back({reinterpret_cast<uint8_t*>(p), sz});
+    } else {
+      host_arenas.push_back(std::make_unique<uint8_t[]>(sz));
+      planned_spans.push_back({host_arenas.back().get(), sz});
+    }
+  }
+  HierarchicalAllocator planned_memory{{planned_spans.data(), planned_spans.size()}};
+  MemoryManager memory_manager{&method_allocator, &planned_memory, &temp_allocator};
+
+  Result<Method> method = program.load_method(method_name, &memory_manager, nullptr);
+  ET_CHECK_MSG(method.ok(), "load_method failed: 0x%" PRIx32, static_cast<uint32_t>(method.error()));
+
+  // One int64 tensor per declared input (numel==1 for a decode step): input 0 is
+  // the token id, the rest carry input_pos. Rank is read from method_meta so this
+  // works whether input_pos is rank-1 ([1]) or rank-2 ([1,1]).
+  const size_t num_inputs = method_meta->num_inputs();
+  std::vector<std::vector<int64_t>> data(num_inputs);
+  std::vector<std::vector<exec_aten::SizesType>> sizes(num_inputs);
+  std::vector<std::vector<exec_aten::DimOrderType>> dim_order(num_inputs);
+  std::vector<std::vector<exec_aten::StridesType>> strides(num_inputs);
+  std::vector<exec_aten::TensorImpl> impls;
+  impls.reserve(num_inputs);
+  for (size_t i = 0; i < num_inputs; ++i) {
+    Result<TensorInfo> ti = method_meta->input_tensor_meta(i);
+    ET_CHECK_MSG(ti.ok(), "input_tensor_meta(%zu) failed", i);
+    const auto& s = ti->sizes();
+    const ssize_t nd = static_cast<ssize_t>(s.size());
+    sizes[i].assign(s.begin(), s.end());
+    dim_order[i].resize(nd);
+    strides[i].resize(nd);
+    exec_aten::StridesType stride = 1;
+    for (ssize_t d = nd - 1; d >= 0; --d) {
+      dim_order[i][d] = static_cast<exec_aten::DimOrderType>(d);
+      strides[i][d] = stride;
+      stride *= static_cast<exec_aten::StridesType>(sizes[i][d]);
+    }
+    size_t numel = 1;
+    for (auto x : sizes[i])
+      numel *= static_cast<size_t>(x);
+    data[i].assign(numel, i == 0 ? 1 : 0);
+    impls.emplace_back(
+        exec_aten::ScalarType::Long, nd, sizes[i].data(), data[i].data(), dim_order[i].data(), strides[i].data());
+  }
+
+  for (int64_t pos : positions) {
+    for (size_t i = 1; i < num_inputs; ++i) {
+      std::fill(data[i].begin(), data[i].end(), pos);
+    }
+    for (size_t i = 0; i < num_inputs; ++i) {
+      ET_CHECK(method->set_input(EValue(exec_aten::Tensor(&impls[i])), i) == Error::Ok);
+    }
+    ET_CHECK_MSG(method->execute() == Error::Ok, "execute() failed at pos %" PRId64, pos);
+  }
+
+  EValue out;
+  ET_CHECK_MSG(method->get_outputs(&out, 1) == Error::Ok, "get_outputs failed");
+  ET_CHECK_MSG(out.isTensor(), "output 0 is not a tensor");
+  exec_aten::Tensor t = out.toTensor();
+  ET_CHECK_MSG(t.scalar_type() == exec_aten::ScalarType::Float, "expected float logits output");
+  // The output may be device-resident; cudaMemcpyDefault copies from host or
+  // device. execute() synchronized (no caller stream) so the result is ready.
+  std::vector<float> result(static_cast<size_t>(t.numel()));
+  ET_CHECK_MSG(
+      cudaMemcpy(result.data(), t.const_data_ptr(), result.size() * sizeof(float), cudaMemcpyDefault) == cudaSuccess,
+      "cudaMemcpy of logits to host failed");
+  for (void* p : cuda_arenas) {
+    cudaFree(p);
+  }
+  return result;
+}
+
+int main(int argc, char** argv) {
+  executorch::runtime::runtime_init();
+  const char* model_path = get_flag(argc, argv, "--model_path", "kv_cache_decode.pte");
+  const double tol = atof(get_flag(argc, argv, "--tol", "1e-3"));
+
+  Result<FileDataLoader> loader = FileDataLoader::from(model_path);
+  ET_CHECK_MSG(loader.ok(), "FileDataLoader::from('%s') failed", model_path);
+  auto loader_ptr = std::make_unique<FileDataLoader>(std::move(loader.get()));
+  Result<Program> program = Program::load(loader_ptr.get());
+  ET_CHECK_MSG(program.ok(), "Failed to parse model '%s'", model_path);
+
+  auto name = program->get_method_name(0);
+  ET_CHECK_MSG(name.ok(), "Program has no methods");
+  const char* method_name = *name;
+  ET_LOG(Info, "Loaded '%s' method '%s'", model_path, method_name);
+
+  // A: pos=1 from a zeroed cache. B: pos=0 then pos=1 (second step sees pos 0).
+  std::vector<float> a = run_decode(*program, method_name, {1});
+  std::vector<float> b = run_decode(*program, method_name, {0, 1});
+
+  ET_CHECK_MSG(a.size() == b.size() && !a.empty(), "output size mismatch (%zu vs %zu)", a.size(), b.size());
+  double max_abs_diff = 0.0;
+  for (size_t i = 0; i < a.size(); ++i) {
+    max_abs_diff = std::max(max_abs_diff, std::fabs(static_cast<double>(a[i]) - static_cast<double>(b[i])));
+  }
+
+  fprintf(
+      stderr,
+      "[kv-check] logits numel=%zu  max|A(no-history) - B(with-history)| = %.6g  (tol=%.3g)\n",
+      a.size(),
+      max_abs_diff,
+      tol);
+  if (max_abs_diff > tol) {
+    fprintf(stderr, "[kv-check] PASS: decode at pos=1 observed the KV written at pos=0 across execute() calls.\n");
+    return 0;
+  }
+  fprintf(stderr, "[kv-check] FAIL: outputs are identical -> the KV write did not persist across execute() calls.\n");
+  return 1;
+}

--- a/examples/torchtrt_executorch_example/export_kv_cache_decode.py
+++ b/examples/torchtrt_executorch_example/export_kv_cache_decode.py
@@ -1,0 +1,115 @@
+"""
+.. _executorch_export_kv_cache:
+
+Exporting a Caller-Owned KV-Cache Decode Model to ExecuTorch (.pte)
+==================================================================
+
+This example exports a minimal single-layer attention decode step whose KV cache
+is a registered buffer updated in place with ``index_copy_``. Torch-TensorRT
+carries the cache as a *caller-owned* mutable buffer through the ExecuTorch
+delegate, so the engine's aliased KV output is bound in place to the caller's
+buffer and persists across ``execute()`` calls.
+
+The companion ``kv_cache_decode_check`` reference runner loads the resulting
+``.pte`` and asserts that a decode step observes the KV a previous step wrote
+(i.e. the cache is shared across ``execute()`` calls).
+
+Prerequisites
+-------------
+Install Torch-TensorRT with the ExecuTorch extra before running this example::
+
+    pip install -e ".[executorch]"
+"""
+
+import argparse
+
+import torch
+import torch_tensorrt
+
+VOCAB = 64
+DIM = 32
+HEADS = 2
+HEAD_DIM = 16
+MAX_LEN = 16
+
+
+class KVDecodeStep(torch.nn.Module):
+    """One attention layer with an in-place (index_copy_) KV cache.
+
+    ``forward(tokens[1,1], input_pos[1]) -> logits[1,1,VOCAB]``. The ``k_cache`` /
+    ``v_cache`` buffers are written at ``input_pos`` and attended over up to
+    ``input_pos`` (causal), so a later step's output depends on earlier steps'
+    writes -- which only holds if the cache persists across ``execute()`` calls.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.embed = torch.nn.Embedding(VOCAB, DIM)
+        self.pos_embed = torch.nn.Embedding(MAX_LEN, DIM)
+        self.q = torch.nn.Linear(DIM, HEADS * HEAD_DIM, bias=False)
+        self.k = torch.nn.Linear(DIM, HEADS * HEAD_DIM, bias=False)
+        self.v = torch.nn.Linear(DIM, HEADS * HEAD_DIM, bias=False)
+        self.o = torch.nn.Linear(HEADS * HEAD_DIM, DIM, bias=False)
+        self.lm = torch.nn.Linear(DIM, VOCAB, bias=False)
+        self.register_buffer("k_cache", torch.zeros(1, HEADS, MAX_LEN, HEAD_DIM))
+        self.register_buffer("v_cache", torch.zeros(1, HEADS, MAX_LEN, HEAD_DIM))
+
+    def forward(self, tokens: torch.Tensor, input_pos: torch.Tensor) -> torch.Tensor:
+        pos_idx = input_pos.reshape(-1)
+        pos = input_pos.reshape(())
+        x = self.embed(tokens) + self.pos_embed(input_pos.reshape(1, 1))
+
+        def split_heads(proj: torch.Tensor) -> torch.Tensor:
+            return proj.view(1, 1, HEADS, HEAD_DIM).transpose(1, 2)
+
+        q = split_heads(self.q(x))
+        k = split_heads(self.k(x))
+        v = split_heads(self.v(x))
+
+        self.k_cache.index_copy_(2, pos_idx, k)
+        self.v_cache.index_copy_(2, pos_idx, v)
+
+        scores = (q @ self.k_cache.transpose(-1, -2)) / (HEAD_DIM**0.5)
+        allowed = torch.arange(MAX_LEN, device=x.device) <= pos
+        bias = torch.where(
+            allowed,
+            torch.zeros((), dtype=x.dtype, device=x.device),
+            torch.full((), torch.finfo(x.dtype).min, dtype=x.dtype, device=x.device),
+        )
+        attn = torch.softmax(scores + bias.view(1, 1, 1, MAX_LEN), dim=-1)
+        out = (attn @ self.v_cache).transpose(1, 2).reshape(1, 1, HEADS * HEAD_DIM)
+        return self.lm(self.o(out))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_path", default="kv_cache_decode.pte", help="Path to save the .pte"
+    )
+    args = parser.parse_args()
+
+    with torch.no_grad():
+        torch.manual_seed(0)
+        model = KVDecodeStep().eval().cuda()
+        tokens = torch.zeros(1, 1, dtype=torch.long).cuda()
+        input_pos = torch.tensor([0], dtype=torch.long).cuda()
+
+        exported_program = torch.export.export(model, (tokens, input_pos))
+        trt_gm = torch_tensorrt.dynamo.compile(
+            exported_program,
+            arg_inputs=(tokens, input_pos),
+            min_block_size=1,
+            truncate_double=True,
+        )
+        torch_tensorrt.save(
+            trt_gm,
+            args.model_path,
+            output_format="executorch",
+            arg_inputs=(tokens, input_pos),
+            retrace=False,
+        )
+        print(f"Saved {args.model_path} successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -1121,6 +1121,14 @@ def save(
                 **kwargs,
             )
         else:
+            # torch.export truncates the engines' aliased KV outputs at the fx
+            # boundary, so a retraced program's signature omits an update the engine
+            # performs unless the mutations are re-declared; the legacy exporter
+            # instead exposes them at transform time. The declaration pass skips
+            # buffers that already carry a spec, so every branch below can run it
+            # whichever exporter produced the program. aot_inductor is left
+            # undeclared: whether an aliased in-place mutation survives
+            # functionalization under inductor is unverified.
             if not retrace:
                 from torch_tensorrt.dynamo._exporter import export
 
@@ -1141,7 +1149,15 @@ def save(
                     dynamic_shapes=dynamic_shapes,
                     use_legacy_exporter=_use_legacy,
                 )
+
+                from torch_tensorrt.dynamo._exporter import (
+                    _declare_aliased_kv_mutations_on_ep,
+                )
+
                 if output_format == "exported_program":
+                    # Must precede normalization, which rewrites the engine constants
+                    # this pass reads aliased_io from.
+                    exp_program = _declare_aliased_kv_mutations_on_ep(exp_program)
                     _normalize_engine_constants_to_python(exp_program)
                     function_overload_with_kwargs(
                         torch.export.save,
@@ -1162,6 +1178,7 @@ def save(
                         package_path=file_path,
                     )
                 elif output_format == "executorch":
+                    exp_program = _declare_aliased_kv_mutations_on_ep(exp_program)
                     _save_as_executorch(
                         exp_program,
                         file_path,
@@ -1237,8 +1254,6 @@ def save(
                     _declare_aliased_kv_mutations_on_ep,
                 )
 
-                # aot_inductor is left undeclared: whether an aliased in-place mutation
-                # survives functionalization under inductor is unverified.
                 if output_format == "aot_inductor" and any(
                     getattr(sub, "aliased_io", None)
                     for _sub_name, sub in module.named_modules()
@@ -1251,11 +1266,8 @@ def save(
                     )
 
                 if output_format == "exported_program":
-                    # torch.export truncates the engines' aliased KV outputs at the fx
-                    # boundary for every format, so the mutation has to be re-declared or
-                    # the signature omits an update the engine performs. Must precede
-                    # normalization, which rewrites the engine constants this pass reads
-                    # aliased_io from.
+                    # Must precede normalization, which rewrites the engine constants
+                    # this pass reads aliased_io from.
                     exp_program = _declare_aliased_kv_mutations_on_ep(exp_program)
                     _normalize_engine_constants_to_python(exp_program)
                     function_overload_with_kwargs(
@@ -1277,8 +1289,6 @@ def save(
                         package_path=file_path,
                     )
                 elif output_format == "executorch":
-                    # retrace=True: torch.export truncates the engines' aliased KV
-                    # outputs, so declare them as buffer mutations before lowering.
                     exp_program = _declare_aliased_kv_mutations_on_ep(exp_program)
                     _save_as_executorch(
                         exp_program,

--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -1129,6 +1129,12 @@ def save(
             # whichever exporter produced the program. aot_inductor is left
             # undeclared: whether an aliased in-place mutation survives
             # functionalization under inductor is unverified.
+            #
+            # Copy-back buffers need the same declaration, but only the retrace=True
+            # branches pass them. Unlike the KV path the pass reclassifies the trailing
+            # copyback_buffers outputs unconditionally, so running it on a program the
+            # legacy exporter already declared would re-slice outputs that are no
+            # longer the trailing ones.
             if not retrace:
                 from torch_tensorrt.dynamo._exporter import export
 
@@ -1153,6 +1159,16 @@ def save(
                 from torch_tensorrt.dynamo._exporter import (
                     _declare_aliased_kv_mutations_on_ep,
                 )
+
+                # The legacy exporter is the only thing that declares copy-back on this
+                # path, so this combination leaves it undeclared.
+                if not _use_legacy and module.meta.get("_copyback_mutation_buffers"):
+                    logger.warning(
+                        "Module has non-KV mutable buffer(s) needing copy-back, but "
+                        "retrace=False with use_legacy_exporter=False does not declare "
+                        "them. The saved program's signature will not reflect those "
+                        "updates. Use the legacy exporter, or retrace=True."
+                    )
 
                 if output_format == "exported_program":
                     # Must precede normalization, which rewrites the engine constants
@@ -1254,6 +1270,8 @@ def save(
                     _declare_aliased_kv_mutations_on_ep,
                 )
 
+                _copyback_bufs = module.meta.get("_copyback_mutation_buffers", [])
+
                 if output_format == "aot_inductor" and any(
                     getattr(sub, "aliased_io", None)
                     for _sub_name, sub in module.named_modules()
@@ -1268,7 +1286,9 @@ def save(
                 if output_format == "exported_program":
                     # Must precede normalization, which rewrites the engine constants
                     # this pass reads aliased_io from.
-                    exp_program = _declare_aliased_kv_mutations_on_ep(exp_program)
+                    exp_program = _declare_aliased_kv_mutations_on_ep(
+                        exp_program, copyback_buffers=_copyback_bufs
+                    )
                     _normalize_engine_constants_to_python(exp_program)
                     function_overload_with_kwargs(
                         torch.export.save,
@@ -1289,7 +1309,6 @@ def save(
                         package_path=file_path,
                     )
                 elif output_format == "executorch":
-                    _copyback_bufs = module.meta.get("_copyback_mutation_buffers", [])
                     exp_program = _declare_aliased_kv_mutations_on_ep(
                         exp_program, copyback_buffers=_copyback_bufs
                     )

--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -1289,7 +1289,10 @@ def save(
                         package_path=file_path,
                     )
                 elif output_format == "executorch":
-                    exp_program = _declare_aliased_kv_mutations_on_ep(exp_program)
+                    _copyback_bufs = module.meta.get("_copyback_mutation_buffers", [])
+                    exp_program = _declare_aliased_kv_mutations_on_ep(
+                        exp_program, copyback_buffers=_copyback_bufs
+                    )
                     _save_as_executorch(
                         exp_program,
                         file_path,

--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -1233,7 +1233,30 @@ def save(
                         strict=False,
                     )
 
+                from torch_tensorrt.dynamo._exporter import (
+                    _declare_aliased_kv_mutations_on_ep,
+                )
+
+                # aot_inductor is left undeclared: whether an aliased in-place mutation
+                # survives functionalization under inductor is unverified.
+                if output_format == "aot_inductor" and any(
+                    getattr(sub, "aliased_io", None)
+                    for _sub_name, sub in module.named_modules()
+                ):
+                    logger.warning(
+                        "Module has TensorRT engine(s) with aliased I/O (e.g. KV-cache), "
+                        "but output_format='aot_inductor' does not declare those aliased "
+                        "outputs as buffer mutations. The saved program's signature will "
+                        "not reflect the in-place update."
+                    )
+
                 if output_format == "exported_program":
+                    # torch.export truncates the engines' aliased KV outputs at the fx
+                    # boundary for every format, so the mutation has to be re-declared or
+                    # the signature omits an update the engine performs. Must precede
+                    # normalization, which rewrites the engine constants this pass reads
+                    # aliased_io from.
+                    exp_program = _declare_aliased_kv_mutations_on_ep(exp_program)
                     _normalize_engine_constants_to_python(exp_program)
                     function_overload_with_kwargs(
                         torch.export.save,
@@ -1254,6 +1277,9 @@ def save(
                         package_path=file_path,
                     )
                 elif output_format == "executorch":
+                    # retrace=True: torch.export truncates the engines' aliased KV
+                    # outputs, so declare them as buffer mutations before lowering.
+                    exp_program = _declare_aliased_kv_mutations_on_ep(exp_program)
                     _save_as_executorch(
                         exp_program,
                         file_path,

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -5,7 +5,6 @@ import logging
 import os
 import platform
 import warnings
-
 from typing import Any, Collection, Dict, List, Optional, Sequence, Tuple, Union
 
 import sympy
@@ -45,6 +44,7 @@ from torch_tensorrt.dynamo.lowering import (
     pre_export_lowering,
 )
 from torch_tensorrt.dynamo.lowering._buffer_lifting import (
+    assert_predicted_kv_aliased,
     inline_lifted_buffers_into_gm,
     lift_mutated_buffers,
 )
@@ -792,6 +792,8 @@ def compile(
     # module-held cache). Returns a fresh GraphModule whose forward signature
     # reflects the new placeholders.
     gm, lifted_buffers = lift_mutated_buffers(gm)
+    _copyback_mutation_buffers = gm.meta.get("_copyback_mutation_buffers", [])
+    _predicted_kv_bindings = gm.meta.get("_predicted_kv_bindings", [])
     if lifted_buffers:
         # Append each lifted buffer as an engine input AFTER the user inputs.
         # Buffer tensors live on the gm's state; prepare an Input spec for
@@ -832,6 +834,12 @@ def compile(
         engine_cache,
         graph_signature=exported_program.graph_signature,
     )
+    if _copyback_mutation_buffers:
+        trt_gm.meta["_copyback_mutation_buffers"] = _copyback_mutation_buffers
+    # Ground-truth check: every write lift classified as KV (engine-aliased, so its
+    # copy_ was dropped) must actually appear in a compiled engine's aliased_io,
+    # else its write-back would be silently lost -- fail loudly instead.
+    assert_predicted_kv_aliased(trt_gm, _predicted_kv_bindings)
     if lifted_buffers:
         # Inline buffers into the compiled gm as get_attr nodes + registered
         # buffers. The resulting gm's forward takes only user inputs; buffers

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -791,7 +791,7 @@ def compile(
     # prerequisite for IKVCacheUpdateLayer / aliased I/O to fire on a
     # module-held cache). Returns a fresh GraphModule whose forward signature
     # reflects the new placeholders.
-    gm, lifted_buffers = lift_mutated_buffers(gm)
+    gm, lifted_buffers = lift_mutated_buffers(gm, settings)
     _copyback_mutation_buffers = gm.meta.get("_copyback_mutation_buffers", [])
     _predicted_kv_bindings = gm.meta.get("_predicted_kv_bindings", [])
     if lifted_buffers:
@@ -2012,7 +2012,7 @@ def convert_exported_program_to_serialized_trt_engine(
     # in the order returned here.
     lifted_buffers: List[Tuple[str, str, torch.Tensor]] = []
     if lift_mutable_buffers:
-        gm, lifted_buffers = lift_mutated_buffers(gm)
+        gm, lifted_buffers = lift_mutated_buffers(gm, settings)
         if lifted_buffers:
             buffer_tensors = [t for _, _, t in lifted_buffers]
             buffer_inputs = prepare_inputs(buffer_tensors)

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -597,14 +597,50 @@ def _declare_aliased_kv_mutations_on_ep(
             if out_name not in aliased_io:
                 continue
             in_name = aliased_io[out_name][0]
+            # The alias map comes from the engine's own bindings, so an entry that does
+            # not resolve to a delegate input arg means the map and the engine disagree.
+            # The mutation is then left undeclared and only surfaces as a delegate arity
+            # error at execute, so log which output was dropped.
             if in_name not in in_names:
+                logger.warning(
+                    "Aliased output %s references input %s, which is not an engine "
+                    "input binding; leaving the mutation undeclared.",
+                    out_name,
+                    in_name,
+                )
                 continue
             ii = in_names.index(in_name)
             if ii >= len(input_nodes):
+                logger.warning(
+                    "Aliased output %s maps to input index %d, out of range for %d "
+                    "delegate args; leaving the mutation undeclared.",
+                    out_name,
+                    ii,
+                    len(input_nodes),
+                )
                 continue
             buf_node = input_nodes[ii]
             buf_fqn = inputs_to_buffers.get(getattr(buf_node, "name", None))
-            if buf_fqn is None or buf_fqn in already_exposed:
+            if buf_fqn is None:
+                # A caller-supplied cache that is not a registered buffer: there is no
+                # buffer to declare a mutation of, and the engine still has the output
+                # binding, so the delegate ends up one arg short at execute.
+                logger.warning(
+                    "Aliased output %s updates %s in place, but that input is not a "
+                    "registered buffer, so no buffer mutation is declared for it.",
+                    out_name,
+                    in_name,
+                )
+                continue
+            if buf_fqn in already_exposed:
+                # Already declared, by this pass for another engine sharing the buffer
+                # or by the exporter at transform time. Expected, not a fault.
+                logger.debug(
+                    "Buffer %s already carries a mutation spec; skipping aliased "
+                    "output %s.",
+                    buf_fqn,
+                    out_name,
+                )
                 continue
             oi = out_names.index(out_name)
             while len(val_list) <= oi:

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -371,7 +371,47 @@ def create_trt_exp_program(
     input_nodes = [node for node in gm.graph.nodes if node.op == "placeholder"]
     output_nodes = [node for node in gm.graph.nodes if node.op == "output"]
     assert output_nodes
-    output_nodes = output_nodes[0].args[0]
+    _output_node = output_nodes[0]
+    output_nodes = _output_node.args[0]
+
+    # Copy-back mutable buffers (non-KV, e.g. a convolution-state ring-buffer):
+    # lift_mutated_buffers appended each buffer's new-value as a trailing graph output. Tag it
+    # BUFFER_MUTATION (reusing the KV `_kv_mutation_target` path) so the runtime
+    # threads it and ExecuTorch copies it back to the caller-owned buffer, then move
+    # all mutation outputs before the user outputs (ExportedProgram verifier requires
+    # BUFFER_MUTATIONs to be contiguous at the front).
+    _copyback = gm.meta.get("_copyback_mutation_buffers", [])
+    if _copyback:
+        # A write-only buffer -- every reader served by the value being written
+        # -- has a dead get_attr, and `transform` already ran DCE. `lift` derives
+        # BUFFER input specs from get_attr nodes alone, so without one the
+        # BUFFER_MUTATION declared below names a buffer the signature never
+        # declares. An unused get_attr is enough: `lift` rewrites it to a
+        # placeholder, which fx's dead-code pass never removes. Must be a
+        # registered buffer, else `lift` makes it a parameter or constant.
+        _attrs = {n.target for n in gm.graph.nodes if n.op == "get_attr"}
+        _registered = dict(gm.named_buffers())
+        _first_node = next(iter(gm.graph.nodes))
+        for _buf in _copyback:
+            if _buf in _attrs or _buf not in _registered:
+                continue
+            with gm.graph.inserting_before(_first_node):
+                gm.graph.get_attr(_buf)
+            _attrs.add(_buf)
+
+        _outs = list(output_nodes)
+        for _n, _buf in zip(_outs[-len(_copyback) :], _copyback):
+            if isinstance(_n, torch.fx.Node):
+                _n.meta["_kv_mutation_target"] = _buf
+
+        def _is_mut(_n: Any) -> bool:
+            return isinstance(_n, torch.fx.Node) and "_kv_mutation_target" in _n.meta
+
+        output_nodes = tuple(
+            [_n for _n in _outs if _is_mut(_n)]
+            + [_n for _n in _outs if not _is_mut(_n)]
+        )
+        _output_node.args = (output_nodes,)
 
     # Outputs tagged by `_expose_aliased_buffer_mutations` become BUFFER_MUTATION
     # specs (their `_kv_mutation_target` meta names the backing buffer); the rest
@@ -532,17 +572,34 @@ def create_trt_exp_program(
 
 def _declare_aliased_kv_mutations_on_ep(
     exp_program: ExportedProgram,
+    copyback_buffers: Optional[List[str]] = None,
 ) -> ExportedProgram:
     """retrace=True post-export pass: declare each engine's aliased KV output as a
-    BUFFER_MUTATION of its caller-owned buffer input.
+    BUFFER_MUTATION of its caller-owned buffer input, and reclassify any copy-back
+    outputs as BUFFER_MUTATIONs of their buffers.
 
     torch.export produces execute_engine nodes whose meta['val'] covers only the
     user outputs (the aliased KV outputs are network bindings excluded at the fx
     boundary), so the KV buffers -- though BUFFER inputs -- are never recorded as
     mutated and get frozen downstream. This surfaces each aliased output as a
     getitem and declares it a BUFFER_MUTATION of the aliased input's buffer,
-    mirroring create_trt_exp_program's handling on the retrace=False path. Returns
-    exp_program unchanged when no engine has aliased KV outputs.
+    mirroring create_trt_exp_program's handling on the retrace=False path.
+
+    Non-KV mutable buffers (e.g. a convolution-state ring-buffer) have no engine
+    aliasing: lift_mutated_buffers appended their new values as trailing user outputs, which
+    torch.export kept as the last ``len(copyback_buffers)`` outputs. Those are
+    reclassified from USER_OUTPUT to BUFFER_MUTATION here so ExecuTorch copies them
+    back to the caller-owned buffers after the delegate runs.
+
+    Args:
+        exp_program: the retraced ExportedProgram to rewrite.
+        copyback_buffers: buffer FQNs, in output order, for the trailing copy-back
+            outputs to reclassify as BUFFER_MUTATION. Threaded from
+            ``gm.meta['_copyback_mutation_buffers']`` by ``save()``; empty/None means
+            KV-only (no copy-back).
+
+    Returns exp_program unchanged when no engine has aliased KV outputs and there are
+    no copy-back buffers.
     """
     from torch_tensorrt.dynamo.runtime._serialized_engine_layout import (
         ALIASED_IO_IDX,
@@ -653,29 +710,89 @@ def _declare_aliased_kv_mutations_on_ep(
             mutation_outputs.append((getitem_node, buf_fqn))
         node.meta["val"] = tuple(val_list)
 
-    if not mutation_outputs:
+    copyback_buffers = copyback_buffers or []
+    num_copyback = len(copyback_buffers)
+    # Unlike the KV path this reclassifies the trailing num_copyback outputs by
+    # position, so it cannot skip an already-declared buffer the way already_exposed
+    # does: after a first declaration the mutations sit at the front and the trailing
+    # outputs are the user's. Declaring twice would retarget those, dropping a user
+    # output and leaving the buffer with two mutation specs.
+    redeclared = sorted(set(copyback_buffers) & already_exposed)
+    if redeclared:
+        raise RuntimeError(
+            f"Copy-back buffer(s) {redeclared} already carry a BUFFER_MUTATION spec. "
+            "Declaring them again would reclassify the trailing outputs, which are no "
+            "longer the copy-back ones. Pass copyback_buffers only for a program whose "
+            "exporter has not already declared them."
+        )
+    if not mutation_outputs and not num_copyback:
         return exp_program
 
-    # BUFFER_MUTATION outputs must precede USER_OUTPUTs (ExportedProgram verifier).
     out_args = list(output_node.args[0])
-    output_node.args = (tuple([g for g, _ in mutation_outputs] + out_args),)
+    orig_specs = list(sig.output_specs)
+
+    kv_getitems = [g for g, _ in mutation_outputs]
+    kv_specs = [
+        OutputSpec(OutputKind.BUFFER_MUTATION, TensorArgument(name=g.name), fqn)
+        for g, fqn in mutation_outputs
+    ]
+
+    # Copy-back mutable buffers (non-KV, e.g. a convolution-state ring-buffer): lift
+    # appended each buffer's new-value as a trailing user output; torch.export kept them as the
+    # last num_copyback outputs. Reclassify those from USER_OUTPUT to BUFFER_MUTATION
+    # so ET copies them back to the caller-owned buffers.
+    copyback_getitems: List[torch.fx.Node] = []
+    copyback_specs: List[OutputSpec] = []
+    remaining_specs = orig_specs
+    if num_copyback:
+        copyback_getitems = list(out_args[-num_copyback:])
+        remaining_args = out_args[:-num_copyback]
+        remaining_specs = orig_specs[:-num_copyback]
+        copyback_specs = [
+            OutputSpec(OutputKind.BUFFER_MUTATION, TensorArgument(name=g.name), buf)
+            for g, buf in zip(copyback_getitems, copyback_buffers)
+            if isinstance(g, torch.fx.Node)
+        ]
+        out_args = remaining_args
+
+    # BUFFER_MUTATIONs (KV + copy-back) must precede USER_OUTPUTs (verifier).
+    output_node.args = (tuple(kv_getitems + copyback_getitems + out_args),)
     gm.graph.lint()
     gm.recompile()
 
-    new_output_specs = [
-        OutputSpec(OutputKind.BUFFER_MUTATION, TensorArgument(name=g.name), fqn)
-        for g, fqn in mutation_outputs
-    ] + list(sig.output_specs)
+    new_output_specs = kv_specs + copyback_specs + list(remaining_specs)
     new_signature = ExportGraphSignature(
         input_specs=list(sig.input_specs), output_specs=new_output_specs
     )
+
+    # Copy-back outputs were user returns in the retraced program, so torch.export's
+    # out_spec counts them; after reclassifying them as BUFFER_MUTATION only the real
+    # user outputs remain. Rebuild the top-level out_spec (mirroring
+    # create_trt_exp_program) so to_edge's unflatten sees the right leaf count.
+    module_call_graph = exp_program.module_call_graph
+    if num_copyback and module_call_graph:
+        new_out_spec = pytree.tree_flatten(tuple(out_args))[1]
+        _e0 = module_call_graph[0]
+        _sig0 = _e0.signature
+        module_call_graph = [
+            ModuleCallEntry(
+                _e0.fqn,
+                ModuleCallSignature(
+                    inputs=_sig0.inputs if _sig0 is not None else [],
+                    outputs=[],
+                    in_spec=_sig0.in_spec if _sig0 is not None else None,
+                    out_spec=new_out_spec,
+                ),
+            )
+        ] + list(module_call_graph[1:])
+
     return ExportedProgram(
         root=gm,
         graph=gm.graph,
         graph_signature=new_signature,
         state_dict=exp_program.state_dict,
         range_constraints=exp_program.range_constraints,
-        module_call_graph=exp_program.module_call_graph,
+        module_call_graph=module_call_graph,
         example_inputs=exp_program.example_inputs,
         constants=exp_program.constants,
         verifiers=exp_program.verifiers,

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -1,7 +1,8 @@
 import base64
 import copy
+import logging
 import operator
-from typing import Any, Dict, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 import torch
 import torch.utils._pytree as pytree
@@ -23,6 +24,8 @@ from torch.export.exported_program import (
 from torch.fx.graph import _PyTreeCodeGen
 from torch_tensorrt._features import ENABLED_FEATURES
 from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import ENGINE_IDX, NAME_IDX
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_lifted_custom_obj(
@@ -72,7 +75,9 @@ def export(
         inputs (torch.Tensor): Torch input tensors
         cross_compile_module (bool): Flag to indicated whether it is cross_compilation enabled or not
     """
-    patched_module = transform(gm, cross_compile_module)
+    patched_module = transform(
+        gm, cross_compile_module, expose_aliased_mutations=bool(use_legacy_exporter)
+    )
     if not use_legacy_exporter:
         args = ()
         if arg_inputs is not None:
@@ -97,6 +102,7 @@ def export(
 def transform(
     gm: torch.fx.GraphModule,
     cross_compile_module: Optional[bool] = False,
+    expose_aliased_mutations: bool = True,
 ) -> torch.fx.GraphModule:
     """
     Transforms the graphmodule by inlining Pytorch and TensorRT submodules.
@@ -115,7 +121,7 @@ def transform(
     gm = copy.deepcopy(gm)
 
     # Inline TensorRT submodules
-    inline_trt_modules(gm, cross_compile_module)
+    inline_trt_modules(gm, cross_compile_module, expose_aliased_mutations)
 
     # Inline pytorch submodules
     inline_torch_modules(gm)
@@ -367,12 +373,29 @@ def create_trt_exp_program(
     assert output_nodes
     output_nodes = output_nodes[0].args[0]
 
+    # Outputs tagged by `_expose_aliased_buffer_mutations` become BUFFER_MUTATION
+    # specs (their `_kv_mutation_target` meta names the backing buffer); the rest
+    # are ordinary user outputs, used below to rebuild the user-facing out_spec.
+    user_output_nodes = [
+        node for node in output_nodes if "_kv_mutation_target" not in node.meta
+    ]
+
     input_specs = [
         InputSpec(InputKind.USER_INPUT, TensorArgument(name=node.name), node.target)
         for node in input_nodes
     ]
     output_specs = [
-        OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name=node.name), node.target)
+        (
+            OutputSpec(
+                OutputKind.BUFFER_MUTATION,
+                TensorArgument(name=node.name),
+                node.meta["_kv_mutation_target"],
+            )
+            if "_kv_mutation_target" in node.meta
+            else OutputSpec(
+                OutputKind.USER_OUTPUT, TensorArgument(name=node.name), node.target
+            )
+        )
         for node in output_nodes
     ]
 
@@ -411,7 +434,9 @@ def create_trt_exp_program(
                 if set(kwarg_targets) == set(example_kwargs):
                     example_kwargs = {key: example_kwargs[key] for key in kwarg_targets}
             in_spec = pytree.tree_flatten((example_args, example_kwargs))[1]
-        out_spec = pytree.tree_flatten(tuple(output_nodes))[1]
+        # out_spec describes the user-visible return structure only; buffer
+        # mutations are stripped before unflatten.
+        out_spec = pytree.tree_flatten(tuple(user_output_nodes))[1]
         assert in_spec.num_leaves == len(input_nodes), (
             f"create_trt_exp_program: in_spec has {in_spec.num_leaves} leaves but "
             f"the graph has {len(input_nodes)} input placeholder(s)"
@@ -505,8 +530,115 @@ def create_trt_exp_program(
     return trt_exp_program
 
 
+def _declare_aliased_kv_mutations_on_ep(
+    exp_program: ExportedProgram,
+) -> ExportedProgram:
+    """retrace=True post-export pass: declare each engine's aliased KV output as a
+    BUFFER_MUTATION of its caller-owned buffer input.
+
+    torch.export produces execute_engine nodes whose meta['val'] covers only the
+    user outputs (the aliased KV outputs are network bindings excluded at the fx
+    boundary), so the KV buffers -- though BUFFER inputs -- are never recorded as
+    mutated and get frozen downstream. This surfaces each aliased output as a
+    getitem and declares it a BUFFER_MUTATION of the aliased input's buffer,
+    mirroring create_trt_exp_program's handling on the retrace=False path. Returns
+    exp_program unchanged when no engine has aliased KV outputs.
+    """
+    from torch_tensorrt.dynamo.runtime._serialized_engine_layout import (
+        ALIASED_IO_IDX,
+        INPUT_BINDING_NAMES_IDX,
+        OUTPUT_BINDING_NAMES_IDX,
+        deserialize_binding_names,
+    )
+    from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import (
+        deserialize_aliased_io,
+    )
+    from torch_tensorrt.executorch.backend import _get_engine_info_for_node
+
+    def _estr(engine_info: List[Any], idx: int) -> str:
+        if idx < 0 or idx >= len(engine_info) or engine_info[idx] is None:
+            return ""
+        v = engine_info[idx]
+        return v.decode("utf-8", "replace") if isinstance(v, bytes) else str(v)
+
+    gm = exp_program.graph_module
+    sig = exp_program.graph_signature
+    inputs_to_buffers = sig.inputs_to_buffers
+    output_node = next(n for n in gm.graph.nodes if n.op == "output")
+    exec_target = torch.ops.tensorrt.execute_engine.default
+
+    already_exposed: Set[str] = set()
+    mutation_outputs: List[Tuple[torch.fx.Node, str]] = []
+    for node in gm.graph.nodes:
+        if node.op != "call_function" or node.target is not exec_target:
+            continue
+        engine_info = _get_engine_info_for_node(exp_program, node)
+        aliased_io = deserialize_aliased_io(_estr(engine_info, ALIASED_IO_IDX))
+        if not aliased_io:
+            continue
+        in_names = deserialize_binding_names(
+            _estr(engine_info, INPUT_BINDING_NAMES_IDX)
+        )
+        out_names = deserialize_binding_names(
+            _estr(engine_info, OUTPUT_BINDING_NAMES_IDX)
+        )
+        input_nodes = list(node.args[0])
+        val_list = list(node.meta["val"])
+        for out_name in out_names:
+            if out_name not in aliased_io:
+                continue
+            in_name = aliased_io[out_name][0]
+            if in_name not in in_names:
+                continue
+            ii = in_names.index(in_name)
+            if ii >= len(input_nodes):
+                continue
+            buf_node = input_nodes[ii]
+            buf_fqn = inputs_to_buffers.get(getattr(buf_node, "name", None))
+            if buf_fqn is None or buf_fqn in already_exposed:
+                continue
+            oi = out_names.index(out_name)
+            while len(val_list) <= oi:
+                val_list.append(buf_node.meta["val"])
+            val_list[oi] = buf_node.meta["val"]
+            with gm.graph.inserting_after(node):
+                getitem_node = gm.graph.call_function(operator.getitem, (node, oi))
+            getitem_node.meta["val"] = buf_node.meta["val"]
+            already_exposed.add(buf_fqn)
+            mutation_outputs.append((getitem_node, buf_fqn))
+        node.meta["val"] = tuple(val_list)
+
+    if not mutation_outputs:
+        return exp_program
+
+    # BUFFER_MUTATION outputs must precede USER_OUTPUTs (ExportedProgram verifier).
+    out_args = list(output_node.args[0])
+    output_node.args = (tuple([g for g, _ in mutation_outputs] + out_args),)
+    gm.graph.lint()
+    gm.recompile()
+
+    new_output_specs = [
+        OutputSpec(OutputKind.BUFFER_MUTATION, TensorArgument(name=g.name), fqn)
+        for g, fqn in mutation_outputs
+    ] + list(sig.output_specs)
+    new_signature = ExportGraphSignature(
+        input_specs=list(sig.input_specs), output_specs=new_output_specs
+    )
+    return ExportedProgram(
+        root=gm,
+        graph=gm.graph,
+        graph_signature=new_signature,
+        state_dict=exp_program.state_dict,
+        range_constraints=exp_program.range_constraints,
+        module_call_graph=exp_program.module_call_graph,
+        constants=exp_program.constants,
+    )
+
+
 def inline_trt_modules(
-    gm: torch.fx.GraphModule, cross_compile_module: Optional[bool] = False
+    gm: torch.fx.GraphModule,
+    cross_compile_module: Optional[bool] = False,
+    expose_aliased_mutations: bool = True,
 ) -> torch.fx.GraphModule:
     """
     Replace TRT submodules with trt engine nodes.
@@ -568,10 +700,135 @@ def inline_trt_modules(
             for idx, getitem_node in enumerate(getitem_nodes):
                 getitem_node.meta["val"] = trt_node.meta["val"][idx]
 
+        # Expose the engine's aliased (KV-cache) outputs as graph-level buffer
+        # mutations so the ExecuTorch path sees a real mutable buffer instead of
+        # a frozen constant. Only on the legacy (create_trt_exp_program) path,
+        # which declares the BUFFER_MUTATION specs; on the torch.export path the
+        # extra outputs would just perturb the user outputs (see save()'s
+        # post-export declaration for retrace=True). Non-cross-compile only.
+        if not cross_compile_module and expose_aliased_mutations:
+            _expose_aliased_buffer_mutations(gm, trt_node, trt_module, num_outputs)
+
         # Erase the TRT submodule (call_module) node.
         gm.graph.erase_node(trt_module_node)
 
     return gm
+
+
+def _expose_aliased_buffer_mutations(
+    gm: torch.fx.GraphModule,
+    trt_node: torch.fx.Node,
+    trt_module: Any,
+    num_user_outputs: int,
+) -> None:
+    """Surface an engine's aliased KV-cache outputs as graph buffer mutations.
+
+    The interpreter appends aliased layer outputs (e.g. ``IKVCacheUpdateLayer``)
+    to the engine's network bindings *after* the fx output boundary, so
+    ``trt_node.meta["val"]`` (and the partitioner-emitted getitems) only cover
+    the user outputs. Here we add a ``getitem`` for each aliased output binding
+    and route it to the graph output tagged as a buffer mutation of the aliased
+    input's backing buffer. ``create_trt_exp_program`` turns the tag into a
+    ``BUFFER_MUTATION`` OutputSpec, so ``torch.export``/``to_edge`` record the
+    cache in ``buffers_to_mutate`` -- without a graph ``copy_`` that
+    functionalization would fold away (the aliased output shares the buffer's
+    storage, so a ``copy_`` from it is a no-op self-copy).
+    """
+    aliased_io = getattr(trt_module, "aliased_io", None)
+    if not aliased_io:
+        return
+
+    in_names = list(getattr(trt_module, "input_binding_names", []))
+    out_names = list(getattr(trt_module, "output_binding_names", []))
+    input_arg_nodes = list(trt_node.args[0])
+
+    # Only get_attr nodes backed by a *registered buffer* can be declared
+    # BUFFER_MUTATION targets; a get_attr that lift() would classify as a
+    # constant (not in named_buffers) is not a valid mutation target.
+    registered_buffers = {name for name, _ in gm.named_buffers()}
+
+    # A buffer can be declared mutated at most once in the graph signature.
+    # Multiple engines can alias the same backing buffer (they share its
+    # storage), so dedup exposures across engines.
+    already_exposed = gm.meta.setdefault("_kv_exposed_mutation_targets", set())
+
+    output_node = next(node for node in gm.graph.nodes if node.op == "output")
+
+    val_list = list(trt_node.meta["val"])
+    new_mutation_outputs: List[torch.fx.Node] = []
+    for oi, out_name in enumerate(out_names):
+        if out_name not in aliased_io:
+            continue
+        in_name = aliased_io[out_name][0]
+        # These two are internal invariant violations: aliased_io is built from the
+        # engine's own bindings, so an aliased output must map to a real input arg.
+        # If it doesn't, the mutation can't be wired and its in-place update would be
+        # silently dropped (a corrupted cache) -- fail loudly rather than degrade.
+        if in_name not in in_names:
+            raise RuntimeError(
+                f"Aliased output {out_name!r} references input {in_name!r} which is "
+                "not an engine input binding -- the engine's aliased_io map is "
+                "inconsistent with its input bindings."
+            )
+        ii = in_names.index(in_name)
+        if ii >= len(input_arg_nodes):
+            raise RuntimeError(
+                f"Aliased output {out_name!r} -> input {in_name!r} maps to arg index "
+                f"{ii}, out of range for {len(input_arg_nodes)} delegate args -- the "
+                "engine's aliased_io map is inconsistent with the delegate args."
+            )
+        buffer_node = input_arg_nodes[ii]
+        buf_target = getattr(buffer_node, "target", None)
+        if buffer_node.op != "get_attr" or not isinstance(buf_target, str):
+            logger.warning(
+                "Aliased input %s for engine output %s is not a buffer get_attr "
+                "(op=%s); skipping buffer-mutation exposure.",
+                in_name,
+                out_name,
+                buffer_node.op,
+            )
+            continue
+        if buf_target not in registered_buffers:
+            logger.warning(
+                "Aliased input %s for engine output %s resolves to get_attr %s "
+                "which is not a registered buffer; skipping buffer-mutation exposure.",
+                in_name,
+                out_name,
+                buf_target,
+            )
+            continue
+        if buf_target in already_exposed:
+            logger.warning(
+                "Buffer %s (engine output %s / input %s) already exposed as a "
+                "mutation by another engine; skipping duplicate.",
+                buf_target,
+                out_name,
+                in_name,
+            )
+            continue
+        already_exposed.add(buf_target)
+
+        # Ensure the engine node advertises at least oi+1 outputs so getitem(oi)
+        # is in range; the aliased output has the shape/dtype of its input buffer.
+        while len(val_list) <= oi:
+            val_list.append(buffer_node.meta["val"])
+        val_list[oi] = buffer_node.meta["val"]
+
+        with gm.graph.inserting_after(trt_node):
+            getitem_node = gm.graph.call_function(operator.getitem, (trt_node, oi))
+        getitem_node.meta["val"] = buffer_node.meta["val"]
+        getitem_node.meta["_kv_mutation_target"] = buf_target
+        new_mutation_outputs.append(getitem_node)
+
+    if not new_mutation_outputs:
+        return
+
+    trt_node.meta["val"] = tuple(val_list)
+    # BUFFER_MUTATION outputs must precede USER_OUTPUTs (the ExportedProgram
+    # verifier treats output_nodes[num_tokens:num_tokens+num_mutations] as the
+    # mutations), so prepend.
+    out_args = list(output_node.args[0])
+    output_node.args = (tuple(new_mutation_outputs + out_args),)
 
 
 def replace_execute_engine_no_op_node(

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -567,7 +567,16 @@ def _declare_aliased_kv_mutations_on_ep(
     output_node = next(n for n in gm.graph.nodes if n.op == "output")
     exec_target = torch.ops.tensorrt.execute_engine.default
 
-    already_exposed: Set[str] = set()
+    # Seeded from the incoming signature, not empty: exposure is decided both by
+    # the exporter (the legacy one declares at transform time) and by save()'s
+    # per-format branch, so this pass can run on a program whose mutations are
+    # already declared. Re-declaring appends a second spec for the same buffer and
+    # the ExportedProgram verifier then rejects the output ordering.
+    already_exposed: Set[str] = {
+        spec.target
+        for spec in sig.output_specs
+        if spec.kind == OutputKind.BUFFER_MUTATION and spec.target
+    }
     mutation_outputs: List[Tuple[torch.fx.Node, str]] = []
     for node in gm.graph.nodes:
         if node.op != "call_function" or node.target is not exec_target:

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -771,8 +771,9 @@ def _expose_aliased_buffer_mutations(
         if out_name not in aliased_io:
             continue
         in_name = aliased_io[out_name][0]
-        # These two are internal invariant violations: aliased_io is built from the
-        # engine's own bindings, so an aliased output must map to a real input arg.
+        # The two checks below are internal invariant violations: aliased_io is
+        # built from the engine's own bindings, so an aliased output must map to a
+        # real input arg.
         # If it doesn't, the mutation can't be wired and its in-place update would be
         # silently dropped (a corrupted cache) -- fail loudly rather than degrade.
         if in_name not in in_names:

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -738,19 +738,30 @@ def _declare_aliased_kv_mutations_on_ep(
     ]
 
     # Copy-back mutable buffers (non-KV, e.g. a convolution-state ring-buffer): lift
-    # appended each buffer's new-value as a trailing user output; torch.export kept them as the
-    # last num_copyback outputs. Reclassify those from USER_OUTPUT to BUFFER_MUTATION
-    # so ET copies them back to the caller-owned buffers.
+    # appended each buffer's new-value as a trailing user output. torch.export usually
+    # leaves them as the last outputs, but when it recognises the mutation itself it
+    # declares them BUFFER_MUTATION and moves them to the front, because the verifier
+    # requires mutations to precede user outputs. Taking the tail unconditionally then
+    # reclassifies a real user output as a buffer mutation, and the runtime later fails
+    # copying that output into a buffer of a different shape. Reclassify only the buffers
+    # the program does not already declare as mutated.
     copyback_getitems: List[torch.fx.Node] = []
     copyback_specs: List[OutputSpec] = []
     remaining_specs = orig_specs
-    if num_copyback:
-        copyback_getitems = list(out_args[-num_copyback:])
-        remaining_args = out_args[:-num_copyback]
-        remaining_specs = orig_specs[:-num_copyback]
+    already_mutated = {
+        spec.target
+        for spec in orig_specs
+        if spec.kind == OutputKind.BUFFER_MUTATION and isinstance(spec.target, str)
+    }
+    pending_copyback = [buf for buf in copyback_buffers if buf not in already_mutated]
+    if pending_copyback:
+        num_pending = len(pending_copyback)
+        copyback_getitems = list(out_args[-num_pending:])
+        remaining_args = out_args[:-num_pending]
+        remaining_specs = orig_specs[:-num_pending]
         copyback_specs = [
             OutputSpec(OutputKind.BUFFER_MUTATION, TensorArgument(name=g.name), buf)
-            for g, buf in zip(copyback_getitems, copyback_buffers)
+            for g, buf in zip(copyback_getitems, pending_copyback)
             if isinstance(g, torch.fx.Node)
         ]
         out_args = remaining_args
@@ -770,7 +781,7 @@ def _declare_aliased_kv_mutations_on_ep(
     # user outputs remain. Rebuild the top-level out_spec (mirroring
     # create_trt_exp_program) so to_edge's unflatten sees the right leaf count.
     module_call_graph = exp_program.module_call_graph
-    if num_copyback and module_call_graph:
+    if copyback_specs and module_call_graph:
         new_out_spec = pytree.tree_flatten(tuple(out_args))[1]
         _e0 = module_call_graph[0]
         _sig0 = _e0.signature

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -631,7 +631,9 @@ def _declare_aliased_kv_mutations_on_ep(
         state_dict=exp_program.state_dict,
         range_constraints=exp_program.range_constraints,
         module_call_graph=exp_program.module_call_graph,
+        example_inputs=exp_program.example_inputs,
         constants=exp_program.constants,
+        verifiers=exp_program.verifiers,
     )
 
 

--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -738,13 +738,15 @@ def _declare_aliased_kv_mutations_on_ep(
     ]
 
     # Copy-back mutable buffers (non-KV, e.g. a convolution-state ring-buffer): lift
-    # appended each buffer's new-value as a trailing user output. torch.export usually
-    # leaves them as the last outputs, but when it recognises the mutation itself it
-    # declares them BUFFER_MUTATION and moves them to the front, because the verifier
-    # requires mutations to precede user outputs. Taking the tail unconditionally then
-    # reclassifies a real user output as a buffer mutation, and the runtime later fails
-    # copying that output into a buffer of a different shape. Reclassify only the buffers
-    # the program does not already declare as mutated.
+    # appended each buffer's new-value as a trailing user output, in copyback_buffers
+    # order. Those appended values are internal plumbing, so the whole run leaves the
+    # user outputs whether or not torch.export also recorded the mutation itself. It
+    # does record it when it recognises the write, and then places that BUFFER_MUTATION
+    # ahead of the user outputs because the verifier requires mutations to come first;
+    # re-declaring such a buffer here would describe one mutation twice. So detach the
+    # full run first and pair it positionally with the full buffer list, then keep only
+    # the buffers not already declared. Filtering before slicing would pair a value with
+    # the wrong buffer, and the runtime would copy it into a buffer of a different shape.
     copyback_getitems: List[torch.fx.Node] = []
     copyback_specs: List[OutputSpec] = []
     remaining_specs = orig_specs
@@ -753,18 +755,19 @@ def _declare_aliased_kv_mutations_on_ep(
         for spec in orig_specs
         if spec.kind == OutputKind.BUFFER_MUTATION and isinstance(spec.target, str)
     }
-    pending_copyback = [buf for buf in copyback_buffers if buf not in already_mutated]
-    if pending_copyback:
-        num_pending = len(pending_copyback)
-        copyback_getitems = list(out_args[-num_pending:])
-        remaining_args = out_args[:-num_pending]
-        remaining_specs = orig_specs[:-num_pending]
-        copyback_specs = [
-            OutputSpec(OutputKind.BUFFER_MUTATION, TensorArgument(name=g.name), buf)
-            for g, buf in zip(copyback_getitems, pending_copyback)
-            if isinstance(g, torch.fx.Node)
-        ]
-        out_args = remaining_args
+    if num_copyback:
+        trailing = list(out_args[-num_copyback:])
+        out_args = out_args[:-num_copyback]
+        remaining_specs = orig_specs[:-num_copyback]
+        for value, buf in zip(trailing, copyback_buffers):
+            if not isinstance(value, torch.fx.Node) or buf in already_mutated:
+                continue
+            copyback_getitems.append(value)
+            copyback_specs.append(
+                OutputSpec(
+                    OutputKind.BUFFER_MUTATION, TensorArgument(name=value.name), buf
+                )
+            )
 
     # BUFFER_MUTATIONs (KV + copy-back) must precede USER_OUTPUTs (verifier).
     output_node.args = (tuple(kv_getitems + copyback_getitems + out_args),)
@@ -777,11 +780,12 @@ def _declare_aliased_kv_mutations_on_ep(
     )
 
     # Copy-back outputs were user returns in the retraced program, so torch.export's
-    # out_spec counts them; after reclassifying them as BUFFER_MUTATION only the real
-    # user outputs remain. Rebuild the top-level out_spec (mirroring
-    # create_trt_exp_program) so to_edge's unflatten sees the right leaf count.
+    # out_spec counts them; after detaching them only the real user outputs remain.
+    # Rebuild the top-level out_spec (mirroring create_trt_exp_program) so to_edge's
+    # unflatten sees the right leaf count. Keyed on num_copyback, not on the specs we
+    # added, because an already-declared buffer still had its value detached above.
     module_call_graph = exp_program.module_call_graph
-    if copyback_specs and module_call_graph:
+    if num_copyback and module_call_graph:
         new_out_spec = pytree.tree_flatten(tuple(out_args))[1]
         _e0 = module_call_graph[0]
         _sig0 = _e0.signature

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -308,9 +308,7 @@ def lift_mutated_buffers(
         # BUFFER_MUTATION output below, then drop the (now input-target) copy_.
         new_value = copy_node.args[1] if len(copy_node.args) > 1 else None
         if isinstance(new_value, torch.fx.Node):
-            if _kv_write_will_alias(
-                new_value, tuple(buffer_tensor.shape), settings
-            ):
+            if _kv_write_will_alias(new_value, tuple(buffer_tensor.shape), settings):
                 predicted_kv_bindings.add(replacement.name)
             else:
                 copyback.append((new_value, buffer_name))

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -35,6 +35,92 @@ import torch
 logger = logging.getLogger(__name__)
 
 
+def _kv_write_will_alias(value_node: object, cache_shape: Tuple[int, ...]) -> bool:
+    """Whether the converter will emit an ``IKVCacheUpdateLayer`` (with in-place
+    aliased I/O) for this mutated buffer's new-value node.
+
+    Eligibility depends on the write dim, static shapes, and the cache being a
+    direct network input, so this reuses the converters' own eligibility
+    predicates. A ``slice_scatter`` / ``index_copy`` that is not eligible is
+    lowered to a non-aliasing scatter, so its write-back is kept as a
+    BUFFER_MUTATION output (copy-back) rather than dropped. Imports are local to
+    avoid a lowering<->conversion import cycle.
+    """
+    if not (isinstance(value_node, torch.fx.Node) and value_node.op == "call_function"):
+        return False
+    args = value_node.args
+    # The KV layer aliases the cache only if it is a direct network input; after
+    # lifting, the mutated buffer is a placeholder the write op reads from.
+    if not (
+        args and isinstance(args[0], torch.fx.Node) and args[0].op == "placeholder"
+    ):
+        return False
+
+    if value_node.target is torch.ops.aten.index_copy.default:
+        from torch_tensorrt.dynamo.conversion.aten_ops_converters import (
+            _index_copy_kv_eligible,
+        )
+
+        return _index_copy_kv_eligible(value_node)
+
+    if value_node.target is torch.ops.aten.slice_scatter.default:
+        from torch_tensorrt.dynamo.conversion.impl.slice_scatter import _kv_eligible
+
+        dim = args[2] if len(args) > 2 and isinstance(args[2], int) else 0
+        start = args[3] if len(args) > 3 and isinstance(args[3], int) else 0
+        # Prefer the source's extent along `dim` for the write length; fall back
+        # to end-start from the slice bounds.
+        update_len = None
+        src = args[1] if len(args) > 1 else None
+        if isinstance(src, torch.fx.Node):
+            src_val = src.meta.get("val")
+            if src_val is not None and dim < len(src_val.shape):
+                s = src_val.shape[dim]
+                update_len = s if isinstance(s, int) else None
+        if update_len is None:
+            end = (
+                args[4]
+                if len(args) > 4 and isinstance(args[4], int)
+                else (cache_shape[dim] if dim < len(cache_shape) else 0)
+            )
+            update_len = max(end - start, 0)
+        eligible, _reason = _kv_eligible(tuple(cache_shape), dim, start, update_len)
+        return eligible
+
+    return False
+
+
+def assert_predicted_kv_aliased(
+    gm: torch.fx.GraphModule, predicted_kv_bindings: List[str]
+) -> None:
+    """Ground-truth check for the KV predictions :func:`_kv_write_will_alias` made.
+
+    Each write ``lift_mutated_buffers`` classified as KV-aliased had its ``copy_``
+    dropped in the expectation that the engine would alias it in place. If the
+    converter did not actually emit an ``IKVCacheUpdateLayer`` for it, that
+    write-back is silently lost. So assert every predicted-KV input binding
+    appears in a compiled engine's ``aliased_io``, and raise loudly otherwise.
+    Keyed on the ``buf_*`` binding name, which is stable across the later buffer
+    rename and is what ``aliased_io`` records on the input side.
+    """
+    if not predicted_kv_bindings:
+        return
+    aliased_in: set = set()
+    for _name, sub in gm.named_children():
+        amap = getattr(sub, "aliased_io", None)
+        if amap:
+            for v in amap.values():
+                aliased_in.add(v[0] if isinstance(v, (tuple, list)) else v)
+    missing = [b for b in predicted_kv_bindings if b not in aliased_in]
+    if missing:
+        raise RuntimeError(
+            "lift_mutated_buffers classified these buffer writes as KV-cache "
+            "(engine-aliased) and dropped their copy_, but the compiled engine "
+            f"did not alias them (absent from aliased_io): {missing}. Their "
+            "write-back would be silently dropped."
+        )
+
+
 def lift_mutated_buffers(
     gm: torch.fx.GraphModule,
 ) -> Tuple[torch.fx.GraphModule, List[Tuple[str, str, torch.Tensor]]]:
@@ -55,6 +141,19 @@ def lift_mutated_buffers(
       tuples, in the order placeholders were appended (which matches the
       order they appear in the new gm's forward signature, after the
       original user inputs).
+
+    Side effects: the trailing ``copy_`` of each mutated buffer is erased. A write
+    the converter will lower to an ``IKVCacheUpdateLayer`` with in-place aliased
+    I/O (an eligible ``slice_scatter`` / ``index_copy``, per
+    :func:`_kv_write_will_alias`) relies on that engine aliasing for its
+    write-back, so nothing further is added. Every other mutation -- a non-KV
+    buffer, or a ``slice_scatter`` / ``index_copy`` that fails eligibility and is
+    lowered to a non-aliasing scatter -- has no engine aliasing, so its new value
+    is re-appended as a graph output ("copy-back") and its buffer name recorded,
+    in output order, in ``gm.meta['_copyback_mutation_buffers']`` -- the
+    downstream exporters (``create_trt_exp_program`` /
+    ``_declare_aliased_kv_mutations_on_ep``) read that list to reclassify those
+    outputs as BUFFER_MUTATIONs.
     """
     # Find all aten.copy_(get_attr_X, _) calls. The first arg's target is
     # the buffer name. Some EPs emit copy_.default, others copy_.
@@ -81,6 +180,27 @@ def lift_mutated_buffers(
 
     lifted: List[Tuple[str, str, torch.Tensor]] = []
     seen_buffers: Dict[str, torch.fx.Node] = {}  # buffer name -> new placeholder node
+
+    # Each mutated buffer's write-back is handled one of two ways downstream:
+    #   - Engine-level aliasing (zero-copy): the slice_scatter / index_copy
+    #     converters emit an IKVCacheUpdateLayer whose output is aliased in-place
+    #     to the cache input. We drop the copy_ and rely on that aliasing.
+    #   - Copy-back: any other mutation (a non-KV buffer such as a convolution-
+    #     state ring-buffer, OR a slice_scatter / index_copy the converter cannot
+    #     turn into an IKVCacheUpdateLayer) has no aliasing, so its new value is
+    #     re-attached as an ordinary BUFFER_MUTATION output that ExecuTorch copies
+    #     back after the delegate runs.
+    # `_kv_write_will_alias` decides between them by reusing the converters' own
+    # eligibility predicates (not the op target alone), so a non-aliasable
+    # slice_scatter / index_copy falls to copy-back rather than being dropped.
+    # index_put has no aliasing converter, so it always falls to copy-back too.
+    copyback: List[Tuple[torch.fx.Node, str]] = []  # (new_value_node, buffer_name)
+    # Input-binding names of writes predicted to alias (KV). compile() asserts each
+    # actually appears in the engine's aliased_io, turning a mis-prediction into a
+    # loud error instead of a silently dropped write-back. The binding name (buf_*)
+    # is the stable key: it survives the buffer renaming inline does later, and it
+    # is exactly what aliased_io records on the input side.
+    predicted_kv_bindings: set[str] = set()
 
     for copy_node, get_attr_node in mutation_pairs:
         buffer_name = get_attr_node.target
@@ -138,17 +258,39 @@ def lift_mutated_buffers(
         # to the new placeholder.
         get_attr_node.replace_all_uses_with(replacement)
 
-        # Drop the trailing copy_ (it's now redundant — the mutation lands on the
-        # placeholder's storage via engine-level aliasing).
+        # KV writes rely on engine-level aliasing, so the trailing copy_ is
+        # redundant and dropped. Other (non-KV) mutations have no aliasing:
+        # record their new value so we can re-attach it as a copy-back
+        # BUFFER_MUTATION output below, then drop the (now input-target) copy_.
+        new_value = copy_node.args[1] if len(copy_node.args) > 1 else None
+        if isinstance(new_value, torch.fx.Node):
+            if _kv_write_will_alias(new_value, tuple(buffer_tensor.shape)):
+                predicted_kv_bindings.add(replacement.name)
+            else:
+                copyback.append((new_value, buffer_name))
         gm.graph.erase_node(copy_node)
 
         # Erase the now-unused get_attr.
         if not get_attr_node.users:
             gm.graph.erase_node(get_attr_node)
 
+    # Re-attach non-KV mutation new-values as graph outputs so they survive
+    # compilation (otherwise, with the copy_ gone, they are dead and eliminated).
+    # Appended in order; recorded so create_trt_exp_program / _declare can tag the
+    # corresponding engine outputs as BUFFER_MUTATION (copy-back) downstream.
+    copyback_buffers: List[str] = []
+    if copyback:
+        output_node = next(n for n in gm.graph.nodes if n.op == "output")
+        out_args = list(output_node.args[0])
+        out_args.extend(nv for nv, _ in copyback)
+        output_node.args = (tuple(out_args),)
+        copyback_buffers = [buf for _, buf in copyback]
+
     gm.graph.lint()
 
     if not lifted:
+        gm.meta["_copyback_mutation_buffers"] = copyback_buffers
+        gm.meta["_predicted_kv_bindings"] = sorted(predicted_kv_bindings)
         return gm, []
 
     # ExportedProgram.module() produces a GraphModule whose forward is
@@ -179,11 +321,14 @@ def lift_mutated_buffers(
             except AttributeError:
                 pass
     new_gm.recompile()
+    new_gm.meta["_copyback_mutation_buffers"] = copyback_buffers
+    new_gm.meta["_predicted_kv_bindings"] = sorted(predicted_kv_bindings)
 
     logger.debug(
-        "Lifted %d mutated buffer(s) to placeholders: %s",
+        "Lifted %d mutated buffer(s) to placeholders: %s; copy-back buffers: %s",
         len(lifted),
         [(p, b) for p, b, _ in lifted],
+        copyback_buffers,
     )
 
     return new_gm, lifted
@@ -244,6 +389,18 @@ def inline_lifted_buffers_into_gm(
         if not hasattr(gm, attr_name):
             gm.register_buffer(attr_name, tensor.clone())
         buf_to_attr[buf_name] = attr_name
+
+    # Copy-back mutation targets were recorded (in gm.meta) under the buffers'
+    # original names; nested ones were just flattened to lifted_buf_* above. Remap
+    # the recorded targets through the same mapping so the downstream exporter
+    # names a buffer that still exists -- otherwise the ExportedProgram verifier
+    # rejects the BUFFER_MUTATION ("output ... does not point to a buffer that
+    # exists").
+    copyback = gm.meta.get("_copyback_mutation_buffers")
+    if copyback:
+        gm.meta["_copyback_mutation_buffers"] = [
+            buf_to_attr.get(name, name) for name in copyback
+        ]
 
     # Find placeholders we need to replace. Insert get_attr nodes BEFORE
     # removing the placeholders so the graph remains valid throughout.

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -36,15 +36,17 @@ from torch_tensorrt.dynamo._settings import CompilationSettings
 logger = logging.getLogger(__name__)
 
 
-def _write_is_excluded_from_tensorrt(
+def _write_op_is_torch_executed(
     value_node: object,
     settings: Optional[CompilationSettings] = None,
 ) -> bool:
-    """Whether the caller kept this buffer write out of TensorRT.
+    """Whether this write's op is in ``settings.torch_executed_ops``.
 
-    An excluded write stays in PyTorch and is claimed by whichever other backend
-    partitions the graph, so TensorRT must leave the buffer alone. Lifting it would
-    move the mutation across a delegate boundary, which ExecuTorch cannot express.
+    Matched the way the partitioners match it, so the two agree about the op. This is
+    only one of the reasons a node can end up in PyTorch (a missing converter, a failed
+    capability validator, ``min_block_size`` and others do the same), so it is a
+    sufficient reason to rule engine aliasing out, never a proof that aliasing happens.
+    ``assert_predicted_kv_aliased`` remains the ground-truth check for the rest.
     """
     if settings is None or not settings.torch_executed_ops:
         return False
@@ -81,8 +83,9 @@ def _kv_write_will_alias(
     # An op the caller excluded from TensorRT never reaches a converter, so it
     # cannot emit an IKVCacheUpdateLayer and the engine will not alias it. Without
     # this the write is classified as engine-aliased, its copy_ is dropped, and
-    # compile() later fails its own aliased_io cross-check.
-    if _write_is_excluded_from_tensorrt(value_node, settings):
+    # compile() later fails its own aliased_io cross-check. It still gets lifted and
+    # copied back like any other non-aliasing write.
+    if _write_op_is_torch_executed(value_node, settings):
         return False
     # The KV layer aliases the cache only if it is a direct network input; after
     # lifting, the mutated buffer is a placeholder the write op reads from.
@@ -240,14 +243,6 @@ def lift_mutated_buffers(
 
     for copy_node, get_attr_node in mutation_pairs:
         buffer_name = get_attr_node.target
-        new_value_probe = copy_node.args[1] if len(copy_node.args) > 1 else None
-        if _write_is_excluded_from_tensorrt(new_value_probe, settings):
-            logger.debug(
-                "lift_mutated_buffers: %s is written by an op excluded from "
-                "TensorRT; leaving it to the other backend",
-                buffer_name,
-            )
-            continue
         # A get_attr target is fully qualified, so a buffer owned by a submodule
         # arrives as "layers.0.self_attn.kv_cache.k_cache". getattr does not walk a
         # dotted path, so it reports every nested buffer as missing; get_buffer

--- a/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
+++ b/py/torch_tensorrt/dynamo/lowering/_buffer_lifting.py
@@ -28,14 +28,43 @@ This module provides:
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import torch
+from torch_tensorrt.dynamo._settings import CompilationSettings
 
 logger = logging.getLogger(__name__)
 
 
-def _kv_write_will_alias(value_node: object, cache_shape: Tuple[int, ...]) -> bool:
+def _write_is_excluded_from_tensorrt(
+    value_node: object,
+    settings: Optional[CompilationSettings] = None,
+) -> bool:
+    """Whether the caller kept this buffer write out of TensorRT.
+
+    An excluded write stays in PyTorch and is claimed by whichever other backend
+    partitions the graph, so TensorRT must leave the buffer alone. Lifting it would
+    move the mutation across a delegate boundary, which ExecuTorch cannot express.
+    """
+    if settings is None or not settings.torch_executed_ops:
+        return False
+    if not (isinstance(value_node, torch.fx.Node) and value_node.op == "call_function"):
+        return False
+    from torch_tensorrt.dynamo.conversion._ConverterRegistry import ConverterRegistry
+
+    excluded = set(settings.torch_executed_ops)
+    target = value_node.target
+    return (
+        ConverterRegistry.qualified_name_or_str(target) in excluded
+        or target in excluded
+    )
+
+
+def _kv_write_will_alias(
+    value_node: object,
+    cache_shape: Tuple[int, ...],
+    settings: Optional[CompilationSettings] = None,
+) -> bool:
     """Whether the converter will emit an ``IKVCacheUpdateLayer`` (with in-place
     aliased I/O) for this mutated buffer's new-value node.
 
@@ -49,6 +78,12 @@ def _kv_write_will_alias(value_node: object, cache_shape: Tuple[int, ...]) -> bo
     if not (isinstance(value_node, torch.fx.Node) and value_node.op == "call_function"):
         return False
     args = value_node.args
+    # An op the caller excluded from TensorRT never reaches a converter, so it
+    # cannot emit an IKVCacheUpdateLayer and the engine will not alias it. Without
+    # this the write is classified as engine-aliased, its copy_ is dropped, and
+    # compile() later fails its own aliased_io cross-check.
+    if _write_is_excluded_from_tensorrt(value_node, settings):
+        return False
     # The KV layer aliases the cache only if it is a direct network input; after
     # lifting, the mutated buffer is a placeholder the write op reads from.
     if not (
@@ -123,6 +158,7 @@ def assert_predicted_kv_aliased(
 
 def lift_mutated_buffers(
     gm: torch.fx.GraphModule,
+    settings: Optional[CompilationSettings] = None,
 ) -> Tuple[torch.fx.GraphModule, List[Tuple[str, str, torch.Tensor]]]:
     """Lift each mutated buffer from a ``get_attr`` to a ``placeholder``.
 
@@ -204,6 +240,14 @@ def lift_mutated_buffers(
 
     for copy_node, get_attr_node in mutation_pairs:
         buffer_name = get_attr_node.target
+        new_value_probe = copy_node.args[1] if len(copy_node.args) > 1 else None
+        if _write_is_excluded_from_tensorrt(new_value_probe, settings):
+            logger.debug(
+                "lift_mutated_buffers: %s is written by an op excluded from "
+                "TensorRT; leaving it to the other backend",
+                buffer_name,
+            )
+            continue
         # A get_attr target is fully qualified, so a buffer owned by a submodule
         # arrives as "layers.0.self_attn.kv_cache.k_cache". getattr does not walk a
         # dotted path, so it reports every nested buffer as missing; get_buffer
@@ -264,7 +308,9 @@ def lift_mutated_buffers(
         # BUFFER_MUTATION output below, then drop the (now input-target) copy_.
         new_value = copy_node.args[1] if len(copy_node.args) > 1 else None
         if isinstance(new_value, torch.fx.Node):
-            if _kv_write_will_alias(new_value, tuple(buffer_tensor.shape)):
+            if _kv_write_will_alias(
+                new_value, tuple(buffer_tensor.shape), settings
+            ):
                 predicted_kv_bindings.add(replacement.name)
             else:
                 copyback.append((new_value, buffer_name))

--- a/py/torch_tensorrt/dynamo/runtime/meta_ops/register_meta_ops.py
+++ b/py/torch_tensorrt/dynamo/runtime/meta_ops/register_meta_ops.py
@@ -352,12 +352,34 @@ def fake_no_op_placeholder_for_execute_engine(
     C++ schema validator.  Output shapes are inferred from the serialized metadata
     embedded in the op's string args, same as fake_tensorrt_execute_engine.
     """
-    from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import TorchTensorRTModule
+    from torch_tensorrt.dynamo.runtime._serialized_engine_layout import (
+        deserialize_binding_names,
+    )
+    from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import (
+        TorchTensorRTModule,
+        deserialize_aliased_io,
+    )
 
     metadata = TorchTensorRTModule.decode_metadata(serialized_metadata)
     shape_info = metadata.get("inout_symexprs") if metadata else None
     if shape_info:
-        return _apply_symbolic_shape_expressions(inputs, shape_info)
+        outputs = _apply_symbolic_shape_expressions(inputs, shape_info)
+        # Append the engine's aliased (KV-cache) outputs so the getitem indices
+        # produced when to_edge re-traces this op stay in range: the aliased
+        # outputs are network bindings appended after the fx output boundary, so
+        # their shape/dtype come from the aliased input binding.
+        aliased_io = deserialize_aliased_io(serialized_aliased_io)
+        if aliased_io:
+            in_names = deserialize_binding_names(serialized_in_binding_names)
+            out_names = deserialize_binding_names(serialized_out_binding_names)
+            for out_name in out_names:
+                if out_name in aliased_io:
+                    in_name = aliased_io[out_name][0]
+                    if in_name in in_names:
+                        outputs.append(
+                            torch.empty_like(inputs[in_names.index(in_name)])
+                        )
+        return outputs
     else:
         raise RuntimeError(
             "No symbolic shape expressions found in TensorRT engine metadata. "

--- a/py/torch_tensorrt/executorch/backend.py
+++ b/py/torch_tensorrt/executorch/backend.py
@@ -12,6 +12,7 @@ from executorch.exir.backend.backend_details import (
 from torch.export.exported_program import ExportedProgram
 from torch_tensorrt.dynamo._exporter import _resolve_lifted_custom_obj
 from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import (
+    ALIASED_IO_IDX,
     DEVICE_IDX,
     ENGINE_IDX,
     HW_COMPATIBLE_IDX,
@@ -20,6 +21,7 @@ from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import (
     REQUIRES_OUTPUT_ALLOCATOR_IDX,
     SERIALIZED_METADATA_IDX,
     TARGET_PLATFORM_IDX,
+    deserialize_aliased_io,
 )
 from torch_tensorrt.executorch.serialization import (
     TensorRTBlobMetadata,
@@ -306,8 +308,14 @@ class TensorRTBackend(BackendDetails):  # type: ignore[misc]
             TensorRTIOBinding(name=name, is_input=True) for name in input_names
         ] + [TensorRTIOBinding(name=name, is_input=False) for name in output_names]
 
+        # Carry the KV-cache / user aliasing (out->in, kind) into the blob so the
+        # C++ backend binds each aliased output to its aliased input's tensor
+        # (in-place) and reflects the update back into the delegate output.
+        aliased_io = deserialize_aliased_io(_get_str(engine_info, ALIASED_IO_IDX))
+
         metadata = TensorRTBlobMetadata(
             io_bindings=io_bindings,
+            aliased_io=aliased_io,
             hardware_compatible=_get_str(engine_info, HW_COMPATIBLE_IDX) == "1",
             device_id=_parse_device_id(engine_info[DEVICE_IDX]),
             serialized_metadata=_get_str(engine_info, SERIALIZED_METADATA_IDX),

--- a/py/torch_tensorrt/executorch/backend.py
+++ b/py/torch_tensorrt/executorch/backend.py
@@ -1,5 +1,6 @@
 # ExecuTorch TensorRT backend: serialize engines to a libtorch-free runtime blob.
 
+import operator
 from typing import Any, List, final
 
 import torch
@@ -253,6 +254,57 @@ def _reorder_input_names_for_executorch(
     return [input_names[i] for i in order]
 
 
+def _validate_output_binding_order(
+    edge_program: ExportedProgram, engine_node: Any, output_names: List[str]
+) -> None:
+    """Check the delegate's outputs are the engine's output bindings, in order.
+
+    The runtime binds output ``i`` to ``output_binding_names[i]``, and nothing
+    downstream re-derives that correspondence: it holds because the partition's
+    outputs are ``getitem(engine_node, i)`` in index order. A pass that reordered
+    them -- ``arrange_graph_outputs`` moves buffer mutations ahead of user outputs,
+    which only stays a no-op here while the mutated buffers are kept above the
+    delegate -- would swap the names silently. Inputs cannot rely on position at
+    all and recover their order by node identity in
+    ``_reorder_input_names_for_executorch``.
+    """
+    output_node = next(
+        node for node in edge_program.graph_module.graph.nodes if node.op == "output"
+    )
+    out_args = list(output_node.args[0])
+    # A single-output engine is returned directly rather than through a getitem,
+    # and one binding has no order to get wrong.
+    if len(out_args) == 1 and out_args[0] is engine_node:
+        if len(output_names) != 1:
+            raise ValueError(
+                "TensorRT ExecuTorch backend: the delegate returns the engine node "
+                f"directly but the engine declares {len(output_names)} output "
+                "bindings; only a single-output engine can be returned unwrapped."
+            )
+        return
+    indices: List[Any] = []
+    for node in out_args:
+        if (
+            not isinstance(node, torch.fx.Node)
+            or node.op != "call_function"
+            or node.target is not operator.getitem
+            or node.args[0] is not engine_node
+        ):
+            raise ValueError(
+                "TensorRT ExecuTorch backend: delegate output "
+                f"{getattr(node, 'name', node)!r} is not a getitem of the engine "
+                "node; cannot establish a reliable output binding order."
+            )
+        indices.append(node.args[1])
+    if indices != list(range(len(output_names))):
+        raise ValueError(
+            "TensorRT ExecuTorch backend: delegate outputs map to engine output "
+            f"indices {indices}, expected {list(range(len(output_names)))} -- the "
+            "runtime binds output i to output_binding_names[i], so a permuted or "
+            "incomplete output list would bind the wrong tensors."
+        )
+
+
 def _get_str(engine_info: List[Any], index: int, default: str = "") -> str:
     if index < 0 or index >= len(engine_info):
         return default
@@ -304,6 +356,7 @@ class TensorRTBackend(BackendDetails):  # type: ignore[misc]
         output_names = _split_binding_names(
             _get_str(engine_info, OUTPUT_BINDING_NAMES_IDX)
         )
+        _validate_output_binding_order(edge_program, engine_node, output_names)
         io_bindings = [
             TensorRTIOBinding(name=name, is_input=True) for name in input_names
         ] + [TensorRTIOBinding(name=name, is_input=False) for name in output_names]

--- a/py/torch_tensorrt/executorch/backend.py
+++ b/py/torch_tensorrt/executorch/backend.py
@@ -321,7 +321,7 @@ class TensorRTBackend(BackendDetails):  # type: ignore[misc]
     """Backend that serializes TensorRT engines for the native ExecuTorch runtime.
 
     The partition contains a single execute_engine node; we extract the engine
-    and metadata and encode them as a standalone TR01 blob. The C++ runtime
+    and metadata and encode them as a standalone blob. The C++ runtime
     backend parses that blob directly without the legacy Torch-TensorRT C++ runtime.
     """
 

--- a/py/torch_tensorrt/executorch/backend.py
+++ b/py/torch_tensorrt/executorch/backend.py
@@ -221,14 +221,26 @@ def _reorder_input_names_for_executorch(
     first arg lists its input nodes in binding order, so sort the names by each
     node's slot among the graph placeholders (its runtime delegate-arg position).
 
-    Only inputs need this. Outputs are also bound positionally by the runtime,
-    but they are ``getitem(engine_node, idx)`` nodes whose index order equals the
-    engine output-binding order. ExecuTorch lowering can reorder delegate outputs
-    (``arrange_graph_outputs`` moves buffer-mutation outputs ahead of user
-    outputs), but a TensorRT delegate partition is a functional inference engine
-    with no mutation outputs, so that pass is a no-op here and the output order is
-    preserved. If a TRT partition ever produced mutation outputs, outputs would
-    need the same node-identity reordering as inputs.
+    Only inputs need this. Outputs are also bound positionally, but they are
+    ``getitem(engine_node, idx)`` nodes whose index order equals the engine
+    output-binding order, and that order survives lowering -- though not because
+    the partition is mutation-free. With aliased-I/O (KV-cache) support a TensorRT
+    partition *does* produce mutation outputs, and ``arrange_graph_outputs`` does
+    move buffer-mutation outputs ahead of user outputs. It stays a no-op here
+    because ``_keep_mutated_buffers_above_delegate`` (``partitioner.py``) strips
+    the ``delegation_tag`` from mutated buffer placeholders, so they stay out of
+    the delegate's state dict and constants; ExecuTorch's ``_get_new_signature``
+    then records the mutation as a plain ``USER_OUTPUT`` rather than a
+    ``BUFFER_MUTATION`` (it uses the latter only when the delegate itself consumes
+    the buffer). The lowered submodule therefore has no mutation specs, so
+    ``arrange_graph_outputs`` computes the identity permutation and the getitem
+    indices still line up with the engine's output bindings.
+
+    That guarantee is conditional, not structural: if a mutated buffer is ever
+    tagged into a delegate its spec becomes ``BUFFER_MUTATION``, the delegate's
+    outputs are permuted, and they would need the same node-identity reordering as
+    the inputs below. ``_validate_output_binding_order`` checks that correspondence
+    on every preprocess, so it would fail loudly rather than mis-bind.
     """
     input_nodes = list(engine_node.args[0])
     if len(input_nodes) != len(input_names):

--- a/py/torch_tensorrt/executorch/partitioner.py
+++ b/py/torch_tensorrt/executorch/partitioner.py
@@ -80,6 +80,28 @@ def normalize_weight_streaming_budget_per_engine(
     return str(weight_streaming_budget_per_engine).encode("ascii")
 
 
+def _keep_mutated_buffers_above_delegate(exported_program: ExportedProgram) -> None:
+    """Undo tag_constant_data freezing a delegate-mutated buffer as constant.
+
+    tag_constant_data detects a mutated buffer only via its *direct* users, so a
+    buffer whose mutation is produced inside the delegate (the mutation is a
+    getitem off the call_delegate, not a direct user of the buffer placeholder)
+    is misclassified as constant data and tagged into the delegate. A TensorRT
+    engine is stateless across executions, so an absorbed mutable buffer would be
+    a frozen constant (the KV-cache update would be lost). Strip the delegation
+    tag from any buffer that is a mutation target so it stays a caller-owned
+    mutable buffer owned above the delegate.
+    """
+    sig = exported_program.graph_signature
+    mutated_buffer_targets = set(sig.buffers_to_mutate.values())
+    for node in exported_program.graph_module.graph.nodes:
+        if (
+            node.op == "placeholder"
+            and sig.inputs_to_buffers.get(node.name) in mutated_buffer_targets
+        ):
+            node.meta.pop("delegation_tag", None)
+
+
 class TensorRTPartitioner(Partitioner):  # type: ignore[misc]
     """Partitions the graph for TensorRT delegation.
 
@@ -181,6 +203,7 @@ class TensorRTPartitioner(Partitioner):  # type: ignore[misc]
                 )
 
         tag_constant_data(exported_program)
+        _keep_mutated_buffers_above_delegate(exported_program)
 
         return PartitionResult(
             tagged_exported_program=exported_program,

--- a/py/torch_tensorrt/executorch/serialization.py
+++ b/py/torch_tensorrt/executorch/serialization.py
@@ -10,7 +10,7 @@ import dataclasses
 import json
 import struct
 from dataclasses import dataclass, field
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 TENSORRT_MAGIC = b"TR01"
 HEADER_FORMAT = "<4sIIIQ8s"
@@ -32,6 +32,11 @@ class TensorRTIOBinding:
 @dataclass
 class TensorRTBlobMetadata:
     io_bindings: List[TensorRTIOBinding] = field(default_factory=list)
+    # Aliased output->input bindings: out_name -> (in_name, kind). "kind" is an
+    # AliasKind value ("kv_cache_update" or "user"); the C++ backend binds each
+    # aliased engine output to its aliased input's tensor (in-place) so the
+    # update lands in the caller-owned buffer.
+    aliased_io: Dict[str, Tuple[str, str]] = field(default_factory=dict)
     hardware_compatible: bool = False
     device_id: int = 0
     serialized_metadata: str = ""
@@ -50,6 +55,12 @@ class TensorRTBlobMetadata:
                 }
                 for binding in self.io_bindings
             ],
+            # List form (not a dict) so the small C++ parser can walk it like
+            # io_bindings. Emitted right after io_bindings, before the scalars.
+            "aliased_io": [
+                {"output": out, "input": inp, "kind": kind}
+                for out, (inp, kind) in self.aliased_io.items()
+            ],
             "hardware_compatible": self.hardware_compatible,
             "device_id": self.device_id,
             "serialized_metadata": self.serialized_metadata,
@@ -67,8 +78,13 @@ class TensorRTBlobMetadata:
             )
             for binding in parsed.get("io_bindings", [])
         ]
+        aliased_io = {
+            b["output"]: (b["input"], b.get("kind", "kv_cache_update"))
+            for b in parsed.get("aliased_io", [])
+        }
         return cls(
             io_bindings=io_bindings,
+            aliased_io=aliased_io,
             hardware_compatible=parsed.get("hardware_compatible", False),
             device_id=parsed.get("device_id", 0),
             serialized_metadata=parsed.get("serialized_metadata", ""),

--- a/py/torch_tensorrt/executorch/serialization.py
+++ b/py/torch_tensorrt/executorch/serialization.py
@@ -12,7 +12,14 @@ import struct
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
 
+# A blob carrying aliased_io means something different to a parser that ignores it:
+# the runtime would bind each aliased output to its own allocation instead of the
+# input it aliases, and return wrong results rather than fail. The only field a
+# pre-aliasing parser validates is the magic, so aliased blobs carry TR02 and it
+# rejects them. Blobs without aliased_io keep TR01 and stay readable everywhere.
 TENSORRT_MAGIC = b"TR01"
+TENSORRT_MAGIC_ALIASED_IO = b"TR02"
+SUPPORTED_MAGICS = (TENSORRT_MAGIC, TENSORRT_MAGIC_ALIASED_IO)
 HEADER_FORMAT = "<4sIIIQ8s"
 HEADER_SIZE = struct.calcsize(HEADER_FORMAT)
 
@@ -99,7 +106,7 @@ def serialize_engine(engine_bytes: bytes, metadata: TensorRTBlobMetadata) -> byt
     reserved = b"\x01" + b"\x00" * 7
     header = struct.pack(
         HEADER_FORMAT,
-        TENSORRT_MAGIC,
+        TENSORRT_MAGIC_ALIASED_IO if metadata.aliased_io else TENSORRT_MAGIC,
         metadata_offset,
         len(metadata_json),
         engine_offset,
@@ -116,7 +123,7 @@ def deserialize_engine(blob: bytes) -> Tuple[bytes, TensorRTBlobMetadata]:
     magic, metadata_offset, metadata_size, engine_offset, engine_size, _ = (
         struct.unpack(HEADER_FORMAT, blob[:HEADER_SIZE])
     )
-    if magic != TENSORRT_MAGIC:
+    if magic not in SUPPORTED_MAGICS:
         raise ValueError(f"Invalid magic: {magic!r}")
     if engine_offset % 16 != 0:
         raise ValueError(f"Engine offset is not 16-byte aligned: {engine_offset}")

--- a/tests/cpp/executorch/test_executorch_blob_header.cpp
+++ b/tests/cpp/executorch/test_executorch_blob_header.cpp
@@ -107,6 +107,48 @@ TEST(ExecuTorchTensorRTBlobHeader, RejectsMissingIoBindingsMetadata) {
   EXPECT_FALSE(TensorRTBlobHeader::parse(blob.data(), blob.size(), header));
 }
 
+TEST(ExecuTorchTensorRTBlobHeader, ParsesAliasedIo) {
+  const std::string metadata = R"({"io_bindings":[{"name":"in_k","is_input":true},{"name":"out_k","is_input":false},)"
+                               R"({"name":"in_u","is_input":true},{"name":"out_u","is_input":false}],)"
+                               R"("aliased_io":[{"output":"out_k","input":"in_k","kind":"kv_cache_update"},)"
+                               R"({"output":"out_u","input":"in_u","kind":"user"}],)"
+                               R"("hardware_compatible":false,"device_id":0})";
+  const auto blob = make_blob(metadata);
+
+  TensorRTBlobHeader header;
+  ASSERT_TRUE(TensorRTBlobHeader::parse(blob.data(), blob.size(), header));
+
+  ASSERT_EQ(header.aliased_io.size(), 2u);
+  EXPECT_EQ(header.aliased_io[0].output, "out_k");
+  EXPECT_EQ(header.aliased_io[0].input, "in_k");
+  EXPECT_EQ(header.aliased_io[0].kind, "kv_cache_update");
+  EXPECT_EQ(header.aliased_io[1].output, "out_u");
+  EXPECT_EQ(header.aliased_io[1].input, "in_u");
+  EXPECT_EQ(header.aliased_io[1].kind, "user");
+}
+
+TEST(ExecuTorchTensorRTBlobHeader, DefaultsMissingAliasedIo) {
+  // Blobs written before aliased_io existed omit the key; parsing must still
+  // succeed and leave aliased_io empty (backward compatible).
+  const auto blob =
+      make_blob(R"({"io_bindings":[{"name":"input_0","is_input":true},{"name":"output_0","is_input":false}],)"
+                R"("hardware_compatible":false,"device_id":0})");
+
+  TensorRTBlobHeader header;
+  ASSERT_TRUE(TensorRTBlobHeader::parse(blob.data(), blob.size(), header));
+  EXPECT_TRUE(header.aliased_io.empty());
+}
+
+TEST(ExecuTorchTensorRTBlobHeader, ParsesEmptyAliasedIo) {
+  const auto blob =
+      make_blob(R"({"io_bindings":[{"name":"input_0","is_input":true},{"name":"output_0","is_input":false}],)"
+                R"("aliased_io":[],"hardware_compatible":false,"device_id":0})");
+
+  TensorRTBlobHeader header;
+  ASSERT_TRUE(TensorRTBlobHeader::parse(blob.data(), blob.size(), header));
+  EXPECT_TRUE(header.aliased_io.empty());
+}
+
 } // namespace
 } // namespace executorch_backend
 } // namespace torch_tensorrt

--- a/tests/cpp/executorch/test_executorch_blob_header.cpp
+++ b/tests/cpp/executorch/test_executorch_blob_header.cpp
@@ -13,6 +13,7 @@ namespace executorch_backend {
 namespace {
 
 constexpr char TENSORRT_MAGIC[4] = {'T', 'R', '0', '1'};
+constexpr char TENSORRT_MAGIC_ALIASED_IO[4] = {'T', 'R', '0', '2'};
 constexpr uint32_t METADATA_OFFSET_FIELD_OFFSET = 4;
 constexpr uint32_t METADATA_SIZE_FIELD_OFFSET = 8;
 constexpr uint32_t ENGINE_OFFSET_FIELD_OFFSET = 12;
@@ -29,13 +30,16 @@ std::size_t align_up(std::size_t value, std::size_t alignment) {
   return ((value + alignment - 1) / alignment) * alignment;
 }
 
-std::vector<uint8_t> make_blob(const std::string& metadata, std::size_t engine_size = 4) {
+std::vector<uint8_t> make_blob(
+    const std::string& metadata,
+    std::size_t engine_size = 4,
+    const char* magic = TENSORRT_MAGIC) {
   const auto metadata_offset = static_cast<uint32_t>(HEADER_SIZE);
   const auto metadata_size = static_cast<uint32_t>(metadata.size());
   const auto engine_offset = static_cast<uint32_t>(align_up(metadata_offset + metadata_size, ENGINE_ALIGNMENT));
   std::vector<uint8_t> blob(static_cast<std::size_t>(engine_offset) + engine_size, 0);
 
-  std::memcpy(blob.data(), TENSORRT_MAGIC, sizeof(TENSORRT_MAGIC));
+  std::memcpy(blob.data(), magic, sizeof(TENSORRT_MAGIC));
   write_field(blob, METADATA_OFFSET_FIELD_OFFSET, metadata_offset);
   write_field(blob, METADATA_SIZE_FIELD_OFFSET, metadata_size);
   write_field(blob, ENGINE_OFFSET_FIELD_OFFSET, engine_offset);
@@ -147,6 +151,27 @@ TEST(ExecuTorchTensorRTBlobHeader, ParsesEmptyAliasedIo) {
   TensorRTBlobHeader header;
   ASSERT_TRUE(TensorRTBlobHeader::parse(blob.data(), blob.size(), header));
   EXPECT_TRUE(header.aliased_io.empty());
+}
+
+TEST(ExecuTorchTensorRTBlobHeader, ParsesAliasedIoMagic) {
+  const std::string metadata = R"({"io_bindings":[{"name":"in_k","is_input":true},{"name":"out_k","is_input":false}],)"
+                               R"("aliased_io":[{"output":"out_k","input":"in_k","kind":"kv_cache_update"}]})";
+  const auto blob = make_blob(metadata, 4, TENSORRT_MAGIC_ALIASED_IO);
+
+  TensorRTBlobHeader header;
+  ASSERT_TRUE(TensorRTBlobHeader::parse(blob.data(), blob.size(), header));
+  ASSERT_EQ(header.aliased_io.size(), 1u);
+  EXPECT_EQ(header.aliased_io[0].output_name, "out_k");
+  EXPECT_EQ(header.aliased_io[0].input_name, "in_k");
+}
+
+TEST(ExecuTorchTensorRTBlobHeader, RejectsUnknownFutureMagic) {
+  constexpr char kFutureMagic[4] = {'T', 'R', '0', '3'};
+  const std::string metadata = R"({"io_bindings":[{"name":"x","is_input":true}]})";
+  const auto blob = make_blob(metadata, 4, kFutureMagic);
+
+  TensorRTBlobHeader header;
+  EXPECT_FALSE(TensorRTBlobHeader::parse(blob.data(), blob.size(), header));
 }
 
 } // namespace

--- a/tests/py/dynamo/executorch/test_backend.py
+++ b/tests/py/dynamo/executorch/test_backend.py
@@ -1,8 +1,8 @@
 import ast
+import operator
+import struct
 from pathlib import Path
 from types import SimpleNamespace
-
-import struct
 
 import pytest
 
@@ -20,14 +20,14 @@ from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import (  # noqa: E402
     SERIALIZATION_LEN,
 )
 from torch_tensorrt.executorch.backend import (  # noqa: E402
-    _get_engine_info_from_edge_program,
     TensorRTBackend,
+    _get_engine_info_from_edge_program,
 )
 from torch_tensorrt.executorch.serialization import (  # noqa: E402
-    deserialize_engine,
     HEADER_FORMAT,
     HEADER_SIZE,
     TENSORRT_MAGIC,
+    deserialize_engine,
 )
 
 
@@ -77,7 +77,18 @@ def _build_edge_program(
         _ENGINE_OP,
         (engine_inputs, *engine_info),
     )
-    graph.output((engine_node,))
+    # A multi-output engine is consumed through one getitem per output binding, in
+    # index order; a single-output engine is returned unwrapped.
+    out_names = [n for n in str(engine_info[OUTPUT_BINDING_NAMES_IDX]).split("%") if n]
+    if len(out_names) > 1:
+        graph.output(
+            tuple(
+                graph.call_function(operator.getitem, (engine_node, i))
+                for i in range(len(out_names))
+            )
+        )
+    else:
+        graph.output((engine_node,))
 
     graph_signature = SimpleNamespace(
         input_specs=[
@@ -368,3 +379,61 @@ def test_preprocess_preserves_output_binding_order():
         False,
         False,
     ]
+
+
+def _engine_partition(output_indices):
+    """A one-engine partition whose graph outputs are getitem(engine, i) for each i
+    in `output_indices`, in that order."""
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    engine = g.call_function(
+        torch.ops.tensorrt.no_op_placeholder_for_execute_engine.default, ([x],)
+    )
+    g.output(
+        tuple(g.call_function(operator.getitem, (engine, i)) for i in output_indices)
+    )
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+    return SimpleNamespace(graph_module=gm), engine
+
+
+@pytest.mark.unit
+def test_validate_output_binding_order_accepts_index_order():
+    from torch_tensorrt.executorch.backend import _validate_output_binding_order
+
+    ep, engine = _engine_partition([0, 1, 2])
+    _validate_output_binding_order(ep, engine, ["out0", "out1", "out2"])
+
+
+@pytest.mark.unit
+def test_validate_output_binding_order_rejects_permuted_outputs():
+    """The runtime binds output i to output_binding_names[i]. A pass that moved a
+    mutation output ahead of the user outputs would rename them silently."""
+    from torch_tensorrt.executorch.backend import _validate_output_binding_order
+
+    ep, engine = _engine_partition([2, 0, 1])
+    with pytest.raises(ValueError, match="engine output indices"):
+        _validate_output_binding_order(ep, engine, ["out0", "out1", "out2"])
+
+
+@pytest.mark.unit
+def test_validate_output_binding_order_rejects_dropped_output():
+    from torch_tensorrt.executorch.backend import _validate_output_binding_order
+
+    ep, engine = _engine_partition([0, 1])
+    with pytest.raises(ValueError, match="engine output indices"):
+        _validate_output_binding_order(ep, engine, ["out0", "out1", "out2"])
+
+
+@pytest.mark.unit
+def test_validate_output_binding_order_accepts_unwrapped_single_output():
+    """A single-output engine is returned directly, not through a getitem."""
+    from torch_tensorrt.executorch.backend import _validate_output_binding_order
+
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    engine = g.call_function(
+        torch.ops.tensorrt.no_op_placeholder_for_execute_engine.default, ([x],)
+    )
+    g.output((engine,))
+    ep = SimpleNamespace(graph_module=torch.fx.GraphModule(torch.nn.Module(), g))
+    _validate_output_binding_order(ep, engine, ["out"])

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -1,0 +1,157 @@
+"""Export-side coverage for caller-owned KV-cache buffer mutations.
+
+Both retrace modes must surface an engine's aliased KV outputs as graph-level
+BUFFER_MUTATIONs so the ExecuTorch delegate keeps them as caller-owned mutable
+buffers instead of freezing them:
+
+  * retrace=False (legacy exporter): ``inline_trt_modules`` exposes them at
+    transform time (guarded by ``expose_aliased_mutations``), then
+    ``create_trt_exp_program`` declares the specs.
+  * retrace=True (torch.export): ``torch.export`` truncates the aliased outputs
+    at the fx boundary, so ``_declare_aliased_kv_mutations_on_ep`` re-declares
+    them on the exported program before lowering.
+"""
+
+import operator
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch.export.exported_program import (
+    InputKind,
+    InputSpec,
+    OutputKind,
+    OutputSpec,
+    TensorArgument,
+)
+from torch_tensorrt.dynamo import _exporter as E
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("use_legacy, expected_expose", [(True, True), (False, False)])
+def test_export_exposes_aliased_mutations_only_for_legacy_exporter(
+    monkeypatch, use_legacy, expected_expose
+):
+    """The transform-time KV exposure runs on the retrace=False (legacy) path
+    only; retrace=True defers to the post-export declaration pass, so it must not
+    perturb the user outputs at transform time.
+    """
+    captured = {}
+
+    def fake_transform(gm, cross_compile_module=False, expose_aliased_mutations=True):
+        captured["expose"] = expose_aliased_mutations
+        return gm
+
+    monkeypatch.setattr(E, "transform", fake_transform)
+    monkeypatch.setattr(E, "create_trt_exp_program", lambda *a, **k: "legacy-ep")
+    monkeypatch.setattr(torch.export, "export", lambda *a, **k: "retrace-ep")
+
+    result = E.export(torch.nn.Module(), use_legacy_exporter=use_legacy)
+
+    assert captured["expose"] is expected_expose
+    assert result == ("legacy-ep" if use_legacy else "retrace-ep")
+
+
+@pytest.mark.unit
+def test_declare_aliased_kv_mutations_is_noop_without_engines():
+    """With no execute_engine node carrying aliased I/O, the pass returns the
+    exported program unchanged (same object)."""
+    pytest.importorskip("executorch.exir")
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    g.output((x,))
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+    ep = SimpleNamespace(
+        graph_module=gm,
+        graph_signature=SimpleNamespace(inputs_to_buffers={}),
+    )
+    assert E._declare_aliased_kv_mutations_on_ep(ep) is ep
+
+
+@pytest.mark.unit
+def test_declare_aliased_kv_mutations_declares_buffer_mutation(monkeypatch):
+    """An engine whose aliased KV output is dropped from meta['val'] gets that
+    output surfaced as a getitem and declared a BUFFER_MUTATION of the aliased
+    input's buffer, ordered before the user outputs (verifier requirement)."""
+    pytest.importorskip("executorch.exir")
+    import torch_tensorrt.dynamo.runtime._serialized_engine_layout as L
+    import torch_tensorrt.dynamo.runtime._TorchTensorRTModule as M
+    import torch_tensorrt.executorch.backend as B
+
+    exec_target = torch.ops.tensorrt.execute_engine.default
+
+    # b_k_0 (KV buffer) + tokens feed the engine; meta['val'] covers only the one
+    # user output -- the aliased KV output ("out_k") is truncated at the boundary.
+    g = torch.fx.Graph()
+    b_k_0 = g.placeholder("b_k_0")
+    tokens = g.placeholder("tokens")
+    engine = g.placeholder("engine")
+    eng = g.call_function(exec_target, ([b_k_0, tokens], engine))
+    user_out = g.call_function(operator.getitem, (eng, 0))
+    g.output((user_out,))
+
+    buf_val = torch.zeros(2, 2)
+    out_val = torch.zeros(1)
+    b_k_0.meta["val"] = buf_val
+    tokens.meta["val"] = torch.zeros(1)
+    engine.meta["val"] = None
+    eng.meta["val"] = [out_val]
+    user_out.meta["val"] = out_val
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+    sig = SimpleNamespace(
+        inputs_to_buffers={"b_k_0": "k_0"},
+        input_specs=[
+            InputSpec(InputKind.BUFFER, TensorArgument(name="b_k_0"), "k_0", True),
+        ],
+        output_specs=[
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name="user_out"), None),
+        ],
+    )
+    ep = SimpleNamespace(
+        graph_module=gm,
+        graph_signature=sig,
+        state_dict={},
+        range_constraints={},
+        module_call_graph=[],
+        constants={},
+    )
+
+    info = ["x"] * (L.ALIASED_IO_IDX + 1)
+    info[L.INPUT_BINDING_NAMES_IDX] = "IN"
+    info[L.OUTPUT_BINDING_NAMES_IDX] = "OUT"
+    monkeypatch.setattr(B, "_get_engine_info_for_node", lambda ep_, n: info)
+    monkeypatch.setattr(
+        M, "deserialize_aliased_io", lambda s: {"out_k": ("k_in", "kv_cache_update")}
+    )
+    monkeypatch.setattr(
+        L,
+        "deserialize_binding_names",
+        lambda s: ["k_in", "tokens"] if s == "IN" else ["user_out", "out_k"],
+    )
+
+    captured = {}
+
+    class _CapturingEP:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(E, "ExportedProgram", _CapturingEP)
+
+    E._declare_aliased_kv_mutations_on_ep(ep)
+
+    new_specs = captured["graph_signature"].output_specs
+    # BUFFER_MUTATION for k_0 is declared first, ahead of the user output.
+    assert len(new_specs) == 2
+    assert new_specs[0].kind == OutputKind.BUFFER_MUTATION
+    assert new_specs[0].target == "k_0"
+    assert new_specs[1].kind == OutputKind.USER_OUTPUT
+
+    # The mutation getitem is prepended to the graph output (mutations first).
+    out_node = next(n for n in gm.graph.nodes if n.op == "output")
+    assert out_node.args[0][0].name == new_specs[0].arg.name
+    assert out_node.args[0][1] is user_out
+
+    # The engine's meta['val'] is extended to cover the previously-dropped output.
+    assert len(eng.meta["val"]) == 2

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -246,7 +246,7 @@ def test_declare_aliased_kv_mutations_declares_buffer_mutation(monkeypatch):
     assert out_node.args[0][0].name == new_specs[0].arg.name
     assert out_node.args[0][1] is user_out
 
-    # The engine's meta['val'] is extended to cover the previously-dropped output.
+    # The engine's meta['val'] is extended to cover the truncated aliased output.
     assert len(eng.meta["val"]) == 2
 
     # A rewrite replaces only the graph and signature; every other field of the

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -375,6 +375,155 @@ def test_declare_aliased_kv_mutations_declares_copyback(monkeypatch):
 
 
 @pytest.mark.unit
+def test_declare_aliased_kv_mutations_skips_already_declared_copyback(monkeypatch):
+    """A buffer torch.export already declared BUFFER_MUTATION is not declared twice,
+    and its trailing value still leaves the user outputs.
+
+    torch.export moves a mutation it recognises to the front of the outputs. The
+    trailing value lift appended for that same buffer is internal plumbing, so it must
+    be detached either way, otherwise it stays a user output and the saved model gains
+    a return it never had."""
+    pytest.importorskip("executorch.exir")
+
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    state_in = g.placeholder("state_in")
+    state_new = g.call_function(torch.add, (state_in, x))
+    user_out = g.call_function(torch.add, (x, x))
+    # torch.export's own mutation output first, then the user output, then the
+    # trailing copy-back value lift appended for the same buffer.
+    g.output((state_new, user_out, state_new))
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+    sig = SimpleNamespace(
+        inputs_to_buffers={"state_in": "state_0"},
+        input_specs=[
+            InputSpec(
+                InputKind.BUFFER, TensorArgument(name="state_in"), "state_0", True
+            ),
+            InputSpec(InputKind.USER_INPUT, TensorArgument(name="x"), None),
+        ],
+        output_specs=[
+            OutputSpec(
+                OutputKind.BUFFER_MUTATION,
+                TensorArgument(name=state_new.name),
+                "state_0",
+            ),
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name="user_out"), None),
+            OutputSpec(
+                OutputKind.USER_OUTPUT, TensorArgument(name=state_new.name), None
+            ),
+        ],
+    )
+    ep = SimpleNamespace(
+        graph_module=gm,
+        graph_signature=sig,
+        state_dict={},
+        range_constraints={},
+        module_call_graph=[],
+        constants={},
+    )
+
+    captured = {}
+
+    class _CapturingEP:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(E, "ExportedProgram", _CapturingEP)
+
+    E._declare_aliased_kv_mutations_on_ep(ep, copyback_buffers=["state_0"])
+
+    new_specs = captured["graph_signature"].output_specs
+    # state_0 keeps its single existing mutation spec; no second one is added.
+    mutations = [s for s in new_specs if s.kind == OutputKind.BUFFER_MUTATION]
+    assert [s.target for s in mutations] == ["state_0"]
+    # The trailing copy-back value is gone from the user outputs.
+    user_outputs = [s for s in new_specs if s.kind == OutputKind.USER_OUTPUT]
+    assert [s.arg.name for s in user_outputs] == ["user_out"]
+
+    out_node = next(n for n in gm.graph.nodes if n.op == "output")
+    assert list(out_node.args[0]) == [state_new, user_out]
+
+
+@pytest.mark.unit
+def test_declare_aliased_kv_mutations_pairs_copyback_by_position(monkeypatch):
+    """With a mix of declared and undeclared buffers, each remaining copy-back value
+    is paired with the buffer lift appended it for.
+
+    lift appends the values in copyback_buffers order, so the pairing has to come from
+    that full run. Dropping the declared buffers before slicing shifts the run and
+    declares one buffer's value as another's mutation, which the runtime then copies
+    into a buffer of a different shape."""
+    pytest.importorskip("executorch.exir")
+
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    a_in = g.placeholder("a_in")
+    b_in = g.placeholder("b_in")
+    c_in = g.placeholder("c_in")
+    a_new = g.call_function(torch.add, (a_in, x))
+    b_new = g.call_function(torch.add, (b_in, x))
+    c_new = g.call_function(torch.add, (c_in, x))
+    user_out = g.call_function(torch.add, (x, x))
+    # Only b is recognised by torch.export, so its mutation leads. The trailing run
+    # is a_new, b_new, c_new, matching copyback_buffers order.
+    g.output((b_new, user_out, a_new, b_new, c_new))
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+    def buf_spec(name, target):
+        return InputSpec(InputKind.BUFFER, TensorArgument(name=name), target, True)
+
+    sig = SimpleNamespace(
+        inputs_to_buffers={"a_in": "a", "b_in": "b", "c_in": "c"},
+        input_specs=[
+            buf_spec("a_in", "a"),
+            buf_spec("b_in", "b"),
+            buf_spec("c_in", "c"),
+            InputSpec(InputKind.USER_INPUT, TensorArgument(name="x"), None),
+        ],
+        output_specs=[
+            OutputSpec(
+                OutputKind.BUFFER_MUTATION, TensorArgument(name=b_new.name), "b"
+            ),
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name="user_out"), None),
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name=a_new.name), None),
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name=b_new.name), None),
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name=c_new.name), None),
+        ],
+    )
+    ep = SimpleNamespace(
+        graph_module=gm,
+        graph_signature=sig,
+        state_dict={},
+        range_constraints={},
+        module_call_graph=[],
+        constants={},
+    )
+
+    captured = {}
+
+    class _CapturingEP:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(E, "ExportedProgram", _CapturingEP)
+
+    E._declare_aliased_kv_mutations_on_ep(ep, copyback_buffers=["a", "b", "c"])
+
+    new_specs = captured["graph_signature"].output_specs
+    mutations = [s for s in new_specs if s.kind == OutputKind.BUFFER_MUTATION]
+    # Each buffer appears once, paired with the value appended for it.
+    assert [(s.target, s.arg.name) for s in mutations] == [
+        ("a", a_new.name),
+        ("c", c_new.name),
+        ("b", b_new.name),
+    ]
+    user_outputs = [s for s in new_specs if s.kind == OutputKind.USER_OUTPUT]
+    assert [s.arg.name for s in user_outputs] == ["user_out"]
+
+
+@pytest.mark.unit
 def test_create_trt_exp_program_declares_copyback(monkeypatch):
     """retrace=False: create_trt_exp_program reads
     gm.meta['_copyback_mutation_buffers'], tags the trailing outputs with their

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -69,9 +69,95 @@ def test_declare_aliased_kv_mutations_is_noop_without_engines():
 
     ep = SimpleNamespace(
         graph_module=gm,
-        graph_signature=SimpleNamespace(inputs_to_buffers={}),
+        graph_signature=SimpleNamespace(inputs_to_buffers={}, output_specs=[]),
     )
     assert E._declare_aliased_kv_mutations_on_ep(ep) is ep
+
+
+@pytest.mark.unit
+def test_declare_aliased_kv_mutations_is_idempotent(monkeypatch):
+    """Running on a program whose mutation is already declared must be a no-op.
+
+    Exposure is decided both by the exporter (the legacy one declares at transform
+    time) and by save()'s per-format branch, so this pass can receive a program that
+    already carries the spec. Declaring again appends a second BUFFER_MUTATION for
+    the same buffer, which fails the ExportedProgram verifier's output ordering.
+    """
+    pytest.importorskip("executorch.exir")
+    import torch_tensorrt.dynamo.runtime._serialized_engine_layout as L
+    import torch_tensorrt.dynamo.runtime._TorchTensorRTModule as M
+    import torch_tensorrt.executorch.backend as B
+
+    exec_target = torch.ops.tensorrt.execute_engine.default
+
+    g = torch.fx.Graph()
+    b_k_0 = g.placeholder("b_k_0")
+    tokens = g.placeholder("tokens")
+    engine = g.placeholder("engine")
+    eng = g.call_function(exec_target, ([b_k_0, tokens], engine))
+    user_out = g.call_function(operator.getitem, (eng, 0))
+    kv_out = g.call_function(operator.getitem, (eng, 1))
+    g.output((kv_out, user_out))
+
+    buf_val = torch.zeros(2, 2)
+    out_val = torch.zeros(1)
+    b_k_0.meta["val"] = buf_val
+    tokens.meta["val"] = torch.zeros(1)
+    engine.meta["val"] = None
+    eng.meta["val"] = [out_val, buf_val]
+    user_out.meta["val"] = out_val
+    kv_out.meta["val"] = buf_val
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+    # k_0 already declared -- what the legacy exporter leaves behind.
+    sig = SimpleNamespace(
+        inputs_to_buffers={"b_k_0": "k_0"},
+        input_specs=[
+            InputSpec(InputKind.BUFFER, TensorArgument(name="b_k_0"), "k_0", True),
+        ],
+        output_specs=[
+            OutputSpec(
+                OutputKind.BUFFER_MUTATION, TensorArgument(name=kv_out.name), "k_0"
+            ),
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name="user_out"), None),
+        ],
+    )
+    ep = SimpleNamespace(
+        graph_module=gm,
+        graph_signature=sig,
+        state_dict={},
+        range_constraints={},
+        module_call_graph=[],
+        constants={},
+        example_inputs=_EXAMPLE_INPUTS,
+        verifiers=[Verifier],
+    )
+
+    info = ["x"] * (L.ALIASED_IO_IDX + 1)
+    info[L.INPUT_BINDING_NAMES_IDX] = "IN"
+    info[L.OUTPUT_BINDING_NAMES_IDX] = "OUT"
+    monkeypatch.setattr(B, "_get_engine_info_for_node", lambda ep_, n: info)
+    monkeypatch.setattr(
+        M, "deserialize_aliased_io", lambda s: {"out_k": ("k_in", "kv_cache_update")}
+    )
+    monkeypatch.setattr(
+        L,
+        "deserialize_binding_names",
+        lambda s: ["k_in", "tokens"] if s == "IN" else ["user_out", "out_k"],
+    )
+
+    def _must_not_rebuild(**kwargs):
+        raise AssertionError(
+            "the pass rebuilt the program even though k_0 was already declared"
+        )
+
+    monkeypatch.setattr(E, "ExportedProgram", _must_not_rebuild)
+
+    assert E._declare_aliased_kv_mutations_on_ep(ep) is ep
+    assert [spec.kind for spec in sig.output_specs] == [
+        OutputKind.BUFFER_MUTATION,
+        OutputKind.USER_OUTPUT,
+    ]
 
 
 @pytest.mark.unit

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -260,3 +260,49 @@ def test_declare_aliased_kv_mutations_declares_buffer_mutation(monkeypatch):
         "verifiers",
     ):
         assert captured[field] is getattr(ep, field)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("output_format", ["exported_program", "executorch"])
+@pytest.mark.parametrize("use_legacy", [True, False])
+def test_save_declares_aliased_mutations_without_retrace(
+    monkeypatch, tmp_path, output_format, use_legacy
+):
+    """retrace=False must declare the aliased KV mutations as well.
+
+    Only the legacy exporter exposes them at transform time, so with
+    use_legacy_exporter=False nothing declares them and the saved program omits an
+    update the engine performs. The pass skips buffers already declared, so save()
+    can run it for either exporter.
+    """
+    pytest.importorskip("executorch.exir")
+    import torch_tensorrt
+    from torch_tensorrt import _compile as C
+    from torch_tensorrt.dynamo import _exporter as E
+
+    sentinel = object()
+    declared = []
+
+    def _declare(ep, **kwargs):
+        declared.append(ep)
+        return ep
+
+    monkeypatch.setattr(E, "export", lambda *a, **k: sentinel)
+    monkeypatch.setattr(E, "_declare_aliased_kv_mutations_on_ep", _declare)
+    monkeypatch.setattr(C, "_normalize_engine_constants_to_python", lambda ep: None)
+    monkeypatch.setattr(C, "_save_as_executorch", lambda *a, **k: None)
+    monkeypatch.setattr(torch.export, "save", lambda *a, **k: None)
+
+    g = torch.fx.Graph()
+    g.output((g.placeholder("x"),))
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+    torch_tensorrt.save(
+        gm,
+        str(tmp_path / "out.pte"),
+        output_format=output_format,
+        retrace=False,
+        use_legacy_exporter=use_legacy,
+    )
+
+    assert declared == [sentinel]

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from torch._export.verifier import Verifier
 from torch.export.exported_program import (
     InputKind,
     InputSpec,
@@ -25,6 +26,10 @@ from torch.export.exported_program import (
     TensorArgument,
 )
 from torch_tensorrt.dynamo import _exporter as E
+
+# A real ExportedProgram carries these, so the stubs below do too -- the pass has to
+# hand them on rather than let them reset to their defaults.
+_EXAMPLE_INPUTS = ((torch.randn(2),), {})
 
 
 @pytest.mark.unit
@@ -116,6 +121,8 @@ def test_declare_aliased_kv_mutations_declares_buffer_mutation(monkeypatch):
         range_constraints={},
         module_call_graph=[],
         constants={},
+        example_inputs=_EXAMPLE_INPUTS,
+        verifiers=[Verifier],
     )
 
     info = ["x"] * (L.ALIASED_IO_IDX + 1)
@@ -155,3 +162,15 @@ def test_declare_aliased_kv_mutations_declares_buffer_mutation(monkeypatch):
 
     # The engine's meta['val'] is extended to cover the previously-dropped output.
     assert len(eng.meta["val"]) == 2
+
+    # A rewrite replaces only the graph and signature; every other field of the
+    # source program has to come through untouched.
+    for field in (
+        "state_dict",
+        "range_constraints",
+        "module_call_graph",
+        "constants",
+        "example_inputs",
+        "verifiers",
+    ):
+        assert captured[field] is getattr(ep, field)

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -306,3 +306,239 @@ def test_save_declares_aliased_mutations_without_retrace(
     )
 
     assert declared == [sentinel]
+
+
+@pytest.mark.unit
+def test_declare_aliased_kv_mutations_declares_copyback(monkeypatch):
+    """retrace=True: a trailing copy-back output (a non-KV mutable buffer with no
+    engine aliasing) is reclassified from USER_OUTPUT to BUFFER_MUTATION of its
+    buffer and ordered ahead of the user outputs."""
+    pytest.importorskip("executorch.exir")
+
+    # No execute_engine node -> the pure copy-back case (num_copyback drives the
+    # pass). ``user_out`` is a real return; ``state_new`` is the copy-back new value
+    # that lift_mutated_buffers appended as the trailing output.
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    state_in = g.placeholder("state_in")
+    user_out = g.call_function(torch.add, (x, x))
+    state_new = g.call_function(torch.add, (state_in, x))
+    g.output((user_out, state_new))
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+    sig = SimpleNamespace(
+        inputs_to_buffers={"state_in": "state_0"},
+        input_specs=[
+            InputSpec(
+                InputKind.BUFFER, TensorArgument(name="state_in"), "state_0", True
+            ),
+            InputSpec(InputKind.USER_INPUT, TensorArgument(name="x"), None),
+        ],
+        output_specs=[
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name="user_out"), None),
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name="state_new"), None),
+        ],
+    )
+    ep = SimpleNamespace(
+        graph_module=gm,
+        graph_signature=sig,
+        state_dict={},
+        range_constraints={},
+        module_call_graph=[],
+        constants={},
+        example_inputs=_EXAMPLE_INPUTS,
+        verifiers=[Verifier],
+    )
+
+    captured = {}
+
+    class _CapturingEP:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(E, "ExportedProgram", _CapturingEP)
+
+    E._declare_aliased_kv_mutations_on_ep(ep, copyback_buffers=["state_0"])
+
+    new_specs = captured["graph_signature"].output_specs
+    # The trailing copy-back output becomes a BUFFER_MUTATION of state_0, first.
+    assert len(new_specs) == 2
+    assert new_specs[0].kind == OutputKind.BUFFER_MUTATION
+    assert new_specs[0].target == "state_0"
+    assert new_specs[0].arg.name == state_new.name
+    assert new_specs[1].kind == OutputKind.USER_OUTPUT
+
+    # Mutation is prepended to the graph output; the user output follows.
+    out_node = next(n for n in gm.graph.nodes if n.op == "output")
+    assert out_node.args[0][0] is state_new
+    assert out_node.args[0][1] is user_out
+
+
+@pytest.mark.unit
+def test_create_trt_exp_program_declares_copyback(monkeypatch):
+    """retrace=False: create_trt_exp_program reads
+    gm.meta['_copyback_mutation_buffers'], tags the trailing outputs with their
+    buffer target, and emits them as BUFFER_MUTATION specs ahead of the user
+    outputs."""
+    pytest.importorskip("executorch.exir")
+
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    state_in = g.placeholder("state_in")
+    user_out = g.call_function(torch.add, (x, x))
+    state_new = g.call_function(torch.add, (state_in, x))
+    g.output((user_out, state_new))
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+    gm.recompile()
+    gm.meta["_copyback_mutation_buffers"] = ["state_0"]
+
+    captured = {}
+
+    class _CapturingEP:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    # Stub the heavy tail: lift() (param/buffer lifting) and the real EP ctor.
+    monkeypatch.setattr(E, "ExportedProgram", _CapturingEP)
+    monkeypatch.setattr(E, "lift", lambda gm_, sig_: (gm_, sig_, {}, {}))
+
+    E.create_trt_exp_program(gm)
+
+    specs = captured["graph_signature"].output_specs
+    assert len(specs) == 2
+    assert specs[0].kind == OutputKind.BUFFER_MUTATION
+    assert specs[0].target == "state_0"
+    assert specs[0].arg.name == state_new.name
+    assert specs[1].kind == OutputKind.USER_OUTPUT
+
+    # The trailing output is tagged with its buffer and reordered mutation-first.
+    assert state_new.meta["_kv_mutation_target"] == "state_0"
+    out_node = next(n for n in gm.graph.nodes if n.op == "output")
+    assert out_node.args[0][0] is state_new
+    assert out_node.args[0][1] is user_out
+
+
+@pytest.mark.unit
+def test_create_trt_exp_program_declares_write_only_copyback_buffer():
+    """A copy-back buffer with no reader must still reach ``lift`` as a get_attr.
+
+    ``transform``'s dead-code pass drops the get_attr of a buffer nothing reads,
+    and ``lift`` derives BUFFER input specs from get_attr nodes alone, so the
+    BUFFER_MUTATION declared here would name a buffer the signature never
+    declares. Drives the real ``lift``/``ExportedProgram`` constructor so a
+    regression reproduces the verifier error instead of passing vacuously.
+    """
+    pytest.importorskip("executorch.exir")
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    fake_mode = FakeTensorMode()
+    with fake_mode:
+        fake_x = torch.randn(2)
+
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    x.meta["val"] = fake_x
+    # Neither output reads the buffer -- the write-only shape.
+    user_out = g.call_function(torch.ops.aten.mul.Tensor, (x, x))
+    user_out.meta["val"] = fake_x
+    state_new = g.call_function(torch.ops.aten.add.Tensor, (x, x))
+    state_new.meta["val"] = fake_x
+    g.output((user_out, state_new))
+
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+    gm.register_buffer("state_0", torch.zeros(2))
+    gm.recompile()
+    gm.meta["_copyback_mutation_buffers"] = ["state_0"]
+
+    ep = E.create_trt_exp_program(gm, arg_inputs=(torch.randn(2),))
+
+    buffer_inputs = [
+        s.target for s in ep.graph_signature.input_specs if s.kind == InputKind.BUFFER
+    ]
+    mutations = [
+        (s.target, s.kind)
+        for s in ep.graph_signature.output_specs
+        if s.kind == OutputKind.BUFFER_MUTATION
+    ]
+    assert buffer_inputs == ["state_0"]
+    assert mutations == [("state_0", OutputKind.BUFFER_MUTATION)]
+
+
+@pytest.mark.unit
+def test_create_trt_exp_program_does_not_duplicate_copyback_get_attr(monkeypatch):
+    """The re-add is keyed on the existing get_attr targets, so a copy-back buffer
+    that still has a live reader keeps its single get_attr, and a name that is not
+    registered on the module is left alone rather than producing a dangling one."""
+    pytest.importorskip("executorch.exir")
+
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    state_in = g.get_attr("state_0")
+    user_out = g.call_function(torch.add, (x, x))
+    state_new = g.call_function(torch.add, (state_in, x))
+    g.output((user_out, state_new))
+    root = torch.nn.Module()
+    root.register_buffer("state_0", torch.zeros(2))
+    gm = torch.fx.GraphModule(root, g)
+    gm.recompile()
+    # "ghost" is not registered on the module, so it cannot be re-added.
+    gm.meta["_copyback_mutation_buffers"] = ["state_0", "ghost"]
+
+    monkeypatch.setattr(E, "ExportedProgram", lambda **kwargs: None)
+    monkeypatch.setattr(E, "lift", lambda gm_, sig_: (gm_, sig_, {}, {}))
+
+    E.create_trt_exp_program(gm)
+
+    targets = sorted(n.target for n in gm.graph.nodes if n.op == "get_attr")
+    assert targets == ["state_0"]
+
+
+@pytest.mark.unit
+def test_declare_aliased_kv_mutations_rejects_redeclared_copyback():
+    """Declaring copy-back twice must fail rather than corrupt the signature.
+
+    The copy-back path reclassifies the trailing outputs by position, so on a
+    program whose exporter already declared them the trailing outputs are the
+    user's: a second pass would retarget those, dropping a user output and giving
+    the buffer two mutation specs.
+    """
+    pytest.importorskip("executorch.exir")
+
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    state_in = g.placeholder("state_in")
+    user_out = g.call_function(torch.add, (x, x))
+    state_new = g.call_function(torch.add, (state_in, x))
+    g.output((state_new, user_out))
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+
+    # state_0 already declared -- what the legacy exporter leaves behind.
+    sig = SimpleNamespace(
+        inputs_to_buffers={"state_in": "state_0"},
+        input_specs=[
+            InputSpec(
+                InputKind.BUFFER, TensorArgument(name="state_in"), "state_0", True
+            )
+        ],
+        output_specs=[
+            OutputSpec(
+                OutputKind.BUFFER_MUTATION,
+                TensorArgument(name=state_new.name),
+                "state_0",
+            ),
+            OutputSpec(OutputKind.USER_OUTPUT, TensorArgument(name="user_out"), None),
+        ],
+    )
+    ep = SimpleNamespace(
+        graph_module=gm,
+        graph_signature=sig,
+        state_dict={},
+        range_constraints={},
+        module_call_graph=[],
+        constants={},
+        example_inputs=_EXAMPLE_INPUTS,
+        verifiers=[Verifier],
+    )
+
+    with pytest.raises(RuntimeError, match="already carry a BUFFER_MUTATION"):
+        E._declare_aliased_kv_mutations_on_ep(ep, copyback_buffers=["state_0"])

--- a/tests/py/dynamo/executorch/test_kv_cache_export.py
+++ b/tests/py/dynamo/executorch/test_kv_cache_export.py
@@ -542,3 +542,39 @@ def test_declare_aliased_kv_mutations_rejects_redeclared_copyback():
 
     with pytest.raises(RuntimeError, match="already carry a BUFFER_MUTATION"):
         E._declare_aliased_kv_mutations_on_ep(ep, copyback_buffers=["state_0"])
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("use_legacy, expect_warning", [(True, False), (False, True)])
+def test_save_warns_when_copyback_cannot_be_declared(
+    monkeypatch, tmp_path, caplog, use_legacy, expect_warning
+):
+    """retrace=False only declares copy-back through the legacy exporter, so the
+    non-legacy combination drops it. Say so rather than saving a signature that
+    omits the update."""
+    pytest.importorskip("executorch.exir")
+    import torch_tensorrt
+    from torch_tensorrt import _compile as C
+    from torch_tensorrt.dynamo import _exporter as E
+
+    monkeypatch.setattr(E, "export", lambda *a, **k: object())
+    monkeypatch.setattr(E, "_declare_aliased_kv_mutations_on_ep", lambda ep, **k: ep)
+    monkeypatch.setattr(C, "_normalize_engine_constants_to_python", lambda ep: None)
+    monkeypatch.setattr(torch.export, "save", lambda *a, **k: None)
+
+    g = torch.fx.Graph()
+    g.output((g.placeholder("x"),))
+    gm = torch.fx.GraphModule(torch.nn.Module(), g)
+    gm.meta["_copyback_mutation_buffers"] = ["state_0"]
+
+    with caplog.at_level("WARNING"):
+        torch_tensorrt.save(
+            gm,
+            str(tmp_path / "out.pt2"),
+            output_format="exported_program",
+            retrace=False,
+            use_legacy_exporter=use_legacy,
+        )
+
+    warned = any("copy-back" in r.message for r in caplog.records)
+    assert warned is expect_warning

--- a/tests/py/dynamo/executorch/test_partitioner.py
+++ b/tests/py/dynamo/executorch/test_partitioner.py
@@ -40,9 +40,51 @@ def test_partitioner_tags_proposed_partitions(monkeypatch):
     )
 
     graph_module = SimpleNamespace(graph=SimpleNamespace(nodes=[]))
-    exported_program = SimpleNamespace(graph_module=graph_module)
+    exported_program = SimpleNamespace(
+        graph_module=graph_module,
+        graph_signature=SimpleNamespace(buffers_to_mutate={}, inputs_to_buffers={}),
+    )
 
     result = TensorRTPartitioner().partition(exported_program)
 
     assert tagged["called"]
     assert sorted(result.partition_tags.keys()) == ["tensorrt_1", "tensorrt_2"]
+
+
+@pytest.mark.unit
+def test_keep_mutated_buffers_above_delegate_untags_only_mutation_targets():
+    """The un-tag post-pass keeps a delegate-mutated buffer above the delegate
+    (strips its delegation_tag) while leaving non-mutated constants tagged into
+    the delegate and non-placeholder nodes untouched.
+    """
+    from torch_tensorrt.executorch.partitioner import (
+        _keep_mutated_buffers_above_delegate,
+    )
+
+    mutated_buf = SimpleNamespace(
+        op="placeholder", name="b_k_0", meta={"delegation_tag": "tensorrt_0"}
+    )
+    const_buf = SimpleNamespace(
+        op="placeholder", name="b_w", meta={"delegation_tag": "tensorrt_0"}
+    )
+    engine_node = SimpleNamespace(
+        op="call_function", name="tensorrt_0", meta={"delegation_tag": "tensorrt_0"}
+    )
+    exported_program = SimpleNamespace(
+        graph_module=SimpleNamespace(
+            graph=SimpleNamespace(nodes=[mutated_buf, const_buf, engine_node])
+        ),
+        graph_signature=SimpleNamespace(
+            buffers_to_mutate={"getitem_5": "k_0"},
+            inputs_to_buffers={"b_k_0": "k_0", "b_w": "w"},
+        ),
+    )
+
+    _keep_mutated_buffers_above_delegate(exported_program)
+
+    # k_0 is a mutation target -> its buffer placeholder is kept above the delegate
+    assert "delegation_tag" not in mutated_buf.meta
+    # w is not mutated -> still frozen into the delegate
+    assert const_buf.meta["delegation_tag"] == "tensorrt_0"
+    # non-placeholder nodes are untouched
+    assert engine_node.meta["delegation_tag"] == "tensorrt_0"

--- a/tests/py/dynamo/executorch/test_partitioner_target_device.py
+++ b/tests/py/dynamo/executorch/test_partitioner_target_device.py
@@ -45,6 +45,7 @@ def _engine_node(device_id):
 def _edge_program(*nodes):
     return SimpleNamespace(
         graph_module=SimpleNamespace(graph=SimpleNamespace(nodes=list(nodes))),
+        graph_signature=SimpleNamespace(buffers_to_mutate={}, inputs_to_buffers={}),
         constants={},
     )
 

--- a/tests/py/dynamo/executorch/test_serialization.py
+++ b/tests/py/dynamo/executorch/test_serialization.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from torch_tensorrt.executorch.serialization import (
     HEADER_SIZE,
@@ -37,3 +39,40 @@ def test_serialize_engine_writes_tr01_blob():
 def test_deserialize_engine_rejects_bad_magic():
     with pytest.raises(ValueError, match="Invalid magic"):
         deserialize_engine(b"NOPE" + b"\x00" * (HEADER_SIZE - 4))
+
+
+@pytest.mark.unit
+def test_serialize_engine_round_trips_aliased_io():
+    metadata = TensorRTBlobMetadata(
+        io_bindings=[
+            TensorRTIOBinding(name="in_k", is_input=True),
+            TensorRTIOBinding(name="out_k", is_input=False),
+            TensorRTIOBinding(name="in_u", is_input=True),
+            TensorRTIOBinding(name="out_u", is_input=False),
+        ],
+        aliased_io={
+            "out_k": ("in_k", "kv_cache_update"),
+            "out_u": ("in_u", "user"),
+        },
+    )
+
+    engine, parsed = deserialize_engine(serialize_engine(b"eng", metadata))
+    assert engine == b"eng"
+    assert parsed.aliased_io == {
+        "out_k": ("in_k", "kv_cache_update"),
+        "out_u": ("in_u", "user"),
+    }
+
+
+@pytest.mark.unit
+def test_metadata_from_json_without_aliased_io_defaults_empty():
+    # Blobs written before aliased_io existed omit the key entirely; parsing must
+    # default to an empty mapping rather than raising (backward compatibility).
+    metadata = TensorRTBlobMetadata(
+        io_bindings=[TensorRTIOBinding(name="x", is_input=True)]
+    )
+    data = json.loads(metadata.to_json().decode("utf-8"))
+    del data["aliased_io"]
+
+    restored = TensorRTBlobMetadata.from_json(json.dumps(data).encode("utf-8"))
+    assert restored.aliased_io == {}

--- a/tests/py/dynamo/executorch/test_serialization.py
+++ b/tests/py/dynamo/executorch/test_serialization.py
@@ -4,6 +4,7 @@ import pytest
 from torch_tensorrt.executorch.serialization import (
     HEADER_SIZE,
     TENSORRT_MAGIC,
+    TENSORRT_MAGIC_ALIASED_IO,
     TensorRTBlobMetadata,
     TensorRTIOBinding,
     deserialize_engine,
@@ -76,3 +77,46 @@ def test_metadata_from_json_without_aliased_io_defaults_empty():
 
     restored = TensorRTBlobMetadata.from_json(json.dumps(data).encode("utf-8"))
     assert restored.aliased_io == {}
+
+
+@pytest.mark.unit
+def test_aliased_io_blob_uses_the_bumped_magic():
+    """aliased_io changes what a blob means: a parser that ignores it binds each
+    aliased output to its own allocation instead of the input it aliases, and
+    returns wrong results. The magic is the only field such a parser validates, so
+    aliased blobs must not present as TR01."""
+    metadata = TensorRTBlobMetadata(
+        io_bindings=[
+            TensorRTIOBinding(name="x", is_input=True),
+            TensorRTIOBinding(name="out_k", is_input=False),
+        ],
+        aliased_io={"out_k": ("x", "kv_cache_update")},
+    )
+    blob = serialize_engine(b"engine-bytes", metadata)
+    assert blob[:4] == TENSORRT_MAGIC_ALIASED_IO
+    assert blob[:4] != TENSORRT_MAGIC
+
+
+@pytest.mark.unit
+def test_blob_without_aliased_io_keeps_the_original_magic():
+    """Nothing about a non-aliased blob is new, so it stays loadable by a parser
+    that predates aliased_io."""
+    metadata = TensorRTBlobMetadata(
+        io_bindings=[TensorRTIOBinding(name="x", is_input=True)]
+    )
+    assert serialize_engine(b"engine-bytes", metadata)[:4] == TENSORRT_MAGIC
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("aliased_io", [{}, {"out_k": ("x", "kv_cache_update")}])
+def test_deserialize_accepts_both_magics(aliased_io):
+    metadata = TensorRTBlobMetadata(
+        io_bindings=[
+            TensorRTIOBinding(name="x", is_input=True),
+            TensorRTIOBinding(name="out_k", is_input=False),
+        ],
+        aliased_io=aliased_io,
+    )
+    engine, parsed = deserialize_engine(serialize_engine(b"engine-bytes", metadata))
+    assert engine == b"engine-bytes"
+    assert parsed.aliased_io == aliased_io

--- a/tests/py/dynamo/lowering/test_buffer_lifting.py
+++ b/tests/py/dynamo/lowering/test_buffer_lifting.py
@@ -30,6 +30,7 @@ import torch
 from torch.export import export
 from torch.testing._internal.common_utils import TestCase, run_tests
 from torch_tensorrt.dynamo.lowering._buffer_lifting import (
+    assert_predicted_kv_aliased,
     inline_lifted_buffers_into_gm,
     lift_mutated_buffers,
 )
@@ -282,6 +283,288 @@ class TestInlineLiftedBuffers(TestCase):
         if isinstance(out, tuple):
             out = out[0]
         self.assertEqual(out.item(), 33.0)
+
+    def test_inline_remaps_copyback_targets_for_nested_buffers(self):
+        """A nested (dotted) buffer is registered under a flattened
+        ``lifted_buf_*`` name (``register_buffer`` rejects "."), so the recorded
+        copy-back targets -- which still use the original dotted name -- must be
+        remapped through the same mapping. Otherwise the ``BUFFER_MUTATION``
+        OutputSpec names a buffer that no longer exists and the ExportedProgram
+        verifier rejects the program. A flat name maps to itself and is unchanged.
+        """
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        b_state = graph.placeholder("buf_state")
+        b_nested = graph.placeholder("buf_nested")
+        s = graph.call_function(torch.add, args=(x, b_state))
+        out = graph.call_function(torch.add, args=(s, b_nested))
+        graph.output(out)
+        gm = torch.fx.GraphModule({}, graph)
+        gm.recompile()
+        # lift_mutated_buffers records copy-back targets under the buffers'
+        # original names (dotted for a submodule-owned cache).
+        gm.meta["_copyback_mutation_buffers"] = ["state", "layers.0.attn.k_cache"]
+
+        new_gm = inline_lifted_buffers_into_gm(
+            gm,
+            lifted_buffers=[
+                ("buf_state", "state", torch.zeros(4)),
+                ("buf_nested", "layers.0.attn.k_cache", torch.zeros(4)),
+            ],
+        )
+
+        registered = dict(new_gm.named_buffers())
+        # Flat name kept; nested name flattened to a valid attribute.
+        self.assertIn("state", registered)
+        self.assertIn("lifted_buf_layers_0_attn_k_cache", registered)
+        # Copy-back targets remapped: flat unchanged, nested -> flattened name.
+        self.assertEqual(
+            new_gm.meta["_copyback_mutation_buffers"],
+            ["state", "lifted_buf_layers_0_attn_k_cache"],
+        )
+        # Every recorded target now names a buffer that actually exists.
+        for name in new_gm.meta["_copyback_mutation_buffers"]:
+            self.assertIn(name, registered)
+
+
+class TestCopyBackClassification(TestCase):
+    """``lift_mutated_buffers`` splits mutated buffers into two kinds.
+
+    An *eligible* ``slice_scatter`` / ``index_copy`` KV write (one the converter
+    lowers to an ``IKVCacheUpdateLayer`` with in-place aliased I/O) relies on that
+    engine aliasing and is NOT recorded for copy-back. Every other mutation --
+    including a ``slice_scatter`` / ``index_copy`` that fails the converter's
+    eligibility (wrong rank/dim/shape) and is lowered to a non-aliasing scatter --
+    has no engine aliasing, so its new value is re-appended as a trailing graph
+    output and its buffer name recorded in
+    ``gm.meta['_copyback_mutation_buffers']`` for the exporters to reclassify as
+    a BUFFER_MUTATION.
+    """
+
+    def test_kv_slice_scatter_write_no_copyback(self):
+        """A slice-assignment KV write is aliased downstream, not copied back."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(2, 4, 16, 8))
+
+            def forward(self, x):
+                self.cache[:, :, 3:4, :] = x
+                return self.cache.sum()
+
+        gm = _ep_module_decomposed(M(), (torch.ones(2, 4, 1, 8),))
+        new_gm, lifted = lift_mutated_buffers(gm)
+        self.assertEqual(len(lifted), 1)
+        self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], [])
+        # Predicted-KV binding recorded so compile() can assert it actually aliases.
+        self.assertEqual(new_gm.meta["_predicted_kv_bindings"], ["buf_cache"])
+
+    def test_kv_index_copy_write_no_copyback(self):
+        """An eligible ``index_copy`` KV write (4-D static cache, dim=2, batch 1,
+        single-position source) is aliased by the KV converter, so it is not
+        copied back."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(1, 4, 16, 8))
+
+            def forward(self, x):
+                self.cache.index_copy_(2, torch.tensor([3]), x)
+                return self.cache.sum()
+
+        gm = _ep_module_decomposed(M(), (torch.ones(1, 4, 1, 8),))
+        new_gm, lifted = lift_mutated_buffers(gm)
+        self.assertEqual(len(lifted), 1)
+        self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], [])
+
+    def test_non_kv_mutation_recorded_for_copyback(self):
+        """A non-KV in-place mutation is recorded for copy-back by buffer name."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("state", torch.zeros(4))
+
+            def forward(self, x):
+                self.state.add_(x)
+                return self.state.sum()
+
+        gm = _ep_module_decomposed(M(), (torch.ones(4),))
+        new_gm, lifted = lift_mutated_buffers(gm)
+        self.assertEqual(len(lifted), 1)
+        self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], ["state"])
+        # A non-KV mutation is not predicted to alias, so nothing to assert later.
+        self.assertEqual(new_gm.meta["_predicted_kv_bindings"], [])
+
+    def test_copyback_value_appended_as_last_output(self):
+        """The non-KV new value is re-attached as a trailing graph output so it
+        survives DCE; at the lift stage it is the LAST output and equals the
+        updated buffer."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("state", torch.zeros(4))
+
+            def forward(self, x):
+                self.state.add_(x)
+                return self.state.sum()
+
+        x = torch.arange(4, dtype=torch.float32)
+        gm = _ep_module_decomposed(M(), (x.clone(),))
+        new_gm, lifted = lift_mutated_buffers(gm)
+        _, buf_name, buf_tensor = lifted[0]
+        self.assertEqual(buf_name, "state")
+
+        out = new_gm(x.clone(), buf_tensor.clone())
+        self.assertIsInstance(out, tuple)
+        # Last output is the copy-back value == state + x.
+        self.assertTrue(torch.allclose(out[-1], buf_tensor + x))
+
+    def test_index_put_is_copyback_not_kv(self):
+        """Regression: ``index_put`` has no aliasing converter, so it must fall
+        into copy-back rather than being dropped in expectation of aliasing."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("state", torch.zeros(4, 8))
+
+            def forward(self, x):
+                self.state[torch.tensor([1, 3])] = x
+                return self.state.sum()
+
+        gm = _ep_module_decomposed(M(), (torch.ones(2, 8),))
+        new_gm, lifted = lift_mutated_buffers(gm)
+        self.assertEqual(len(lifted), 1)
+        self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], ["state"])
+
+    def test_mixed_kv_and_copyback(self):
+        """One KV buffer + one non-KV buffer: only the non-KV one is recorded."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(2, 4, 16, 8))
+                self.register_buffer("state", torch.zeros(4))
+
+            def forward(self, x_kv, x_state):
+                self.cache[:, :, 3:4, :] = x_kv
+                self.state.add_(x_state)
+                return self.cache.sum() + self.state.sum()
+
+        gm = _ep_module_decomposed(M(), (torch.ones(2, 4, 1, 8), torch.ones(4)))
+        new_gm, lifted = lift_mutated_buffers(gm)
+        self.assertEqual(len(lifted), 2)
+        self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], ["state"])
+
+    def test_ineligible_index_copy_is_copyback(self):
+        """Regression: an ``index_copy`` the KV converter cannot alias (here a 2-D
+        cache / dim 0, not the 4-D dim=2 layout ``IKVCacheUpdateLayer`` requires)
+        is lowered to a non-aliasing scatter, so its write-back must be preserved
+        as copy-back rather than dropped."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(4, 8))
+
+            def forward(self, x):
+                self.cache.index_copy_(0, torch.tensor([2]), x)
+                return self.cache.sum()
+
+        gm = _ep_module_decomposed(M(), (torch.ones(1, 8),))
+        new_gm, lifted = lift_mutated_buffers(gm)
+        self.assertEqual(len(lifted), 1)
+        self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], ["cache"])
+
+    def test_ineligible_slice_scatter_is_copyback(self):
+        """Regression: a ``slice_scatter`` on a KV-shaped 4-D cache but the wrong
+        axis (dim 1, not dim 2) is not IKVCacheUpdateLayer-eligible, so it is
+        lowered to a non-aliasing scatter and must fall to copy-back rather than
+        being dropped."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(2, 16, 4, 8))
+
+            def forward(self, x):
+                self.cache[:, 3:4, :, :] = x  # write on dim 1, not the seq dim 2
+                return self.cache.sum()
+
+        gm = _ep_module_decomposed(M(), (torch.ones(2, 1, 4, 8),))
+        new_gm, lifted = lift_mutated_buffers(gm)
+        self.assertEqual(len(lifted), 1)
+        self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], ["cache"])
+
+
+class _FakeEngine:
+    """Stand-in for a compiled TRT submodule exposing an ``aliased_io`` map."""
+
+    def __init__(self, aliased_io):
+        self.aliased_io = aliased_io
+
+
+class _FakeGM:
+    """Stand-in for a compiled GraphModule whose children are TRT engines."""
+
+    def __init__(self, children):
+        self._children = children
+
+    def named_children(self):
+        return list(self._children.items())
+
+
+class TestPredictedKvAssertion(TestCase):
+    """`assert_predicted_kv_aliased` is the ground-truth backstop for the
+    pre-conversion KV prediction: every write predicted to alias must actually
+    appear in a compiled engine's `aliased_io`, else its write-back would be
+    silently dropped."""
+
+    def test_passes_when_predicted_kv_is_aliased(self):
+        gm = _FakeGM(
+            {
+                "_run_on_acc_0": _FakeEngine(
+                    {"out_k": ("buf_k_cache", "kv_cache_update")}
+                )
+            }
+        )
+        # buf_k_cache is aliased -> no error.
+        assert_predicted_kv_aliased(gm, ["buf_k_cache"])
+
+    def test_raises_when_predicted_kv_not_aliased(self):
+        # Predicted KV for buf_conv_state, but the engine aliased only buf_k_cache
+        # (the converter emitted no IKVCacheUpdateLayer for conv_state) -> must
+        # raise rather than silently drop the write-back.
+        gm = _FakeGM(
+            {
+                "_run_on_acc_0": _FakeEngine(
+                    {"out_k": ("buf_k_cache", "kv_cache_update")}
+                )
+            }
+        )
+        with self.assertRaises(RuntimeError):
+            assert_predicted_kv_aliased(gm, ["buf_conv_state"])
+
+    def test_aggregates_aliased_io_across_engines(self):
+        gm = _FakeGM(
+            {
+                "_run_on_acc_0": _FakeEngine(
+                    {"out_k": ("buf_k_cache", "kv_cache_update")}
+                ),
+                "_run_on_acc_1": _FakeEngine(
+                    {"out_v": ("buf_v_cache", "kv_cache_update")}
+                ),
+            }
+        )
+        # Both predicted-KV bindings are aliased across the two engines -> no error.
+        assert_predicted_kv_aliased(gm, ["buf_k_cache", "buf_v_cache"])
+
+    def test_noop_when_no_prediction(self):
+        assert_predicted_kv_aliased(_FakeGM({}), [])
 
 
 if __name__ == "__main__":

--- a/tests/py/dynamo/lowering/test_buffer_lifting.py
+++ b/tests/py/dynamo/lowering/test_buffer_lifting.py
@@ -29,6 +29,7 @@ import inspect
 import torch
 from torch.export import export
 from torch.testing._internal.common_utils import TestCase, run_tests
+from torch_tensorrt.dynamo._settings import CompilationSettings
 from torch_tensorrt.dynamo.lowering._buffer_lifting import (
     assert_predicted_kv_aliased,
     inline_lifted_buffers_into_gm,
@@ -499,6 +500,51 @@ class TestCopyBackClassification(TestCase):
         new_gm, lifted = lift_mutated_buffers(gm)
         self.assertEqual(len(lifted), 1)
         self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], ["cache"])
+
+    def test_torch_executed_write_is_copyback_not_kv(self):
+        """A KV-shaped write whose op the caller excluded from TensorRT cannot reach a
+        converter, so no IKVCacheUpdateLayer can alias it.
+
+        It must still be lifted and copied back. Dropping the buffer instead would
+        leave the copy_ with no users, and post_lowering's dead-node pass would erase
+        it, silently losing the write."""
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(2, 4, 16, 8))
+
+            def forward(self, x):
+                self.cache[:, :, 3:4, :] = x
+                return self.cache.sum()
+
+        args = (torch.ones(2, 4, 1, 8),)
+        # Without the exclusion the same write is predicted to alias inside the engine.
+        gm = _ep_module_decomposed(M(), args)
+        baseline_gm, baseline_lifted = lift_mutated_buffers(gm)
+        self.assertEqual(len(baseline_lifted), 1)
+        self.assertEqual(baseline_gm.meta["_copyback_mutation_buffers"], [])
+        self.assertEqual(len(baseline_gm.meta["_predicted_kv_bindings"]), 1)
+
+        gm = _ep_module_decomposed(M(), args)
+        settings = CompilationSettings(
+            torch_executed_ops={"torch.ops.aten.slice_scatter.default"}
+        )
+        new_gm, lifted = lift_mutated_buffers(gm, settings)
+        self.assertEqual(len(lifted), 1)
+        self.assertEqual(new_gm.meta["_copyback_mutation_buffers"], ["cache"])
+        self.assertEqual(new_gm.meta["_predicted_kv_bindings"], [])
+
+        # The write survives as a real graph output, so it cannot be dead-code
+        # eliminated the way an orphaned copy_ would be.
+        out_node = next(n for n in new_gm.graph.nodes if n.op == "output")
+        self.assertEqual(len(out_node.args[0]), 2)
+        erasable = [
+            n
+            for n in new_gm.graph.nodes
+            if n is not out_node and not n.users and n.all_input_nodes
+        ]
+        self.assertEqual(erasable, [])
 
 
 class _FakeEngine:


### PR DESCRIPTION
> **Depends on #4459.** These fixes are on top of that branch, so the file diff here
> includes its commits and CI will stay red until it lands. Only the last four commits
> are mine (`af29266c7ed4..HEAD`), at +280/-20 across five files, three of which are
> tests.

## What this fixes

Two problems that stop a model from exporting when part of its graph runs on a different
backend, plus the nested-buffer follow-ups that only become visible once the graph gets
that far.

### 1. An op excluded from TensorRT was predicted to alias

`_kv_write_will_alias` decides whether a buffer write becomes engine-level aliasing by
looking at the op, and never saw the ops the caller excluded via `torch_executed_ops`. An
excluded write was still predicted to alias, its `copy_` was dropped, and the cross-check
in `compile()` then failed:

```
RuntimeError: lift_mutated_buffers classified these buffer writes as KV-cache
(engine-aliased) and dropped their copy_, but the compiled engine did not alias them
(absent from aliased_io): [...]. Their write-back would be silently dropped.
```

An op that never reaches a converter cannot emit an `IKVCacheUpdateLayer`, so the
prediction now honors the exclusion list, matched with
`ConverterRegistry.qualified_name_or_str` the same way the partitioners match it. The
write is still lifted and still copied back, like any other write the engine does not
alias.

That guard is worth calling out: it turned a cache that would silently stop updating into
a clear error naming every affected buffer.

### 2. A copy-back output could be paired with the wrong buffer

`lift_mutated_buffers` appends each copy-back buffer's new value as a trailing output, in
`copyback_buffers` order, and the exporter reclassified them by taking the last N.

That breaks once `torch.export` recognises a mutation itself, because it then records its
own `BUFFER_MUTATION` and moves it ahead of the user outputs. Filtering the buffer list
first and slicing the same number of trailing outputs shifts the two lists against each
other:

```
buffers  [a, b, c], b already declared
pending  [a, c]  ->  takes the last two values, which are b's and c's
result   a is declared as the mutation of b's value
```

With different shapes the runtime fails copying that value into the buffer; with matching
shapes it silently writes the wrong state. On a transformer whose cache write stays inside
the engine, an earlier form of this bug declared the model's logits as a cache update and
export failed with `expand: attempting to expand a dimension of length 16 -> 4096`.

The fix detaches the full trailing run first and pairs it positionally with the full
buffer list, then keeps only the buffers not already declared. When every buffer was
already declared, nothing used to be detached and the appended values stayed as user
outputs, changing the saved model's output arity.

### 3. Renamed nested buffers left the mutation targets dangling

`register_buffer` rejects dots, so a nested buffer is renamed to `lifted_buf_*`. The
recorded mutation targets kept the original dotted names, which no longer resolve:

```
SpecViolationError: Buffer output getitem_1 does not point to a buffer that exists.
  mutated target   : 'layers.0.self_attn.kv_cache.k_cache'
  buffer available : 'lifted_buf_layers_0_self_attn_kv_cache_k_cache'
```

They are remapped through the same mapping.

## What changed since the first version

The first version of this PR also skipped an excluded buffer entirely, leaving the
`get_attr` and `copy_` in place, on the theory that another backend would claim the write.
That was wrong outside ExecuTorch. `lift_mutated_buffers` runs for every `compile()`
caller, and `post_lowering`'s `remove_num_users_is_0_nodes` erases the orphaned `copy_`
because nothing reads it, so the buffer froze at its compile-time contents and the cache
silently stopped updating. Worse, that input used to fail loudly at the cross-check above,
so the skip turned a clear error into wrong numbers.

The delegate-boundary error that motivated the skip has a different cause. ExecuTorch only
rejects a mutation consumed after a delegate when the delegate also **absorbed the
buffer**; returning a mutation value out of a delegate is a supported, tested path
(`exir/backend/test/test_partitioner.py::test_not_delegate_mutable_buffers`). Absorption is
already prevented, by `tag_constant_data` skipping mutated buffers and by
`_keep_mutated_buffers_above_delegate` covering the case it misses. So the copy-back route
handles this correctly and no skip is needed.

Also dropped `gm.meta["_lifted_buffer_attr_names"]`, which had no reader.

## Testing

`tests/py/dynamo/lowering/test_buffer_lifting.py` and
`tests/py/dynamo/executorch/test_kv_cache_export.py`, plus three new regression tests,
each of which fails on the behavior it replaces:

- `test_torch_executed_write_is_copyback_not_kv`: an excluded write is lifted, recorded as
  copy-back rather than predicted-aliased, and leaves no dead nodes for `post_lowering` to
  erase.
- `test_declare_aliased_kv_mutations_pairs_copyback_by_position`: with `[a, b, c]` and only
  `b` already declared, each buffer is paired with its own value.
- `test_declare_aliased_kv_mutations_skips_already_declared_copyback`: an already-declared
  buffer is not declared twice, and its trailing value still leaves the user outputs.

Note the nested-buffer lookup itself (`gm.get_buffer`) landed separately in #4472 and is
inherited here through this branch's base, so it is no longer part of this PR's changes.
