### PR TITLE
fix(runtime): pass the workspace size to set_device_memory

### DIFF
--- a/py/torch_tensorrt/dynamo/runtime/_TRTEngine.py
+++ b/py/torch_tensorrt/dynamo/runtime/_TRTEngine.py
@@ -1341,12 +1341,15 @@ class TRTEngine(OpaqueBase):  # type: ignore[misc]
                 engine_stream.wait_stream(caller_stream)
             with torch.cuda.stream(engine_stream):
                 if self.resource_allocation_strategy:
+                    workspace_bytes = self.cuda_engine.device_memory_size_v2
                     self._dynamic_workspace = torch.empty(
-                        self.cuda_engine.device_memory_size_v2,
+                        workspace_bytes,
                         dtype=torch.uint8,
                         device=torch.cuda.current_device(),
                     )
-                    self.context.set_device_memory(self._dynamic_workspace.data_ptr())
+                    self.context.set_device_memory(
+                        self._dynamic_workspace.data_ptr(), workspace_bytes
+                    )
 
                 if effective_cudagraphs:
                     if need_cudagraphs_record:


### PR DESCRIPTION
## Summary

The dynamic workspace test added in #4503 fails on every open pull request and on `main`:

```
self.context.set_device_memory(self._dynamic_workspace.data_ptr())
TypeError: set_device_memory(): incompatible function arguments.
  The following argument types are supported:
    1. (self: IExecutionContext, memory: SupportsInt, size: SupportsInt) -> None
  Invoked with: <IExecutionContext>, 60607692800
```

TensorRT wants the pointer **and** the size. The Python runtime passes only the pointer, so the call never succeeds and dynamic workspace allocation does not work there.

## Why

#4503 fixed this on the C++ side and added the test, but the Python path was not changed:

```cpp
const auto workspace_bytes = compiled_engine->cuda_engine->getDeviceMemorySizeV2();
dynamic_workspace = torch::empty({workspace_bytes}, ...kUInt8...kCUDA);
ctx->setDeviceMemoryV2(dynamic_workspace.data_ptr(), workspace_bytes);
```

This makes the two match: hoist the size into a variable and pass it.

Note the Python path already allocated a `uint8` tensor, so it never had the four times overallocation the C++ side did. Only the missing size argument applies here.

## Testing

The failing test is the one #4503 added, `tests/py/dynamo/runtime/test_dynamic_workspace_allocation.py::TestDynamicWorkspaceAllocation::test_workspace_is_allocated_in_bytes`. It needs a GPU, so it is verified by CI on this pull request rather than locally.
