### PR TITLE
Fix where bfloat16 promotion

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/converter_utils.py
+++ b/py/torch_tensorrt/dynamo/conversion/converter_utils.py
@@ -1181,16 +1181,23 @@ def promote_trt_tensors_to_same_dtype(
         A tuple of (lhs_cast, rhs_cast) TensorRT tensors, both cast to the promoted dtype.
     """
 
-    # Define supported float types (TensorRT supports float16 and float32)
-    float_types = {trt.float16, trt.float32}
+    # bfloat16 must be treated as float; omitting it sends bf16 pairs to int32.
+    float_types = {trt.float16, trt.bfloat16, trt.float32}
+
+    lhs_is_float = lhs.dtype in float_types
+    rhs_is_float = rhs.dtype in float_types
 
     # Case 1: If either tensor is a float, promote to the wider float type
-    if lhs.dtype in float_types or rhs.dtype in float_types:
+    if lhs_is_float or rhs_is_float:
         # Prefer float32 if either tensor is float32
         if lhs.dtype == trt.float32 or rhs.dtype == trt.float32:
             promoted_dtype = trt.float32
+        elif lhs_is_float and rhs_is_float and lhs.dtype != rhs.dtype:
+            # float16/bfloat16: neither contains the other; widen like torch.
+            promoted_dtype = trt.float32
         else:
-            promoted_dtype = trt.float16
+            # Same float dtype, or float vs int: keep the float.
+            promoted_dtype = lhs.dtype if lhs_is_float else rhs.dtype
     else:
         # Case 2: If both tensors are int types (e.g., int32, int64), promote to int32
         # (Note: TensorRT does not support int64 for many ops like select/where)

--- a/tests/py/dynamo/conversion/test_where_aten.py
+++ b/tests/py/dynamo/conversion/test_where_aten.py
@@ -145,6 +145,28 @@ class TestWhereConverter(DispatchTestCase):
         ]
         self.run_test_with_dynamic_shape(Where(), input_specs)
 
+    @parameterized.expand(
+        [
+            (torch.bfloat16, torch.bfloat16),
+            (torch.float16, torch.bfloat16),
+            (torch.bfloat16, torch.float32),
+            (torch.bfloat16, torch.int32),
+        ]
+    )
+    def test_bf16_promotion(self, x_dtype, y_dtype):
+        class Where(nn.Module):
+            def forward(self, condition, x, y):
+                return torch.ops.aten.where.self(condition, x, y)
+
+        # Fractional values: int32 truncation would turn these into integers.
+        x = torch.tensor([[0.5, 1.5, -2.25, 3.75]], dtype=x_dtype)
+        if y_dtype == torch.int32:
+            y = torch.tensor([[0, 1, -2, 3]], dtype=y_dtype)
+        else:
+            y = torch.tensor([[0.25, -1.5, 2.75, -0.5]], dtype=y_dtype)
+        condition = torch.tensor([[True, False, True, False]])
+        self.run_test(Where(), (condition, x, y))
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
# Description

promote_trt_tensors_to_same_dtype only treats float16 / float32 as floats. Two bfloat16 operands fall through to the int path and are cast to int32, truncating values in where and related ops.

Include trt.bfloat16 in the float-type set so bf16 pairs promote correctly.

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X ] My code follows the style guidelines of this project (You can use the linters)
- [ X] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas and hacks
- [X ] I have made corresponding changes to the documentation
- [X ] I have added tests to verify my fix or my feature
- [X ] New and existing unit tests pass locally with my changes
- [X ] I have added the relevant labels to my PR in so that relevant reviewers are notified
