### PR TITLE
fix(executorch): register device copy kernels in the packaged runner

### DIFF
--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -172,6 +172,25 @@ cc_library(
     }),
 )
 
+# Registration only, for the same reason as the allocator above: the kernel
+# registry aborts when the same kernel is registered twice, so this cannot ride
+# along with the backend. Executables that run a TensorRT delegated program
+# depend on this directly.
+#
+# Not part of :executorch_backend_source_files. The CMake build of the reference
+# runner links executorch::kernels, which already registers these.
+cc_library(
+    name = "tensorrt_executorch_device_copy_kernels",
+    srcs = [
+        "src/torch_tensorrt/executorch/RegisterDeviceCopyKernels.cpp",
+    ],
+    alwayslink = True,
+    deps = [
+        "@executorch//:executorch_device_copy_kernels",
+        "@executorch//:executorch_headers",
+    ],
+)
+
 cc_library(
     name = "tensorrt_executorch_backend",
     srcs = [

--- a/cpp/src/torch_tensorrt/executorch/RegisterDeviceCopyKernels.cpp
+++ b/cpp/src/torch_tensorrt/executorch/RegisterDeviceCopyKernels.cpp
@@ -1,0 +1,32 @@
+#include <executorch/extension/kernel_util/make_boxed_from_unboxed_functor.h>
+
+namespace torch {
+namespace executor {
+namespace native {
+
+using executorch::aten::Tensor;
+using executorch::runtime::KernelRuntimeContext;
+
+// ExecuTorch publishes no header for its portable kernel sources, and the
+// Bazel target that owns this file compiles op__device_copy.cpp straight from
+// the pinned tree, so the two entry points are declared here.
+Tensor& _h2d_copy_out(KernelRuntimeContext& ctx, const Tensor& self, Tensor& out);
+Tensor& _d2h_copy_out(KernelRuntimeContext& ctx, const Tensor& self, Tensor& out);
+
+} // namespace native
+} // namespace executor
+} // namespace torch
+
+// A program delegated to TensorRT still runs two ops outside the delegate: the
+// host to device copy of its inputs and the device to host copy of its outputs,
+// which the device placement pass inserts at export time. ExecuTorch registers
+// their kernels from a generated kernel library, which this Bazel build does
+// not produce, so a runner linking the core runtime alone fails every
+// load_method with
+//
+//   kernel 'et_copy::_h2d_copy.out' not found.
+//
+// Register those two rather than the whole portable kernel set, which a fully
+// delegated program never calls.
+EXECUTORCH_LIBRARY(et_copy, "_h2d_copy.out", torch::executor::native::_h2d_copy_out);
+EXECUTORCH_LIBRARY(et_copy, "_d2h_copy.out", torch::executor::native::_d2h_copy_out);

--- a/examples/executorch_reference_runner/BUILD
+++ b/examples/executorch_reference_runner/BUILD
@@ -26,6 +26,7 @@ cc_binary(
     deps = [
         "//cpp:tensorrt_executorch_backend",
         "//cpp:tensorrt_executorch_cuda_device_allocator",
+        "//cpp:tensorrt_executorch_device_copy_kernels",
         "@executorch//:executorch_core",
         "@executorch//:executorch_file_data_loader",
         "@executorch//:extension_cuda",
@@ -38,6 +39,7 @@ cc_binary(
     deps = [
         "//cpp:tensorrt_executorch_backend",
         "//cpp:tensorrt_executorch_cuda_device_allocator",
+        "//cpp:tensorrt_executorch_device_copy_kernels",
         "@cuda//:cudart",
         "@executorch//:executorch_core",
         "@executorch//:executorch_file_data_loader",

--- a/tests/py/dynamo/conversion/test_cumsum_aten.py
+++ b/tests/py/dynamo/conversion/test_cumsum_aten.py
@@ -33,9 +33,7 @@ class TestCumsumConverter(DispatchTestCase):
                 )
             return
 
-        self.run_test(
-            Cumsum(), inputs, immutable_weights=False, use_dynamo_tracer=True
-        )
+        self.run_test(Cumsum(), inputs, immutable_weights=False, use_dynamo_tracer=True)
 
     @parameterized.expand(
         [
@@ -108,10 +106,7 @@ class TestCumsumConverter(DispatchTestCase):
             == opt_shape[positive_dim]
             == max_shape[positive_dim]
         )
-        if (
-            has_static_trip_count
-            and not is_tensorrt_rtx_version_supported("1.7")
-        ):
+        if has_static_trip_count and not is_tensorrt_rtx_version_supported("1.7"):
             with self.assertRaises(UnsupportedOperatorException):
                 self.run_test_with_dynamic_shape(
                     Cumsum(),

--- a/third_party/executorch/BUILD
+++ b/third_party/executorch/BUILD
@@ -147,6 +147,21 @@ cc_library(
     ],
 )
 
+# The kernels behind the device copies that an exported program runs around the
+# delegate. In the pinned ExecuTorch release these reach a binary only through
+# the generated kernel library, which this overlay does not build, so compile
+# the two implementations on their own. Registering them is left to
+# //cpp:tensorrt_executorch_device_copy_kernels, because a binary that already
+# gets them from ExecuTorch's own kernel library must not register them twice.
+cc_library(
+    name = "executorch_device_copy_kernels",
+    srcs = ["executorch/kernels/portable/cpu/op__device_copy.cpp"],
+    deps = [
+        ":executorch_core",
+        ":executorch_headers",
+    ],
+)
+
 cc_library(
     name = "executorch_headers",
     hdrs = glob(


### PR DESCRIPTION
## What is broken

The `executorch-runtime-build` jobs are red on `main`, 10 of them. The example runner builds fine and then fails at run time:

```
kernel 'et_copy::_h2d_copy.out' not found
load_method('forward') failed with error 0x14
```

## Why

An exported program that is fully delegated to TensorRT still runs two operators outside the delegate: the host to device copy of its inputs and the device to host copy of its outputs. The device placement pass inserts them at export time.

The Bazel build of the example runner links the core ExecuTorch runtime only, and the core runtime carries no kernels, so those two operators have nothing to dispatch to and loading any exported program fails. The CMake build does not hit this because it links ExecuTorch's own kernel library.

## Fix

Compile the two kernel implementations from the pinned ExecuTorch tree and register them from a small registration-only library that executables depend on directly.

Two deliberate choices:

- only these two kernels are registered, not the whole portable kernel set, because a fully delegated program never calls the rest;
- registration lives in its own library rather than in the backend library, because the kernel registry aborts when the same kernel is registered twice and the backend can be linked into both a shared library and an executable. It is also kept out of the CMake source list, since that build already links a kernel library and would hit exactly that double registration.

## Verification

No GPU was available for an end to end run, so this was checked at the symbol level: both translation units compile against the pinned ExecuTorch headers, the registration object's undefined symbols match the kernel object's defined symbols, and the registered names are exactly `et_copy::_h2d_copy.out` and `et_copy::_d2h_copy.out`.

The end to end path is covered by the CI job that runs the example runner, which is the job that is currently failing.
