### PR TITLE
ci: fix the ExecuTorch runtime artifact name collapsing to one name

### DIFF
--- a/.github/workflows/executorch-build-linux.yml
+++ b/.github/workflows/executorch-build-linux.yml
@@ -56,7 +56,7 @@ jobs:
       build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
       pre-script: packaging/pre_build_script.sh
       fail-on-empty: false
-      upload-artifact: torch-tensorrt-executorch-runtime-${{ matrix.python_version }}-${{ matrix.desired_cuda }}-${{ inputs.architecture }}
+      upload-artifact: torch-tensorrt-executorch-runtime
       script: |
         set -euo pipefail
         BAZELISK_VERSION="1.26.0"

--- a/.github/workflows/executorch-test-linux.yml
+++ b/.github/workflows/executorch-test-linux.yml
@@ -55,7 +55,7 @@ jobs:
       test-infra-ref: ${{ inputs.test-infra-ref }}
       build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
       pre-script: packaging/pre_build_script.sh
-      additional-artifact: torch-tensorrt-executorch-runtime-${{ matrix.python_version }}-${{ matrix.desired_cuda }}-${{ inputs.architecture }}
+      additional-artifact: torch-tensorrt-executorch-runtime
       script: |
         set -euo pipefail
         mkdir -p "${RUNNER_TEMP}/bin"

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -50,11 +50,11 @@ on:
         default: false
         type: boolean
       upload-artifact:
-        description: 'Name to give wheel artifacts uploaded from the repository dist directory'
+        description: 'Name prefix for wheel artifacts uploaded from the repository dist directory. This workflow appends -<python_version>-<desired_cuda>-<architecture>, plus -python-only and -rtx when those inputs are set. Rows that differ only in matrix.tensorrt.version are not separated by it.'
         default: ''
         type: string
       additional-artifact:
-        description: "Optional additional artifact to install alongside the core wheel"
+        description: "Name prefix of an optional additional artifact to install alongside the core wheel. The same suffix is appended, so it lines up with what upload-artifact produced when both calls are given the same build matrix and the same architecture."
         default: ""
         type: string
       use-rtx:
@@ -94,6 +94,10 @@ jobs:
       ARCH: ${{ inputs.architecture }}
       USE_TRT_RTX: ${{ inputs.use-rtx }}
       DOWNLOAD_ARTIFACT_NAME: pytorch_tensorrt_${{ matrix.tensorrt.version }}_${{ matrix.python_version }}_${{ matrix.desired_cuda }}_${{ inputs.architecture }}${{ inputs.python-only && '_python_only' || '' }}${{ inputs.use-rtx && '_rtx' || '' }}
+      # matrix.* and inputs.architecture are out of scope at a workflow_call site, so a
+      # per-row suffix can only be built here. The stem stays with the caller, and the
+      # producer and the consumer have to pass the same one.
+      ARTIFACT_NAME_SUFFIX: ${{ matrix.python_version }}-${{ matrix.desired_cuda }}-${{ inputs.architecture }}${{ inputs.python-only && '-python-only' || '' }}${{ inputs.use-rtx && '-rtx' || '' }}
     name: ${{ inputs.job-name }}-${{ matrix.tensorrt.version }}-${{ matrix.python_version }}-${{ matrix.desired_cuda }}
     runs-on: ${{ inputs.runner != '' && inputs.runner || matrix.validation_runner }}
     container:
@@ -168,7 +172,7 @@ jobs:
         if: ${{ inputs.additional-artifact != '' }}
         uses: actions/download-artifact@v7
         with:
-          name: ${{ inputs.additional-artifact }}
+          name: ${{ inputs.additional-artifact }}-${{ env.ARTIFACT_NAME_SUFFIX }}
           path: /opt/torch-tensorrt-builds/
       - name: Pack script
         continue-on-error: ${{ inputs.continue-on-error }}
@@ -226,7 +230,7 @@ jobs:
         uses: actions/upload-artifact@v6
         if: ${{ inputs.upload-artifact != '' }}
         with:
-          name: ${{ inputs.upload-artifact }}
+          name: ${{ inputs.upload-artifact }}-${{ env.ARTIFACT_NAME_SUFFIX }}
           path: ${{ inputs.repository }}/dist/
           if-no-files-found: error
 


### PR DESCRIPTION
## Problem

`executorch-build-linux.yml` built its artifact name from `matrix.*` and
`inputs.architecture` at the point where it calls `linux-test.yml`. Neither
one holds a value there.

A calling job can read `matrix` at a `with:` key, but only its own:
`_test-linux.yml:131-138` declares a `strategy` and passes `matrix.suite` in
exactly that position. The two ExecuTorch jobs, `executorch-build-linux.yml:47`
and `executorch-test-linux.yml:47`, declare no `strategy` at all. The ten rows
come from the matrix `linux-test.yml` builds for itself, which does not exist
yet at the call site, so `matrix.*` there is empty. `architecture` is not
declared in either ExecuTorch workflow's `workflow_call` inputs either, so
`inputs.architecture` is undefined too. All three interpolations rendered as
the empty string and every row uploaded under one literal name:

```
torch-tensorrt-executorch-runtime---
```

Run 32426063155 contains exactly that artifact, 5,183,012 bytes. The download
side of `executorch-test-linux.yml` built its name from the same three
interpolations, so producer and consumer agreed on the wrong name and the
mistake stayed invisible.

Nothing is lost yet, because that run had one row. On a pull request the
matrix reduces to a single row, and run 32426063155 was one: job 96629066505
uploaded under the collapsed name and job 96637181841 downloaded it, both
steps green. Once ten rows run, which is what a push to main produces, all ten
go through the same upload under that one name, and neither outcome is
acceptable:

