### PR TITLE
ci: stop the uv.lock job from building the project

### DIFF
--- a/.github/workflows/uv-update.yml
+++ b/.github/workflows/uv-update.yml
@@ -20,12 +20,11 @@ jobs:
     if: ${{ ! contains(github.actor, 'pytorchbot') }}
     environment: pytorchbot-env
     container:
-      # Unlike the other jobs, this one does not run packaging/pre_build_script.sh, so it builds
-      # against the checked-in MODULE.bazel instead of one rendered from
-      # toolchains/ci_workspaces/MODULE.bazel.tmpl. That means the ${CUDA_HOME} substitution never
-      # happens here and Bazel reads the literal path in MODULE.bazel. Keep this tag's CUDA version
-      # equal to the cuda new_local_repository path in MODULE.bazel or the build fails to fetch
-      # @cuda and the lockfile silently stops being refreshed.
+      # Unlike the other jobs, this one does not run packaging/pre_build_script.sh, so Bazel reads
+      # the literal CUDA path in the checked-in MODULE.bazel rather than one rendered from
+      # toolchains/ci_workspaces/MODULE.bazel.tmpl with ${CUDA_HOME} substituted. No step here
+      # builds the project, so that path does not have to exist in this image and this tag does
+      # not have to track it.
       image: pytorch/manylinux2_28-builder:cuda13.2
       options: --gpus all
       env:
@@ -80,8 +79,19 @@ jobs:
         run: |
           set -euo pipefail
           set -x
