### PR TITLE
fix: stop nm symbol checks failing on SIGPIPE in the reference runner gate

### DIFF
--- a/.github/scripts/verify-executorch-reference-runner.sh
+++ b/.github/scripts/verify-executorch-reference-runner.sh
@@ -311,6 +311,17 @@ for _tool in ldd readelf nm; do
   fi
 done
 
+# Capture nm output instead of piping it into `grep -q`. grep exits at its first
+# match and closes the pipe, so nm dies of SIGPIPE and pipefail reports 141, which
+# reads as a false verdict in either direction.
+nm_matches() {
+  local _pattern="$1"
+  shift
+  local _symbols
+  _symbols="$(nm "$@" 2>/dev/null)"
+  grep -qE "${_pattern}" <<<"${_symbols}"
+}
+
 # The runner must not pull in libtorch: this native path is libtorch-free.
 if ldd "${runner_path}" |
     grep -E "libtorch|libtorch_cpu|libtorch_cuda|libc10" >&2; then
@@ -340,7 +351,7 @@ fi
 # the assertion pass vacuously. A private definition would satisfy the reference
 # at link time and leave no import here.
 for _symbol in getCallerStream CallerStreamGuard; do
-  if ! nm -D --undefined-only "${runner_path}" 2>/dev/null | grep -q "${_symbol}"; then
+  if ! nm_matches "${_symbol}" -D --undefined-only "${runner_path}"; then
     echo "example_executorch_runner does not import ${_symbol} from libextension_cuda.so" >&2
     exit 1
   fi
@@ -352,15 +363,14 @@ done
 # must be the sole definer the runner sees.
 loaded_extension_cuda="$(
   ldd "${runner_path}" 2>/dev/null |
-    sed -n 's/.*libextension_cuda\.so[^ ]* => \([^ ]*\).*/\1/p' |
-    head -n1
+    sed -n 's/.*libextension_cuda\.so[^ ]* => \([^ ]*\).*/\1/p'
 )"
+loaded_extension_cuda="${loaded_extension_cuda%%$'\n'*}"
 if [[ -z "${loaded_extension_cuda}" || ! -f "${loaded_extension_cuda}" ]]; then
   echo "Could not resolve the libextension_cuda.so the runner loads" >&2
   exit 1
 fi
-if ! nm --defined-only --dynamic "${loaded_extension_cuda}" 2>/dev/null |
-    grep -q "getCallerStream"; then
+if ! nm_matches "getCallerStream" --defined-only --dynamic "${loaded_extension_cuda}"; then
   echo "Loaded ${loaded_extension_cuda} does not export getCallerStream" >&2
   exit 1
 fi
@@ -379,8 +389,7 @@ if [[ ! -f "${packaged_extension_cuda}" ]]; then
   echo "Packaged libextension_cuda.so missing at ${packaged_extension_cuda}" >&2
   exit 1
 fi
-if ! nm --defined-only --dynamic "${packaged_extension_cuda}" 2>/dev/null |
-    grep -q "getCallerStream"; then
+if ! nm_matches "getCallerStream" --defined-only --dynamic "${packaged_extension_cuda}"; then
   echo "Packaged libextension_cuda.so does not export getCallerStream" >&2
   exit 1
 fi
@@ -394,7 +403,7 @@ if ldd "${packaged_runner}" | grep -E "libextension_cuda\.so.*=>.*not found" >&2
   exit 1
 fi
 for _symbol in getCallerStream CallerStreamGuard; do
-  if ! nm -D --undefined-only "${packaged_runner}" 2>/dev/null | grep -q "${_symbol}"; then
+  if ! nm_matches "${_symbol}" -D --undefined-only "${packaged_runner}"; then
     echo "Packaged runner does not import ${_symbol} from libextension_cuda.so" >&2
     exit 1
   fi
@@ -406,8 +415,7 @@ extra_defs="$(
   find "${TORCH_TENSORRT_ROOT}/lib" -maxdepth 1 -type f -name '*.so*' \
     ! -name 'libextension_cuda.so' -print0 2>/dev/null |
     while IFS= read -r -d '' _so; do
-      if nm --defined-only --dynamic "${_so}" 2>/dev/null |
-          grep -qE "getCallerStream|CallerStreamGuard"; then
+      if nm_matches "getCallerStream|CallerStreamGuard" --defined-only --dynamic "${_so}"; then
         echo "${_so}"
       fi
     done
@@ -440,7 +448,8 @@ for _log in "${runner_log}" "${packaged_runner_log}"; do
     exit 1
   fi
 
-  _values="$(sed -n 's/.*first [0-9]* values://p' "${_log}" | head -n1)"
+  _values="$(sed -n 's/.*first [0-9]* values://p' "${_log}")"
+  _values="${_values%%$'\n'*}"
   if [[ -z "${_values}" ]]; then
     echo "No output values line in ${_log}" >&2
     exit 1


### PR DESCRIPTION
## Problem

The ExecuTorch reference runner CI gate fails at random on builds that are perfectly fine, and it blames a different missing symbol each time.

The symbol checks look like this:

```bash
if ! nm -D --undefined-only "${runner_path}" 2>/dev/null | grep -q "${_symbol}"; then
```

`grep -q` stops at its first match and closes the pipe. `nm` is then killed by SIGPIPE and exits 141. The script runs under `set -o pipefail`, so the pipeline reports 141, and `if !` flips that into a false "does not import" followed by `exit 1`.

Whether it fires depends on whether `nm` still has output buffered when `grep` leaves, so it follows where the symbol sits in the symbol table:

| case | false failures |
| --- | --- |
| symbol early in a large symbol table | 25 / 25 |
| symbol on the very last line | 0 / 25 |

That is why the symbol named in the error changes from run to run.

## One check fails the other way, silently

The sweep for duplicate caller-stream definitions is not negated:

```bash
if nm --defined-only --dynamic "${_so}" 2>/dev/null | grep -qE "getCallerStream|CallerStreamGuard"; then
```

Here a 141 reads as "no duplicate found", so the guard passes without really checking. Against a real shared library that returned a false negative 40 times out of 40, meaning this guard has not been protecting anything.

## Fix

Read the tool output into a variable, then match against the variable, so there is no pipe to close. A small helper does it once for all five call sites:

```bash
nm_matches() {
  local _pattern="$1"
  shift
  local _symbols
  _symbols="$(nm "$@" 2>/dev/null)"
  grep -qE "${_pattern}" <<<"${_symbols}"
}
```

Two `head -n1` pipelines had the same hazard and now trim the first line with a parameter expansion instead.

## Testing

- Reproduced the mechanism and showed which stage dies:

  ```
  $ nm -D --undefined-only "$(command -v python3)" | grep -q malloc
  status: 141   PIPESTATUS: 141 0
  ```

- 40 runs of each form against a real binary: old form 40/40 false failures, new form 0/40.
- Same contrast on the duplicate-definition sweep against a real shared library: old form 40/40 false negatives, new form correct every time.
- Confirmed the checks still fail when a symbol is genuinely absent, so they did not become vacuous.
- Re-audited the script for any remaining pipeline whose last stage exits early. None remain.
- `bash -n` passes.

Only the CI verification script changes. No runtime or build code is touched.