- Several artifacts end up sharing a name. Measured on the `@v4.6.2` upload at
  `build_linux.yml:450`, which had the same collision until it was fixed on
  main, a second upload under an already finalized name is accepted rather
  than rejected. In run 32510769801, job 96861736307 finalized
  `pytorch_tensorrt__3.10_cu130_x86_64` as artifact 9457600534, 4,186,575
  bytes, and job 96861752281 finalized the same name as artifact 9457991253,
  636,178 bytes, twelve minutes later. Two records with two ids and two sizes,
  and an artifact is only listed once its finalize call has returned. The step
  status is no evidence either way, since that upload runs under
  `continue-on-error: true`. That run holds 340 artifacts and 20 duplicated
  names.
- `download-artifact` then picks one by id. None of this repository's calls
  pass a `github-token`, so it takes the same-run path in `actions/toolkit`,
  `packages/artifact/src/internal/find/get-artifact.ts:109-111`, which sorts
  on `databaseId` descending and takes the first. The newest wins, so a test
  row can be handed the wheel of another row. If the two rows differ in Python
  version, pip refuses the wheel, because its ABI tag does not match the
  interpreter, and the row fails loudly. If they differ only in CUDA version,
  the wheel installs cleanly and the row silently tests the wrong build.

The upload this change touches is pinned at `@v6`, at `linux-test.yml:230`,
and sets no `overwrite` and no `continue-on-error`. Whether v6 also accepts
the second upload or rejects it is not established here. If it rejects, the
step and the job fail. If it accepts, the run behaves like the case above.

## Solution

Build the per-row suffix inside `linux-test.yml`, where `matrix.*` is in
scope and `architecture` is declared at `:34-38` with an `x86_64` default,
and pass only the stem from the callers.

The suffix is a job-level `env`, `ARTIFACT_NAME_SUFFIX` at `:100`, next to the
existing `DOWNLOAD_ARTIFACT_NAME` at `:96`. The upload at `:233` and the
download at `:175` both append it. It has to be built here rather than at the
call sites, since that is the only place where the values it needs are in
scope.

Producer and consumer are still two separate calls of `linux-test.yml`,
`executorch-build-linux.yml:49` and `executorch-test-linux.yml:49`. They
produce the same suffix because `ci-linux-x86_64.yml:138` and `:155` hand both
of them the same `generate-matrix` output and neither passes `architecture`,
so both take its `x86_64` default. The stem is still written separately in
`executorch-build-linux.yml:59` and `executorch-test-linux.yml:58`, so that
half is still kept in step by hand. This change narrows the failure mode, it
does not remove it entirely.

The suffix is Python version, CUDA version, architecture, and the
`python-only` and `use-rtx` markers when those inputs are set. The last two
follow `DOWNLOAD_ARTIFACT_NAME` at `linux-test.yml:96` and the fixes in #4569
and #4561: one
call site can be reached by several channels in a single run that differ only
in those two flags, and then the caller's stem cannot tell them apart. No
caller sets a stem and one of those flags together today, so this part is a
guard rather than a fix.

The suffix still leaves out `matrix.tensorrt.version`, which
`DOWNLOAD_ARTIFACT_NAME` does include, because no matrix reaching these two
inputs carries that key: `filter-matrix.py` does not emit one, and
`generate-tensorrt-test-matrix.py`, which does, has no caller under
`.github/`. A matrix that varied only by that key would still collide.

The two reusable inputs changed meaning, from a full artifact name to a
prefix, so their descriptions at `linux-test.yml:52-59` are updated to say so,
to name what gets appended, and to state that gap.

## Blast radius

`linux-test.yml` has three callers: `_test-linux.yml:136`,
`executorch-build-linux.yml:49` and `executorch-test-linux.yml:49`.
`_test-linux.yml` sets neither `upload-artifact` nor `additional-artifact`,
both default to `''`, and both steps are gated on the input being non-empty,
so it is unaffected. A grep of `.github/` finds no other producer or
consumer of this artifact name.

## Test plan

`actionlint` 1.7.12, run by hand since this repository does not run it in CI,
reports the bug on the base commit: `property "python_version" is not defined
in object type {}` at `executorch-build-linux.yml:59` and
`executorch-test-linux.yml:58`, where the empty object type is the missing
matrix at the call site. Both diagnostics are gone at this commit, and no new
diagnostic appears anywhere in `.github/workflows/`.

On a plain `pull_request` event the ExecuTorch matrix reduces to one row, and
the expected artifact name is
`torch-tensorrt-executorch-runtime-3.10-cu130-x86_64`. That row is 3.10 and
not 3.12 because `generate_binary_build_matrix` emits four rows on that event,
all `python_version` 3.10, so `pick_pr_representative` in
`.github/scripts/filter-matrix.py` finds no 3.12 row, falls through to the
first entry, and the resulting job is named
`executorch-runtime-build--3.10-cu130`. Job 97227000366 on this branch printed
`ARTIFACT_NAME_SUFFIX: 3.10-cu130-x86_64`, which is that value; this caller
sets neither `python-only` nor `use-rtx`, so the two new markers are empty for
it. Other events keep the full matrix and the 3.12 preference does apply: run
32654482563 on this branch, triggered by a review, selected
`executorch-runtime-build--3.12-cu130`, so the expected name there ends in
`-3.12-cu130-x86_64`.

Not covered: the changed upload has never executed. `executorch-runtime-build`
exits 134 before reaching the artifact steps, on this branch and on main
alike, most recently in job 97183822776 on main, so that failure is not from
this change and both the renamed upload at `linux-test.yml:233` and the
renamed download at `:175` are unexercised. Once the build lane is green, the check is to look at
the run's artifact list and confirm ten distinctly named
`torch-tensorrt-executorch-runtime-*` entries, and that the test job downloads
the one matching its own row.
