### PR TITLE
ci: check the ExecuTorch build job installed a wheel with the C++ runtime

### DIFF
--- a/.github/workflows/executorch-build-linux.yml
+++ b/.github/workflows/executorch-build-linux.yml
@@ -82,6 +82,13 @@ jobs:
         python -m pip install pyyaml "executorch==1.4.1"
         export TORCH_TENSORRT_EXECUTORCH_RUNTIME_VERSION="$(python -c 'import importlib.metadata; print(importlib.metadata.version("torch-tensorrt"))')"
 
+        # The downloaded wheel has to carry the C++ runtime. A wheel built with
+        # PYTHON_ONLY=1 has no libtorchtrt.so, which leaves
+        # ENABLED_FEATURES.torch_tensorrt_runtime False, and the export near the
+        # end of this script then fails after the Bazel builds have already run.
+        # Check it here so the wrong wheel is reported as the wrong wheel.
+        python -c 'from torch_tensorrt._features import ENABLED_FEATURES as f; assert f.torch_tensorrt_runtime, f'
+
         # Bazel truncates a failing action's output at 1 MB by default and then
         # prints nothing but the size, which hid the real error behind
         #   stdout ... exceeds maximum size of


### PR DESCRIPTION
## Problem

`executorch-runtime-build` installs a `torch_tensorrt` wheel that it downloads
from its own run, and then exports a model, which needs the C++ runtime. A wheel
built with `PYTHON_ONLY=1` ships no `lib/libtorchtrt.so`, so `_features.py:51`
leaves `_TORCHTRT_RT_AVAIL` False and the job fails at `_compile.py:1365`.

Nothing makes that happen today. #4569 gave the python-only lane its own
artifact name, so the name this job downloads has a single producer and the job
gets the full wheel. What is left is a regression risk, not a live bug.

What makes it worth a check is where the failure lands. The export runs near the
end of the script, after the runtime wheel build and the `//:libtorchtrt` build.
Measured on the `3.10-cu130` row in job 97183822776: the whole script step takes
44.8 minutes, and those two builds account for 29.1 and 5.2 minutes of it, both
before the export. So a wheel without the runtime costs around 35 minutes before
anything is reported, and the message then points at the export rather than at
the wheel.

## Solution

Assert `ENABLED_FEATURES.torch_tensorrt_runtime` immediately after the
downloaded wheel's version is captured, which is the first point in the script
where the wheel is installed and importable. The assertion prints the whole
feature set, so a failure says which features are missing.

One line and a comment. It changes nothing when the wheel is correct.

This is what remains of a larger change. The rest of it built the wheel from the
checkout and installed it over the downloaded one, to make the job independent
of which upload won. #4569 removed the reason for that, so it is dropped rather
than rebased.

## Test plan

The expression is the one the library already uses, at `_compile.py:1365` and
`_features.py:124`, reading the `FeatureSet` field declared at
`_features.py:17-21`.

An earlier revision of this branch ran this same line in CI, in job 97182421448
(`executorch-runtime-build--3.10-cu130`), after a full wheel was installed. It
passed, so the expression evaluates and imports correctly in this image.

Not covered: the assertion has not been observed failing in this job, and it has
not yet run against the wheel the job downloads rather than one installed by the
step before it.