### PR TITLE
dryrun stats observable

### DIFF
--- a/docsrc/contributors/observer.rst
+++ b/docsrc/contributors/observer.rst
@@ -141,6 +141,19 @@ compilation pipelines.
 
 ----
 
+Built-in Observables
+----------------------
+
+Functions Torch-TensorRT already exposes as ``@observable``:
+
+``torch_tensorrt.dynamo._DryRunTracker.dryrun_stats_display``
+    Callbacks receive ``ctx.args == (dryrun_tracker, dryrun_enabled)``, giving the
+    dryrun report — operator coverage, unsupported ops, per-engine shapes — as
+    structured data. Fires once per ``compile_module`` call, whether or not ``dryrun``
+    is set. See :ref:`dryrun-programmatic`.
+
+----
+
 Observing Existing Compiler Functions
 ----------------------------------------
 

--- a/docsrc/tutorials/compilation_analysis/dryrun.rst
+++ b/docsrc/tutorials/compilation_analysis/dryrun.rst
@@ -196,3 +196,39 @@ The dryrun output is also available at ``DEBUG`` log level even when ``dryrun=Fa
 
     import logging
     logging.getLogger("torch_tensorrt").setLevel(logging.DEBUG)
+
+----
+
+.. _dryrun-programmatic:
+
+Capturing the Stats Programmatically
+--------------------------------------
+
+To use the stats in a CI check or a coverage sweep, register a callback on
+``dryrun_stats_display`` rather than parsing its output. It is an
+:ref:`@observable() <observer>`, so its ``pre`` and ``post`` observers receive the
+``DryRunTracker`` behind the report:
+
+.. code-block:: python
+
+    from torch_tensorrt.dynamo._DryRunTracker import dryrun_stats_display
+    from torch_tensorrt.dynamo.observer import ObserveContext
+
+    trackers = []
+
+    def capture(ctx: ObserveContext) -> None:
+        trackers.append(ctx.args[0])  # ctx.args == (tracker, dryrun_enabled)
+
+    with dryrun_stats_display.observers.pre.add(capture):
+        torch_tensorrt.dynamo.compile(exp_program, arg_inputs=inputs, dryrun=True)
+
+    tracker = trackers[0]
+    print(f"{tracker.supported_ops_in_graph}/{tracker.total_ops_in_graph} supported")
+
+The tracker holds every field in the report: ``total_ops_in_graph``,
+``supported_ops_in_graph``, ``unsupported_ops``, ``to_run_in_torch``,
+``tensorrt_graph_count``, ``per_subgraph_data`` and ``compilation_settings``.
+
+The callback fires once per ``compile_module`` call — so once per graph break, and on
+ordinary compiles too, since ``dryrun`` only controls where the report is written. Graphs
+with no TRT coverage report as well, with ``tensorrt_graph_count == 0``.

--- a/py/torch_tensorrt/dynamo/_DryRunTracker.py
+++ b/py/torch_tensorrt/dynamo/_DryRunTracker.py
@@ -9,6 +9,7 @@ import torch
 from torch_tensorrt.dynamo._settings import CompilationSettings
 from torch_tensorrt.dynamo.conversion._ConverterRegistry import ConverterRegistry
 from torch_tensorrt.dynamo.conversion.converter_utils import get_node_name
+from torch_tensorrt.dynamo.observer import observable
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +68,7 @@ class DryRunTracker:
     to_run_in_torch: List[str] = field(default_factory=list)
 
 
+@observable()
 def dryrun_stats_display(
     dryrun_tracker: DryRunTracker, dryrun_enabled: Union[bool, str]
 ) -> None:

--- a/py/torch_tensorrt/dynamo/_DryRunTracker.py
+++ b/py/torch_tensorrt/dynamo/_DryRunTracker.py
@@ -68,7 +68,7 @@ class DryRunTracker:
     to_run_in_torch: List[str] = field(default_factory=list)
 
 
