### PR TITLE
Reformat the parametrize decorator black wants wrapped

### DIFF
--- a/tests/py/dynamo/lowering/test_complex_rewrite.py
+++ b/tests/py/dynamo/lowering/test_complex_rewrite.py
@@ -1251,7 +1251,9 @@ def test_none_placeholder():
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("scale", [torch.tensor(2.0), 2, True], ids=["tensor", "int", "bool"])
+@pytest.mark.parametrize(
+    "scale", [torch.tensor(2.0), 2, True], ids=["tensor", "int", "bool"]
+)
 def test_non_tensor_scalar_placeholder(scale):
     class RotaryComplex(nn.Module):
         def forward(self, xq, freqs_cis, scale):


### PR DESCRIPTION
## Summary

`Python Linting` is currently failing on **every** open pull request, including ones that do not touch this file:

```
would reformat tests/py/dynamo/lowering/test_complex_rewrite.py
1 file would be reformatted, 593 files would be left unchanged.
```

The `@pytest.mark.parametrize` decorator added for `test_non_tensor_scalar_placeholder` in #4507 (merged 2026-08-20 4:06 PM PDT) is slightly over the line length black enforces, so black wants it wrapped. `black --check` reproduces this on a clean checkout of `main` at `691b788` with no local modifications, so it is not specific to any pull request.

## Fix

```diff
-@pytest.mark.parametrize("scale", [torch.tensor(2.0), 2, True], ids=["tensor", "int", "bool"])
+@pytest.mark.parametrize(
+    "scale", [torch.tensor(2.0), 2, True], ids=["tensor", "int", "bool"]
+)
```

This is exactly `black`'s own output. Formatting only — the parameters, the ids and the test body are unchanged.

## Verification

- `black --check` on the file: clean after this change, fails before it.
- `python -m py_compile`: clean.
- `black --check` on the rest of the tree was already clean (593 files), so this is the only offender.

## Note

The linter job also logs a separate, unrelated problem on pull requests from forks:

```
Request POST /repos/pytorch/TensorRT/pulls/<n>/reviews failed with 403: Forbidden
Unable to submit in depth review, please review logs for linting issues
```

`.github/scripts/run_py_linter.py` tries to post a review, which a fork's read-only `GITHUB_TOKEN` cannot do. To be precise about cause and effect: this 403 is **not** what fails the job. This PR's own `Python Linting` run passes while still logging the 403 five times, so the message is noise that survives a green run. The formatting error is the real and only cause. Mentioning it only so the logs are not misread.
