### PR TITLE
fix(tests): repair two ExecuTorch save() tests broken by production changes

### DIFF
--- a/tests/py/dynamo/executorch/test_api.py
+++ b/tests/py/dynamo/executorch/test_api.py
@@ -744,9 +744,14 @@ def test_public_save_forwards_lowering_kwargs_graphmodule_no_retrace(
 
     calls = _stub_save_as_executorch(monkeypatch)
     # retrace=False routes through the dynamo exporter (TRT-specific graph surgery);
-    # stub it so the test isolates save()'s option extraction + forwarding.
-    sentinel_ep = object()
-    monkeypatch.setattr(_exporter, "export", lambda *a, **k: sentinel_ep)
+    # stub it so the test isolates save()'s option extraction + forwarding. The stub
+    # returns a real ExportedProgram because save() runs
+    # _declare_aliased_kv_mutations_on_ep over the exporter's result before forwarding
+    # it, and that pass reads .graph_module / .graph_signature. This program has no
+    # engine nodes, so the pass returns it unchanged and the identity assertion below
+    # still pins exactly what the exporter produced.
+    stub_ep = torch.export.export(_AddOne(), (torch.randn(2, 2),))
+    monkeypatch.setattr(_exporter, "export", lambda *a, **k: stub_ep)
 
     methods = {"get_max_seq_len": 128}
     passes = [object()]
@@ -769,7 +774,7 @@ def test_public_save_forwards_lowering_kwargs_graphmodule_no_retrace(
     )
 
     assert len(calls) == 1
-    assert calls[0]["module"] is sentinel_ep
+    assert calls[0]["module"] is stub_ep
     _assert_lowering_kwargs_forwarded(calls[0]["kwargs"], methods, passes, cfg)
 
 

--- a/tests/py/dynamo/executorch/test_edge_cases.py
+++ b/tests/py/dynamo/executorch/test_edge_cases.py
@@ -56,10 +56,19 @@ def test_save_as_executorch_uses_public_lowering_and_persists_data(
         backend_config=backend_config,
     )
 
+    # The complete set of lowering options _save_as_executorch forwards. The five this
+    # test does not pass are still forwarded explicitly, as None or False rather than
+    # left out. backend_config is absent by design -- it is not a lowering option and is
+    # routed to to_executorch() below.
     export.assert_called_once_with(
         source,
         partitioners=partitioners,
         compile_specs=compile_specs,
+        transform_passes=None,
+        compile_config=None,
+        constant_methods=None,
+        generate_etrecord=False,
+        weight_streaming_budget_per_engine=None,
     )
     edge.to_executorch.assert_called_once_with(config=backend_config)
     program.write_to_file.assert_called_once()


### PR DESCRIPTION
## Summary

Two tests under `tests/py/dynamo/executorch/` currently fail on `main`. Both are defects in the tests themselves — each was left behind when the production code it pins changed underneath it — and in both cases the production behaviour is correct and unchanged by this PR.

`tests/py/dynamo/executorch/test_api.py::test_public_save_forwards_lowering_kwargs_graphmodule_no_retrace` fails with `AttributeError: 'object' object has no attribute 'graph_module'`. The test stubs the dynamo exporter so it can assert exactly what `save()` forwards to `_save_as_executorch`, and the stub returned a bare `object()` marker. #4445 subsequently inserted a call to `_declare_aliased_kv_mutations_on_ep()` between the exporter and `_save_as_executorch` on the `retrace=False` path, and that pass dereferences `.graph_module` and `.graph_signature` on the exporter's result — so the opaque marker no longer survives the trip. The fix is for the stub to return a real, engine-free `ExportedProgram`. That program contains no `execute_engine` nodes, so `_declare_aliased_kv_mutations_on_ep()` returns it unchanged and the test's identity assertion still pins the forwarded object exactly as before; as a bonus the test now also covers that pass's no-op path.

`tests/py/dynamo/executorch/test_edge_cases.py::test_save_as_executorch_uses_public_lowering_and_persists_data` fails with `AssertionError: expected call not found`. The test pins the exact call `_save_as_executorch` makes into the public `torch_tensorrt.executorch.export()`, using `assert_called_once_with`. #4433 added `transform_passes`, `compile_config`, `constant_methods` and `generate_etrecord` to that call site, and #4336 added `weight_streaming_budget_per_engine`; neither PR updated the expectation, which still listed only `partitioners` and `compile_specs`. The fix brings the expectation back in line with the call site, listing all seven forwarded lowering options. `backend_config` is deliberately not among them: it is not a lowering option and is routed to `to_executorch()` instead, which the immediately following assertion already covers.

## Changes

Test-only. No production code is modified.

- `tests/py/dynamo/executorch/test_api.py` — the stubbed dynamo exporter returns a real `ExportedProgram` instead of a bare `object()`.
- `tests/py/dynamo/executorch/test_edge_cases.py` — the `assert_called_once_with` expectation lists the complete set of options forwarded to `export()`.

## Testing

`pytest tests/py/dynamo/lowering/test_buffer_lifting.py tests/py/dynamo/executorch/` goes from `4 failed, 194 passed` to `2 failed, 196 passed`. The two remaining failures (`test_cuda_partitioner_composition.py::test_erfinv_routes_to_cuda_backend` and `::test_weighted_partition_persists_external_data`) are unrelated to this change and are environmental: they need a full CUDA toolkit to AOT-compile the CUDA-backend partition, and fail with `fatal error: cuda.h: No such file or directory`.

Both fixed tests were confirmed to still discriminate — each one fails again when the production behaviour it exists to pin is deliberately broken (dropping a forwarded lowering kwarg, forwarding the wrong module, bypassing the public `export()` re-export, skipping the external-tensor-data write, or forwarding a wrong default).
