### PR TITLE
Fix CPU-only import

### DIFF
--- a/py/torch_tensorrt/_Device.py
+++ b/py/torch_tensorrt/_Device.py
@@ -145,7 +145,7 @@ class Device(object):
 
     @classmethod
     def _current_device(cls) -> Device:
-        dev_id = torch.cuda.current_device()
+        dev_id = torch.cuda.current_device() if torch.cuda.is_available() else 0
         return cls(gpu_id=dev_id)
 
     @staticmethod

--- a/py/torch_tensorrt/_utils.py
+++ b/py/torch_tensorrt/_utils.py
@@ -87,18 +87,24 @@ def is_tensorrt_version_supported(min_version: str) -> bool:
 
 
 def is_tegra_platform() -> bool:
+    if not torch.cuda.is_available():
+        return False
     if torch.cuda.get_device_capability() in [(8, 7), (7, 2)]:
         return True
     return False
 
 
 def is_orin() -> bool:
+    if not torch.cuda.is_available():
+        return False
     if torch.cuda.get_device_capability() in [(8, 7)]:
         return True
     return False
 
 
 def is_thor() -> bool:
+    if not torch.cuda.is_available():
+        return False
     if torch.cuda.get_device_capability() in [(11, 0)]:
         return True
     return False

--- a/py/torch_tensorrt/dynamo/_defaults.py
+++ b/py/torch_tensorrt/dynamo/_defaults.py
@@ -97,4 +97,6 @@ RUNTIME_CACHE_PATH = os.path.join(
 
 
 def default_device() -> Device:
+    if not torch.cuda.is_available():
+        return Device(gpu_id=0)
     return Device(gpu_id=torch.cuda.current_device())


### PR DESCRIPTION
# Description

import torch_tensorrt currently fails on hosts without an NVIDIA driver because several CUDA queries run at import / def time with no torch.cuda.is_available() guard.

Guard is_tegra_platform(), default_device(), and Device._current_device() so the package imports cleanly on CPU-only machines. GPU paths are unchanged once a driver is present.

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ X] My code follows the style guidelines of this project (You can use the linters)
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas and hacks
- [ X] I have made corresponding changes to the documentation
- [X ] I have added tests to verify my fix or my feature
- [ X] New and existing unit tests pass locally with my changes
- [ X] I have added the relevant labels to my PR in so that relevant reviewers are notified
