### PR TITLE
Fix empty inputs=()

### DIFF
--- a/py/torch_tensorrt/_compile.py
+++ b/py/torch_tensorrt/_compile.py
@@ -424,7 +424,7 @@ def cross_compile_for_windows(
             "'arg_inputs' and 'inputs' should not be used at the same time."
         )
 
-    arg_inputs = inputs or arg_inputs
+    arg_inputs = inputs if inputs is not None else arg_inputs
 
     if kwarg_inputs is None:
         kwarg_inputs = {}
@@ -524,7 +524,7 @@ def convert_method_to_trt_engine(
         raise AssertionError(
             "'arg_inputs' and 'inputs' should not be used at the same time."
         )
-    arg_inputs = arg_inputs or inputs
+    arg_inputs = inputs if inputs is not None else arg_inputs
 
     module_type = _parse_module_type(module)
     target_ir = _get_target_fe(module_type, ir)
@@ -564,7 +564,7 @@ def convert_method_to_trt_engine(
         torchtrt_arg_inputs = prepare_inputs(normalized_arg_inputs)
         torchtrt_kwarg_inputs = prepare_inputs(kwarg_inputs)
 
-        exp_program = torch_tensorrt.dynamo.trace(
+        exp_program = dynamo_trace(
             module, torchtrt_arg_inputs, kwarg_inputs=torchtrt_kwarg_inputs, **kwargs
         )
 
@@ -826,12 +826,12 @@ def save(
         raise ValueError(
             "Not all inputs provided are torch.Tensor or torch_tensorrt.Input objects. Please provide inputs of a valid type"
         )
-    if arg_inputs and inputs:
+    if arg_inputs is not None and inputs is not None:
         raise AssertionError(
             "'arg_inputs' and 'inputs' should not be used at the same time."
         )
 
-    arg_inputs = inputs or arg_inputs
+    arg_inputs = inputs if inputs is not None else arg_inputs
 
     if kwarg_inputs is None:
         kwarg_inputs = {}

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -310,7 +310,7 @@ def cross_compile_for_windows(
             "'arg_inputs' and 'inputs' should not be used at the same time."
         )
 
-    arg_inputs = inputs or arg_inputs
+    arg_inputs = inputs if inputs is not None else arg_inputs
 
     if kwarg_inputs is None:
         kwarg_inputs = {}
@@ -710,7 +710,7 @@ def compile(
             "'arg_inputs' and 'inputs' should not be used at the same time."
         )
 
-    arg_inputs = inputs or arg_inputs
+    arg_inputs = inputs if inputs is not None else arg_inputs
 
     if kwarg_inputs is None:
         kwarg_inputs = {}
@@ -1942,7 +1942,7 @@ def convert_exported_program_to_serialized_trt_engine(
             "'arg_inputs' and 'inputs' should not be used at the same time."
         )
 
-    arg_inputs = inputs or arg_inputs
+    arg_inputs = inputs if inputs is not None else arg_inputs
 
     if kwarg_inputs is None:
         kwarg_inputs = {}

--- a/tests/py/dynamo/runtime/test_000_compiler_utils.py
+++ b/tests/py/dynamo/runtime/test_000_compiler_utils.py
@@ -139,5 +139,26 @@ class TestPrepareInputs(unittest.TestCase):
         self.assertIsInstance(bool_result, torch_tensorrt.Input)
 
 
+class TestDeprecatedInputsAlias(unittest.TestCase):
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+    def test_empty_inputs_tuple_with_kwarg_inputs(self):
+        class KwargsOnly(torch.nn.Module):
+            def forward(self, *, x):
+                return x + 1
+
+        model = KwargsOnly().eval().cuda()
+        x = torch.randn(2, 3, device="cuda")
+        ep = torch.export.export(model, (), {"x": x})
+        trt_gm = torch_tensorrt.dynamo.compile(
+            ep,
+            inputs=(),
+            kwarg_inputs={"x": x},
+            min_block_size=1,
+            cache_built_engines=False,
+            reuse_cached_engines=False,
+        )
+        torch.testing.assert_close(trt_gm(x=x), model(x=x), rtol=1e-2, atol=1e-2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/py/dynamo/runtime/test_000_compiler_utils.py
+++ b/tests/py/dynamo/runtime/test_000_compiler_utils.py
@@ -159,6 +159,33 @@ class TestDeprecatedInputsAlias(unittest.TestCase):
         )
         torch.testing.assert_close(trt_gm(x=x), model(x=x), rtol=1e-2, atol=1e-2)
 
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+    def test_empty_arg_inputs_tuple_convert_method_to_trt_engine(self):
+        class KwargsOnly(torch.nn.Module):
+            def forward(self, *, x):
+                return x + 1
+
+        model = KwargsOnly().eval().cuda()
+        x = torch.randn(2, 3, device="cuda")
+        engine = torch_tensorrt.convert_method_to_trt_engine(
+            model,
+            "forward",
+            arg_inputs=(),
+            kwarg_inputs={"x": x},
+            ir="dynamo",
+            min_block_size=1,
+        )
+        self.assertIsInstance(engine, bytes)
+        self.assertGreater(len(engine), 0)
+
+    def test_save_rejects_empty_arg_inputs_with_inputs(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        with self.assertRaises(AssertionError):
+            torch_tensorrt.save(M(), arg_inputs=(), inputs=(torch.randn(2, 3),))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Description

arg_inputs = inputs or arg_inputs treats inputs=() as missing, so a no-arg module becomes arg_inputs=[None] and fails later in input prep with a confusing error.

Use an explicit None check instead of truthiness so empty-tuple inputs stay empty.

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X ] My code follows the style guidelines of this project (You can use the linters)
- [X ] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas and hacks
- [ X] I have made corresponding changes to the documentation
- [X ] I have added tests to verify my fix or my feature
- [ X] New and existing unit tests pass locally with my changes
- [ X] I have added the relevant labels to my PR in so that relevant reviewers are notified
