### PR TITLE
fix(runtime): back a python engine runtime cache with the python handle

### DIFF
--- a/py/torch_tensorrt/runtime/_runtime_cache.py
+++ b/py/torch_tensorrt/runtime/_runtime_cache.py
@@ -222,7 +222,6 @@ class RuntimeCache:
     ``ENABLED_FEATURES.torch_tensorrt_runtime`` is set, else the
     pure-Python :class:`_RuntimeCacheHandle`; both satisfy
     :class:`_RuntimeCacheHandleProtocol` interface which this class uses.
-
     **Identity-based equality.** Two handles wrap distinct underlying
     ``IRuntimeCache`` instances even when they share a path, and the
     runtime treats them as such.
@@ -232,21 +231,36 @@ class RuntimeCache:
         self,
         path: str = "",
         autosave_on_del: bool = False,
+        *,
+        _force_python_backing: bool = False,
     ) -> None:
         # Set the atexit-token slot first so ``__del__`` can safely read it
         # even if a later step in ``__init__`` raises and leaves the object
         # partially constructed.
         self._atexit_token: Optional[Callable[..., None]] = None
 
-        # Pick the backing that matches the active runtime. The torchbind
-        # class ``torch.classes.tensorrt.RuntimeCacheHandle`` is registered by
-        # the C++ shared library; if the .so isn't loaded
+        # Pick the backing that matches the runtime that will consume the
+        # cache. The torchbind class ``torch.classes.tensorrt.RuntimeCacheHandle``
+        # is registered by the C++ shared library; if the .so isn't loaded
         # (``ENABLED_FEATURES.torch_tensorrt_runtime is False``) it doesn't
         # exist as an attribute, so we fall back to the pure-Python
         # ``_RuntimeCacheHandle``. Both satisfy
         # :class:`_RuntimeCacheHandleProtocol`, so the facade methods forward
         # without branching on which backing won.
-        if torch_tensorrt.ENABLED_FEATURES.torch_tensorrt_runtime:
+        #
+        # A loaded .so does not mean the consumer is a cpp engine: a python
+        # ``TRTEngine`` can be built directly from a packed engine tuple while
+        # the .so is loaded. Such a caller sets ``_force_python_backing``,
+        # because ``ensure_cache`` can only materialize through the python
+        # backing. Private and keyword-only on purpose: ``_to_torchbind_handle``
+        # below unwraps a ``RuntimeCache`` straight to ``_handle``, so a
+        # python-backed one reaching a cpp engine would send a plain python
+        # object into a torchbind call and raise. Keeping it out of the public
+        # signature keeps that unreachable from user code.
+        if (
+            torch_tensorrt.ENABLED_FEATURES.torch_tensorrt_runtime
+            and not _force_python_backing
+        ):
             self._handle: _RuntimeCacheHandleProtocol = (
                 torch.classes.tensorrt.RuntimeCacheHandle(path)
             )
@@ -623,9 +637,17 @@ def _to_torchbind_handle(
     if isinstance(rc, torch.ScriptObject):
         return rc
     if isinstance(rc, RuntimeCache):
-        # The facade auto-picks the torchbind sibling on cpp rt (see
-        # ``RuntimeCache.__init__``), so any ``RuntimeCache`` constructed in
-        # this process is already cpp-backed. Unwrap directly.
+        # Checked rather than assumed. The facade normally picks the torchbind
+        # sibling on cpp rt, but ``_force_python_backing`` exists for a python
+        # engine built while the .so is loaded, and unwrapping one of those would
+        # hand a plain python object to a torchbind setter, which raises a type
+        # error naming an internal class.
+        if not isinstance(rc._handle, torch.ScriptObject):
+            raise TypeError(
+                "runtime_cache is backed by the pure-Python handle and cannot be "
+                "passed to a C++ engine. Build it without forcing the Python "
+                "backing, or attach it to a Python engine."
+            )
         return rc._handle
     # Truthy-string check: ``""`` would construct a no-op torchbind handle.
     if isinstance(rc, str) and rc:

--- a/py/torch_tensorrt/runtime/_runtime_config.py
+++ b/py/torch_tensorrt/runtime/_runtime_config.py
@@ -154,6 +154,10 @@ class TRTRuntimeConfig:
         )
         # Live trt.IRuntimeConfig (RTX) or None (non-RTX / pre-init).
         self._live: Any = None
+        # Wrapper built by ``_apply_settings`` for a path-string setting. The
+        # IRuntimeConfig does not own the IRuntimeCache attached to it, so the
+        # wrapper has to stay alive as long as ``_live`` does.
+        self._implicit_cache: Optional["RuntimeCache"] = None
 
     @property
     def settings(self) -> RuntimeSettings:
@@ -197,6 +201,22 @@ class TRTRuntimeConfig:
     def reset(self) -> None:
         """Drop the live ``IRuntimeConfig``; the next ``ensure_initialized`` rebuilds."""
         self._live = None
