### PR TITLE
ci: stop running the ExecuTorch build when the wheel it needs was cancelled

### DIFF
--- a/.github/workflows/ci-linux-x86_64.yml
+++ b/.github/workflows/ci-linux-x86_64.yml
@@ -112,12 +112,21 @@ jobs:
   # ExecuTorch runtime is supported by the standard TensorRT wheel only. Wait
   # for the standard channel to upload its wheel artifact, but still build the
   # runtime if a standard test fails.
+  #
+  # A standard channel that was CANCELLED is different from one that failed a test:
+  # it uploaded no wheel, so this job has nothing to download and dies with
+  # "Artifact not found for name: pytorch_tensorrt__<py>_<cu>_x86_64" after burning a
+  # runner. That is reported as a failure and drags `gate` down with it, which is why
+  # main shows ten red ExecuTorch rows whenever two commits land close together. The
+  # standard channel has its own concurrency group, so it can be cancelled on its own
+  # while this run continues.
   executorch-runtime-build:
     needs: [decide, generate-matrix, standard]
     if: >-
-      always() &&
+      !cancelled() &&
       needs.decide.result == 'success' &&
       needs.generate-matrix.result == 'success' &&
+      needs.standard.result != 'cancelled' &&
       needs.decide.outputs.lane != 'skip' &&
       needs.decide.outputs.backend != 'rtx'
     uses: ./.github/workflows/executorch-build-linux.yml


### PR DESCRIPTION
## Summary

`main` currently shows ten red ExecuTorch rows whenever two commits land close together, and none of them is a real failure. Every one dies the same way:

```
##[error]Unable to download artifact(s):
  Artifact not found for name: pytorch_tensorrt__3.10_cu130_x86_64
```

## Why

`executorch-runtime-build` downloads the wheel the standard channel uploads. When that channel is **cancelled** it uploads nothing, so there is nothing to download. The job ran anyway, because its condition was `always()`, which does not distinguish a channel that failed a test from one that never produced an artifact.

Those two are not the same:

| standard channel | wheel exists | should we build the runtime? |
| --- | --- | --- |
| a test failed | yes | **yes**, this is the documented intent and it stays |
| cancelled | **no** | no, there is nothing to download |

The standard channel has its own concurrency group inside the reusable build workflow, so it can be cancelled on its own while this run keeps going. That is why this fires routinely rather than being a rare race.

## Evidence

From the commit that merged #4454:

```
standard / Build Linux x86_64 wheel   cancelled  12:18 PM
executorch-runtime-build (x10)        failure    12:37-12:40 PM
                                        -> Artifact not found
```

All ten failed at the download step in seven to ten minutes. A real build of this wheel takes about forty. The same signature appears in the runs for #4525 and #4534.

## The change

Skip the job when the standard channel was cancelled, and use `!cancelled()` so a genuinely cancelled run stops here instead of starting work it cannot finish:

```yaml
if: >-
  !cancelled() &&
  needs.decide.result == 'success' &&
  needs.generate-matrix.result == 'success' &&
  needs.standard.result != 'cancelled' &&
  needs.decide.outputs.lane != 'skip' &&
  needs.decide.outputs.backend != 'rtx'
```

A standard **test** failure still lets the runtime build proceed, which is the behaviour the existing comment describes.

`skipped` does not fail `gate`, which is already what `gate` documents, so this also stops `gate` going red for the same non-reason.

`executorch-runtime-test` needs no change: it already requires `executorch-runtime-build` to have succeeded, so it skips when the build skips.

## Testing

The workflow parses, and the resolved condition and the unchanged test-job gate were checked:

```
cond: !cancelled() && needs.decide.result == 'success' && needs.generate-matrix.result == 'success'
      && needs.standard.result != 'cancelled' && needs.decide.outputs.lane != 'skip'
      && needs.decide.outputs.backend != 'rtx'
test still gated on build success: True
```

The behaviour itself is only observable when a run is superseded, so it is verified by the next push that supersedes one rather than by a test here.
