### PR TITLE
fix: keep requires_grad when re-wrapping a lifted parameter

### DIFF
--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -181,10 +181,14 @@ def lift(
                 input_kind = InputKind.CONSTANT_TENSOR
 
                 # state_dict has these parameters/buffers as torch.Tensors. We override them as torch.nn.Parameter/torch.Tensors respectively.
-                for name, _ in gm.named_parameters():
+                for name, param in gm.named_parameters():
                     if node.target == name:
                         input_kind = InputKind.PARAMETER
-                        state_dict[name] = torch.nn.Parameter(state_dict[name])
+                        # state_dict() drops requires_grad and Parameter defaults it
+                        # to True, which an integer weight cannot have.
+                        state_dict[name] = torch.nn.Parameter(
+                            state_dict[name], requires_grad=param.requires_grad
+                        )
                         break
                 for name, _ in gm.named_buffers():
                     if node.target == name:

--- a/tests/py/dynamo/executorch/test_api.py
+++ b/tests/py/dynamo/executorch/test_api.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._subclasses.fake_tensor import FakeTensor
+from torch.export.graph_signature import InputKind
 from torch_tensorrt.dynamo._exporter import _resolve_lifted_custom_obj, lift
 
 
@@ -275,7 +276,7 @@ def test_per_partition_distinct_target_devices(monkeypatch):
 # non-fp32 or non-CPU lifted constant silently gets fp32/cpu meta.
 
 
-def _traced_gm_with_parameter(dtype, device):
+def _traced_gm_with_parameter(dtype, device, requires_grad=False):
     """A symbolically-traced GraphModule with one get_attr parameter (`c`) of the
     given dtype/device, plus a stub graph_signature lift() can mutate."""
     from torch._subclasses.fake_tensor import FakeTensorMode
@@ -284,7 +285,8 @@ def _traced_gm_with_parameter(dtype, device):
         def __init__(self):
             super().__init__()
             self.c = torch.nn.Parameter(
-                torch.zeros(3, 3, dtype=dtype, device=device), requires_grad=False
+                torch.zeros(3, 3, dtype=dtype, device=device),
+                requires_grad=requires_grad,
             )
 
         def forward(self, x):
@@ -333,3 +335,34 @@ def test_lift_preserves_constant_dtype_device(dtype, device):
     # The source constant is a contiguous 3x3, so from_tensor must carry its real
     # (3, 1) stride onto the meta, not the old all-ones synthetic stride.
     assert val.stride() == torch.zeros(3, 3).stride()
+
+
+# --- lift() preserves parameter kind and requires_grad -----------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "dtype, requires_grad",
+    [
+        (torch.uint8, False),
+        (torch.int8, False),
+        (torch.float32, False),
+        # A trainable weight, so hardcoding either flag value fails the test.
+        (torch.float32, True),
+    ],
+)
+def test_lift_keeps_parameter_for_any_dtype(dtype, requires_grad):
+    gm, sig = _traced_gm_with_parameter(dtype, "cpu", requires_grad)
+    _, graph_signature, state_dict, constants = lift(gm, sig)
+
+    kinds = [spec.kind for spec in graph_signature.input_specs]
+    assert InputKind.PARAMETER in kinds, f"expected a PARAMETER, got {kinds}"
+
+    # The weight belongs in the state dict as a parameter, not in constants, or a
+    # caller can no longer load a checkpoint into the exported module.
+    assert "c" in state_dict, f"weight missing from state_dict: {list(state_dict)}"
+    assert isinstance(state_dict["c"], torch.nn.Parameter)
+    assert state_dict["c"].dtype == dtype
+    assert "c" not in constants
+
+    assert state_dict["c"].requires_grad is requires_grad


### PR DESCRIPTION
## The problem

Legacy export fails when a registered parameter has an integer dtype. It breaks while the
exporter turns the graph attributes into placeholders.

Each named parameter is re-wrapped there:

```python
state_dict[name] = torch.nn.Parameter(state_dict[name])
```

`gm.state_dict()` hands back plain tensors, so the original `requires_grad` flag is
already gone by this point, and `Parameter` puts it back as `True` by default. An integer
tensor cannot require gradients, so the export stops:

```
RuntimeError: Only Tensors of floating point and complex dtype can require gradients
```

This is easy to hit without any quantizer involved: constant folding registers folded
constants as parameters, so an integer constant expression reaches the same line.

There is a second, quieter problem. A float parameter the model had frozen comes back
trainable, which builds an autograd graph inside a program meant only for inference.

## The fix

The loop already has the module's parameter in hand, so carry its flag across instead of
throwing it away:

```python
for name, param in gm.named_parameters():
    if node.target == name:
        input_kind = InputKind.PARAMETER
        state_dict[name] = torch.nn.Parameter(
            state_dict[name], requires_grad=param.requires_grad
        )
        break
```

Nothing else about the classification changes. The weight stays a `PARAMETER`, stays in
the state dict as a `Parameter`, and stays out of the constants mapping, so loading a
checkpoint into the exported module keeps working. This matches `torch.export`, which
takes the input kind from module registration rather than from dtype.

## Testing

Extended the existing `lift()` parameter test to assert the input kind, the container type
and the `requires_grad` flag, not just the dtype and stride. It covers both flag values, so
an implementation that hardcodes either one fails.

Checked against the current code and against three wrong implementations:

```
correct fix                          4 passed
hardcode requires_grad=False         1 failed
hardcode requires_grad=True          3 failed
read the flag off the state dict     1 failed
current code, no fix                 3 failed
```

That last mutant matters: `state_dict()` detaches, so reading the flag from it always
yields `False` and looks correct until a trainable parameter is exported.

Full file: 20 passed.

These tests live in the `executorch` suite, which only the nightly lane selects, so they do
not run on this PR by default.
