### PR TITLE
Fix 4x dynamic engine workspace overallocation

### DIFF
--- a/core/runtime/execute_engine.cpp
+++ b/core/runtime/execute_engine.cpp
@@ -279,10 +279,10 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
 
   torch::Tensor dynamic_workspace;
   if (compiled_engine->resource_allocation_strategy == TRTEngine::ResourceAllocationStrategy::kDynamic) {
-    dynamic_workspace = torch::empty(
-        {compiled_engine->cuda_engine->getDeviceMemorySizeV2()},
-        torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA));
-    ctx->setDeviceMemory(dynamic_workspace.data_ptr());
+    const auto workspace_bytes = compiled_engine->cuda_engine->getDeviceMemorySizeV2();
+    dynamic_workspace =
+        torch::empty({workspace_bytes}, torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA));
+    ctx->setDeviceMemoryV2(dynamic_workspace.data_ptr(), workspace_bytes);
   }
 
   auto run_standard_execution = [&]() {

--- a/core/runtime/execute_engine.cpp
+++ b/core/runtime/execute_engine.cpp
@@ -279,7 +279,9 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
 
   torch::Tensor dynamic_workspace;
   if (compiled_engine->resource_allocation_strategy == TRTEngine::ResourceAllocationStrategy::kDynamic) {
-    dynamic_workspace = torch::empty(compiled_engine->cuda_engine->getDeviceMemorySizeV2(), {torch::kCUDA});
+    dynamic_workspace = torch::empty(
+        {compiled_engine->cuda_engine->getDeviceMemorySizeV2()},
+        torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA));
     ctx->setDeviceMemory(dynamic_workspace.data_ptr());
   }
 

--- a/tests/py/dynamo/runtime/test_dynamic_workspace_allocation.py
+++ b/tests/py/dynamo/runtime/test_dynamic_workspace_allocation.py
@@ -3,8 +3,9 @@ import unittest
 
 import torch
 import torch_tensorrt as torch_trt
-import tensorrt as trt  # isort: skip  # imported after torch_tensorrt for RTX alias
 from torch_tensorrt.dynamo.runtime import TorchTensorRTModule
+
+import tensorrt as trt  # isort: skip  # imported after torch_tensorrt for RTX alias
 
 
 class TestDynamicWorkspaceAllocation(unittest.TestCase):
@@ -40,9 +41,7 @@ class TestDynamicWorkspaceAllocation(unittest.TestCase):
         self.assertEqual(len(runtime_modules), 1)
 
         runtime = trt.Runtime(trt.Logger(trt.Logger.ERROR))
-        engine = runtime.deserialize_cuda_engine(
-            runtime_modules[0].serialized_engine
-        )
+        engine = runtime.deserialize_cuda_engine(runtime_modules[0].serialized_engine)
         self.assertIsNotNone(engine)
         workspace_bytes = engine.device_memory_size_v2
         self.assertGreater(workspace_bytes, 0)

--- a/tests/py/dynamo/runtime/test_dynamic_workspace_allocation.py
+++ b/tests/py/dynamo/runtime/test_dynamic_workspace_allocation.py
@@ -1,0 +1,71 @@
+import gc
+import unittest
+
+import torch
+import torch_tensorrt as torch_trt
+import tensorrt as trt  # isort: skip  # imported after torch_tensorrt for RTX alias
+from torch_tensorrt.dynamo.runtime import TorchTensorRTModule
+
+
+class TestDynamicWorkspaceAllocation(unittest.TestCase):
+    def test_workspace_is_allocated_in_bytes(self):
+        self.addCleanup(torch._dynamo.reset)
+
+        class ConvNet(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv1 = torch.nn.Conv2d(3, 6, 3, 1)
+                self.conv2 = torch.nn.Conv2d(6, 16, 3, 1)
+
+            def forward(self, x):
+                return torch.relu(self.conv2(torch.relu(self.conv1(x))))
+
+        inputs = [torch.rand((100, 3, 224, 224), device="cuda")]
+        compiled_module = torch_trt.compile(
+            ConvNet().eval().cuda(),
+            inputs=inputs,
+            ir="dynamo",
+            immutable_weights=False,
+            lazy_engine_init=True,
+            dynamically_allocate_resources=True,
+            min_block_size=1,
+        )
+
+        warmup_output = compiled_module(*inputs)
+        runtime_modules = [
+            module
+            for module in compiled_module.modules()
+            if isinstance(module, TorchTensorRTModule)
+        ]
+        self.assertEqual(len(runtime_modules), 1)
+
+        runtime = trt.Runtime(trt.Logger(trt.Logger.ERROR))
+        engine = runtime.deserialize_cuda_engine(
+            runtime_modules[0].serialized_engine
+        )
+        self.assertIsNotNone(engine)
+        workspace_bytes = engine.device_memory_size_v2
+        self.assertGreater(workspace_bytes, 0)
+        del engine, runtime, warmup_output
+        gc.collect()
+
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        baseline_allocated = torch.cuda.memory_allocated()
+        torch.cuda.reset_peak_memory_stats()
+
+        output = compiled_module(*inputs)
+        torch.cuda.synchronize()
+        peak_delta = torch.cuda.max_memory_allocated() - baseline_allocated
+        output_bytes = output.numel() * output.element_size()
+        allocator_tolerance = max(1024**2, workspace_bytes // 8)
+
+        self.assertLessEqual(
+            peak_delta,
+            workspace_bytes + output_bytes + allocator_tolerance,
+            msg=(
+                "Dynamic allocation exceeded the TensorRT byte requirement: "
+                f"peak delta={peak_delta}, workspace={workspace_bytes}, "
+                f"output={output_bytes}, tolerance={allocator_tolerance}"
+            ),
+        )


### PR DESCRIPTION
# Description

Fix an overallocation issue.
`getDeviceMemorySizeV2()` returns bytes, `torch::empty()` allocates with dtype float32 by default. This resulted in an overallocation for the workspace of 3x.

```
 Model   | Peak before | Peak fixed | Reduction
━━━━━━━━━+━━━━━━━━━━━━━+━━━━━━━━━━━━+━━━━━━━━━━━
 FLUX.2  |   4.608 GiB |  3.363 GiB | 1.245 GiB
─────────|─────────────+────────────+───────────
 SeedVR2 |   8.559 GiB |  7.242 GiB | 1.317 GiB
```

## Type of change

- Optimization

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
