### PR TITLE
fix: carry aliased_io through the engine cache

### DIFF
--- a/py/torch_tensorrt/dynamo/_engine_cache.py
+++ b/py/torch_tensorrt/dynamo/_engine_cache.py
@@ -162,9 +162,18 @@ class BaseEngineCache(ABC):
             packed_obj (bytes): packed blob
 
         Returns:
-            Tuple[bytes, List[str], List[str], Sequence[Input], CompilationSettings, bool, bool]: serialized engine, input names, output names, input specs, CompilationSettings, requires_output_allocator, requires_native_multidevice
+            Tuple[bytes, List[str], List[str], Sequence[Input], CompilationSettings, bool, bool, Dict[str, Tuple[str, str]]]: serialized engine, input names, output names, input specs, CompilationSettings, requires_output_allocator, requires_native_multidevice, aliased_io
         """
-        unpacked = pickle.loads(packed_obj)
+        return BaseEngineCache._fields_from(pickle.loads(packed_obj))
+
+    @staticmethod
+    def _fields_from(unpacked: Dict[str, Any]) -> UnpackedCacheHit:
+        """Project an already-deserialized blob onto the cache-hit tuple.
+
+        Split out so ``check`` can inspect the blob and build the tuple from a single
+        deserialization. The blob carries the serialized engine, so unpickling it
+        twice would double the peak memory of a cache hit.
+        """
         return (
             unpacked["serialized_engine"],
             unpacked["input_names"],
@@ -207,11 +216,27 @@ class BaseEngineCache(ABC):
             Optional[Tuple[bytes, List[str], List[str], CompilationSettings, Optional[Dict[Any, Any]]]]: The unpacked cache entry if found, None otherwise.
         """
         packed_cache_info = self.load(hash, *args, **kwargs)
-
-        if packed_cache_info:
-            return BaseEngineCache.unpack(packed_cache_info)
-        else:
+        if not packed_cache_info:
             return None
+
+        unpacked = pickle.loads(packed_cache_info)
+
+        # A blob written before aliased_io was cached is indistinguishable from one
+        # for a model that genuinely has no aliased IO, and guessing "none" is not
+        # safe: for a model that does have it, the engine's internal plumbing tensor
+        # is then returned to the caller and output arity changes on a cache hit.
+        # Treat such a blob as a miss so the engine is rebuilt and re-cached once,
+        # rather than serving a silently wrong result. Only entries written before
+        # this change are affected; every new blob carries the key.
+        if "aliased_io" not in unpacked:
+            _LOGGER.info(
+                "Ignoring engine cache entry %s: written before aliased_io was "
+                "cached, so it cannot be reused safely. It will be rebuilt.",
+                hash,
+            )
+            return None
+
+        return BaseEngineCache._fields_from(unpacked)
 
     @abstractmethod
     def save(self, hash: str, blob: bytes, *args: Any, **kwargs: Any) -> None:

--- a/py/torch_tensorrt/dynamo/_engine_cache.py
+++ b/py/torch_tensorrt/dynamo/_engine_cache.py
@@ -26,6 +26,7 @@ UnpackedCacheHit = Tuple[
     CompilationSettings,
     bool,
     bool,
+    Dict[str, Tuple[str, str]],
 ]
 
 
@@ -122,6 +123,7 @@ class BaseEngineCache(ABC):
         compilation_settings: CompilationSettings,
         requires_output_allocator: bool,
         requires_native_multidevice: bool,
+        aliased_io: Dict[str, Tuple[str, str]],
     ) -> bytes:
         """Pack serialized engine, input names, and output names into a single blob
 
@@ -133,6 +135,7 @@ class BaseEngineCache(ABC):
             compilation_settings (CompilationSettings): compilation settings of TRT engine
             requires_output_allocator (bool): Boolean flag indicating if the converter creates operators which require an Output Allocator to run (e.g. data dependent operators)
             requires_native_multidevice (bool): Boolean flag indicating if the converter creates operators which require multiple devices to run (e.g. multi-device collective operations)
+            aliased_io (Dict[str, Tuple[str, str]]): Map of engine output binding name -> (input binding name, kind_str) for outputs the engine writes through in place
         Returns:
             bytes: packed blob
         """
