### PR TITLE
fix: unblock the ExecuTorch runtime wheel configure (Python::Python on manylinux)

### DIFF
--- a/py/torch-tensorrt-executorch-runtime/native/CMakeLists.txt
+++ b/py/torch-tensorrt-executorch-runtime/native/CMakeLists.txt
@@ -35,6 +35,54 @@ find_package(TensorRT REQUIRED)
 find_package(CUDAToolkit REQUIRED)
 find_package(Threads REQUIRED)
 
+# ExecuTorch declares every pybind module with pybind11_add_module(<target> SHARED
+# ...). pybind11 maps a non-MODULE type onto pybind11::embed, and CMake's
+# python_add_library then requires the Python::Python target, so the first module
+# ExecuTorch declares (codegen/tools/selective_build) aborts the configure with:
+#
+#   Python_ADD_LIBRARY: dependent target 'Python::Python' is not defined.
+#      Did you miss to request COMPONENT 'Development.Embed'?
+#
+# Do NOT take that hint literally. Development.Embed needs a libpython, and the
+# manylinux CPython in the release image is built without one, so requesting it
+# just fails the whole find_package instead:
+#
+#   Could NOT find Python (missing: Python_INCLUDE_DIRS Python_LIBRARIES ...)
+#
+# pybind11 hit this and deliberately made the component optional for manylinux
+# (pybind11NewTools.cmake: "Development.Module support (required for manylinux)"),
+# so match that: Module required, Embed optional. Finding Python before pybind11
+# is the override pybind11 documents.
+#
+# PYTHON_EXECUTABLE is bridged first because the build passes the interpreter
+# under that name while FindPython reads Python_EXECUTABLE. ExecuTorch does the
+# same bridge, but only after this point, so without it this call could resolve a
+# different interpreter than the rest of the build.
+if(PYTHON_EXECUTABLE AND NOT Python_EXECUTABLE)
+  set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
+endif()
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module
+             OPTIONAL_COMPONENTS Development.Embed)
+
+# With Embed optional, Python::Python does not exist on manylinux, and the SHARED
+# declaration above still demands it. Supply an empty stand-in for that case only.
+# It links nothing, which is what an extension module needs: Python symbols
+# resolve from the interpreter that loads the module, never from a linked
+# libpython. Where the image does provide a usable libpython, the real imported
+# target is used instead.
+#
+# This is a workaround for a defect upstream, not the root fix. Those three
+# modules should be declared MODULE rather than SHARED: CMake skips this check
+# entirely for MODULE, and MODULE is what a Python extension is. Filed upstream.
+if(NOT TARGET Python::Python)
+  add_library(Python::Python INTERFACE IMPORTED)
+  # The real Python::Python carries INTERFACE_INCLUDE_DIRECTORIES. Forward those
+  # through Python::Module so the stand-in is not silently header-less if a
+  # consumer ever relies on them. Python::Module links no libpython.
+  set_target_properties(Python::Python PROPERTIES
+    INTERFACE_LINK_LIBRARIES Python::Module)
+endif()
+
 set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
 set(EXECUTORCH_BUILD_PYBIND ON CACHE BOOL "" FORCE)
 set(EXECUTORCH_BUILD_EXTENSION_MODULE ON CACHE BOOL "" FORCE)
@@ -133,6 +181,7 @@ foreach(_torch_tensorrt_executorch_runtime_target portable_lib data_loader)
   target_link_options(${_torch_tensorrt_executorch_runtime_target} PRIVATE
     -static-libstdc++
     -static-libgcc)
+
 endforeach()
 
 # The runtime wheel intentionally does not bundle PyTorch, TensorRT, or CUDA.
@@ -156,3 +205,4 @@ set_target_properties(data_loader PROPERTIES SUFFIX ".so")
 install(TARGETS portable_lib data_loader LIBRARY DESTINATION lib)
 
 add_custom_target(torch_tensorrt_executorch_portable_lib DEPENDS portable_lib data_loader)
+

--- a/tests/py/dynamo/executorch/test_api.py
+++ b/tests/py/dynamo/executorch/test_api.py
@@ -123,6 +123,36 @@ def test_runtime_extension_has_dependency_wheel_rpaths():
     assert "set(EXECUTORCH_BUILD_XNNPACK ON" in cmake
 
 
+@pytest.mark.unit
+def test_runtime_extension_does_not_require_an_embeddable_python():
+    """Development.Embed must stay optional, or the release build cannot configure.
+
+    ExecuTorch declares its pybind modules SHARED, so CMake requires the
+    Python::Python target and suggests asking for Development.Embed. Taking that
+    suggestion breaks the build: the release image's CPython ships no libpython, so
+    the component cannot be satisfied and the whole find_package fails. The
+    component is therefore requested optionally, matching pybind11, and the target
+    is stood in for when it is absent.
+    """
+    cmake = (
+        _REPO_ROOT / "py/torch-tensorrt-executorch-runtime/native/CMakeLists.txt"
+    ).read_text(encoding="utf-8")
+
+    assert "REQUIRED COMPONENTS Interpreter Development.Module" in cmake
+    assert "if(NOT TARGET Python::Python)" in cmake
+
+    # Every mention of the component in actual code, comments excluded, must be an
+    # optional one. A required request is what fails on an image without libpython.
+    code = [line for line in cmake.splitlines() if not line.lstrip().startswith("#")]
+    embed_lines = [line for line in code if "Development.Embed" in line]
+    assert embed_lines, "Development.Embed should be requested, optionally"
+    for line in embed_lines:
+        assert "OPTIONAL_COMPONENTS" in line, (
+            "Development.Embed must stay optional; the release image has no "
+            f"libpython: {line.strip()!r}"
+        )
+
+
 def _setup_tree():
     return ast.parse(_SETUP_PY.read_text(encoding="utf-8"))
 


