### PR TITLE
Derive the ExecuTorch requirement from the version pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ def load_dep_info():
     global __tensorrt_version__
     global __tensorrt_rtx_version__
     global __tensorrt_llm_version__
+    global __executorch_version__
     with open("dev_dep_versions.yml", "r") as stream:
         versions = yaml.safe_load(stream)
         if (gpu_arch_version := os.environ.get("CU_VERSION")) is not None:
@@ -83,6 +84,7 @@ def load_dep_info():
         __tensorrt_version__ = versions["__tensorrt_version__"]
         __tensorrt_rtx_version__ = versions["__tensorrt_rtx_version__"]
         __tensorrt_llm_version__ = versions["__tensorrt_llm_version__"]
+        __executorch_version__ = versions["__executorch_version__"]
 
 
 load_dep_info()
@@ -206,7 +208,11 @@ else:
 # runtime API is not stable across minor releases, and an unbounded floor would resolve a future
 # minor against a backend built for this one. Patch releases stay allowed because they come off the
 # same release branch; the exact pin belongs in the runtime package, which does derive it.
-EXECUTORCH_REQUIREMENT = "executorch>=1.4.1,<1.5"
+_executorch_major, _executorch_minor = __executorch_version__.split(".")[:2]
+EXECUTORCH_REQUIREMENT = (
+    f"executorch>={__executorch_version__},"
+    f"<{_executorch_major}.{int(_executorch_minor) + 1}"
+)
 # TODO: Enable this once the runtime wheel is published to the PyTorch index.
 # EXECUTORCH_RUNTIME_REQUIREMENT = (
 #     f"torch-tensorrt-executorch-runtime=={__version__}; " "platform_system == 'Linux'"

--- a/tests/ci/runner.py
+++ b/tests/ci/runner.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import glob
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -20,6 +21,19 @@ from .suites import SUITES, Suite, Variant, by_name
 REPO_ROOT = Path(
     os.environ.get("TRT_REPO_ROOT", str(Path(__file__).resolve().parents[2]))
 )
+
+
+def _executorch_requirement() -> str:
+    # Read the pin the way the drift test does, so this file is not a second
+    # place to edit when it moves. Regex rather than yaml: the runner declares
+    # no runtime dependencies of its own and importing it should not add one.
+    text = (REPO_ROOT / "dev_dep_versions.yml").read_text()
+    version = dict(re.findall(r'^(__\w+__): "([^"]+)"', text, re.MULTILINE))[
+        "__executorch_version__"
+    ]
+    major, minor = version.split(".")[:2]
+    return f"executorch>={version},<{major}.{int(minor) + 1}"
+
 
 # Known transient cudagraph/TRT-driver flake signatures. Expand ONLY with
 # concrete evidence — a broad regex hides real bugs.
@@ -119,7 +133,8 @@ def _setup_commands(step: str) -> list[tuple[list[str], Path]]:
     if step == "executorch":
         return [
             (
-                launcher + ["-m", "pip", "install", "pyyaml", "executorch>=1.4.1,<1.5"],
+                launcher
+                + ["-m", "pip", "install", "pyyaml", _executorch_requirement()],
                 REPO_ROOT,
             )
         ]