-@observable()
+@observable()  # type: ignore[misc]
 def dryrun_stats_display(
     dryrun_tracker: DryRunTracker, dryrun_enabled: Union[bool, str]
 ) -> None:
@@ -76,11 +76,17 @@ def dryrun_stats_display(
     formatted_stats = "\n"
 
     # Print overall stats about the graph, operator counts, etc.
+    total_ops = dryrun_tracker.total_ops_in_graph
+    coverage = (
+        round(dryrun_tracker.supported_ops_in_graph * 100 / total_ops, 2)
+        if total_ops
+        else 0.0
+    )
     formatted_stats += "+" * 50 + " Dry-Run Results for Graph " + "+" * 50 + "\n\n"
     formatted_stats += (
         f"The graph consists of {dryrun_tracker.total_ops_in_graph} Total Operators, "
         f"of which {dryrun_tracker.supported_ops_in_graph} operators are supported, "
-        f"{round(dryrun_tracker.supported_ops_in_graph*100/dryrun_tracker.total_ops_in_graph, 2)}% coverage\n\n"
+        f"{coverage}% coverage\n\n"
     )
     if dryrun_tracker.unsupported_ops:
         parsed_ops = "\n".join(

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -1284,8 +1284,10 @@ def compile_module(
     CONVERTERS.set_compilation_settings(settings)
 
     # Check the number of supported operations in the graph
-    num_supported_ops, total_ops = partitioning.get_graph_converter_support(
-        gm, settings.torch_executed_ops
+    num_supported_ops, total_ops, op_support = (
+        partitioning.get_graph_converter_support_overview(
+            gm, settings.torch_executed_ops
+        )
     )
 
     dryrun_tracker.total_ops_in_graph = total_ops
@@ -1307,6 +1309,11 @@ def compile_module(
             f"{num_supported_ops} supported operations detected in subgraph containing {total_ops} computational nodes. "
             f"Skipping this subgraph, since min_block_size was detected to be {settings.min_block_size}"
         )
+
+        dryrun_tracker.unsupported_ops = op_support.unsupported_operators
+        dryrun_tracker.to_run_in_torch.extend(parse_non_trt_nodes(gm))
+        parse_graph_io(gm, dryrun_tracker)
+        dryrun_stats_display(dryrun_tracker, settings.dryrun)
         return gm
     else:
         logger.debug(

--- a/py/torch_tensorrt/dynamo/partitioning/__init__.py
+++ b/py/torch_tensorrt/dynamo/partitioning/__init__.py
@@ -5,5 +5,6 @@ from .common import (
     build_profile_source_bounds,
     construct_submodule_inputs,
     get_graph_converter_support,
+    get_graph_converter_support_overview,
     run_shape_analysis,
 )

--- a/py/torch_tensorrt/dynamo/partitioning/common.py
+++ b/py/torch_tensorrt/dynamo/partitioning/common.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, Tuple
 
 import sympy
 import torch
@@ -12,6 +12,9 @@ from torch_tensorrt.dynamo.utils import (
     extract_var_range_info,
     extract_var_range_info_for_profile,
 )
+
+if TYPE_CHECKING:
+    from ._global_partitioner import TorchTensorRTOperatorSupport
 
 logger = logging.getLogger(__name__)
 
@@ -438,6 +441,19 @@ def get_graph_converter_support(
     Returns:
         The number of supported call_function nodes in the graph
     """
+    number_of_supported_nodes, total_functional_nodes, _ = (
+        get_graph_converter_support_overview(graph_module, torch_executed_ops)
+    )
+    return number_of_supported_nodes, total_functional_nodes
+
+
+def get_graph_converter_support_overview(
+    graph_module: torch.fx.GraphModule,
+    torch_executed_ops: Optional[Set[str]] = None,
+) -> Tuple[int, int, "TorchTensorRTOperatorSupport"]:
+    """As get_graph_converter_support, but also returns the operator support object,
+    which holds *which* operators are unsupported rather than just how many
+    """
     from ._global_partitioner import TorchTensorRTOperatorSupport
 
     # Instantiate operator support object and module dictionary
@@ -458,4 +474,4 @@ def get_graph_converter_support(
     # Print node support overview prior to partitioning
     op_support.print_support_overview(print_node_support=True)
 
-    return number_of_supported_nodes, total_functional_nodes
+    return number_of_supported_nodes, total_functional_nodes, op_support

--- a/tests/py/dynamo/runtime/test_dryrun_stats_observable.py
+++ b/tests/py/dynamo/runtime/test_dryrun_stats_observable.py
@@ -1,0 +1,48 @@
+# type: ignore
+
+import unittest
+
+import torch
+import torch_tensorrt
+from torch.testing._internal.common_utils import TestCase, run_tests
+from torch_tensorrt.dynamo._DryRunTracker import DryRunTracker, dryrun_stats_display
+from torch_tensorrt.dynamo.observer import ObserveContext
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA required")
+class TestDryRunStatsObservable(TestCase):
+    def test_observer_captures_tracker(self):
+        class Add(torch.nn.Module):
+            def forward(self, x):
+                return x + x
+
+        model = Add().cuda().eval()
+        x = torch.randn(2, 3, device="cuda")
+        trackers = []
+
+        def capture(ctx: ObserveContext) -> None:
+            trackers.append(ctx.args[0])
+
+        with dryrun_stats_display.observers.pre.add(capture):
+            torch_tensorrt.dynamo.compile(
+                model,
+                [x],
+                dryrun=True,
+                min_block_size=1,
+                enabled_precisions={torch.float32},
+            )
+
+        self.assertEqual(len(trackers), 1)
+        tracker = trackers[0]
+        self.assertIsInstance(tracker, DryRunTracker)
+        self.assertGreater(tracker.total_ops_in_graph, 0)
+        self.assertGreaterEqual(tracker.supported_ops_in_graph, 0)
+        self.assertLessEqual(
+            tracker.supported_ops_in_graph, tracker.total_ops_in_graph
+        )
+        self.assertGreaterEqual(tracker.tensorrt_graph_count, 1)
+        self.assertEqual(len(tracker.per_subgraph_data), tracker.tensorrt_graph_count)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/py/dynamo/runtime/test_dryrun_stats_observable.py
+++ b/tests/py/dynamo/runtime/test_dryrun_stats_observable.py
@@ -9,27 +9,35 @@ from torch_tensorrt.dynamo._DryRunTracker import DryRunTracker, dryrun_stats_dis
 from torch_tensorrt.dynamo.observer import ObserveContext
 
 
+class Add(torch.nn.Module):
+    def forward(self, x):
+        return x + x
+
+
+def capture_trackers(trackers):
+    def capture(ctx: ObserveContext) -> None:
+        trackers.append(ctx.args[0])
+
+    return capture
+
+
+def exported_add():
+    x = torch.randn(2, 3, device="cuda")
+    return torch.export.export(Add().cuda().eval(), (x,)), x
+
+
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA required")
 class TestDryRunStatsObservable(TestCase):
     def test_observer_captures_tracker(self):
-        class Add(torch.nn.Module):
-            def forward(self, x):
-                return x + x
-
-        model = Add().cuda().eval()
-        x = torch.randn(2, 3, device="cuda")
+        exp_program, x = exported_add()
         trackers = []
 
-        def capture(ctx: ObserveContext) -> None:
-            trackers.append(ctx.args[0])
-
-        with dryrun_stats_display.observers.pre.add(capture):
+        with dryrun_stats_display.observers.pre.add(capture_trackers(trackers)):
             torch_tensorrt.dynamo.compile(
-                model,
-                [x],
+                exp_program,
+                arg_inputs=(x,),
                 dryrun=True,
                 min_block_size=1,
-                enabled_precisions={torch.float32},
             )
 
         self.assertEqual(len(trackers), 1)
@@ -37,11 +45,71 @@ class TestDryRunStatsObservable(TestCase):
         self.assertIsInstance(tracker, DryRunTracker)
         self.assertGreater(tracker.total_ops_in_graph, 0)
         self.assertGreaterEqual(tracker.supported_ops_in_graph, 0)
-        self.assertLessEqual(
-            tracker.supported_ops_in_graph, tracker.total_ops_in_graph
-        )
+        self.assertLessEqual(tracker.supported_ops_in_graph, tracker.total_ops_in_graph)
         self.assertGreaterEqual(tracker.tensorrt_graph_count, 1)
         self.assertEqual(len(tracker.per_subgraph_data), tracker.tensorrt_graph_count)
+
+    def test_observer_fires_with_no_supported_ops(self):
+        """compile_module returns before partitioning, but still emits a tracker"""
+        exp_program, x = exported_add()
+        trackers = []
+
+        with dryrun_stats_display.observers.pre.add(capture_trackers(trackers)):
+            torch_tensorrt.dynamo.compile(
+                exp_program,
+                arg_inputs=(x,),
+                dryrun=True,
+                min_block_size=1,
+                torch_executed_ops={"torch.ops.aten.add.Tensor"},
+            )
+
+        self.assertEqual(len(trackers), 1)
+        tracker = trackers[0]
+        self.assertIsInstance(tracker, DryRunTracker)
+        self.assertGreater(tracker.total_ops_in_graph, 0)
+        self.assertEqual(tracker.supported_ops_in_graph, 0)
+        self.assertEqual(tracker.tensorrt_graph_count, 0)
+        self.assertEqual(tracker.per_subgraph_data, [])
+        self.assertEqual(tracker.unsupported_ops, {"torch.ops.aten.add.Tensor": 1})
+        self.assertTrue(
+            any("add" in node for node in tracker.to_run_in_torch),
+            msg=f"Expected the add node in to_run_in_torch, got {tracker.to_run_in_torch}",
+        )
+
+    def test_post_observer_receives_tracker(self):
+        exp_program, x = exported_add()
+        trackers = []
+
+        with dryrun_stats_display.observers.post.add(capture_trackers(trackers)):
+            torch_tensorrt.dynamo.compile(
+                exp_program,
+                arg_inputs=(x,),
+                dryrun=True,
+                min_block_size=1,
+            )
+
+        self.assertEqual(len(trackers), 1)
+        self.assertIsInstance(trackers[0], DryRunTracker)
+
+    def test_observer_deregistered_after_context(self):
+        exp_program, x = exported_add()
+        trackers = []
+
+        with dryrun_stats_display.observers.pre.add(capture_trackers(trackers)):
+            pass
+
+        torch_tensorrt.dynamo.compile(
+            exp_program,
+            arg_inputs=(x,),
+            dryrun=True,
+            min_block_size=1,
+        )
+
+        self.assertEqual(trackers, [])
+
+    def test_display_handles_graph_with_no_operators(self):
+        """No computational nodes reports 0% rather than dividing by zero"""
+        dryrun_stats_display(DryRunTracker(), False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

dryrun=True builds a full DryRunTracker (coverage, unsupported ops, engine count) and only prints it. There is no supported way to read those stats for CI or sweeps without monkeypatching.

Mark dryrun_stats_display with @observable() so callers can register on observers.pre / post and capture the tracker without a new public API.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X ] My code follows the style guidelines of this project (You can use the linters)
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas and hacks
- [X ] I have made corresponding changes to the documentation
- [ X] I have added tests to verify my fix or my feature
- [ X] New and existing unit tests pass locally with my changes
- [ X] I have added the relevant labels to my PR in so that relevant reviewers are notified