### PR DESCRIPTION
## The problem

The ExecuTorch runtime wheel has never built. `executorch-runtime-build` has failed
on every commit since it was added, on all ten matrix rows, and
`executorch-runtime-test` is gated on it:

```yaml
# .github/workflows/ci-linux-x86_64.yml
executorch-runtime-test:
  if: ... needs.executorch-runtime-build.result == 'success'
```

That test job is the only thing that runs `tests/py/dynamo/executorch/` and the
reference-runner verification, so no ExecuTorch change is covered by CI today. And
because the job also fails on main, it reads as a safe pre-existing failure.

## Why it fails

The build stops during CMake configure, before anything compiles:

```
Python_ADD_LIBRARY: dependent target 'Python::Python' is not defined.
   Did you miss to request COMPONENT 'Development.Embed'?
Call Stack (most recent call first):
  .../pybind11/tools/pybind11NewTools.cmake:269 (python_add_library)
  .../executorch/codegen/tools/CMakeLists.txt:11 (pybind11_add_module)
```

ExecuTorch declares its Python extension modules as
`pybind11_add_module(<target> SHARED ...)`. pybind11 maps a non-MODULE type onto
`pybind11::embed`, and CMake's `python_add_library` then requires `Python::Python`,
which exists only when Python is found with `Development.Embed`.

Requesting that component does not work here. It needs a libpython, and the
manylinux CPython has none, so the whole `find_package` fails instead:

```
Could NOT find Python (missing: Python_INCLUDE_DIRS Python_LIBRARIES ...)
```

pybind11 already handles this and asks for the component optionally on purpose:

```cmake
# pybind11NewTools.cmake
# Development.Module support (required for manylinux) started in 3.18
set(_pybind11_dev_component Development.Module OPTIONAL_COMPONENTS Development.Embed)
```

`codegen/tools` cannot be switched off on its own. It is gated only on
`EXECUTORCH_BUILD_PYBIND`, which has to stay on because this build requires
`portable_lib`.

## The change

Match pybind11's pattern, then fill the one gap it leaves:

- `Development.Module` required, `Development.Embed` optional. Finding Python before
  pybind11 is the override pybind11 documents.
- Where `Development.Embed` is genuinely absent, supply `Python::Python` as an empty
  `INTERFACE`, guarded on `NOT TARGET` so a real libpython wins when the image has
  one. It forwards `Python::Module` for include directories and links no libpython,
  which is correct for an extension module: its Python symbols resolve from the
  interpreter that loads it.

`PYTHON_EXECUTABLE` is bridged to `Python_EXECUTABLE` first, because the build
passes the interpreter under the former name while FindPython reads the latter.
ExecuTorch does the same bridge but only later, so without it this call could pick a
different interpreter than the rest of the build.

A test pins the invariant, added to the file that already pins eight properties of
this same CMakeLists as text: the component must stay optional, and the stand-in
must stay guarded.

## The root fix belongs upstream

One keyword: `selective_build`, `portable_lib` and `data_loader` should be `MODULE`,
not `SHARED`. CMake skips the check entirely for `MODULE`, no `Python::Python` is
needed and no libpython is linked, which is what an extension module wants. That
fixes it for every consumer. This change defers to the real target if a later pin
provides one.

## Testing

The configure failure only reproduces in the release image, so the mechanism was
verified separately with cmake 3.30 and 4.4:

- Embed absent, stand-in used: configures and links.
- Embed present, real target used: configures and links.
- Requesting Embed as REQUIRED on an image without libpython fails, so the mechanism
  is not imagined.

The new test was verified in all three directions, because a test that cannot fail
proves nothing:

```
fixed tree                          1 passed
Development.Embed made required     1 failed
stand-in removed                    1 failed
```

## On the readelf assertion, deliberately not here

An earlier revision asserted at build time, with `readelf -d`, that neither
extension links libpython. It is removed rather than kept, for three reasons:

- It made binutils a hard build dependency on Linux for a check that cannot fire on
  the current ExecuTorch pin, where `strip_python_lib()` already removes both
  `Python::Python` and `pybind11::embed` from those targets
  (`executorch/CMakeLists.txt:283`, called at `:1161` and `:1195`).
- This repository already asserts that class of property from a test, not from the
  build: `tests/py/core/test_libtorchtrt_linkage.py` runs `readelf -d` on the shipped
  library with `check=True`.
- Keeping it here mixed a packaging-hygiene concern into a configure fix.

It is worth having as a test against the built artifact, and belongs in its own
change. Flagging it rather than dropping it quietly.

## What this does not fix

With the configure fixed, the build reaches 86% and stops at a **pre-existing** link
failure that was previously unreachable:

```
[ 86%] Linking CXX shared library _portable_lib.so
ld.gold: error: .../13/libstdc++.a(functexcept.o): multiple definition of
  'std::__throw_bad_array_new_length()'
ld.gold: .../libstdc++_nonshared.a(functexcept80.o): previous definition here
```

That is not this change. `git diff` against the merge base touches no line of the
static-libstdc++ logic, and this change is purely additive. Every earlier build died
in configure, so nothing had reached the link step before. The wheel therefore needs
a second, separate fix before it builds.

Making that error visible at all required raising bazel's output limit, which is
#4524.

Also worth stating: a pull request push resolves the fast lane, so one matrix row is
scheduled rather than ten.