-          if ! uv sync --frozen; then
-            echo "Error: Failed to run uv sync --frozen"
+          # --no-install-project keeps this a lockfile check. Installing the root
+          # project runs a full Bazel build of the native library, which this job
+          # does not need and which ties it to the CUDA toolkit path MODULE.bazel
+          # names. Dependencies are still downloaded and hash-verified, so a
+          # broken lock is still caught.
+          # --prerelease=allow has to match the lock step above: uv records the
+          # resolution mode in uv.lock and --locked rejects a lock resolved under
+          # a different mode.
+          # --all-extras so the optional dependencies are covered too. Dependency
+          # groups are not covered: --all-groups on its own is rejected, because
+          # pyproject.toml declares test_ext and quantization as conflicting.
+          if ! uv sync --locked --prerelease=allow --no-install-project --all-extras; then
+            echo "Error: Failed to run uv sync --locked --prerelease=allow --no-install-project --all-extras"
             exit 1
           fi
           echo "valid_changes=true" >> "$GITHUB_OUTPUT"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -74,8 +74,8 @@ new_local_repository(
 # CUDA should be installed on the system locally
 # for linux x86_64 and aarch64
 # Jobs that render MODULE.bazel from toolchains/ci_workspaces/MODULE.bazel.tmpl substitute
-# ${CUDA_HOME} here. Jobs that use this file directly, such as .github/workflows/uv-update.yml,
-# need a container that actually provides the path below.
+# ${CUDA_HOME} here. Jobs that use this file directly need a container that actually provides
+# the path below as soon as anything they run resolves a target that depends on @cuda.
 new_local_repository(
     name = "cuda",
     build_file = "@//third_party/cuda:BUILD",


### PR DESCRIPTION
## Problem

The uv-update job refreshes uv.lock and then validates it with
`uv sync --frozen`. A plain `uv sync` installs the root project, and
installing the root project runs its build backend, which runs a full Bazel
build of the native library and needs the CUDA toolkit at the exact path
MODULE.bazel names.

That build is not what this step is for. The step exists to check that the
lock the previous step just wrote is usable. Building the library only ties
a lockfile job to the CUDA layout of its container.

That tie has been breaking the job. The last successful run of this workflow
was on 2026-06-01. The CUDA upgrade that landed the next day moved the path
in MODULE.bazel to /usr/local/cuda-13.2 while this job still ran on a CUDA
13.0 container, so from then on the validation step died with `The
repository's path is "/usr/local/cuda-13.2" ... but it does not exist`.
Thirty two runs since, none of them green.

A recent change moved the container to a CUDA 13.2 tag. That removes the path
mismatch, but the two runs it has had since, 32620825255 and 32623081006, both
fail earlier than before: the GPU runner's driver does not satisfy the image's
`cuda>=13.2` requirement, so with `--gpus all` the container never starts and
no step in the job runs at all. Either way, a job whose only purpose is to
refresh a lockfile is tied to a CUDA layout it has no reason to care about.

## Solution

Validate without installing the project:

```
uv sync --locked --prerelease=allow --no-install-project --all-extras
```

`--no-install-project` skips installing the root project, which is where the
Bazel build happens, so no Bazel build runs in this job. It does not skip the
root project entirely: `pyproject.toml:53` marks version, dependencies and
optional-dependencies as dynamic, so uv reads that metadata through the build
backend, which imports setup.py. Dependencies are still downloaded, so a lock
that points at something unfetchable still fails the step. Hashes are checked
where the lock carries them, which is 2,733 of its 2,983 url entries. The 250
without one all come from download.pytorch.org and download-r2.pytorch.org,
and that includes every torch wheel.

`--locked` replaces `--frozen`. `--frozen` skips the lockfile check entirely:
it installs whatever uv.lock already says and never asks whether that lock
still matches pyproject.toml. `--locked` does ask. Since this step exists to
check the lock the previous step just wrote, that is the flag it should have
been using.

`--prerelease=allow` is needed because of that swap. The lock step above uses
it, so uv writes `[options] prerelease-mode = "allow"` into uv.lock, and
`--locked` rejects a lock resolved under a different mode. `--frozen` never
looked, which is why the flag was not needed before. Without it the step would
fail on every run that has changes to validate.

`--all-extras` so the optional dependencies are checked too. Without it the
step covers 69 of the 222 packages in the lock and never touches executorch,
which is one of the packages this workflow exists to bump. With it the step
covers 114.

The default dependency group is already covered and stays covered.
`pyproject.toml:164` opens a `[tool.uv]` table that sets no `default-groups`,
so uv's own default applies and the `dev` group is installed. `dev` includes
`lint` and `test`, so black, clang-format, isort, ruff, mypy, typos,
pre-commit, expecttest and pytest are all in the step's scope. Exported
against the committed lock, `--all-extras` yields 124 requirement lines and
`--all-extras --no-default-groups` yields 96, so the default group accounts
for 28 of them.

The non-default groups are the gap. `--all-groups` on its own is rejected,
because `pyproject.toml:174-179` declares test_ext and quantization as
conflicting. `--all-extras --all-groups --no-group quantization` is accepted
and raises the export to 190 lines. Adding it is a reasonable follow-up and is
left out here to keep this change to the one problem it is about.

Two comments described the old behaviour and are updated with it: the
container comment in this workflow and the CUDA comment in MODULE.bazel. No
step in this job builds a Bazel target now, so the container's CUDA version
no longer has to match the path in MODULE.bazel. The step that installs bazel
stays, because bazel is still needed on PATH: reading the dynamic metadata
imports setup.py and `setup.py:250-253` exits when bazel is missing. The lock
step always reads it. The validation step reads it only on a cold cache, and
in this job the lock step runs first, so the cache is warm.

## Test plan

Ran the job's two commands against this branch on CPython 3.11, which is the
interpreter the container provides.

1. `uv lock --refresh --prerelease=allow` exits 0, resolves 222 packages,
   writes `[options] prerelease-mode = "allow"` into uv.lock and moves
   executorch from 1.3.1 to 1.4.1. So a real run does reach the validation
   step with changes to validate.
2. Against that lock, the same command without `--prerelease=allow` exits 1
   with `The lockfile at 'uv.lock' needs to be updated, but '--locked' was
   provided`. This is why the flag is not optional.
3. `uv sync --locked --prerelease=allow --no-install-project --all-extras`
   exits 0 and installs 114 packages, including executorch 1.4.1.
4. The same command without `--all-extras` exits 0 and installs 69 packages,
   with no executorch.
5. Traced the PEP 517 hooks with a build backend that logs every call.
   `uv lock` calls `prepare_metadata_for_build_editable`. The sync with
   `--no-install-project` calls that same hook on a cold cache and no hook at
   all on a warm one. The sync without it calls `build_editable`, which is the
   hook that runs the Bazel build. So the flag removes the build and keeps the
   metadata read, which is what this change claims.

Not covered: this workflow has no `pull_request` trigger, so the changed step
cannot run on this pull request. It needs one run with `has_changes=true`
after merge.

That run is also still blocked by the container failure described above, which
this change does not touch. Removing the Bazel build is what makes the GPU
runner and the `--gpus all` container unnecessary here, but actually changing
them is a separate decision about where this job should run, and it belongs in
its own change.