### PR TITLE
perf(runtime): skip TensorRT engine fakification during export by reporting tracing_mode "real"

### DIFF
--- a/core/runtime/register_jit_hooks.cpp
+++ b/core/runtime/register_jit_hooks.cpp
@@ -70,6 +70,12 @@ static auto TORCHTRT_UNUSED TRTEngineTSRegistrtion =
         .def("__str__", &TRTEngine::to_str)
         .def("__repr__", &TRTEngine::to_str)
         .def("__obj_flatten__", &TRTEngine::__obj_flatten__)
+        // Reporting "real" makes torch's tracing_with_real skip fakification and hand
+        // the engine itself to the meta kernel, which reads only
+        // get_serialized_metadata() -- nothing executes or mutates it. Otherwise each
+        // fakification serializes the whole engine through __obj_flatten__ and
+        // deep-copies it through the pickle. The Python TRTEngine reports "real" too.
+        .def("tracing_mode", [](const c10::intrusive_ptr<TRTEngine>& self) -> std::string { return "real"; })
         .def("enable_profiling", &TRTEngine::enable_profiling)
         .def("set_profile_format", &TRTEngine::set_profile_format)
         .def("disable_profiling", &TRTEngine::disable_profiling)


### PR DESCRIPTION
## Description

`torch.export` fakifies every TorchBind script object it traces through, and for a TensorRT engine that is expensive twice over:

- `maybe_to_fake_obj` calls `__obj_flatten__`, which runs `TRTEngine::serialize()` — a full `cuda_engine->serialize()` plus base64 — and `FakeTRTEngine.__obj_unflatten__` then base64-decodes it again.
- `FakeScriptObject.__init__` deep-copies the real object, which for a TorchBind class goes through `def_pickle`: serialize, then a full `deserializeCudaEngine` of a second copy onto the device.

The fake never reads any of it. `FakeTRTEngine` assigns the blob to `self.serialized_engine` and every field it actually uses is metadata. ExecuTorch re-runs decompositions during `to_edge_transform_and_lower`, so this happens roughly three times per engine, and the cost grows with engine count and size.

`torch` already provides the opt-out: `tracing_with_real()` returns True for an object whose `tracing_mode()` reports `"real"`, and `maybe_to_fake_obj` then hands the real object to the meta kernel untouched. This adds that method to the TorchBind engine.

## Why this is safe

`fake_tensorrt_execute_engine` already handles being given a real engine: it branches on `real_obj` and otherwise calls `get_serialized_metadata()` directly, taking output shapes from the symbolic expressions stored in the engine's metadata. Nothing executes and nothing mutates the engine during tracing.

The Python `TRTEngine` has reported `"real"` for exactly this reason since it was added — its docstring cites `tracing_with_real`. The TorchBind class simply never did the same.

## Measurements

The mechanism is `torch.export` fakification, so any export carrying TensorRT engines benefits; the numbers below come from a two-layer Gemma4-MoE exported through the hybrid TensorRT + CUDA ExecuTorch path (3 engines), fresh Inductor cache, otherwise identical runs:

| | wall | fakification |
|---|---|---|
| before | 706.3 s | 517.9 s |
| after | 180.4 s | 0.0 s |

The exported program is unchanged: same delegate count, operators and values, and byte-identical delegate payloads.

## Testing

Verified by rebuilding and re-running the export above with no patches: fakification drops to zero and the artifact is byte-identical to the baseline. Existing `tests/py/dynamo/executorch` and `tests/py/dynamo/lowering/test_buffer_lifting.py` pass (75).

No automated test is included. Nothing in `tests/` currently exercises fakification of an engine, and the meaningful property — that export stops serializing the engine per fakify call — is a timing assertion. The cheapest real check would be asserting `tracing_mode() == "real"` on a built engine, which requires a GPU. Happy to add that if you want it gated.
