### PR TITLE
Bound the ExecuTorch requirement to the compiled release

### DIFF
--- a/.github/workflows/executorch-test-linux.yml
+++ b/.github/workflows/executorch-test-linux.yml
@@ -64,7 +64,7 @@ jobs:
         chmod +x "${RUNNER_TEMP}/bin/bazel"
         export PATH="${RUNNER_TEMP}/bin:${PATH}"
 
-        python -m pip install pyyaml executorch
+        python -m pip install pyyaml "executorch==1.4.1"
         # Keep this diagnostic until the native runtime initialization crash is understood.
         ulimit -c unlimited || true
         if command -v gdb >/dev/null 2>&1; then

--- a/justfile
+++ b/justfile
@@ -85,7 +85,7 @@ summary *args:
 # Install optional test deps so model/kernels/quantization/executorch suites run
 install-test-ext:
     uv pip install --group test-ext --group kernels --group quantization
-    uv pip install pyyaml "executorch>=1.4.0"
+    uv pip install pyyaml "executorch>=1.4.1,<1.5"
 
 # ── Linting ───────────────────────────────────────────────────────────────────
 

--- a/setup.py
+++ b/setup.py
@@ -201,7 +201,10 @@ if RELEASE:
 else:
     __version__ = f"{get_base_version()}.dev0+{get_git_revision_short_hash()}"
 
-EXECUTORCH_REQUIREMENT = "executorch>=1.4.0"
+# Upper-bounded because the ExecuTorch delegate is compiled against the exact source
+# revision pinned in MODULE.bazel, and ExecuTorch's C++ runtime API is not stable across
+# minor releases. An unbounded floor would resolve a future minor against that backend.
+EXECUTORCH_REQUIREMENT = "executorch>=1.4.1,<1.5"
 # TODO: Enable this once the runtime wheel is published to the PyTorch index.
 # EXECUTORCH_RUNTIME_REQUIREMENT = (
 #     f"torch-tensorrt-executorch-runtime=={__version__}; " "platform_system == 'Linux'"

--- a/setup.py
+++ b/setup.py
@@ -201,9 +201,11 @@ if RELEASE:
 else:
     __version__ = f"{get_base_version()}.dev0+{get_git_revision_short_hash()}"
 
-# Upper-bounded because the ExecuTorch delegate is compiled against the exact source
-# revision pinned in MODULE.bazel, and ExecuTorch's C++ runtime API is not stable across
-# minor releases. An unbounded floor would resolve a future minor against that backend.
+# The delegate is compiled from the ExecuTorch source revision pinned in MODULE.bazel, so the
+# installed wheel should agree with it. The upper bound is the load-bearing half: ExecuTorch's C++
+# runtime API is not stable across minor releases, and an unbounded floor would resolve a future
+# minor against a backend built for this one. Patch releases stay allowed because they come off the
+# same release branch; the exact pin belongs in the runtime package, which does derive it.
 EXECUTORCH_REQUIREMENT = "executorch>=1.4.1,<1.5"
 # TODO: Enable this once the runtime wheel is published to the PyTorch index.
 # EXECUTORCH_RUNTIME_REQUIREMENT = (

--- a/tests/ci/runner.py
+++ b/tests/ci/runner.py
@@ -119,7 +119,7 @@ def _setup_commands(step: str) -> list[tuple[list[str], Path]]:
     if step == "executorch":
         return [
             (
-                launcher + ["-m", "pip", "install", "pyyaml", "executorch>=1.4.0"],
+                launcher + ["-m", "pip", "install", "pyyaml", "executorch>=1.4.1,<1.5"],
                 REPO_ROOT,
             )
         ]


### PR DESCRIPTION
## Summary

The ExecuTorch delegate is compiled against the exact source revision pinned in `MODULE.bazel` — `e4d02f41f7909e8ed5bf4a14ffc520d733453d9f`, which is the `v1.4.1` tag — but the pip requirement was an unbounded `executorch>=1.4.0`. Two problems follow.

**The floor names a release the tree is not built against.** `1.4.0` satisfies `>=1.4.0` while the backend is compiled for `1.4.1`.

**The requirement has no upper bound**, so it resolves whatever is newest on the index. That happens to be `1.4.1` today, so the current behaviour is correct by luck rather than by construction. Once ExecuTorch `1.5.0` publishes, `torch-tensorrt[executorch]` and `docgen.yml`'s `.[executorch]` install would silently pick it up against a backend compiled for `1.4.1`. ExecuTorch's C++ runtime API is not stable across minor releases, and the delegate links `executorch` and `extension_cuda` directly.

This bounds the requirement to `>=1.4.1,<1.5` in the three places that declare it:

| File | Before | After |
| --- | --- | --- |
| `setup.py:204` | `executorch>=1.4.0` | `executorch>=1.4.1,<1.5` |
| `justfile:88` | `executorch>=1.4.0` | `executorch>=1.4.1,<1.5` |
| `tests/ci/runner.py:122` | `executorch>=1.4.0` | `executorch>=1.4.1,<1.5` |
| `.github/workflows/executorch-test-linux.yml:67` | `executorch` (unconstrained) | `executorch==1.4.1` |

`setup.py:204` is the one that reaches users, via the live `executorch` and `all` extras.

The last row was found in review and is the sharpest case: that install had **no constraint at all**, so it resolved whatever was newest on the index, and the job then asserts the compiled CUDA delegate registers (`assert runtime.backend_registry.is_available("CudaBackend")`). It gets the exact pin rather than the range, matching `executorch-build-linux.yml:82`, because it loads the delegate built from the `MODULE.bazel` revision.

Two levels of strictness, on purpose: the range is for the optional extra that users resolve, while jobs and packages that load the compiled delegate use `==`.

## Deliberately not changed

`.github/workflows/executorch-build-linux.yml:122` keeps its `executorch>=1.4.0`. Its comment says `this is to verify the end user's workflow`, so it re-tests against a stock wheel and genuinely wants a floor rather than the build's exact pin.

## Verification

Specifier semantics, checked with `packaging`:

```
1.3.1    -> reject
1.4.0    -> reject
1.4.1    -> ACCEPT   <- the compiled release
1.4.2    -> ACCEPT   <- future patches still allowed
1.5.0    -> reject   <- the case this PR is for
```

`black --check` clean on both touched Python files. `python -m py_compile` clean.

## Note for a follow-up

`uv.lock` records ExecuTorch `1.3.1` (line 964) and `specifier = ">=1.3.1"` (lines 4916-4917), i.e. it was resolved against an older `setup.py` and never re-resolved.

To be accurate about cause, since an earlier draft of this description got it wrong in two ways. First, the lock *does* track the extra: `uv.lock:4916-4917` carries `extra == 'executorch'` and `extra == 'all'` entries, so it is stale rather than absent. Second, and more importantly, **this PR is not what fixes it.** The `Sync uv.lock` job's own logs show the resolver already selecting the right version under the *old* floor:

```
DEBUG Adding direct dependency: executorch>=1.4.0
DEBUG Selecting: executorch==1.4.1 [compatible]
```

The lock is stale because that job's auto-commit step has been unreachable since 2026-06-02, not because the floor was wrong. #4543 fixes that job and is sufficient on its own; this PR is neither necessary nor sufficient for the lockfile. Regenerating `uv.lock` is left to that job, or to a separate reviewable PR if it does not self-heal.
