### PR TITLE
ci: stop gdb --batch from masking native runtime crashes

### DIFF
--- a/.github/workflows/executorch-test-linux.yml
+++ b/.github/workflows/executorch-test-linux.yml
@@ -65,12 +65,23 @@ jobs:
         export PATH="${RUNNER_TEMP}/bin:${PATH}"
 
         python -m pip install pyyaml "executorch==1.4.1"
-        # Keep this diagnostic until the native runtime initialization crash is understood.
+        # Run the check directly so its exit status is the step's exit status.
+        # Wrapping it in `gdb --batch` reports gdb's own status, which is 0
+        # whatever the program does, so a SIGSEGV here was passing.
+        # On failure, re-run under gdb for the backtrace, then fail the step.
         ulimit -c unlimited || true
-        if command -v gdb >/dev/null 2>&1; then
-          gdb --batch -ex "set pagination off" -ex run -ex "thread apply all bt" --args python -u -X faulthandler -c 'import torch; print(torch.__version__, torch.version.cuda); from torch_tensorrt_executorch_runtime import BACKEND_NAME, get_runtime; print(1); runtime = get_runtime(); print(2); assert runtime.backend_registry.is_available(BACKEND_NAME); assert runtime.backend_registry.is_available("XnnpackBackend"); assert runtime.backend_registry.is_available("CudaBackend")'
-        else
-          PYTHONFAULTHANDLER=1 python -u -X faulthandler -c 'import torch; print(torch.__version__, torch.version.cuda); from torch_tensorrt_executorch_runtime import BACKEND_NAME, get_runtime; print(1); runtime = get_runtime(); print(2); assert runtime.backend_registry.is_available(BACKEND_NAME); assert runtime.backend_registry.is_available("XnnpackBackend"); assert runtime.backend_registry.is_available("CudaBackend")'
+        runtime_check='import torch; print(torch.__version__, torch.version.cuda); from torch_tensorrt_executorch_runtime import BACKEND_NAME, get_runtime; print(1); runtime = get_runtime(); print(2); assert runtime.backend_registry.is_available(BACKEND_NAME); assert runtime.backend_registry.is_available("XnnpackBackend"); assert runtime.backend_registry.is_available("CudaBackend")'
+        check_status=0
+        PYTHONFAULTHANDLER=1 python -u -X faulthandler -c "${runtime_check}" ||
+          check_status=$?
+        if [[ "${check_status}" -ne 0 ]]; then
+          echo "::error::native runtime check failed with status ${check_status}"
+          if command -v gdb >/dev/null 2>&1; then
+            gdb --batch -ex "set pagination off" -ex run \
+              -ex "thread apply all bt" \
+              --args python -u -X faulthandler -c "${runtime_check}" || true
+          fi
+          exit "${check_status}"
         fi
 
         source tests/py/utils/ci_helpers.sh


### PR DESCRIPTION
## Problem

The native runtime check ran as the inferior of `gdb --batch`, so the step
observed gdb's exit status instead of the program's. `gdb --batch` exits 0
whatever the program does, so a crash in this check reported success.

It has been hiding a real crash. Job 96637181841
(`executorch-runtime-test--3.10-cu130`, run 32426063155) is recorded as
SUCCESS and its log contains:

```
Thread 1 "python" received signal SIGSEGV, Segmentation fault.
0x00007fdc65acf944 in std::codecvt<char16_t, char, __mbstate_t>::do_unshift(...)
  from .../torch_tensorrt_executorch_runtime/libaoti_cuda_shims.so
...
Thread 1 (Thread 0x7fdd5782b740 (LWP 1907) "python"):
#0  0x00007fdc65acf944 in ...do_unshift... from .../libaoti_cuda_shims.so
#2  0x00007fdc3f4e05b1 in ?? () from .../tensorrt_libs/libnvinfer.so.11
#3  0x00007fdc3e478838 in ?? () from .../tensorrt_libs/libnvinfer.so.11
#4  0x00007fdd5760f11a in call_init (...) at dl-init.c:72
#6  _dl_init (main_map=0x1e33b870, ...) at dl-init.c:119
#11 0x00007fdd57616b81 in _dl_open (
      file=".../torch_tensorrt_executorch_runtime/_portable_lib.cpython-310-x86_64-linux-gnu.so",
      ...) at dl-open.c:870
```

Thread 1's backtrace puts the crash in a static initializer of
`tensorrt_libs/libnvinfer.so.11`, reached from `_dl_open` of
`torch_tensorrt_executorch_runtime/_portable_lib...so`, which the check
triggers through `get_runtime()`. The script printed `1` and never printed
`2`, so `get_runtime()` never returned and none of the three backend
assertions ran. Green check, dead process.

## Solution

Run the check directly so its status is the step's status, and re-run it
under gdb only on failure, so a reproducible failure still produces a
backtrace.

Measured with gdb 9.1 on three programs: a clean exit, an exit 1, and a
segfault.

| invocation | exit 0 | exit 1 | SIGSEGV |
| --- | --- | --- | --- |
| direct | 0 | 1 | 139 |
| `gdb --batch -ex run` | 0 | 0 | 0 |
| `gdb --batch --return-child-result -ex run` | 0 | 1 | 255 |

`--return-child-result` would also have unmasked the crash. The direct run is
preferred because the status then comes from the program running on its own
rather than from a process under a debugger, so nothing gdb does to it can
change the result. The exit code is also the true one, 139 for a signal where
`--return-child-result` reports 255.

The cost is that a failing check runs twice, once for the status and once
for the backtrace. That is acceptable, because the second run only happens
when the step is already failing.

The Python one-liner was written out twice, once for each branch of the old
`if command -v gdb` test. It is now a shell variable so the two runs cannot
drift apart. The one-liner itself is byte for byte unchanged.

## What lands with this

This does not fix the SIGSEGV. It stops the SIGSEGV being reported as green.

`executorch-runtime-test` runs only when `executorch-runtime-build`
succeeds, which `ci-linux-x86_64.yml:148` enforces. That build is failing
today: on run 32629959843, a main run carrying no changes at all, every one of
the ten `executorch-runtime-build` rows failed and `executorch-runtime-test`
was skipped. So this change is inert until the build is fixed. Once it is, the
test job will run and, until the SIGSEGV is fixed, fail. That is the
intended outcome. A crash should be red.

If a red run is not wanted, there are two ways to soften it, and this change
takes neither. `linux-test.yml:48` declares a `continue-on-error` input and
`:166` applies it to the "Pack script" step; the "Run Script" step at `:179`,
where this check runs, does not reference it, so the same line added there
would let the step fail without failing the job. The other way is to drop
`executorch-runtime-test` from the `gate` job's `needs` at
`ci-linux-x86_64.yml:159`, which is what decides whether the run as a whole
goes red.

## Test plan

Measured the exit status table above with gdb 9.1 on the three programs
described.

Not covered: the changed script cannot run in this pull request's own CI,
because `executorch-runtime-build` fails before the test job would start and
`executorch-runtime-test` is therefore skipped. It needs one run on a branch
where that build succeeds.