### PR TITLE
feat: add aten.glu converter

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -488,6 +488,54 @@ def aten_ops_hardtanh(
     )
 
 
+def glu_validator(node: Node, settings: Optional[CompilationSettings] = None) -> bool:
+    input_meta = node.args[0].meta
+    input_val = input_meta.get("tensor_meta")
+    if input_val is None:
+        input_val = input_meta.get("val")
+    if input_val is None:
+        _LOGGER.warning(
+            "Meta information of input is missing. Unable to validate GLU's "
+            "split dimension, falling back to PyTorch operation."
+        )
+        return False
+
+    input_shape = input_val.shape
+    dim = get_positive_dim(args_bounds_check(node.args, 1, -1), len(input_shape))
+    split_dim_size = input_shape[dim]
+
+    return isinstance(split_dim_size, int) and split_dim_size % 2 == 0
+
+
+@dynamo_tensorrt_converter(
+    torch.ops.aten.glu.default,
+    capability_validator=glu_validator,
+    supports_dynamic_shapes=True,
+)
+@enforce_tensor_types(
+    {
+        0: (TRTTensor,),
+    }
+)
+def aten_ops_glu(
+    ctx: ConversionContext,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> Union[TRTTensor, Sequence[TRTTensor]]:
+    input_val = args[0]
+    dim = get_positive_dim(args_bounds_check(args, 1, -1), len(input_val.shape))
+    split_size = input_val.shape[dim] // 2
+    first, second = impl.split.split(
+        ctx, target, SourceIR.ATEN, f"{name}_split", input_val, split_size, dim
+    )
+    gated = impl.activation.sigmoid(
+        ctx, target, SourceIR.ATEN, f"{name}_sigmoid", second
+    )
+    return impl.elementwise.mul(ctx, target, SourceIR.ATEN, f"{name}_mul", first, gated)
+
+
 @dynamo_tensorrt_converter(torch.ops.aten.sigmoid.default, supports_dynamic_shapes=True)
 def aten_ops_sigmoid(
     ctx: ConversionContext,

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -2,7 +2,18 @@
 
 import logging
 import operator
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
 
 import numpy as np
 import torch
@@ -488,6 +499,10 @@ def aten_ops_hardtanh(
     )
 
 
+def _get_glu_dim(args: Tuple[Argument, ...], kwargs: Mapping[str, Argument]) -> int:
+    return cast(int, kwargs.get("dim", args_bounds_check(args, 1, -1)))
+
+
 def glu_validator(node: Node, settings: Optional[CompilationSettings] = None) -> bool:
     input_meta = node.args[0].meta
     input_val = input_meta.get("tensor_meta")
@@ -501,10 +516,14 @@ def glu_validator(node: Node, settings: Optional[CompilationSettings] = None) ->
         return False
 
     input_shape = input_val.shape
-    dim = get_positive_dim(args_bounds_check(node.args, 1, -1), len(input_shape))
+    dim = get_positive_dim(_get_glu_dim(node.args, node.kwargs), len(input_shape))
     split_dim_size = input_shape[dim]
 
-    return isinstance(split_dim_size, int) and split_dim_size % 2 == 0
+    return (
+        isinstance(split_dim_size, int)
+        and split_dim_size > 0
+        and split_dim_size % 2 == 0
+    )
 
 
 @dynamo_tensorrt_converter(
@@ -525,7 +544,7 @@ def aten_ops_glu(
     name: str,
 ) -> Union[TRTTensor, Sequence[TRTTensor]]:
     input_val = args[0]
-    dim = get_positive_dim(args_bounds_check(args, 1, -1), len(input_val.shape))
+    dim = get_positive_dim(_get_glu_dim(args, kwargs), len(input_val.shape))
     split_size = input_val.shape[dim] // 2
     first, second = impl.split.split(
         ctx, target, SourceIR.ATEN, f"{name}_split", input_val, split_size, dim

--- a/tests/py/dynamo/conversion/test_glu_aten.py
+++ b/tests/py/dynamo/conversion/test_glu_aten.py
@@ -1,0 +1,43 @@
+import torch
+import torch.nn as nn
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+from torch_tensorrt import Input
+
+from .harness import DispatchTestCase
+
+
+class TestGluConverter(DispatchTestCase):
+    @parameterized.expand(
+        [
+            ("last_dim_fp32", (2, 8), -1, torch.float32),
+            ("first_dim_fp32", (6, 4), 0, torch.float32),
+            ("middle_dim_fp16", (2, 4, 6), 1, torch.float16),
+        ]
+    )
+    def test_glu(self, _, input_shape, dim, dtype):
+        class Glu(nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.glu.default(input, dim)
+
+        inputs = [torch.randn(input_shape, dtype=dtype)]
+        self.run_test(Glu(), inputs, use_dynamo_tracer=True)
+
+    def test_glu_with_dynamic_batch(self):
+        class Glu(nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.glu.default(input, -1)
+
+        input_specs = [
+            Input(
+                min_shape=(2, 4, 8),
+                opt_shape=(3, 4, 8),
+                max_shape=(5, 4, 8),
+                dtype=torch.float32,
+            ),
+        ]
+        self.run_test_with_dynamic_shape(Glu(), input_specs, use_dynamo_tracer=True)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/py/dynamo/conversion/test_glu_aten.py
+++ b/tests/py/dynamo/conversion/test_glu_aten.py
@@ -1,8 +1,10 @@
 import torch
 import torch.nn as nn
 from parameterized import parameterized
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import TestCase, run_tests
 from torch_tensorrt import Input
+from torch_tensorrt.dynamo.conversion import UnsupportedOperatorException
+from torch_tensorrt.dynamo.conversion.aten_ops_converters import glu_validator
 
 from .harness import DispatchTestCase
 
@@ -23,6 +25,31 @@ class TestGluConverter(DispatchTestCase):
         inputs = [torch.randn(input_shape, dtype=dtype)]
         self.run_test(Glu(), inputs, use_dynamo_tracer=True)
 
+    def test_glu_keyword_dim(self):
+        class Glu(nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.glu.default(input, dim=0)
+
+        inputs = [torch.randn(6, 4)]
+        self.run_test(Glu(), inputs, use_dynamo_tracer=False, propagate_shapes=True)
+
+    def test_glu_default_dim(self):
+        class Glu(nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.glu.default(input)
+
+        inputs = [torch.randn(2, 8)]
+        self.run_test(Glu(), inputs, use_dynamo_tracer=False, propagate_shapes=True)
+
+    def test_glu_zero_sized_split_dim_rejected(self):
+        class Glu(nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.glu.default(input, dim=0)
+
+        inputs = [torch.randn(0, 4)]
+        with self.assertRaises(UnsupportedOperatorException):
+            self.run_test(Glu(), inputs, use_dynamo_tracer=False, propagate_shapes=True)
+
     def test_glu_with_dynamic_batch(self):
         class Glu(nn.Module):
             def forward(self, input):
@@ -37,6 +64,49 @@ class TestGluConverter(DispatchTestCase):
             ),
         ]
         self.run_test_with_dynamic_shape(Glu(), input_specs, use_dynamo_tracer=True)
+
+
+class TestGluValidator(TestCase):
+    @staticmethod
+    def make_glu_node(input_shape=None, dim=None, *, keyword=False, include_meta=True):
+        graph = torch.fx.Graph()
+        input_node = graph.placeholder("input")
+        args = (input_node,)
+        kwargs = {}
+        if dim is not None:
+            if keyword:
+                kwargs["dim"] = dim
+            else:
+                args += (dim,)
+        glu_node = graph.call_function(
+            torch.ops.aten.glu.default, args=args, kwargs=kwargs
+        )
+        graph.output(glu_node)
+        if include_meta:
+            input_node.meta["val"] = torch.empty(input_shape)
+        return glu_node
+
+    def test_keyword_dim(self):
+        node = self.make_glu_node((6, 3), dim=0, keyword=True)
+        self.assertTrue(glu_validator(node))
+
+    def test_default_dim(self):
+        node = self.make_glu_node((3, 8))
+        self.assertTrue(glu_validator(node))
+
+    @parameterized.expand(
+        [
+            ("zero_sized_split_dim", (0, 4), 0),
+            ("odd_split_dim", (2, 7), -1),
+        ]
+    )
+    def test_rejects_invalid_split_dim(self, _, input_shape, dim):
+        node = self.make_glu_node(input_shape, dim=dim)
+        self.assertFalse(glu_validator(node))
+
+    def test_rejects_missing_metadata(self):
+        node = self.make_glu_node(include_meta=False)
+        self.assertFalse(glu_validator(node))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Adds Dynamo converter support for `torch.ops.aten.glu.default`. The converter implements GLU as an equal split followed by sigmoid and elementwise multiplication, and conservatively requires the split dimension to be statically known and even while allowing other dimensions to remain dynamic.

This avoids a PyTorch fallback and extra TensorRT engine partitions for models that use GLU, including the Conformer use case described in #2197. No additional dependencies are required.

Validation performed locally:

- Converter tests cover FP32, FP16, `dim=0/1/-1`, rank 2/3, and a dynamic batch range.
- GLU, split, and sigmoid converter tests: 17 passed.
- Full-compilation `torch.export` checks on two RTX 3090 GPUs produced a single TensorRT module with no PyTorch fallback for FP32, FP16, and dynamic shapes; outputs matched eager PyTorch exactly in the tested cases.
- Black, Ruff, isort, mypy, and `git diff --check` passed for the changed files.

The full repository test suite and GitHub CI have not been run. The dynamic GLU split dimension remains unsupported; invalid odd split dimensions retain PyTorch's existing error behavior.

Fixes #2663

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks (no non-obvious hacks were added)
- [x] I have made corresponding changes to the documentation (not required; supported-op documentation is generated from the converter registry)
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
