### PR TITLE
fix: preserve multi-value shape tensor inputs

### DIFF
--- a/py/torch_tensorrt/dynamo/utils.py
+++ b/py/torch_tensorrt/dynamo/utils.py
@@ -184,12 +184,13 @@ def get_torch_tensor(
     input: Input,
     device: torch.device,
     mode: str = "",
-) -> Union[int, torch.Tensor]:
+) -> Union[int, List[int], torch.Tensor]:
     if input.is_shape_tensor:
-        # TODO: All the shape tensors we've encountered so far are plain integers.
-        # Validate this assumption on more models.
         assert isinstance(input.shape, dict)
-        return input.shape["opt_shape"][0]
+        opt_shape = input.shape["opt_shape"]
+        # Scalar shape tensors supply SymInt parameters, while multi-element
+        # shape tensors supply SymInt[] parameters such as aten.full's size.
+        return opt_shape[0] if len(opt_shape) == 1 else list(opt_shape)
 
     if len(mode) > 0:
         return input.example_tensor(mode).to(device)
@@ -201,7 +202,10 @@ def get_torch_inputs(
     inputs: Sequence[Input] | Dict[str, Any],
     device: Union[Device, torch.device, str],
     mode: str = "",
-) -> Sequence[Union[int, torch.Tensor]] | Dict[str, Union[int, torch.Tensor]]:
+) -> (
+    Sequence[Union[int, List[int], torch.Tensor]]
+    | Dict[str, Union[int, List[int], torch.Tensor]]
+):
     """
     Return the torch_tensor from the Input object. If mode is set, this implies
     user is using dynamic shaped inputs and return the corresponding input based
@@ -210,7 +214,7 @@ def get_torch_inputs(
     device = to_torch_device(device)
 
     if isinstance(inputs, dict):
-        result_dict: Dict[str, Union[int, torch.Tensor]] = {}
+        result_dict: Dict[str, Union[int, List[int], torch.Tensor]] = {}
         for k, v in inputs.items():
             if isinstance(v, (list, tuple, dict)):
                 result_dict[k] = get_torch_inputs(v, device)
@@ -218,7 +222,7 @@ def get_torch_inputs(
                 result_dict[k] = get_torch_tensor(v, device, mode)
         return result_dict
     else:
-        result_list: List[Union[int, torch.Tensor]] = []
+        result_list: List[Union[int, List[int], torch.Tensor]] = []
         for input in inputs:
             if isinstance(input, Input):
                 result_list.append(get_torch_tensor(input, device, mode))

--- a/tests/py/dynamo/runtime/test_000_compiler_utils.py
+++ b/tests/py/dynamo/runtime/test_000_compiler_utils.py
@@ -3,6 +3,7 @@ import unittest
 import torch
 import torch_tensorrt
 from torch_tensorrt.dynamo.utils import (
+    get_torch_tensor,
     prepare_inputs,
     to_torch_device,
     to_torch_tensorrt_device,
@@ -55,6 +56,21 @@ class TestToTorchTRTDevice(unittest.TestCase):
         prepared_device = to_torch_tensorrt_device(device)
         self.assertTrue(isinstance(prepared_device, torch_tensorrt.Device))
         self.assertTrue(prepared_device.gpu_id == gpu_id)
+
+
+class TestGetTorchTensor(unittest.TestCase):
+    def test_shape_tensor_preserves_multiple_values(self):
+        shape = torch_tensorrt.Input(
+            min_shape=(3, 5),
+            opt_shape=(3, 7),
+            max_shape=(4, 10),
+            dtype=torch.int64,
+            is_shape_tensor=True,
+        )
+
+        value = get_torch_tensor(shape, torch.device("cpu"))
+
+        self.assertEqual(value, [3, 7])
 
 
 class TestPrepareInputs(unittest.TestCase):


### PR DESCRIPTION
# Description

`get_torch_tensor()` assumed every shape tensor contained one value and always returned the first optimized shape value. Multi-value shape tensors were therefore converted to a scalar and could not be used for `SymInt[]` arguments such as `aten.full`'s `size`.

This change preserves the existing scalar behavior for one-element shape tensors and returns the full optimized shape as a list for multi-element shape tensors. It also updates the related type annotations and adds a focused regression test.

No new dependencies are required.

Fixes #3202

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Validation

- Targeted Dynamo runtime, converter, and partitioning tests: 44 passed on each of two RTX 3090 GPUs
- Eager, `torch.export`, and TensorRT FP32/FP16 comparisons with static and dynamic shapes: maximum absolute error 0 on both GPUs
- Changed-file pre-commit hooks, mypy, Ruff, Black, `py_compile`, and `git diff --check`

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation (not applicable: this does not change a user-facing API)
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified (left to maintainers and repository automation; no review was requested)