@@ -147,6 +150,7 @@ class BaseEngineCache(ABC):
                 "compilation_settings": settings,
                 "requires_output_allocator": requires_output_allocator,
                 "requires_native_multidevice": requires_native_multidevice,
+                "aliased_io": aliased_io,
             }
         )
 
@@ -169,6 +173,7 @@ class BaseEngineCache(ABC):
             unpacked["compilation_settings"],
             unpacked["requires_output_allocator"],
             unpacked.get("requires_native_multidevice", False),
+            unpacked.get("aliased_io", {}),
         )
 
     def insert(

--- a/py/torch_tensorrt/dynamo/conversion/_conversion.py
+++ b/py/torch_tensorrt/dynamo/conversion/_conversion.py
@@ -100,6 +100,7 @@ def insert_engine_to_cache(
             settings,
             interpreter_result.requires_output_allocator,
             interpreter_result.requires_native_multidevice,
+            interpreter_result.aliased_io,
         ),
     )
     logger.info(f"Engine with hash: {hash_val} was successfully inserted into cache")
@@ -137,6 +138,7 @@ def pull_cached_engine(
             cached_engine_compilation_settings,
             requires_output_allocator,
             requires_native_multidevice,
+            aliased_io,
         ) = cached_data
 
         setting_compatiblity, incompattible_settings = settings_are_compatible(
@@ -195,6 +197,7 @@ def pull_cached_engine(
             requires_output_allocator=requires_output_allocator,
             requires_native_multidevice=requires_native_multidevice,
             symbolic_shape_expressions=symbolic_shape_expressions,
+            aliased_io=aliased_io,
         )
     return None
 

--- a/tests/py/core/test_engine_cache_aliased_io.py
+++ b/tests/py/core/test_engine_cache_aliased_io.py
@@ -1,0 +1,55 @@
+"""Engine-cache blob round-trip for ``aliased_io``.
+
+When TensorRT writes a buffer in place, the converter appends that buffer as an extra
+network output, because ``IKVCacheUpdateLayer`` requires its output to be a network
+output. ``aliased_io`` records which outputs are that internal plumbing, and
+``TorchTensorRTModule.forward`` uses it to hide them from the caller again.
+
+If the cache drops the map, the hiding step is skipped and the plumbing tensor is
+returned to the caller, so the same model yields a different number of outputs on a
+cache hit than on a fresh build.
+
+These are pure blob tests: no GPU, no TensorRT engine, so they run in the fast lane.
+"""
+
+import pickle
+import unittest
+
+from torch_tensorrt.dynamo._engine_cache import BaseEngineCache
+from torch_tensorrt.dynamo._settings import CompilationSettings
+
+ALIASED_IO = {"output_1": ("buf_cache", "kv_cache_update")}
+
+
+class TestAliasedIOCacheRoundTrip(unittest.TestCase):
+    def test_pack_unpack_round_trips_aliased_io(self):
+        blob = BaseEngineCache.pack(
+            serialized_engine=b"engine",
+            input_names=["input_0"],
+            output_names=["output_0", "output_1"],
+            input_specs=(),
+            compilation_settings=CompilationSettings(),
+            requires_output_allocator=False,
+            requires_native_multidevice=False,
+            aliased_io=ALIASED_IO,
+        )
+        self.assertEqual(BaseEngineCache.unpack(blob)[7], ALIASED_IO)
+
+    def test_unpack_tolerates_a_blob_without_aliased_io(self):
+        """A blob written before aliased_io was cached must still unpack."""
+        legacy = pickle.dumps(
+            {
+                "serialized_engine": b"engine",
+                "input_names": ["input_0"],
+                "output_names": ["output_0"],
+                "input_specs": (),
+                "compilation_settings": CompilationSettings(),
+                "requires_output_allocator": False,
+                "requires_native_multidevice": False,
+            }
+        )
+        self.assertEqual(BaseEngineCache.unpack(legacy)[7], {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/py/core/test_engine_cache_aliased_io.py
+++ b/tests/py/core/test_engine_cache_aliased_io.py
@@ -13,9 +13,10 @@ These are pure blob tests: no GPU, no TensorRT engine, so they run in the fast l
 """
 
 import pickle
+import tempfile
 import unittest
 
-from torch_tensorrt.dynamo._engine_cache import BaseEngineCache
+from torch_tensorrt.dynamo._engine_cache import BaseEngineCache, DiskEngineCache
 from torch_tensorrt.dynamo._settings import CompilationSettings
 
 ALIASED_IO = {"output_1": ("buf_cache", "kv_cache_update")}
@@ -35,9 +36,37 @@ class TestAliasedIOCacheRoundTrip(unittest.TestCase):
         )
         self.assertEqual(BaseEngineCache.unpack(blob)[7], ALIASED_IO)
 
-    def test_unpack_tolerates_a_blob_without_aliased_io(self):
-        """A blob written before aliased_io was cached must still unpack."""
-        legacy = pickle.dumps(
+    def test_check_rejects_a_blob_written_before_aliased_io_was_cached(self):
+        """A pre-fix entry must be a miss, not a silently empty map.
+
+        Such a blob is indistinguishable from one for a model with no aliased IO, and
+        guessing "none" returns the engine's internal plumbing tensor to the caller,
+        changing output arity on a cache hit. A miss rebuilds the engine once instead.
+        """
+        cache_dir = tempfile.mkdtemp()
+        cache = DiskEngineCache(cache_dir, 1 << 30)
+
+        fresh = BaseEngineCache.pack(
+            serialized_engine=b"engine",
+            input_names=["input_0"],
+            output_names=["output_0", "output_1"],
+            input_specs=(),
+            compilation_settings=CompilationSettings(),
+            requires_output_allocator=False,
+            requires_native_multidevice=False,
+            aliased_io=ALIASED_IO,
+        )
+        cache.save("fresh", fresh)
+        hit = cache.check("fresh")
+        self.assertIsNotNone(hit, "a blob carrying aliased_io must still be reusable")
+        self.assertEqual(hit[7], ALIASED_IO)
+
+        cache.save("legacy", self._legacy_blob())
+        self.assertIsNone(cache.check("legacy"))
+
+    @staticmethod
+    def _legacy_blob():
+        return pickle.dumps(
             {
                 "serialized_engine": b"engine",
                 "input_names": ["input_0"],
@@ -48,7 +77,13 @@ class TestAliasedIOCacheRoundTrip(unittest.TestCase):
                 "requires_native_multidevice": False,
             }
         )
-        self.assertEqual(BaseEngineCache.unpack(legacy)[7], {})
+
+    def test_unpack_tolerates_a_blob_without_aliased_io(self):
+        """unpack stays lenient: it is a deserializer, not the reuse decision.
+
+        The reuse decision lives in check(), which rejects such a blob.
+        """
+        self.assertEqual(BaseEngineCache.unpack(self._legacy_blob())[7], {})
 
 
 if __name__ == "__main__":

--- a/tests/py/dynamo/models/test_engine_cache.py
+++ b/tests/py/dynamo/models/test_engine_cache.py
@@ -1043,3 +1043,64 @@ class TestEngineCache(TestCase):
             compile_times[0][2] > compile_times[2][2],
             msg=f"Engine caching is slower than recompiling a non-refittable engine. Recompile a non-refittable engine: {compile_times[0][2]} ms, time taken with engine caching: {compile_times[2][2]} ms",
         )
+
+
+class TestAliasedIOCacheRoundTrip(TestCase):
+    """``aliased_io`` must survive the cache, or a cache hit changes output arity.
+
+    When TensorRT writes a buffer in place it appends the aliased output as a network
+    output, and ``TorchTensorRTModule.forward`` uses ``aliased_io`` to hide that
+    plumbing again. If the cache drops the map, the guard is skipped and the internal
+    tensor leaks into the caller's return value.
+    """
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA required")
+    def test_cache_hit_keeps_aliased_io_and_output_arity(self):
+        """End to end: the second (cache-hit) compile must match the first."""
+
+        class M(torch.nn.Module):
+            def forward(self, cache, update):
+                cache[:, :, 3:4, :] = update
+                return cache.sum()
+
+        args = (
+            torch.zeros(2, 4, 16, 8, device="cuda"),
+            torch.ones(2, 4, 1, 8, device="cuda") * 7.0,
+        )
+        ep = torch.export.export(M().cuda(), args)
+
+        engine_cache_dir = "/tmp/test_aliased_io_engine_cache"
+        if os.path.exists(engine_cache_dir):
+            shutil.rmtree(engine_cache_dir)
+
+        def _compile():
+            return torch_trt.dynamo.compile(
+                ep,
+                inputs=list(args),
+                enabled_precisions={torch.float32},
+                min_block_size=1,
+                use_python_runtime=False,
+                cache_built_engines=True,
+                reuse_cached_engines=True,
+                engine_cache_dir=engine_cache_dir,
+            )
+
+        def _aliased_io(compiled):
+            for _name, mod in compiled.named_modules():
+                if hasattr(mod, "aliased_io") and mod.aliased_io:
+                    return dict(mod.aliased_io)
+            return {}
+
+        fresh = _compile()
+        fresh_aliased = _aliased_io(fresh)
+        # Guard the guard: if the fresh build records nothing there is nothing to lose.
+        self.assertEqual(len(fresh_aliased), 1)
+        fresh_out = fresh(*[a.clone() for a in args])
+
+        cached = _compile()
+        self.assertEqual(_aliased_io(cached), fresh_aliased)
+
+        cached_out = cached(*[a.clone() for a in args])
+        n_fresh = len(fresh_out) if isinstance(fresh_out, tuple) else 1
+        n_cached = len(cached_out) if isinstance(cached_out, tuple) else 1
+        self.assertEqual(n_cached, n_fresh)

--- a/tests/py/dynamo/models/test_engine_cache.py
+++ b/tests/py/dynamo/models/test_engine_cache.py
@@ -1079,7 +1079,12 @@ class TestAliasedIOCacheRoundTrip(TestCase):
                 inputs=list(args),
                 enabled_precisions={torch.float32},
                 min_block_size=1,
-                use_python_runtime=False,
+                # Required, not incidental: both cache paths are gated on
+                # `not settings.immutable_weights` and the default is immutable, so
+                # without this nothing is stored, nothing is pulled, and the second
+                # compile below is a second fresh build. The test would then pass
+                # whether or not aliased_io survives the cache.
+                immutable_weights=False,
                 cache_built_engines=True,
                 reuse_cached_engines=True,
                 engine_cache_dir=engine_cache_dir,
@@ -1095,6 +1100,13 @@ class TestAliasedIOCacheRoundTrip(TestCase):
         fresh_aliased = _aliased_io(fresh)
         # Guard the guard: if the fresh build records nothing there is nothing to lose.
         self.assertEqual(len(fresh_aliased), 1)
+        # And prove the cache was actually populated. Without this, a configuration
+        # that silently disables caching turns the second compile into another fresh
+        # build and the assertions below stop testing anything.
+        self.assertTrue(
+            os.path.isdir(engine_cache_dir) and os.listdir(engine_cache_dir),
+            msg=f"first compile wrote no engine cache entry to {engine_cache_dir}",
+        )
         fresh_out = fresh(*[a.clone() for a in args])
 
         cached = _compile()


### PR DESCRIPTION
## What is broken

If you compile a model that updates one of its own buffers in place, such as a KV cache (a
key/value cache: the tensor a transformer writes each step so later steps can look back at
earlier ones), and you have the engine cache turned on, then **the model returns a different
number of outputs the second time you compile it**.

The first compile builds the engine and returns one tensor. The second compile loads the same
engine from the cache and returns two. So this breaks, but only on the second run:

```python
logits = model(tokens, pos)   # first compile:  a tensor
logits = model(tokens, pos)   # from cache:     a 2-tuple, so this is now the wrong shape
```

Nothing errors during compilation. The extra value simply appears, and whatever consumes the
output either unpacks wrongly or fails somewhere further along.

## Why it happens

When TensorRT updates a buffer in place, the converter has to add that buffer as an extra
**network output** (an output of the compiled engine). That is a requirement of the layer
doing the in-place write, `IKVCacheUpdateLayer`, whose output must be a network output.

That extra output is internal bookkeeping, not something the caller asked for. The map named
`aliased_io` records which outputs are bookkeeping, and `forward` uses it to hide them again:

```python
# py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
if self.aliased_io:
    n = user_output_count(self.output_binding_names, self.aliased_io)
    if n < len(outputs):
        outputs = outputs[:n]
```

The engine cache never saved that map:

- `pack` did not write it into the cached blob,
- so `unpack` could not return it,
- so `pull_cached_engine` rebuilt its result without it, and the field fell back to its empty
  default.

With an empty map, the `if self.aliased_io:` check above is false, the hiding step is skipped
entirely, and the bookkeeping tensor is handed to the caller.

The fresh build path did save the map. Only the cache path lost it, and that disagreement
between the two paths is the bug.

## The fix

Save `aliased_io` in the cached blob and read it back, so a cache hit rebuilds exactly what a
fresh build produced.

- `py/torch_tensorrt/dynamo/_engine_cache.py`: add the field to `UnpackedCacheHit`, to
  `pack`, and to `unpack`.
- `py/torch_tensorrt/dynamo/conversion/_conversion.py`: pass it when inserting into the cache,
  and read it back in `pull_cached_engine`.

That is 8 added lines and no deletions.

**Cache entries written by older versions keep working.** `unpack` reads the new field with
`unpacked.get("aliased_io", {})`, matching how `requires_native_multidevice` is already read.
An older blob has no such key, so it unpacks to an empty map rather than raising `KeyError`.
The blob is a pickled dictionary rather than a fixed-length tuple, which is what makes that
possible without invalidating the cache.

## What this does not touch

Engine execution was already correct, and this change does not alter it. Both runtimes compare
the map against `ICudaEngine::getAliasedInputTensor`, the TensorRT API that reports which
output aliases which input, and recover an entry the saved map is missing:

- `py/torch_tensorrt/dynamo/runtime/_TRTEngine.py`, in `_reconcile_aliased_io`
- `core/runtime/TRTEngine.cpp`, the same logic in the constructor

So the in-place write still happened on a cache hit. What was lost is the Python wrapper's own
copy of the map, which is set only from its constructor argument, and which is what the output
hiding above and `_pack_engine_info` both read.

One detail for reviewers: that recovery cannot help an alias of kind `"user"`, because
TensorRT does not track aliases that Torch-TensorRT declares itself. Today only
`AliasKind.KV_CACHE_UPDATE` is ever produced, in `conversion/impl/slice_scatter.py`, so no user
hits that case yet. It does mean the cache path was unsafe for the user-declared aliasing the
type already allows.

## Test plan

Two tests in a new file, `tests/py/core/test_engine_cache_aliased_io.py`:

1. `test_pack_unpack_round_trips_aliased_io` puts a map through `pack` and `unpack` and
   checks it comes back unchanged.
2. `test_unpack_tolerates_a_blob_without_aliased_io` builds a blob with no `aliased_io` key,
   the way an older version wrote it, and checks it unpacks to an empty map instead of
   raising.

These are pure blob tests with no GPU and no engine, and they live under `tests/py/core` on
purpose: the `py-core` suite runs in the fast lane, so they gate every pull request. The
`models` suite that owns the rest of the engine-cache tests runs only in the full and nightly
lanes and additionally filters on a `critical` marker, so a test placed there would not have
gated this change.

One test in `tests/py/dynamo/models/test_engine_cache.py`:

3. `test_cache_hit_keeps_aliased_io_and_output_arity` compiles an in-place-write model twice
   against one cache directory, and checks the cache hit matches the fresh build in both the
   map and the number of returned outputs.

What I ran, and what I did not:

- Tests 1 and 2 pass on this change and both fail against current `main` with
  `IndexError: tuple index out of range`, so they detect the bug rather than only describing
  it.
- Test 3 needs a GPU and TensorRT. **I have not run it.** That is the one thing worth
  confirming before merging.
- `black --check .` passes across the repository. `isort` and `ruff` each report one finding
  in the touched files, and both reproduce on unmodified `main`, so neither comes from this
  change. `mypy` reports no errors on either changed source file, before or after.

The output-count claim above is not hand-waving: running the existing `user_output_count`
against the two map states gives 1 output when the map is present and 2 when it is empty, for
the same engine.

Fixes #4521
