### PR TITLE
Run the uv.lock sync in a CUDA 13.2 container

### DIFF
--- a/.github/workflows/uv-update.yml
+++ b/.github/workflows/uv-update.yml
@@ -20,6 +20,12 @@ jobs:
     if: ${{ ! contains(github.actor, 'pytorchbot') }}
     environment: pytorchbot-env
     container:
+      # Unlike the other jobs, this one does not run packaging/pre_build_script.sh, so it builds
+      # against the checked-in MODULE.bazel instead of one rendered from
+      # toolchains/ci_workspaces/MODULE.bazel.tmpl. That means the ${CUDA_HOME} substitution never
+      # happens here and Bazel reads the literal path in MODULE.bazel. Keep this tag's CUDA version
+      # equal to the cuda new_local_repository path in MODULE.bazel or the build fails to fetch
+      # @cuda and the lockfile silently stops being refreshed.
       image: pytorch/manylinux2_28-builder:cuda13.2
       options: --gpus all
       env:

--- a/.github/workflows/uv-update.yml
+++ b/.github/workflows/uv-update.yml
@@ -20,10 +20,10 @@ jobs:
     if: ${{ ! contains(github.actor, 'pytorchbot') }}
     environment: pytorchbot-env
     container:
-      image: pytorch/manylinux2_28-builder:cuda13.0
+      image: pytorch/manylinux2_28-builder:cuda13.2
       options: --gpus all
       env:
-        CUDA_VERSION: 13.0
+        CUDA_VERSION: 13.2
         CUDA_HOME: /usr/local/cuda
 
     steps:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,6 +73,9 @@ new_local_repository(
 
 # CUDA should be installed on the system locally
 # for linux x86_64 and aarch64
+# Jobs that render MODULE.bazel from toolchains/ci_workspaces/MODULE.bazel.tmpl substitute
+# ${CUDA_HOME} here. Jobs that use this file directly, such as .github/workflows/uv-update.yml,
+# need a container that actually provides the path below.
 new_local_repository(
     name = "cuda",
     build_file = "@//third_party/cuda:BUILD",


### PR DESCRIPTION
## Summary

The `Sync uv.lock` job has failed on **every run since 2026-06-02**. Last success was run `26775783834` on 2026-06-01; every run after it failed, across both the weekly cron and every `setup.py`/`pyproject.toml` push.

The regression is `567ba6ab` "build: upgrade cuda to 13.2 (#4315)" (2026-06-02), which changed `MODULE.bazel` from `cuda-13.0/` to `cuda-13.2/` without updating this workflow's container. Everything else that builds Bazel renders `MODULE.bazel` from the template, so this job was the only casualty and nothing surfaced it.

`uv lock --refresh` succeeds. The failure is in the next step, `uv sync --frozen`, which builds `torch-tensorrt` and hits:

```
Error in fail: The repository's path is "/usr/local/cuda-13.2/" (absolute:
"/usr/local/cuda-13.2") but it does not exist or is not a directory
ERROR: no such package '@@+_repo_rules+cuda//'
ERROR: Analysis of target '//:libtorchtrt' failed; build aborted
```

`MODULE.bazel:79` declares the `cuda` repository at `/usr/local/cuda-13.2`, but the job ran `pytorch/manylinux2_28-builder:cuda13.0`, which does not have that directory.

Note this job does **not** run `packaging/pre_build_script.sh`, so it consumes the checked-in `MODULE.bazel` rather than one generated from `toolchains/ci_workspaces/MODULE.bazel.tmpl`. The template declares `path = "${CUDA_HOME}"`, so the substitution that lets other CI jobs be CUDA-version-agnostic never happens here. Setting `CUDA_HOME` in the job env does not help, because Bazel reads the hardcoded path.

## Consequence

The `Validate the changes` step gates `Auto-commit changes`:

```yaml
- name: Auto-commit changes
  if: steps.validate-changes.outputs.valid_changes == 'true'
```

Since validation always fails, the auto-commit never runs and the lockfile is never refreshed. `uv.lock` has been frozen for weeks — it still records `executorch` `1.3.1` (line 964) and `specifier = ">=1.3.1"` (lines 4916-4917), which no longer matches `setup.py`.

## Fix

Move the container to `cuda13.2` so the path `MODULE.bazel` declares actually exists. `cu132` is already a supported configuration in `.github/scripts/filter-matrix.py:16-17`.

```diff
-      image: pytorch/manylinux2_28-builder:cuda13.0
+      image: pytorch/manylinux2_28-builder:cuda13.2
-        CUDA_VERSION: 13.0
+        CUDA_VERSION: 13.2
```

## Verification

- `pytorch/manylinux2_28-builder:cuda13.2` exists on Docker Hub (HTTP 200; `cuda13.1` and `cuda13.3` are 404).
- YAML parses, and the container image/env resolve as intended.
- **The image does contain the required path.** Confirmed from the registry rather than trusting the tag name — the `cuda13.2` amd64 config blob history shows:

```
RUN rm -rf /usr/local/cuda-${BASE_CUDA_VERSION}
COPY /usr/local/cuda-13.2 /usr/local/cuda-13.2      <- the directory MODULE.bazel:79 demands
```

  The rest of the toolchain is otherwise unchanged between the two images (same `gcc-toolset-13`, same conda prefix, same cp312/cp313), so the blast radius of moving the container is small.

## Why `docgen.yml` is deliberately NOT bumped

`.github/workflows/docgen.yml:17` uses the same `cuda13.0` image, so it is a fair question whether it should move too. It should not, and the reason is the mirror image of this bug: `docgen.yml:39` runs `./packaging/pre_build_script.sh`, which regenerates `MODULE.bazel` from the template with `CUDA_HOME=/usr/local/cuda-13.0` substituted in. It is self-consistent and correct today. Bumping only its image, without its `CUDA_HOME`, would be what breaks it.

## Alternative considered

Keep `cuda13.0` and generate `MODULE.bazel` from the template before locking. Rejected as out of scope: `pre_build_script.sh` also force-installs torch and resolves `TORCH_INSTALL_PATH`, needs `CHANNEL`/`CU_VERSION`/`BUILD_VERSION`, and would change what the lock is resolved against.

## Related

One caveat on how far this goes. `uv sync --frozen` has only ever failed at Bazel *analysis*, so clearing the path moves the failure to actually compiling `//:libtorchtrt` in this container. Encouraging evidence: `executorch-runtime-build--3.11-cu132` already builds that same target successfully in the `cuda13.2` image. But note run `26599116607` — the one run that ever got past validation — then failed in `Auto-commit changes` with a non-fast-forward push. So this PR removes the current blocker; it does not guarantee the lockfile refreshes on the first attempt.

Independent of, but complementary to, #4542, which corrects the ExecuTorch requirement in `setup.py`. With this job working again, that merge will refresh the stale `executorch` entry in `uv.lock` automatically, since the workflow triggers on pushes to `setup.py`.