+        # Saved here, explicitly, rather than left to the wrapper's finalizer. Dropping
+        # the last reference would also write the file, but as a garbage-collection side
+        # effect: a settings swap would then block on the cache file's lock inside
+        # whatever code happened to release it, and the autosave path swallows errors,
+        # so a failure would be silent. ``TorchTensorRTModule._set_managed_handle`` saves
+        # at the moment of replacement for the same reason.
+        # Released after ``_live``, never before: the config points at the cache.
+        old, self._implicit_cache = self._implicit_cache, None
+        if old is not None:
+            old.autosave_on_del = False
+            try:
+                old.save()
+            except Exception as e:
+                logger.warning(
+                    f"Failed to save the implicit runtime cache on reset: {e}"
+                )
 
     def create_execution_context(
         self,
@@ -288,7 +308,38 @@ class TRTRuntimeConfig:
         if rc is None:
             logger.debug("Runtime cache disabled (no RuntimeCache provided).")
         elif isinstance(rc, RuntimeCache):
-            self._live.set_runtime_cache(rc.ensure_cache(self._live))
+            cache = rc.ensure_cache(self._live)
+            self._live.set_runtime_cache(cache)
+        elif isinstance(rc, str):
+            # ``TorchTensorRTModule._resolve_runtime_cache`` pre-wraps path
+            # strings on the compile / configure path, but engines created
+            # directly (e.g. the Python ``TRTEngine`` constructed from a
+            # cross-runtime ``.pt2`` load — see
+            # ``test_cross_runtime_serde::test_save_python_load_python``)
+            # get a default ``RuntimeSettings(runtime_cache=RUNTIME_CACHE_PATH)``
+            # that's never seen by the module's resolver. Wrap defensively
+            # here so the load path doesn't crash; this also keeps the
+            # documented contract that callers MAY pass a path string.
+            #
+            # ``RuntimeSettings`` is a frozen dataclass, so we can't store the
+            # wrapper back onto ``self._settings``; it goes on
+            # ``self._implicit_cache`` instead, which keeps the IRuntimeCache
+            # alive for as long as the IRuntimeConfig points at it.
+            #
+            # ``_force_python_backing`` because this method only ever runs for a
+            # python engine. The default backing follows the loaded C++ library
+            # instead, and a cpp-backed handle materializes on the cpp side, so
+            # ``ensure_cache`` would hand back ``None``.
+            wrapped = RuntimeCache(
+                path=rc, autosave_on_del=True, _force_python_backing=True
+            )
+            try:
+                wrapped.load()
+            except Exception as e:
+                logger.warning(f"Failed to warm-load runtime cache from {rc!r}: {e}")
+            cache = wrapped.ensure_cache(self._live)
+            self._live.set_runtime_cache(cache)
+            self._implicit_cache = wrapped
         else:
             raise TypeError(
                 f"runtime_cache must be None or a RuntimeCache by the time it "


### PR DESCRIPTION
## What is broken

Two tests are red on `main`, RTX only:

- `runtime/test_aliased_io.py::TestPythonRuntimeAliasedIO::test_in_place_write_through`
- `runtime/test_aliased_io.py::TestPythonRuntimeAliasedIO::test_streaming_state_accumulates`

```
TypeError: set_runtime_cache(): incompatible function arguments.
  1. (self: IRuntimeConfig, cache: nvinfer1::IRuntimeCache = None) -> bool
Invoked with: <IRuntimeConfig object at 0x...>, None
```

## Why

`RuntimeCache` chooses its backing from whether the C++ library is loaded:

```python
if ENABLED_FEATURES.torch_tensorrt_runtime:
    self._handle = torch.classes.tensorrt.RuntimeCacheHandle(path)
else:
    self._handle = _RuntimeCacheHandle(path=path)
```

A loaded library does not mean a C++ engine is the consumer. These tests build
a python `TRTEngine` straight from a packed engine tuple, which is a documented
way to use it. Its default settings carry a cache path string, so
`TRTRuntimeConfig._apply_settings` wraps that path, gets the torchbind handle,
and asks it for a live cache. The torchbind handle materializes its cache on
the C++ side and cannot pass an `IRuntimeCache` back to python, so
`ensure_cache` returns `None`, and `None` is not a cache.

## Fix

Let the caller say which runtime will consume the cache. `_apply_settings`
only ever runs for a python engine, so it asks for the python backing. Nothing
else changes: every existing caller keeps the old default.

One related detail: `IRuntimeConfig` does not own the cache attached to it, so
the wrapper now lives on the config instead of being dropped at the end of the
call. Before this change the wrapper was released immediately, which was
harmless only because the attach never happened.

## Tested

The RTX path cannot run on this machine. What was checked here, with the C++
library loaded:

- default backing: `ensure_cache` returns `None`, which is the exact input the
  error message reports
- python backing: `ensure_cache` returns the live cache

`test_000_runtime_cache.py`, `test_004_runtime_settings.py` and
`test_aliased_io.py` give the same result before and after the change on
non-RTX TensorRT, 28 passed and 27 skipped.
