### PR TITLE
fix(executorch): drain the stream when a device-to-host copy fails

### DIFF
--- a/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
+++ b/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
@@ -614,6 +614,7 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
   // output_staged_to_host, so outputs_needing_copy is empty on the skip path.
   const bool must_sync = output_staged_to_host || input_staged_from_host || !g_user_stream_set;
   if (must_sync) {
+    Error copy_err = Error::Ok;
     for (auto& output : outputs_needing_copy) {
       exec_aten::Tensor et_out = args[num_inputs + output.first]->toTensor();
       cuda_err =
@@ -624,7 +625,11 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
             "TensorRTBackend::execute: D2H copy failed for output %zu: %s",
             output.first,
             cudaGetErrorString(cuda_err));
-        return Error::InvalidProgram;
+        // The enqueue already succeeded, so the engine is still running on the
+        // stream. Drain below before returning, or the next call mutates a live
+        // execution context, which TensorRT forbids.
+        copy_err = Error::InvalidProgram;
+        break;
       }
     }
     cuda_err = cudaStreamSynchronize(stream);
@@ -632,6 +637,9 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
     if (cuda_err != cudaSuccess) {
       ET_LOG(Error, "TensorRTBackend::execute: cudaStreamSynchronize failed: %s", cudaGetErrorString(cuda_err));
       return Error::InvalidProgram;
+    }
+    if (copy_err != Error::Ok) {
+      return copy_err;
     }
   } else {
     cuda_err = cudaEventRecord(engine->inflight_event, stream);


### PR DESCRIPTION
## The problem

When a device-to-host copy of a delegate output fails, `execute()` returns straight away.
By that point `enqueueV3()` has already succeeded, so the engine is still running on the
stream, and the early return skips two things:

```cpp
      if (cuda_err != cudaSuccess) {
        ET_LOG(Error, "D2H copy failed for output %zu: %s", ...);
        return Error::InvalidProgram;      // <- leaves here
      }
    }
    cuda_err = cudaStreamSynchronize(stream);   // never runs
    engine->inflight_pending = false;           // never runs
```

TensorRT forbids mutating an execution context while one of its enqueues is in flight. The
next call runs `setInputShape` and `setTensorAddress`, both host-side, on a context that may
still be executing.

The in-flight guard at the top of `execute()` cannot save it, because the flag it reads was
left stale:

```cpp
  if (engine->inflight_pending) {          // false, so no wait happens
    cuda_err = cudaEventSynchronize(engine->inflight_event);
```

So the failure is not just an un-awaited copy. It also disarms the mechanism that exists to
prevent exactly this.

## The fix

Record the failure, finish the cleanup, then return:

```cpp
    Error copy_err = Error::Ok;
    for (auto& output : outputs_needing_copy) {
      ...
      if (cuda_err != cudaSuccess) {
        ET_LOG(Error, "D2H copy failed for output %zu: %s", ...);
        copy_err = Error::InvalidProgram;
        break;
      }
    }
    cuda_err = cudaStreamSynchronize(stream);
    engine->inflight_pending = false;
    if (cuda_err != cudaSuccess) { ... return Error::InvalidProgram; }
    if (copy_err != Error::Ok) {
      return copy_err;
    }
```

A copy failure now leaves the engine in the same state a successful call does, so the next
call behaves predictably instead of depending on whether the previous one happened to fail.
The reported error is unchanged.

Note the ordering: a synchronize failure is reported ahead of the copy failure, because a
stream that cannot be drained is the more serious of the two and the copy error is already
logged by then.

## Testing

Built the delegate and ran a program with host-backed outputs, so the copy path is
exercised on every call, and confirmed repeated calls still produce output matching the
eager model. Compiled against TensorRT 11.1 with no new warnings.

I have not built a fault injector for the copy itself, so the recovery path is reasoned from
the code rather than observed. Happy to add a test if there is a good way to force a
`cudaMemcpyAsync` failure in this suite.