### PR TITLE
Drop the ExecuTorch local version from the runtime wheel requirement

### DIFF
--- a/py/torch-tensorrt-executorch-runtime/setup.py
+++ b/py/torch-tensorrt-executorch-runtime/setup.py
@@ -156,7 +156,7 @@ setup(
     python_requires=">=3.10",
     install_requires=[
         f"torch=={public_version(torch.__version__)}",
-        f"executorch=={executorch_version}",
+        f"executorch=={public_version(executorch_version)}",
         f"torch-tensorrt=={torchtrt_version()}",
         f"{TENSORRT_DISTRIBUTION}=={tensorrt_version}",
         f"{CUDA_RUNTIME_DISTRIBUTION}=={cuda_runtime_version}",


### PR DESCRIPTION
## The problem in plain terms

The ExecuTorch runtime wheel does not hardcode its dependency versions. It reads them from whatever is installed in the build environment, then writes them into the wheel as exact pins.

That works for most dependencies, but not for ExecuTorch. ExecuTorch wheels are built separately for each accelerator, and each build tags its version with a suffix saying which one:

```
1.4.1+cpu
1.5.0.dev20260821+cu130
```

The `+cpu` and `+cu130` parts are a PEP 440 "local version". The catch is that **a local version cannot be requested from a package index.** The index publishes the plain version (`1.4.1`), so a requirement that keeps the suffix asks for something no index can serve:

```
executorch==1.4.1+cpu   ->  no matching distribution
```

So the wheel currently records a dependency that cannot be resolved.

## The fix

The repository already has a helper for exactly this, and its docstring states the reason:

```python
def public_version(version: str) -> str:
    """Drop a PEP 440 local suffix that may not be present on package indexes."""
    return version.partition("+")[0]
```

The neighbouring `torch` requirement one line above already uses it. This applies the same helper to ExecuTorch:

```diff
     install_requires=[
         f"torch=={public_version(torch.__version__)}",
-        f"executorch=={executorch_version}",
+        f"executorch=={public_version(executorch_version)}",
```

## Why only this one line

I checked each of the five requirements rather than wrapping them all:

| Requirement | Carries a local suffix? | Needs the helper |
| --- | --- | --- |
| `torch` | yes (`+cu130`) | already wrapped |
| `executorch` | yes (`+cpu`, `+cu130`) | **this change** |
| `torch-tensorrt` | no, comes from `version.txt` | no |
| `tensorrt` | no, publishes plain versions | no |
| CUDA runtime | no, publishes plain versions | no |

## Testing

Checked the transformation against the three version forms ExecuTorch actually publishes, and confirmed each result is a valid PEP 440 requirement:

```
1.4.1+cpu                 ->  1.4.1
1.5.0.dev20260821+cu130   ->  1.5.0.dev20260821
1.4.1                     ->  1.4.1          (unchanged)
```

The last row matters: when there is no suffix the helper is a no-op, so nothing changes for a plain release version.

This is a metadata-only change to one f-string. It does not affect what gets compiled or shipped, only the dependency string recorded in the wheel.
