### PR TITLE
fix(dynamo): stop unpacking complex inputs before the refit output check

### DIFF
--- a/py/torch_tensorrt/dynamo/_refit.py
+++ b/py/torch_tensorrt/dynamo/_refit.py
@@ -37,7 +37,6 @@ from torch_tensorrt.dynamo.runtime._TorchTensorRTModule import TorchTensorRTModu
 from torch_tensorrt.dynamo.runtime._TRTEngine import TRTEngine
 from torch_tensorrt.dynamo.utils import (
     check_module_output,
-    check_output_equal,
     get_torch_inputs,
     to_torch_device,
     to_torch_tensorrt_device,
@@ -436,31 +435,15 @@ def refit_module_weights(
 
     if verify_output and arg_inputs is not None:
         new_gm.to(to_torch_device(settings.device))  # move to device for inference
-        # complex_graph_detection rewrites complex placeholders to real (view_as_real).
-        # The compiled TRT module handles complex→real internally, but the lowered
-        # PyTorch reference module (new_gm) expects real-unpacked inputs directly.
-        has_complex_inputs = any(
-            isinstance(x, torch.Tensor) and x.is_complex() for x in torch_inputs
+        # A complex placeholder stays complex in the lowered reference module; the
+        # unpacking to real happens inside the graph, so both modules take the same
+        # inputs the caller passed.
+        outputs_match = check_module_output(
+            new_module=new_gm,
+            refitted_module=compiled_module,
+            arg_inputs=torch_inputs,
+            kwarg_inputs=torch_kwarg_inputs,
         )
-        if has_complex_inputs:
-            lowered_inputs = [
-                (
-                    torch.view_as_real(x).contiguous()
-                    if isinstance(x, torch.Tensor) and x.is_complex()
-                    else x
-                )
-                for x in torch_inputs
-            ]
-            trt_outputs = compiled_module(*torch_inputs)
-            ref_outputs = new_gm(*lowered_inputs, **torch_kwarg_inputs)
-            outputs_match = check_output_equal(trt_outputs, ref_outputs)
-        else:
-            outputs_match = check_module_output(
-                new_module=new_gm,
-                refitted_module=compiled_module,
-                arg_inputs=torch_inputs,
-                kwarg_inputs=torch_kwarg_inputs,
-            )
         if outputs_match:
             logger.info("Refitting Succeed!")
         else:


### PR DESCRIPTION
## What is broken

Three tests are red on `main`:

- `test_complex_buffer_refit`
- `test_dual_complex_buffer_refit`
- `test_complex_buffer_with_real_param_refit`

```
TypeError: view_as_real is only supported for complex tensors
```

## Why

After refitting, `refit_module_weights(verify_output=True)` runs the lowered
PyTorch module and the compiled module on the same inputs and compares the
results. When an input is complex it first converted that input to a real tensor
of shape `(..., 2)`, because the lowering pass used to rewrite a complex
placeholder into a real one.

That is no longer what the pass does. The placeholder stays complex and the
graph does the unpacking itself:

```
placeholder      arg0_1
call_function    aten.view_as_real.default   (arg0_1,)
call_function    aten.select.int             (view_as_real, 2, 0)
...
```

So the reference module got a real tensor and was then asked to unpack it a
second time, which is what raises.

## Fix

Give both modules the inputs the caller passed. That is what the non-complex
path already did, so the special case goes away and the two paths become one.

## Tested

On an H100 with the three tests above: they fail before this change and pass
after it. The whole file passes, 7 passed and 12 skipped, the skips being the
ones `main` already skips in this environment.
