### PR TITLE
perf: skip the base64 round trip when reading TensorRT engine info

### DIFF
--- a/core/runtime/TRTEngine.cpp
+++ b/core/runtime/TRTEngine.cpp
@@ -583,20 +583,20 @@ FlattenedState TRTEngine::__obj_flatten__() {
       std::tuple("aliased_io", serialized_info[ALIASED_IO_IDX]));
 }
 
-std::vector<std::string> TRTEngine::serialize() {
-  // Serialize TensorRT engine
-  auto serialized_trt_engine = make_trt(this->cuda_engine->serialize());
-
-  // Adding device info related meta data to the serialized file
-  auto trt_engine = std::string((const char*)serialized_trt_engine->data(), serialized_trt_engine->size());
-
+std::vector<std::string> TRTEngine::serialize_metadata_only() {
+  // Nothing here touches the ICudaEngine: each field is a member or a cheap string
+  // encoding of one. ENGINE_IDX is deliberately left empty, so a caller that needs
+  // the engine must use serialize() or serialized_engine_tensor().
+  // rank/world_size are runtime facts (may differ at load time); not serialized.
+  // RuntimeSettings are intentionally NOT serialized: they're per-engine, in-memory
+  // initialization values, not part of the engine's identity.
   std::vector<std::string> serialized_info;
   serialized_info.resize(SERIALIZATION_LEN);
 
   serialized_info[ABI_TARGET_IDX] = ABI_VERSION;
   serialized_info[NAME_IDX] = this->name;
   serialized_info[DEVICE_IDX] = this->device_info.serialize();
-  serialized_info[ENGINE_IDX] = base64_encode(trt_engine);
+  serialized_info[ENGINE_IDX] = "";
   serialized_info[INPUT_BINDING_NAMES_IDX] = serialize_bindings(this->in_binding_names);
   serialized_info[OUTPUT_BINDING_NAMES_IDX] = serialize_bindings(this->out_binding_names);
   serialized_info[HW_COMPATIBLE_IDX] = this->hardware_compatible ? "1" : "0";
@@ -607,9 +607,34 @@ std::vector<std::string> TRTEngine::serialize() {
       this->resource_allocation_strategy == ResourceAllocationStrategy::kDynamic ? "1" : "0";
   serialized_info[REQUIRES_NATIVE_MULTIDEVICE_IDX] = this->requires_native_multidevice ? "1" : "0";
   serialized_info[ALIASED_IO_IDX] = serialize_aliased_io(this->aliased_io);
-  // rank/world_size are runtime facts (may differ at load time); not serialized.
-  // RuntimeSettings are intentionally NOT serialized: they're per-engine, in-memory
-  // initialization values, not part of the engine's identity.
+
+  return serialized_info;
+}
+
+at::Tensor TRTEngine::serialized_engine_tensor() {
+  // Wraps TensorRT's buffer instead of copying it: an engine can be multiple GB, and
+  // at::empty + memcpy would hold that buffer and its copy at the same time. The
+  // captured shared_ptr keeps the IHostMemory alive for exactly as long as the
+  // tensor's storage points into it. The storage is therefore not resizable.
+  auto serialized_trt_engine = make_trt(this->cuda_engine->serialize());
+  auto size = static_cast<int64_t>(serialized_trt_engine->size());
+  void* data = serialized_trt_engine->data();
+  return at::from_blob(
+      data,
+      {size},
+      [holder = std::move(serialized_trt_engine)](void*) mutable { holder.reset(); },
+      at::TensorOptions().dtype(at::kByte).device(at::kCPU));
+}
+
+std::vector<std::string> TRTEngine::serialize() {
+  // Same record as serialize_metadata_only() with the engine filled in. Delegates
+  // rather than repeating the field list, so a newly added field cannot land in one
+  // and be silently missing from the other.
+  auto serialized_info = serialize_metadata_only();
+
+  auto serialized_trt_engine = make_trt(this->cuda_engine->serialize());
+  auto trt_engine = std::string((const char*)serialized_trt_engine->data(), serialized_trt_engine->size());
+  serialized_info[ENGINE_IDX] = base64_encode(trt_engine);
 
   return serialized_info;
 }

--- a/core/runtime/TRTEngine.h
+++ b/core/runtime/TRTEngine.h
@@ -272,6 +272,21 @@ struct TRTEngine : torch::CustomClassHolder {
   // Serde re-export functionality
   FlattenedState __obj_flatten__();
   std::vector<std::string> serialize();
+  // serialize() packs both the metadata and the engine into one vector of strings,
+  // which forces the engine through base64. A caller that wants only metadata pays
+  // that encode for nothing; a caller that wants the engine pays it and then decodes
+  // it back. These expose each half on its own. serialize() still returns the full
+  // base64 record, so serialized engines and .pte artifacts are unaffected.
+  //
+  // The returned record is SERIALIZATION_LEN long with a valid ABI tag and an empty
+  // engine slot, so verify_serialization_fmt accepts it: passing it back to
+  // TRTEngine(std::vector<std::string>) constructs an engine from zero bytes rather
+  // than failing. It is for reading metadata, not for round-tripping.
+  std::vector<std::string> serialize_metadata_only();
+  // Returns uint8 tensor, not std::string: TorchScript maps std::string to a
+  // Python str and engine bytes are not valid UTF-8. A tensor is also the shape
+  // consumers want, so they need not rebuild one from decoded bytes.
+  at::Tensor serialized_engine_tensor();
 
   // CUDAGraph-Related Functionality
   // Keep the captured graph so its executable can be instantiated explicitly.

--- a/core/runtime/register_jit_hooks.cpp
+++ b/core/runtime/register_jit_hooks.cpp
@@ -78,6 +78,8 @@ static auto TORCHTRT_UNUSED TRTEngineTSRegistrtion =
         .def("dump_engine_layer_info", &TRTEngine::dump_engine_layer_info)
         .def("get_engine_layer_info", &TRTEngine::get_engine_layer_info)
         .def("get_serialized_metadata", &TRTEngine::get_serialized_metadata)
+        .def("serialize_metadata_only", &TRTEngine::serialize_metadata_only)
+        .def("serialized_engine_tensor", &TRTEngine::serialized_engine_tensor)
         .def("infer_outputs", &TRTEngine::infer_outputs)
         .def("reset_captured_graph", &TRTEngine::reset_captured_graph)
         .def("set_output_tensors_as_unowned", &TRTEngine::set_output_tensors_as_unowned)

--- a/py/torch_tensorrt/executorch/_export_utils.py
+++ b/py/torch_tensorrt/executorch/_export_utils.py
@@ -32,11 +32,60 @@ def _seed_graph_bound_leaves(value: Any, memo: dict[int, Any]) -> None:
             memo[id(leaf)] = leaf
 
 
-def get_engine_info_from_state(engine_obj: Any) -> list[Any]:
-    """Normalize TensorRT engine state into the serialized engine-info list."""
+_WARNED_MISSING: set[str] = set()
+
+
+def _warn_missing_accessor(name: str) -> None:
+    """Warn once per accessor that the loaded runtime predates it.
+
+    Without this the only symptom is that export gets slower: the fallback is
+    correct, it just re-serializes the whole ICudaEngine and base64-encodes it.
+    It means the Torch-TensorRT C++ library is older than this Python package,
+    i.e. a source or editable build where only the Python half was rebuilt; a
+    wheel ships both halves together, so an unmodified wheel should not see it.
+    """
+    if name in _WARNED_MISSING:
+        return
+    _WARNED_MISSING.add(name)
+    logger.warning(
+        "TensorRT runtime has no %s(); falling back to full engine serialization "
+        "on every read of this engine's info. This is correct but slower, and "
+        "means the Torch-TensorRT C++ library loaded from torch_tensorrt/lib "
+        "predates this Python package -- rebuild the C++ side to avoid it.",
+        name,
+    )
+
+
+def get_engine_info_from_state(
+    engine_obj: Any, *, metadata_only: bool = False
+) -> list[Any]:
+    """Normalize TensorRT engine state into the serialized engine-info list.
+
+    `__getstate__` on a TRT engine is the pickling hook, not a metadata accessor:
+    it re-serializes the whole ICudaEngine and base64-encodes it. ``metadata_only``
+    takes the record from ``serialize_metadata_only`` instead, which touches
+    nothing but members. Pass it from any caller that reads only metadata --
+    device, name, binding names, flags, aliased_io -- that is, anything but the
+    engine itself.
+
+    WARNING: with ``metadata_only`` the ENGINE_IDX slot is not reliable. On a
+    runtime providing ``serialize_metadata_only`` it is an empty string; on an
+    older runtime the fallback returns the full record, engine included. The
+    record keeps its full length either way, so nothing about its shape says
+    which one you got -- reading ENGINE_IDX yields an empty string on some
+    builds and a base64-encoded engine on others, with no error. Use
+    :func:`_resolve_engine_tensor` when the engine itself is needed.
+    """
+    reader = (
+        getattr(engine_obj, "serialize_metadata_only", None) if metadata_only else None
+    )
+    if reader is not None:
+        return list(reader())
+
+    if metadata_only:
+        _warn_missing_accessor("serialize_metadata_only")
     state = engine_obj.__getstate__()
-    engine_info = state[0] if isinstance(state, tuple) else state
-    return list(engine_info)
+    return list(state[0] if isinstance(state, tuple) else state)
 
 
 def validate_engine_info(engine_info: Sequence[Any], *, node_name: str = "") -> None:
@@ -62,10 +111,14 @@ def _schema_name(node: Any) -> str:
     return target._schema.name if hasattr(target, "_schema") else ""
 
 
-def _resolve_engine_info(exported_program: Any, node: Any) -> list[Any]:
-    if node.target is not torch.ops.tensorrt.execute_engine.default:
-        return list(node.args[1:])
+def _resolve_engine_object(exported_program: Any, node: Any) -> Any:
+    """Resolve an execute_engine node's engine to the live TRTEngine object.
 
+    The engine arg is a ``get_attr`` before ExecuTorch lifts constants and a
+    ``placeholder`` after, so both node forms must be resolved here. Raises rather
+    than returning ``None``, so a caller never has to tell "no engine here" apart
+    from "engine argument in a form this does not know".
+    """
     graph_module = exported_program.graph_module
     engine_node = node.args[1]
     if engine_node.op == "get_attr":
@@ -91,7 +144,58 @@ def _resolve_engine_info(exported_program: Any, node: Any) -> list[Any]:
             f"execute_engine node '{node.name}': unexpected engine arg op "
             f"'{engine_node.op}'"
         )
-    return get_engine_info_from_state(engine_obj)
+    return engine_obj
+
+
+def _resolve_engine_info(
+    exported_program: Any, node: Any, *, metadata_only: bool = False
+) -> list[Any]:
+    """Serialized engine-info record for a TensorRT node.
+
+    For a node that is not ``execute_engine`` the record is the node's own args,
+    so ENGINE_IDX holds an FX node rather than a blob and ``metadata_only`` is
+    ignored -- nothing is serialized on that path.
+    """
+    if node.target is not torch.ops.tensorrt.execute_engine.default:
+        return list(node.args[1:])
+    engine_obj = _resolve_engine_object(exported_program, node)
+    return get_engine_info_from_state(engine_obj, metadata_only=metadata_only)
+
+
+def _resolve_engine_tensor(exported_program: Any, node: Any) -> "torch.Tensor":
+    """Return the serialized engine as a uint8 tensor.
+
+    Prefers the engine's tensor accessor so the blob avoids base64 whenever the
+    runtime provides that accessor: serialize() encodes in C++ only for callers
+    that need everything as strings, and the matching decode here is waste when the
+    destination is a byte tensor. Falls back to decoding ENGINE_IDX on a runtime
+    without that accessor. Only ``execute_engine`` nodes are supported: a
+    ``no_op_placeholder_for_execute_engine`` carries its engine as a buffer
+    argument rather than a serialized blob, and is resolved by
+    ``_get_engine_info_for_node`` in backend.py instead.
+
+    The fallback re-resolves the engine's own record with ``_resolve_engine_info``
+    (no ``metadata_only``), so it never reads the empty ENGINE_IDX of a
+    metadata-only record that ``validate_engine_program`` may have stashed in the
+    caller's ``resolved`` dict. That keeps the two record shapes from crossing.
+    """
+    from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import ENGINE_IDX
+
+    if node.target is torch.ops.tensorrt.execute_engine.default:
+        engine_obj = _resolve_engine_object(exported_program, node)
+        raw = getattr(engine_obj, "serialized_engine_tensor", None)
+        if raw is not None:
+            return raw()
+        _warn_missing_accessor("serialized_engine_tensor")
+
+    engine_bytes = _resolve_engine_info(exported_program, node)[ENGINE_IDX]
+    if isinstance(engine_bytes, str):
+        import base64
+
+        engine_bytes = base64.b64decode(engine_bytes)
+    elif not isinstance(engine_bytes, (bytes, bytearray)):
+        engine_bytes = bytes(engine_bytes)
+    return torch.frombuffer(bytearray(engine_bytes), dtype=torch.uint8)
 
 
 def validate_engine_program(
@@ -101,6 +205,12 @@ def validate_engine_program(
 
     Resolving an engine serializes it, so pass a dict as ``resolved`` to keep what was
     resolved here and let the rewrite reuse it instead of serializing a second time.
+
+    Validation reads only metadata, so the records kept in ``resolved`` are
+    metadata-only: their ENGINE_IDX slot is empty. The rewrite reuses them for the
+    plain-string slots and takes the engine itself from :func:`_resolve_engine_tensor`,
+    which never reads a cached record's ENGINE_IDX -- so a metadata-only record is
+    never cross-served as the engine bytes.
     """
     count = 0
     # One engine can feed several execute_engine nodes, and resolving it again would
@@ -123,7 +233,9 @@ def validate_engine_program(
             by_engine_node.get(engine_node) if engine_node is not None else None
         )
         if engine_info is None:
-            engine_info = _resolve_engine_info(exported_program, node)
+            engine_info = _resolve_engine_info(
+                exported_program, node, metadata_only=True
+            )
             if engine_node is not None:
                 by_engine_node[engine_node] = engine_info
         validate_engine_info(engine_info, node_name=node.name)
@@ -349,20 +461,16 @@ def replace_execute_engine(
         engine_node = node.args[1]
         materialized = materialized_engines.get(engine_node)
         if materialized is None:
+            # Metadata reuses what validate_engine_program already resolved (a
+            # metadata-only record, empty ENGINE_IDX); the engine bytes come from
+            # _resolve_engine_tensor, which re-resolves the engine itself rather than
+            # reading this record's ENGINE_IDX, so the empty slot is never consumed.
             engine_info = (resolved or {}).get(node.name)
             if engine_info is None:
-                engine_info = _resolve_engine_info(exported_program, node)
-            engine_bytes = engine_info[ENGINE_IDX]
-            if isinstance(engine_bytes, str):
-                import base64
-
-                engine_bytes = base64.b64decode(engine_bytes)
-            elif not isinstance(engine_bytes, (bytes, bytearray)):
-                engine_bytes = bytes(engine_bytes)
-            # frombuffer needs a writable buffer, and rebinding here releases the
-            # read-only copy instead of holding both for the rest of the loop.
-            engine_bytes = bytearray(engine_bytes)
-            engine_tensor = torch.frombuffer(engine_bytes, dtype=torch.uint8)
+                engine_info = _resolve_engine_info(
+                    exported_program, node, metadata_only=True
+                )
+            engine_tensor = _resolve_engine_tensor(exported_program, node)
 
             buffer_name = _unique_engine_buffer_name(exported_program, graph_module)
             graph_module.register_buffer(buffer_name, engine_tensor, persistent=True)

--- a/tests/py/dynamo/executorch/test_engine_info_accessors.py
+++ b/tests/py/dynamo/executorch/test_engine_info_accessors.py
@@ -1,0 +1,184 @@
+import base64
+
+import pytest
+
+executorch = pytest.importorskip("executorch.exir")
+
+import torch  # noqa: E402
+from torch_tensorrt.dynamo.runtime._serialized_engine_layout import (  # noqa: E402
+    ENGINE_IDX,
+    SERIALIZATION_LEN,
+)
+from torch_tensorrt.executorch import _export_utils  # noqa: E402
+from torch_tensorrt.executorch._export_utils import (  # noqa: E402
+    get_engine_info_from_state,
+)
+
+ENGINE_BYTES = b"ENGINEBYTES"
+
+
+def _record(engine_value):
+    record = [""] * SERIALIZATION_LEN
+    record[ENGINE_IDX] = engine_value
+    return record
+
+
+class RuntimeWithAccessor:
+    """Engine from a runtime that provides ``serialize_metadata_only``."""
+
+    def __init__(self):
+        self.metadata_calls = 0
+        self.getstate_calls = 0
+
+    def serialize_metadata_only(self):
+        self.metadata_calls += 1
+        return _record("")
+
+    def __getstate__(self):
+        self.getstate_calls += 1
+        return (_record("ENGINEBYTES"),)
+
+
+class RuntimeWithoutAccessor:
+    """Engine from a C++ library built before ``serialize_metadata_only`` existed."""
+
+    def __init__(self):
+        self.getstate_calls = 0
+
+    def __getstate__(self):
+        self.getstate_calls += 1
+        return (_record("ENGINEBYTES"),)
+
+
+class RuntimeWithoutTensorAccessor:
+    """Engine with the metadata accessor but not the tensor one.
+
+    Both accessors were added together, so this is not a build that exists; it is
+    the shape that forces ``_resolve_engine_tensor`` down its fallback branch,
+    where the engine bytes come out of a cached record rather than the accessor.
+    """
+
+    def __init__(self):
+        self.metadata_calls = 0
+        self.getstate_calls = 0
+
+    def serialize_metadata_only(self):
+        self.metadata_calls += 1
+        return _record("")
+
+    def __getstate__(self):
+        self.getstate_calls += 1
+        return (_record(base64.b64encode(ENGINE_BYTES).decode()),)
+
+
+class _Program:
+    """Stand-in for ExportedProgram carrying what the two passes touch."""
+
+    def __init__(self, graph_module):
+        self.graph_module = graph_module
+        self.constants = {}
+        self.state_dict = {}
+
+
+def _program_with_engine(engine):
+    """A single-``execute_engine``-node program holding ``engine`` by get_attr."""
+    graph = torch.fx.Graph()
+    root = torch.nn.Module()
+    root.engine = engine
+    engine_node = graph.get_attr("engine")
+    input_node = graph.placeholder("x")
+    node = graph.call_function(
+        torch.ops.tensorrt.execute_engine.default, ([input_node], engine_node)
+    )
+    graph.output((node,))
+    return _Program(torch.fx.GraphModule(root, graph)), node
+
+
+@pytest.mark.unit
+def test_metadata_only_skips_engine_serialization():
+    engine = RuntimeWithAccessor()
+    record = get_engine_info_from_state(engine, metadata_only=True)
+
+    assert len(record) == SERIALIZATION_LEN, (
+        "metadata-only record must match the full record's length, or the "
+        "*_IDX constants address the wrong slots"
+    )
+    assert record[ENGINE_IDX] == "", "metadata-only record must not carry the engine"
+    assert engine.metadata_calls == 1
+    assert engine.getstate_calls == 0, "__getstate__ re-serializes; it must not run"
+
+
+@pytest.mark.unit
+def test_falls_back_when_runtime_lacks_the_accessor():
+    """A mixed build (new Python, older C++) must stay correct, only slower."""
+    engine = RuntimeWithoutAccessor()
+    record = get_engine_info_from_state(engine, metadata_only=True)
+
+    assert engine.getstate_calls == 1
+    assert record[ENGINE_IDX] == "ENGINEBYTES", "fallback must return the real record"
+    assert len(record) == SERIALIZATION_LEN
+
+
+@pytest.mark.unit
+def test_fallback_and_accessor_agree_outside_the_engine_slot():
+    """The paths must differ only in ENGINE_IDX, or readers see different metadata."""
+    via_accessor = get_engine_info_from_state(RuntimeWithAccessor(), metadata_only=True)
+    via_fallback = get_engine_info_from_state(
+        RuntimeWithoutAccessor(), metadata_only=True
+    )
+
+    for index in range(SERIALIZATION_LEN):
+        if index == ENGINE_IDX:
+            continue
+        assert via_accessor[index] == via_fallback[index], f"slot {index} differs"
+
+
+@pytest.mark.unit
+def test_missing_accessor_warns_once(caplog):
+    caplog.set_level("WARNING")
+    _export_utils._WARNED_MISSING.clear()
+
+    get_engine_info_from_state(RuntimeWithoutAccessor(), metadata_only=True)
+    get_engine_info_from_state(RuntimeWithoutAccessor(), metadata_only=True)
+
+    warnings = [r for r in caplog.records if "serialize_metadata_only" in r.message]
+    assert len(warnings) == 1, "a silently slower fallback should announce itself once"
+
+
+@pytest.mark.unit
+def test_metadata_only_record_is_not_cross_served_as_engine_bytes():
+    """The rewrite must not source engine bytes from validation's cached record.
+
+    Export always validates before it rewrites, and validation reads metadata
+    only, so the record ``validate_engine_program`` leaves in ``resolved`` for this
+    engine has an empty ENGINE_IDX by the time the rewrite runs. The rewrite reuses
+    that record for the plain-string slots but must take the engine itself from
+    ``_resolve_engine_tensor``, which re-resolves the engine rather than reading a
+    cached ENGINE_IDX. Serving the metadata-only record as the engine yields a
+    zero-length buffer and a .pte that fails at deserialize rather than here.
+    """
+    engine = RuntimeWithoutTensorAccessor()
+    program, node = _program_with_engine(engine)
+
+    resolved: dict = {}
+    assert _export_utils.validate_engine_program(program, resolved) == 1
+    assert engine.metadata_calls == 1
+    assert engine.getstate_calls == 0
+    assert resolved[node.name][ENGINE_IDX] == "", (
+        "validation must cache a metadata-only record, or this test does not "
+        "exercise the cross-serving hazard"
+    )
+
+    _export_utils.replace_execute_engine(program, resolved)
+
+    no_op = torch.ops.tensorrt.no_op_placeholder_for_execute_engine.default
+    no_op_nodes = [n for n in program.graph_module.graph.nodes if n.target is no_op]
+    assert len(no_op_nodes) == 1
+    buffer_node = no_op_nodes[0].args[1 + ENGINE_IDX]
+    engine_buffer = getattr(program.graph_module, buffer_node.target)
+
+    assert engine_buffer.numpy().tobytes() == ENGINE_BYTES, (
+        "the rewrite wrote a zero-length engine: it sourced bytes from the "
+        "metadata-only record cached by validation rather than re-resolving them"
+    )
+    assert engine.getstate_calls == 1, "the engine record still must be read once"

--- a/tests/py/dynamo/executorch/test_export.py
+++ b/tests/py/dynamo/executorch/test_export.py
@@ -1557,13 +1557,19 @@ def test_export_warns_for_multiple_engines(monkeypatch, caplog):
     not torch_tensorrt.ENABLED_FEATURES.torch_tensorrt_runtime,
     reason="Torch-TensorRT runtime operators are not available",
 )
-def test_rewrite_reuses_resolved_engines_instead_of_serializing_again(monkeypatch):
-    """The rewrite consumes what validation resolved instead of resolving again.
+def test_rewrite_reuses_resolved_metadata_instead_of_reading_it_again(monkeypatch):
+    """The rewrite consumes the metadata validation resolved instead of reading it again.
 
-    Reading an engine's state serializes it and base64 encodes the result, so resolving
-    the same engine in both steps doubles that cost. Staging hands the rewrite a
-    different program object holding the same node names, so the two programs here are
-    separate instances to match that.
+    Reading an engine's metadata serializes it on a runtime without the metadata
+    accessor, so re-reading it in both steps would double that cost. Staging hands the
+    rewrite a different program object holding the same node names, so the two programs
+    here are separate instances to match that.
+
+    The engine bytes are a separate read the tensor path owns, not part of the metadata
+    handoff: the record kept in ``resolved`` is metadata-only, so its ENGINE_IDX is
+    empty and the rewrite must never source the bytes from it. On this accessor-less
+    fake the tensor path falls back to one more full read, which is the second call
+    below; with the accessors present neither call serializes at all.
     """
     export_utils = importlib.import_module("torch_tensorrt.executorch._export_utils")
     source, _, _, _ = _engine_program(lifted=False)
@@ -1572,9 +1578,9 @@ def test_rewrite_reuses_resolved_engines_instead_of_serializing_again(monkeypatc
     calls = []
     real_resolve = export_utils.get_engine_info_from_state
 
-    def counting_get_engine_info_from_state(engine_obj):
-        calls.append(engine_obj)
-        return real_resolve(engine_obj)
+    def counting_get_engine_info_from_state(engine_obj, *, metadata_only=False):
+        calls.append(metadata_only)
+        return real_resolve(engine_obj, metadata_only=metadata_only)
 
     monkeypatch.setattr(
         export_utils, "get_engine_info_from_state", counting_get_engine_info_from_state
@@ -1582,7 +1588,7 @@ def test_rewrite_reuses_resolved_engines_instead_of_serializing_again(monkeypatc
 
     resolved: dict = {}
     assert export_utils.validate_engine_program(source, resolved) == 1
-    assert len(calls) == 1
+    assert calls == [True], "validation reads metadata only, exactly once"
 
     # Staging preserves node identities, which is what lets the rewrite find the earlier
     # work on a different program object.
@@ -1592,5 +1598,7 @@ def test_rewrite_reuses_resolved_engines_instead_of_serializing_again(monkeypatc
 
     export_utils.replace_execute_engine(staged, resolved)
 
-    # Without the handoff the rewrite resolves the engine again and this becomes 2.
-    assert len(calls) == 1
+    # The metadata handoff means the rewrite never re-reads metadata; the one extra read
+    # is the tensor path fetching the bytes, which it re-resolves rather than trusting
+    # the metadata-only record. Without the handoff the first entry would repeat.
+    assert calls == [True, False]


### PR DESCRIPTION
# Description

`TRTEngine::serialize()` base64-encodes the serialized engine so the whole record can travel as a `std::vector<std::string>`. That encoding is the only reason the engine is a string, and both ExecuTorch export consumers pay for it without wanting it:

- `validate_engine_program` reads only flags and binding names, but reaching them goes through `__getstate__`, which serializes the entire `ICudaEngine` and base64-encodes it first.
- `replace_execute_engine` wants the engine as a `uint8` tensor, so it pays the encode in C++ and then an immediate matching decode in Python — an encode plus a decode of a multi-megabyte blob, purely to move bytes through a string.

This adds the two halves as accessors and points the consumers at them.

**C++ (`core/runtime`)**

| accessor | returns |
|---|---|
| `serialize_metadata_only()` | every `serialized_info` field except `ENGINE_IDX`. All plain members, so no engine serialization happens at all. |
| `serialized_engine_tensor()` | the engine as a `uint8` `at::Tensor`. |

`serialized_engine_tensor()` returns `at::Tensor` rather than `std::string` because TorchScript maps `std::string` to a Python `str` and engine bytes are not valid UTF-8 (`UnicodeDecodeError`); a tensor is also what the consumer builds anyway.

`serialize()` now fills `ENGINE_IDX` into `serialize_metadata_only()`'s record rather than carrying a second copy of the field list, so the two cannot drift apart when a field is added.

**Python (`py/torch_tensorrt/executorch/_export_utils.py`)**

A `metadata_only=True` kwarg threaded through `get_engine_info_from_state` / `_resolve_engine_info` routes metadata readers to the cheap accessor, and `_resolve_engine_tensor` takes the engine as a tensor directly (which also drops the `torch.frombuffer` rebuild).

The other engine reader, `_get_engine_info_for_node` in `backend.py`, is left alone. Its one caller (`partitioner.py`) runs after `replace_execute_engine` has rewritten those nodes to `no_op_placeholder`, whose engine argument is already a tensor, so it takes the `node.args[1:]` branch and serializes nothing. The `execute_engine` branch below it would still serialize, but no caller reaches it in the current pass order; threading `metadata_only` through it would change no work today.

## Results

Exporting a model with a 67 MB engine; six runs per configuration, interleaved, one fresh process per run, medians with min–max. **A** is this PR's base #4440; **B** is that base plus these two commits.

Measured against the base (#4440), where the change lands — equivalent to a `main`-relative measurement here, since both resolve each engine's info once and pay the single base64 round trip this PR removes. #4440 already includes #4473 (`fbb10c9565`), whose bulk engine copy sits in both columns and does not move the delta.

| | A (baseline) | B (this PR) |
|---|---|---|
| ExecuTorch lowering phase | 1.81 s | **1.03 s** (−43%) |
| passes that read engine info | 0.82 s | 0.09 s |
| engine-state reads | 0.53 s | 0.05 s |
| Python-side base64 decode | 0.24 s | ~0 |

Validation drops from 0.53 s to about 0.1 ms: it reads only metadata now, and the metadata accessor touches no engine bytes. The rewrite still reads the engine, but as a tensor without the base64 round trip, so its engine read is 0.05 s rather than a 0.53 s `__getstate__` plus a 0.24 s decode. The engine's raw serialization is about 0.08 s of a 0.57 s `__getstate__`, so most of what disappears is the base64 encode and the string copies feeding it. A metadata-only read costs about 10 µs.

The separation is clean — every B run is faster than every A run on each metric — so a permutation test on the lowering phase gives p ≈ 0.002, the floor for six-versus-six fully separated samples.

Neither #4440 nor #4473 overlaps in scope with this change.

## Compatibility

- `serialize()` output is **byte-identical**, so existing serialized engines and `.pte` artifacts are unaffected.
- `serialized_engine_tensor()` wraps TensorRT's buffer with `at::from_blob` rather than copying it, so peak host memory during the call is one engine rather than two — which matters for the multi-GB engines the `untyped_storage()` comment in `backend.py`'s `preprocess` already accounts for. The consequence is that the returned tensor's storage is not resizable; nothing on the export path resizes it.
- The accessors are purely additive; nothing existing changes signature or behavior.
- The Python side **does not require a matching runtime**. Both accessors fall back to the old path when absent, which happens only when the Torch-TensorRT C++ library is older than the Python package — a source or editable build where only the Python half was rebuilt. A wheel ships both halves together. Since the fallback is correct and merely slower, the symptom would otherwise be silence, so it logs a warning once per accessor naming the cause.

## Dependency

Stacked on #4440 (composable Edge export API), which introduces `py/torch_tensorrt/executorch/_export_utils.py`. The C++ commit stands alone; the Python commit needs that file to exist.

## Related work

#4489 is orthogonal and complementary. It stops fakification from serializing the engine through `TRTEngine::__obj_flatten__`; this PR removes the base64 round trip in the engine-info reads. Both cut export-time engine serialization, but at different points, and they compose — neither depends on the other.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
