### PR TITLE
fix(ci): build the Windows download artifact name in the right order

### DIFF
--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -108,10 +108,15 @@ jobs:
           setup-miniconda: false
           python-version: ${{ env.PYTHON_VERSION }}
           cuda-version: ${{ env.CU_VERSION }}
-          arch: ${{ env.ARCH }}
+          # Same value build_windows.yml passes, so the name built here comes out
+          # identical to the one the build uploaded. ARCH is not set anywhere in
+          # this workflow, so the architecture has to come from the input.
+          arch: ${{ inputs.architecture }}
       # The default matrix entries have matrix.tensorrt == '', so their
       # download branch uses ARTIFACT_NAME rather than DOWNLOAD_ARTIFACT_NAME.
-      # Keep it aligned with the RTX build artifact.
+      # Keep it aligned with the RTX build artifact. The build adds these two
+      # suffixes after the architecture, so they have to stay after the step
+      # above, which is what puts the architecture in the name.
       - name: Mark Python-only artifact
         if: ${{ inputs.python-only }}
         run: echo "ARTIFACT_NAME=${ARTIFACT_NAME}_python_only" >> "${GITHUB_ENV}"
@@ -135,7 +140,7 @@ jobs:
         if: ${{ matrix.tensorrt == '' }}
         uses: actions/download-artifact@v7
         with:
-          name: ${{ env.ARTIFACT_NAME }}${{ inputs.architecture }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: ${{ runner.temp }}/artifacts/
       - name: Download artifacts
         if: ${{ matrix.tensorrt != '' }}

--- a/tests/py/dynamo/conversion/test_cumsum_aten.py
+++ b/tests/py/dynamo/conversion/test_cumsum_aten.py
@@ -33,9 +33,7 @@ class TestCumsumConverter(DispatchTestCase):
                 )
             return
 
-        self.run_test(
-            Cumsum(), inputs, immutable_weights=False, use_dynamo_tracer=True
-        )
+        self.run_test(Cumsum(), inputs, immutable_weights=False, use_dynamo_tracer=True)
 
     @parameterized.expand(
         [
@@ -108,10 +106,7 @@ class TestCumsumConverter(DispatchTestCase):
             == opt_shape[positive_dim]
             == max_shape[positive_dim]
         )
-        if (
-            has_static_trip_count
-            and not is_tensorrt_rtx_version_supported("1.7")
-        ):
+        if has_static_trip_count and not is_tensorrt_rtx_version_supported("1.7"):
             with self.assertRaises(UnsupportedOperatorException):
                 self.run_test_with_dynamic_shape(
                     Cumsum(),


### PR DESCRIPTION
## What is broken

Every job in the `CI Windows` workflow on `main` fails at the `Download artifacts` step:

```
Unable to download artifact(s): Artifact not found for name: pytorch_tensorrt__3.12_cu132__python_only_rtxx64
```

170 of 300 jobs failed that way in the latest run, and every non-cancelled `main` run since 2026-08-23 has ended the same way.

## Why

The build job builds the artifact name with the architecture inside the base name, then appends the two marks:

```
pytorch_tensorrt__3.12_cu132_x64  +  _python_only  +  _rtx
```

The test job put the same pieces together in a different order. It asked `setup-binary-builds` for the base name with `arch: ${{ env.ARCH }}`, but `ARCH` is not set anywhere in `windows-test.yml`, so the architecture field came out empty and the base ended with a trailing separator. The two marks were appended to that, and the architecture was concatenated onto the very end at download time:

```
pytorch_tensorrt__3.12_cu132_  +  _python_only  +  _rtx  +  x64
```

This was harmless while the marks did not exist, because the empty architecture field left exactly the separator the architecture needed. It broke as soon as the marks were added, because they now sit between the base and the architecture.

## Fix

Pass `inputs.architecture` to `setup-binary-builds`, the same value `build_windows.yml` passes, so the architecture is part of the base name before the marks are appended. Then download the artifact under `ARTIFACT_NAME` unchanged.

`arch` is used by that action for one thing only, building `ARTIFACT_NAME`, so nothing else in the test job changes.

## Verification

Windows CI cannot be run locally, so this was checked against real data instead: the list of artifacts the latest `main` run actually uploaded, read through the Actions API. All 40 names the fixed workflow composes (5 Python versions, 2 CUDA versions, with and without each mark) are present in that run.

For the case with no marks the fixed expression produces the same string as the old one, character for character, so the jobs that pass today keep downloading exactly what they downloaded before.