--- a/tests/py/dynamo/executorch/test_executorch_pin.py
+++ b/tests/py/dynamo/executorch/test_executorch_pin.py
@@ -10,8 +10,11 @@ compatible patch release, and a build input that takes a range could resolve an 
 the artifact was not compiled against.
 """
 
+import ast
+import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -31,11 +34,12 @@ NAMED_COMMIT = re.compile(r"executorch[_a-z]*[^0-9a-f]*([0-9a-f]{40})", re.IGNOR
 # Requirements that end up in metadata someone resolves at install time. A patch release off
 # the same branch has to stay installable, so these take the range. Everything else pins
 # exactly: a build input compiled against one wheel, or a comment labelling a source sha.
+# Only literal requirements land here. setup.py and tests/ci/runner.py derive theirs from
+# dev_dep_versions.yml, so the search below no longer sees them and
+# test_derived_requirements_match_the_pin covers them instead.
 RANGE_SITES = frozenset(
     {
-        "setup.py",
         "justfile",
-        "tests/ci/runner.py",
     }
 )
 
@@ -97,6 +101,72 @@ def test_every_requirement_matches_the_pin() -> None:
 
     assert found, "no ExecuTorch requirement found, so this test is not looking"
     assert not wrong, "\n  ".join(["", *wrong])
+
+
+def _setup_py_requirement(version: str) -> str:
+    # setup.py cannot be imported here, importing it starts a build, so lift out the
+    # statements that derive the requirement and evaluate only those.
+    derived = {"_executorch_major", "_executorch_minor", "EXECUTORCH_REQUIREMENT"}
+    statements = [
+        node
+        for node in ast.parse((REPO_ROOT / "setup.py").read_text()).body
+        if isinstance(node, ast.Assign)
+        and derived
+        & {
+            name.id
+            for target in node.targets
+            for name in ast.walk(target)
+            if isinstance(name, ast.Name)
+        }
+    ]
+    assert statements, "setup.py no longer derives EXECUTORCH_REQUIREMENT"
+
+    namespace: dict = {"__executorch_version__": version}
+    exec(compile(ast.Module(statements, []), "setup.py", "exec"), namespace)
+    return namespace["EXECUTORCH_REQUIREMENT"]
+
+
+def _runner_requirement(root: Path) -> str:
+    # A subprocess rather than an import, so pointing the runner at another tree cannot
+    # leave a reloaded module behind for whatever runs next.
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from tests.ci.runner import _executorch_requirement; "
+            "print(_executorch_requirement())",
+        ],
+        cwd=REPO_ROOT,
+        env={**os.environ, "TRT_REPO_ROOT": str(root)},
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def test_derived_requirements_match_the_pin() -> None:
+    # setup.py and tests/ci/runner.py build their requirement from the pin, so the search
+    # above cannot see them. Check the strings they produce instead.
+    version = _versions()["__executorch_version__"]
+    major, minor, _ = version.split(".")
+    expected = f"executorch>={version},<{major}.{int(minor) + 1}"
+
+    assert _setup_py_requirement(version) == expected
+    assert _runner_requirement(REPO_ROOT) == expected
+
+
+def test_derived_requirements_roll_the_minor_over(tmp_path: Path) -> None:
+    # The upper bound is a version, not a decimal: 1.9 has to become 1.10, not 1.1.
+    # Spelled through a variable because the search above reads this file too, and a
+    # written-out requirement here would read as a site that drifted from the pin.
+    version = "1.9.0"
+    expected = f"executorch>={version},<1.10"
+    (tmp_path / "dev_dep_versions.yml").write_text(
+        f'__executorch_version__: "{version}"\n'
+    )
+
+    assert _setup_py_requirement(version) == expected
+    assert _runner_requirement(tmp_path) == expected
 
 
 def test_every_source_commit_matches_the_pin() -> None:


### PR DESCRIPTION
## Problem

The ExecuTorch version is written out by hand in every place that needs it.
Moving the pin means editing each copy and hoping none was missed.
`dev_dep_versions.yml` already holds the value, so the places that run Python
and can read a file should read it instead of repeating it.

#4548 added a test that fails when the copies disagree. That test catches a
missed edit, but somebody still has to make every edit. This removes two of the
copies, so there is less to edit next time.

## Solution

Two sites now build the requirement from `__executorch_version__`:

- `setup.py`. `load_dep_info()` already opens `dev_dep_versions.yml` for the
  CUDA and TensorRT versions, so this reads `__executorch_version__` next to
  them.
- `tests/ci/runner.py`, the `executorch` setup step. This file declares no
  runtime dependencies of its own, so it reads the pin with a regular
  expression rather than pulling in `yaml`. That is how the drift test already
  reads the same file.

Both produce the shape the comment above `EXECUTORCH_REQUIREMENT` describes:
the floor is the pinned version, the ceiling is the next minor. With the
current pin that is `executorch>=1.4.1,<1.5`, byte for byte the literal each
one replaces.

Counting every requirement the drift test scans, and leaving out
`dev_dep_versions.yml` itself, the repository goes from 13 lines in 11 files to
11 lines in 9 files.

## What stays literal, and why

Four of the remaining lines are comments sitting next to the Bazel `commit =`
they label, in `MODULE.bazel`, `docker/MODULE.bazel.docker`,
`docker/MODULE.bazel.ngc` and `toolchains/ci_workspaces/MODULE.bazel.tmpl`.
Nothing evaluates them.

Two are in `py/torch-tensorrt-executorch-runtime/README.md`: one command a
reader copies and one sentence of prose.

One is `[build-system] requires` in
`py/torch-tensorrt-executorch-runtime/pyproject.toml`. That is static TOML,
read before any build backend exists, so there is nowhere to run a lookup.

The last four could read the YAML but are left alone on purpose: three shell
lines in the workflows (`executorch-build-linux.yml` twice and
`executorch-test-linux.yml`) and one in the `justfile`. Reading YAML from shell
means either a `python -c` line in front of every install or a `yq`
dependency, and `test_every_requirement_matches_the_pin` already blocks a wrong
value from landing. Trading a readable one-line install for a parsing step buys
nothing here.

## RANGE_SITES

The drift test decides per site whether the requirement should be an exact pin
or a range, and `setup.py` and `tests/ci/runner.py` were listed as range sites.
Its search can no longer find a literal in either file, so those two entries
became unreachable and are removed. `justfile` stays, because its line is still
literal.

## Tests

Two tests are added, next to the drift test:

- `test_derived_requirements_match_the_pin` checks both derived strings against
  what the pin implies. Without it the two sites would have no coverage at all,
  since the search-based test can no longer see them.
- `test_derived_requirements_roll_the_minor_over` feeds in `1.9.0` and checks
  the ceiling comes out as `1.10` and not `1.1`. The bound is a version, not a
  decimal number.

Reading the values back is awkward on both sides, and the helpers carry a
comment saying why. `setup.py` cannot be imported here, importing it starts a
build, so the test parses the file and evaluates only the assignments that
derive the requirement. The runner is read through a subprocess, so pointing it
at a temporary tree cannot leave a reloaded module behind for whatever runs
next.

One wrinkle worth knowing if you edit these tests: the drift test scans this
file too, so a requirement written out in full inside the rollover test reads
as a site that drifted from the pin. The expected string is built from a
variable for that reason.

## Test plan

Run locally on Python 3.11:

```
pytest tests/py/dynamo/executorch/test_executorch_pin.py
4 passed
```

That is the whole file: the two drift tests that were already there and the two
new ones. Both drift tests still pass, which also confirms the shortened
`RANGE_SITES` did not reclassify any site that is still literal.

`black --check` and `isort --check-only` are clean on the three changed files.
`ruff check` reports the same nine findings before and after this change, all
of them pre-existing in `setup.py` and `tests/ci/runner.py`, so none are new.

Not exercised: nothing here touches a build or a GPU path, so no ExecuTorch
suite was run.
