### PR TITLE
Fix complex rewrite non-tensor meta["val"]

### DIFF
--- a/py/torch_tensorrt/dynamo/lowering/passes/complex_graph_rewrite.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/complex_graph_rewrite.py
@@ -1809,15 +1809,13 @@ class ComplexGraphRewriter:
         """
         from torch.fx.passes.fake_tensor_prop import FakeTensorProp
 
-        fake_inputs: List[Optional[torch.Tensor]] = []
+        fake_inputs: List[Any] = []
         for node in self.gm.graph.nodes:
             if node.op == "placeholder":
                 if "val" in node.meta:
                     fake_val = node.meta["val"]
-                    if fake_val is None:
-                        # present-but-None placeholder = a real None input
-                        # (e.g. an optional/None transformer input, common in diffusers)
-                        fake_inputs.append(None)
+                    if not isinstance(fake_val, torch.Tensor):
+                        fake_inputs.append(fake_val)
                     elif fake_val.device.type == "cuda":
                         fake_inputs.append(fake_val.to("cuda"))
                     else:

--- a/tests/py/dynamo/lowering/test_complex_rewrite.py
+++ b/tests/py/dynamo/lowering/test_complex_rewrite.py
@@ -1248,3 +1248,17 @@ def test_none_placeholder():
             return out
 
     _check_op(M(), (_z(), None), "none_placeholder")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("scale", [torch.tensor(2.0), 2, True], ids=["tensor", "int", "bool"])
+def test_non_tensor_scalar_placeholder(scale):
+    class RotaryComplex(nn.Module):
+        def forward(self, xq, freqs_cis, scale):
+            xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
+            out = torch.view_as_real(xq_ * freqs_cis).flatten(3).type_as(xq)
+            return out * scale
+
+    xq = torch.randn(1, 2, 4, 8)
+    freqs = torch.polar(torch.ones(1, 2, 4, 4), torch.randn(1, 2, 4, 4))
+    _export_and_lower(RotaryComplex(), (xq, freqs, scale))


### PR DESCRIPTION
# Description

ComplexGraphRewriter.propagate_metadata assumes every placeholder meta["val"] has a .device. Non-tensor vals (int, bool, SymInt) raise AttributeError and kill lowering.

Guard with isinstance(fake_val, torch.Tensor) (alongside the existing None case) before touching .device.

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ X] My code follows the style guidelines of this project (You can use the linters)
- [ X] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas and hacks
- [X ] I have made corresponding changes to the documentation
- [ X] I have added tests to verify my fix or my feature
- [ X] New and existing unit tests pass locally with my changes
- [ X] I have added the relevant labels to my PR in so that relevant reviewers are notified
