### PR TITLE
tests: skip TestPythonRuntimeAliasedIO on TensorRT-RTX with the C++ runtime

### DIFF
--- a/tests/py/dynamo/runtime/test_aliased_io.py
+++ b/tests/py/dynamo/runtime/test_aliased_io.py
@@ -26,10 +26,13 @@ also honors aliasing by binding the aliased output to the source input's
 storage; :class:`TestPythonRuntimeAliasedIO` exercises that path directly.
 """
 
+import unittest
+
 import torch
 import torch_tensorrt
 from torch.export import export
 from torch.testing._internal.common_utils import TestCase, run_tests
+from torch_tensorrt._features import ENABLED_FEATURES
 from torch_tensorrt.dynamo.runtime._TRTEngine import TRTEngine
 
 
@@ -274,13 +277,23 @@ class TestAliasedIORegressions(TestCase):
         self.assertAlmostEqual(got, expected, places=3)
 
 
+@unittest.skipIf(
+    ENABLED_FEATURES.torch_tensorrt_runtime and ENABLED_FEATURES.tensorrt_rtx,
+    "Hand-built Python TRTEngine is not a configuration TensorRT-RTX produces "
+    "when the C++ runtime is available",
+)
 class TestPythonRuntimeAliasedIO(TestCase):
     """The Python ``TRTEngine`` honors aliasing (in-place write-through).
 
-    In a build with the C++ runtime available, ``TorchTensorRTModule`` always
-    backs itself with the C++ engine, so we drive the Python ``TRTEngine``
-    directly from the compiled module's serialized info (the same tuple both
-    runtimes consume) to exercise its aliasing path.
+    The engine is built directly from the compiled module's serialized info (the
+    same tuple both runtimes consume) to reach the aliasing path without going
+    through ``forward``.
+
+    Skipped only on TensorRT-RTX builds that also have the C++ runtime: there the
+    module always picks the C++ engine, so a hand-built Python engine is a
+    configuration the library never produces and the RTX runtime-cache plumbing
+    is not wired for it. On standard TensorRT that plumbing is short-circuited
+    (``ensure_initialized`` returns early), so the test stays live there.
     """
 
     def _python_engine_for(self, model, args):


### PR DESCRIPTION
# Description

## What

Skip `TestPythonRuntimeAliasedIO` on TensorRT-RTX builds that also ship the C++
runtime, where it currently fails.

## Why

The runtimes are expected to be either/or: the flavor is picked from whether
`libtorchtrt.so` is loaded, and every in-library `TRTEngine` construction site is
gated on that same flag. This class hand-builds a Python `TRTEngine` from packed
engine info regardless, producing a combination the library never does — a
torchbind-backed `RuntimeCache` asked to serve a Python engine. `ensure_cache()`
returns `None` there and `set_runtime_cache` rejects an explicitly-passed `None`,
so both tests in the class fail.

## How

- `test_aliased_io.py`: `skipIf(torch_tensorrt_runtime and tensorrt_rtx)`.
  Deliberately narrow — on standard TensorRT the runtime-config path is
  short-circuited in `ensure_initialized`, so a hand-built engine is harmless and
  the class stays live; it also stays live on python-only builds, where the
  Python `TRTEngine` is the real runtime and the test is the point.

## Testing

| Build | Result |
| --- | --- |
| C++ runtime, `tests/py/dynamo/runtime/` | 170 passed, 46 skipped |

The same suite on `main` reports 2 failed.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
