### PR TITLE
aten.baddbmm decomposition

### DIFF
--- a/py/torch_tensorrt/dynamo/lowering/_decomposition_groups.py
+++ b/py/torch_tensorrt/dynamo/lowering/_decomposition_groups.py
@@ -21,6 +21,7 @@ torch_enabled_decompositions: Set[Union[OpOverload, OpOverloadPacket]] = {
     aten.arange.default,
     aten.arange.start,
     aten.avg_pool2d_backward,
+    aten.baddbmm,
     aten.binary_cross_entropy,
     aten.binary_cross_entropy_backward,
     aten.binary_cross_entropy_with_logits,

--- a/tests/py/dynamo/lowering/test_decompositions.py
+++ b/tests/py/dynamo/lowering/test_decompositions.py
@@ -2460,6 +2460,66 @@ class TestLowering(TestCase):
             f"Masked_scatter TRT outputs don't match with the original model. (diff={max_diff})",
         )
 
+    def test_lowering_baddbmm(self):
+        class Baddbmm(torch.nn.Module):
+            def forward(self, bias, batch1, batch2):
+                return torch.ops.aten.baddbmm.default(bias, batch1, batch2)
+
+        self.assertIn(
+            torch.ops.aten.baddbmm.default,
+            get_decompositions(False),
+        )
+
+        unexpected_ops = {torch.ops.aten.baddbmm.default}
+        expected_ops = {torch.ops.aten.bmm.default}
+
+        inputs = [
+            torch.randn(4, 1, 8).cuda(),
+            torch.randn(4, 3, 5).cuda(),
+            torch.randn(4, 5, 8).cuda(),
+        ]
+
+        fx_graph = torch.fx.symbolic_trace(Baddbmm())
+        unexpected_ops_seen, expected_ops_unseen = lower_graph_testing(
+            fx_graph,
+            inputs,
+            expected_ops=expected_ops,
+            unexpected_ops=unexpected_ops,
+            min_block_size=1,
+        )
+
+        self.assertEqual(
+            len(unexpected_ops_seen),
+            0,
+            f"The following unexpected ops were encountered: {unexpected_ops_seen}",
+        )
+        self.assertEqual(
+            len(expected_ops_unseen),
+            0,
+            f"The following expected ops were not encountered: {expected_ops_unseen}",
+        )
+
+        torch._dynamo.reset()
+
+        optimized_model = torch_tensorrt.compile(
+            fx_graph,
+            "torch_compile",
+            inputs,
+            min_block_size=1,
+            pass_through_build_failures=True,
+        )
+        with torch.no_grad():
+            trt_results = optimized_model(*inputs).detach().cpu()
+            torch_results = fx_graph(*inputs).detach().cpu()
+
+        max_diff = float(torch.max(torch.abs(trt_results - torch_results)))
+        self.assertAlmostEqual(
+            max_diff,
+            0,
+            DECIMALS_OF_AGREEMENT,
+            f"baddbmm TRT outputs don't match with the original model. (diff={max_diff})",
+        )
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
# Description

aten.baddbmm has no converter and is missing from torch_enabled_decompositions, even though PyTorch already ships a core-aten decomp and mm / bmm / addmm are handled.

Allowlist baddbmm in the default decomposition set so it lowers to ops that already convert.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [ X] My code follows the style guidelines of this project (You can use the linters)
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas and hacks
- [ X] I have made corresponding changes to the documentation
- [ X] I have added tests to verify my fix or my feature
- [ X] New and existing unit tests pass locally with my changes
- [ X] I have added the relevant labels to my PR in so that relevant reviewers are notified
