### PR TITLE
fix: stop forcing libstdc++.a into extensions the toolchain already links

### DIFF
--- a/py/torch-tensorrt-executorch-runtime/native/CMakeLists.txt
+++ b/py/torch-tensorrt-executorch-runtime/native/CMakeLists.txt
@@ -142,11 +142,16 @@ target_link_libraries(portable_lib PRIVATE
   CUDA::cudart TensorRT::nvinfer Threads::Threads)
 
 # The build and validation containers do not necessarily provide the same
-# libstdc++. Link the C++ runtime archives explicitly into both Python
-# extensions. In particular, data_loader is an ExecuTorch target and merely
-# passing -static-libstdc++ as a driver option was not sufficient to prevent
-# its shared object from retaining an unresolved
-# exception_ptr::_M_addref reference on the older CI runtime.
+# libstdc++, so both Python extensions link the C++ runtime statically. Setting
+# LINKER_LANGUAGE CXX below is what makes -static-libstdc++ take effect: without
+# it, data_loader is linked by the C driver and its shared object retained an
+# unresolved exception_ptr::_M_addref reference on the older CI runtime. That
+# symbol is supplied by libstdc++_nonshared.a, which the toolchain links for us,
+# so the driver flags plus the correct linker language are sufficient.
+# Probed as a precondition, not as a link input. -static-libstdc++ below makes the
+# driver resolve -lstdc++ to exactly this file, so if it is absent the link fails
+# with a less obvious error. Nothing names it on the link line: doing that is what
+# caused duplicate definitions against libstdc++_nonshared.a.
 execute_process(
   COMMAND "${CMAKE_CXX_COMPILER}" -print-file-name=libstdc++.a
   OUTPUT_VARIABLE TORCH_TENSORRT_STATIC_LIBSTDCXX
@@ -161,9 +166,9 @@ if(NOT EXISTS "${TORCH_TENSORRT_STATIC_LIBSTDCXX}" OR
 endif()
 
 # rules_foreign_cc injects an explicit dynamic -lstdc++ into module and shared
-# linker flags. Remove only that scoped fragment: the archives below provide
-# the C++ runtime, and retaining this injected library makes the wheel depend
-# on the build host's CXXABI version.
+# linker flags. Remove only that scoped fragment: the driver flags below select the
+# static runtime, and retaining this injected library makes the wheel depend on the
+# build host's CXXABI version.
 foreach(_torch_tensorrt_linker_flags CMAKE_MODULE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
   string(REPLACE "-Wl,--push-state,-as-needed -lstdc++ -Wl,--pop-state" ""
     ${_torch_tensorrt_linker_flags} "${${_torch_tensorrt_linker_flags}}")
@@ -175,8 +180,22 @@ foreach(_torch_tensorrt_executorch_runtime_target portable_lib data_loader)
   # leaving CXXABI-versioned exception_ptr symbols for the host runtime.
   set_property(TARGET ${_torch_tensorrt_executorch_runtime_target}
     PROPERTY LINKER_LANGUAGE CXX)
+  # Do not add libstdc++.a here, and in particular do not whole-archive it. The
+  # driver flags below already select the static runtime, and on a Red Hat
+  # gcc-toolset the toolchain adds a second archive of its own: libstdc++.so is a
+  # text linker script, not an ELF object, and it reads
+  #
+  #   INPUT ( /usr/lib64/libstdc++.so.6 -lstdc++_nonshared )
+  #
+  # so libstdc++_nonshared.a arrives as an independent input carrying the
+  # newer-ABI symbols the base libstdc++.so.6 lacks. That archive is a strict
+  # subset of libstdc++.a: measured in the release image with
+  # `nm --defined-only -g`, counting T/W/B/D/R, 1003 definitions and none unique to
+  # it. Counting all global types gives 1141 instead; "none unique" holds either
+  # way, which is the part that matters. Whole-archiving libstdc++.a
+  # forces every member in whether referenced or not, so all 1003 collide and the
+  # link fails on whichever the linker reaches first.
   target_link_libraries(${_torch_tensorrt_executorch_runtime_target} PRIVATE
-    "$<LINK_LIBRARY:WHOLE_ARCHIVE,${TORCH_TENSORRT_STATIC_LIBSTDCXX}>"
     "${TORCH_TENSORRT_STATIC_LIBGCC}")
   target_link_options(${_torch_tensorrt_executorch_runtime_target} PRIVATE
     -static-libstdc++
@@ -204,5 +223,35 @@ set_target_properties(data_loader PROPERTIES SUFFIX ".so")
 
 install(TARGETS portable_lib data_loader LIBRARY DESTINATION lib)
 
-add_custom_target(torch_tensorrt_executorch_portable_lib DEPENDS portable_lib data_loader)
+add_custom_target(torch_tensorrt_executorch_portable_lib ALL DEPENDS portable_lib data_loader)
 
+# Guard the two properties the removed whole-archive used to guarantee, on the real
+# artifacts: no dynamic dependency on the build host's libstdc++, and no undefined
+# exception_ptr::_M_addref. This wheel has no auditwheel step behind it.
+#
+# ALL on the aggregate target above matters: a custom target without it is excluded
+# from the default build, and the default target is what the wheel build runs. The
+# check hangs off that aggregate rather than off portable_lib and data_loader
+# directly, because add_custom_command(TARGET) only accepts targets created in this
+# directory and those two come from ExecuTorch's subdirectory.
+#
+# The predicate captures readelf's output and checks its status before inspecting it,
+# so an unreadable artifact fails the build instead of passing quietly.
+find_program(TORCH_TENSORRT_READELF NAMES readelf llvm-readelf)
+if(NOT TORCH_TENSORRT_READELF AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  message(FATAL_ERROR
+    "readelf is required to verify the Python extensions link the C++ runtime "
+    "statically. Install binutils, or set TORCH_TENSORRT_READELF to a readelf.")
+endif()
+if(TORCH_TENSORRT_READELF)
+  foreach(_torch_tensorrt_checked_target portable_lib data_loader)
+    add_custom_command(TARGET torch_tensorrt_executorch_portable_lib POST_BUILD
+      COMMAND "${CMAKE_COMMAND}" -E echo
+        "checking $<TARGET_FILE_NAME:${_torch_tensorrt_checked_target}> links the C++ runtime statically"
+      COMMAND sh -c
+        "dyn=$(\"$0\" -d \"$1\") || { echo \"FATAL: could not inspect $1 with $0\" >&2; exit 1; }; printf %s \"$dyn\" | grep -qE 'NEEDED.*libstdc\\+\\+' && { echo \"FATAL: $1 has a dynamic libstdc++ dependency\" >&2; exit 1; }; syms=$(\"$0\" -Ws \"$1\") || { echo \"FATAL: could not read symbols of $1\" >&2; exit 1; }; printf %s \"$syms\" | grep -qE 'UND .*_M_addref' && { echo \"FATAL: $1 has an undefined exception_ptr::_M_addref\" >&2; exit 1; }; exit 0"
+        "${TORCH_TENSORRT_READELF}"
+        "$<TARGET_FILE:${_torch_tensorrt_checked_target}>"
+      VERBATIM)
+  endforeach()
+endif()


### PR DESCRIPTION
## The problem

The ExecuTorch runtime wheel does not link. This has always been true and nobody has
seen it: every build died earlier during CMake configure, so the link step was never
reached. With that fixed in #4523 the build gets to 86% and stops here:

```
[ 86%] Linking CXX shared library _portable_lib.so
ld.gold: error: .../gcc-toolset-13/.../13/libstdc++.a(functexcept.o):
  multiple definition of 'std::__throw_bad_array_new_length()'
ld.gold: .../gcc-toolset-13/.../13/libstdc++_nonshared.a(functexcept80.o):
  previous definition here
```

## Why

Two mechanisms each put a full C++ runtime on the link line.

**Explicit.** Both extensions whole-archive `libstdc++.a`, which forces every member
in whether anything references it or not.

**Implicit, and easy to miss.** On a Red Hat gcc-toolset, `libstdc++.so` is not an ELF
object at all. It is a text linker script. Read from the release image,
`docker.io/pytorch/manylinux2_28-builder:cuda13.0`:

```
$ file .../gcc-toolset-13/root/usr/lib/gcc/x86_64-redhat-linux/13/libstdc++.so
ASCII text

$ cat .../libstdc++.so
/* GNU ld script
   Use the shared library, but some functions are only in
   the static library, so try that secondarily.  */
OUTPUT_FORMAT(elf64-x86-64)
INPUT ( /usr/lib64/libstdc++.so.6 -lstdc++_nonshared )
```

So any `-lstdc++` reaching the link pulls `libstdc++_nonshared.a` in as a separate
input. That archive carries the newer-ABI pieces the base `libstdc++.so.6` lacks, and
it is a **strict subset** of `libstdc++.a`. Measured in the same image:

```
global defs in libstdc++.a            5884
global defs in libstdc++_nonshared.a  1003
defined in both                       1003
unique to nonshared                      0
```

Whole-archiving `libstdc++.a` therefore guarantees 1003 duplicate definitions.
`ld.gold` reports the first one it reaches; there are 1002 behind it.

## The change

Drop the whole-archive, and the explicit archive with it. The driver flags already
select the static runtime, and `LINKER_LANGUAGE CXX`, set in the same loop, is what
makes them take effect.

This matches upstream ExecuTorch, which whole-archives its *delegate* but uses plain
`-static-libstdc++ -static-libgcc` for the C++ runtime and never whole-archives
libstdc++ anywhere:

```cmake
# executorch/CMakeLists.txt:1478
target_link_options(executor_runner PRIVATE -static-libstdc++ -static-libgcc)
```

The comment above the block claimed the driver option alone was insufficient, which
reads as though the whole-archive is what fixes it. The symbol it names,
`exception_ptr::_M_addref`, is defined by `libstdc++_nonshared.a` as well as
`libstdc++.a`, so the toolchain already supplies it. The real fix for that bug was
the linker language, and the comment now says so.

The unrelated whole-archive on `torch_tensorrt_executorch_backend` stays. That one is
deliberate: it is how the backend's static registration survives into the module.

## The guard

Because this removes what used to force the static runtime in unconditionally, a
`POST_BUILD` check now asserts the two properties on the real artifacts: no dynamic
`libstdc++` dependency, and no undefined `_M_addref`. This wheel has no auditwheel
step behind it to catch a regression.

Verified in the release image with the Make generator, which is what
`rules_foreign_cc` uses:

```
static runtime, real readelf     build passes
dynamic runtime, real readelf    build fails: "has a dynamic libstdc++ dependency"
static runtime, broken readelf   build fails: "could not inspect"
guard not configured             build passes
default build runs the check     yes, once per extension
```

The predicate captures readelf's output and checks its status before inspecting it,
so an unreadable artifact fails the build rather than passing quietly.

## Limits

The collision itself needs the full ExecuTorch link, so it was not reproduced outside
CI. What is measured directly in the release image is the linker script, the symbol
overlap, the fact that nonshared already provides `_M_addref`, and that the guard
fires correctly in every direction. CI on this branch is the confirmation.

## Relationship to the other changes

Sequenced behind #4523, which fixes the configure so the build reaches the link at
all. Both are needed before `executorch-runtime-build` can pass and
`executorch-runtime-test` stops being skipped. #4524 is what made this error visible,
since bazel was truncating it.