### PR TITLE
fix(runtime): give the TensorRT engine class an __eq__

### DIFF
--- a/core/runtime/register_jit_hooks.cpp
+++ b/core/runtime/register_jit_hooks.cpp
@@ -70,6 +70,15 @@ static auto TORCHTRT_UNUSED TRTEngineTSRegistrtion =
         .def("__str__", &TRTEngine::to_str)
         .def("__repr__", &TRTEngine::to_str)
         .def("__obj_flatten__", &TRTEngine::__obj_flatten__)
+        // Reporting "real" below puts the engine itself into torch's fake tensor
+        // dispatch cache key, and that cache compares keys with ==. Without this the
+        // second lookup raises "'__eq__' is not implemented", which breaks any
+        // re-export of a compiled module. Two handles to one engine are one engine.
+        .def(
+            "__eq__",
+            [](const c10::intrusive_ptr<TRTEngine>& self, const c10::intrusive_ptr<TRTEngine>& other) -> bool {
+              return self.get() == other.get();
+            })
         // Reporting "real" makes torch's tracing_with_real skip fakification and hand
         // the engine itself to the meta kernel, which reads only
         // get_serialized_metadata() -- nothing executes or mutates it. Otherwise each


### PR DESCRIPTION
## What is broken

`tests/py/dynamo/models/test_export_serde.py::test_save_load_aoti` is red on `main`:

```
NotImplementedError: '__eq__' is not implemented for __torch__.torch.classes.tensorrt.Engine
  File "torch/_subclasses/fake_tensor.py", line 1433, in __eq__
    return isinstance(other, _DispatchCacheKey) and self.key == other.key
```

## Why

The engine class reports `tracing_mode` `"real"`, so export hands the engine
object itself to the meta kernel instead of a fake stand-in. The engine then
ends up inside torch's fake tensor dispatch cache key. That cache hashes the
key and, on a hash match, compares with `==`. The class defines no `__eq__`, so
the comparison raises.

Any second trace of an already compiled module hits this. `torch_tensorrt.save`
with `retrace=True` is one such path, which is why the AOT Inductor save test
fails.

torch has the same problem with its own `torch::jit::OpaqueObject` and solves it
the same way, see `torch/csrc/jit/python/opaque_obj.h`.

## Fix

Define `__eq__` on the class and compare by identity. Two handles to one engine
are one engine; two different engines are never equal. A comparison that says
"not equal" only costs a cache miss, so identity is both correct and the
cheapest correct answer.

## Tested

This box has no TensorRT headers, so the library could not be rebuilt here.
Instead the same method was appended to the live class type at runtime, the way
`torch::class_::defineMethod` does, and the body of `test_save_load_aoti` was
run against the real engine class on an H100:

- without the method: the `NotImplementedError` above, every time
- with the method: save, load and run succeed, cosine similarity 1.000000

A second check on a minimal custom class with the same registration shape
(`tracing_mode` `"real"`, `__obj_flatten__`, pickle) reproduces the failure on
re-export without `__eq__` and passes with it.
