### PR TITLE
style: format test_cumsum_aten.py with black

### DIFF
--- a/tests/py/dynamo/conversion/test_cumsum_aten.py
+++ b/tests/py/dynamo/conversion/test_cumsum_aten.py
@@ -33,9 +33,7 @@ class TestCumsumConverter(DispatchTestCase):
                 )
             return
 
-        self.run_test(
-            Cumsum(), inputs, immutable_weights=False, use_dynamo_tracer=True
-        )
+        self.run_test(Cumsum(), inputs, immutable_weights=False, use_dynamo_tracer=True)
 
     @parameterized.expand(
         [
@@ -108,10 +106,7 @@ class TestCumsumConverter(DispatchTestCase):
             == opt_shape[positive_dim]
             == max_shape[positive_dim]
         )
-        if (
-            has_static_trip_count
-            and not is_tensorrt_rtx_version_supported("1.7")
-        ):
+        if has_static_trip_count and not is_tensorrt_rtx_version_supported("1.7"):
             with self.assertRaises(UnsupportedOperatorException):
                 self.run_test_with_dynamic_shape(
                     Cumsum(),


### PR DESCRIPTION
## What is broken

The `Python Linting` job runs `black --check .` over the whole repository. One
file is not formatted, so the job fails, and it fails the same way on every open
pull request no matter what that pull request changes:

```
would reformat tests/py/dynamo/conversion/test_cumsum_aten.py
1 file would be reformatted, 602 files would be left unchanged.
```

## Fix

Run black on that file. Two call sites are split across several lines but fit on
one, so black joins them. Nothing else changes, and there is no behavior change.

## Tested

`black --check .` no longer reports this file.
