### PR TITLE
fix(executorch): copy the engine in bulk instead of byte by byte

### DIFF
--- a/py/torch_tensorrt/executorch/backend.py
+++ b/py/torch_tensorrt/executorch/backend.py
@@ -282,16 +282,16 @@ class TensorRTBackend(BackendDetails):  # type: ignore[misc]
         _validate_engine_info(engine_info)
         serialized_engine = engine_info[ENGINE_IDX]
         if isinstance(serialized_engine, torch.Tensor):
-            # Single copy out of the underlying storage. The prior
-            # `.numpy().tobytes()` path allocated a fresh bytes buffer
-            # on top of the numpy view, which for a >2 GB engine
-            # roughly doubled peak memory at this step. `.cpu()` and
-            # `.contiguous()` are no-ops when already host-side and
-            # contiguous (the common case for the uint8 buffer this
-            # backend produces).
-            engine_info[ENGINE_IDX] = bytes(
-                serialized_engine.cpu().contiguous().untyped_storage()
-            )
+            # `bytes(storage)` looks equivalent but has two problems. It iterates
+            # the storage element by element in Python, costing about two seconds
+            # per megabyte, and it returns the whole backing allocation rather than
+            # the tensor's own extent, so a view of a larger buffer serializes too
+            # many bytes. `memoryview` is not redundant here: on a 0-dim uint8
+            # tensor numpy alone goes through `__index__` and yields that many zero
+            # bytes instead of the value. `.view(torch.uint8)` keeps `.numpy()` from
+            # rejecting a dtype it has no equivalent for.
+            engine_bytes = serialized_engine.cpu().contiguous().view(torch.uint8)
+            engine_info[ENGINE_IDX] = bytes(memoryview(engine_bytes.numpy()))
         elif not isinstance(serialized_engine, (bytes, bytearray)):
             engine_info[ENGINE_IDX] = bytes(serialized_engine)
         input_names = _reorder_input_names_for_executorch(

--- a/tests/py/dynamo/executorch/test_backend.py
+++ b/tests/py/dynamo/executorch/test_backend.py
@@ -2,6 +2,8 @@ import ast
 from pathlib import Path
 from types import SimpleNamespace
 
+import struct
+
 import pytest
 
 executorch = pytest.importorskip("executorch.exir")
@@ -23,6 +25,8 @@ from torch_tensorrt.executorch.backend import (  # noqa: E402
 )
 from torch_tensorrt.executorch.serialization import (  # noqa: E402
     deserialize_engine,
+    HEADER_FORMAT,
+    HEADER_SIZE,
     TENSORRT_MAGIC,
 )
 
@@ -177,6 +181,32 @@ def test_preprocess_serializes_engine_blob():
     assert metadata.device_id == 2
     assert [binding.name for binding in metadata.io_bindings] == ["x", "y"]
     assert [binding.is_input for binding in metadata.io_bindings] == [True, False]
+
+
+@pytest.mark.unit
+def test_preprocess_serializes_only_the_engine_tensors_extent():
+    # A tensor that views part of a larger buffer. Serializing the whole storage
+    # instead of the tensor's own extent pads the engine with the trailing bytes.
+    # The recorded engine size is what exposes it: deserialize_engine trims the
+    # blob back to that size, so an over-long engine still round-trips and only
+    # the size gives it away.
+    payload = b"engine-bytes"
+    backing = torch.frombuffer(bytearray(payload + b"TRAILING"), dtype=torch.uint8)
+    engine_info = [""] * SERIALIZATION_LEN
+    engine_info[ENGINE_IDX] = backing[: len(payload)]
+    engine_info[DEVICE_IDX] = "0%8%0%0%GPU"
+    engine_info[INPUT_BINDING_NAMES_IDX] = "x"
+    engine_info[OUTPUT_BINDING_NAMES_IDX] = "y"
+    edge_program = _build_edge_program(engine_info)
+
+    result = TensorRTBackend.preprocess(edge_program, [])
+
+    _, _, _, _, engine_size, _ = struct.unpack(
+        HEADER_FORMAT, result.processed_bytes[:HEADER_SIZE]
+    )
+    assert engine_size == len(payload)
+    engine, _ = deserialize_engine(result.processed_bytes)
+    assert engine == payload
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## The problem

Serializing a TensorRT engine to bytes goes through `bytes(tensor.untyped_storage())`.
That reads like a bulk copy, but it iterates the storage one element at a time in Python,
at roughly two seconds per megabyte:

```
16.8 MB   bytes(untyped_storage())   36.27 s
16.8 MB   memoryview(... .numpy())    0.01 s
```

For a model whose graph produces many engines, this step dominates the entire export. A
program with 8.8 GB of engines spends about five hours here. One with 70 GB spends closer
to two days. It is easy to mistake for a slow engine build, because the export simply sits
there making no visible progress.

## It is also wrong for a view

`contiguous()` is a no-op for a tensor that is already contiguous, including a row slice of
a larger tensor. In that case the storage holds neighbouring bytes, so the serialized
engine comes out longer than the tensor it came from:

```python
base = torch.arange(8, dtype=torch.uint8).reshape(2, 4)
row = base[0]                                    # tensor is [0, 1, 2, 3]

bytes(row.contiguous().untyped_storage())        # [0, 1, 2, 3, 4, 5, 6, 7]
bytes(memoryview(row.contiguous().numpy()))      # [0, 1, 2, 3]
```

Today's engines happen to own their whole storage, so this does not bite in practice yet.
It is a trap for anyone who later produces the engine buffer as a slice.

## The fix

Copy through a `memoryview` over the tensor's own buffer:

```python
engine_info[ENGINE_IDX] = bytes(
    memoryview(serialized_engine.cpu().contiguous().view(torch.uint8).numpy())
)
```

The comment on the previous code explains what it was avoiding: `.numpy().tobytes()`
allocates a second full-size buffer, which roughly doubles peak memory for a multi-gigabyte
engine. `memoryview` keeps that property, since it is a view rather than a copy, while
doing the copy in one shot and respecting the tensor's bounds.

## Testing

Verified byte-for-byte equality against the previous path for the shapes this code sees:

```
host contiguous uint8    old 8.4 MB   new 8.4 MB   identical
device uint8             old 8.4 MB   new 8.4 MB   identical
non-contiguous view      old 16.8 MB  new 8.4 MB   differs, and the new value is correct
```

The third row is the bug above: the old path returned the whole storage rather than the
tensor.

Also exported a multi-method model that produces ten engines totalling 8.8 GB. Before the
change the serialization step ran for over an hour and a half without finishing; after it,
the same step completes in minutes and produces a program that loads and runs.