### PR TITLE
Added TorchAO INT4 weight-only quantization + Linear, FLUX, and Qwen examples

### DIFF
--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -104,7 +104,7 @@ sphinx_gallery_conf = {
         "tutorials/_rendered_examples/distributed_inference",
     ],
     # Exclude pure utility modules that aren't standalone runnable examples.
-    "ignore_pattern": r"(utils\.py|static_fp8_utils\.py|rotary_embedding\.py|tensor_parallel_initialize_dist\.py)",
+    "ignore_pattern": r"(utils\.py|static_fp8_utils\.py|int4_utils\.py|rotary_embedding\.py|tensor_parallel_initialize_dist\.py)",
 }
 
 # Setup the breathe extension

--- a/docsrc/debugging/troubleshooting.rst
+++ b/docsrc/debugging/troubleshooting.rst
@@ -223,6 +223,11 @@ Accuracy / Performance Issues
     For **static FP8** (activations and weights, with a calibration loop), see
     :ref:`quantize_linear_fp8_static`.
 
+    For **INT4 weight-only** quantization with TorchAO, see
+    :ref:`quantize_linear_int4_woq`, :ref:`torch_export_flux_int4_woq`, and
+    :ref:`torch_export_qwen3_int4_woq`. Use symmetric INT4 (zero zero-point)
+    and ``immutable_weights=True`` so engine constants stay ``Datatype: Int4``.
+
 ----
 
 Distributed / Tensor-Parallel Issues

--- a/docsrc/tutorials/huggingface/index.rst
+++ b/docsrc/tutorials/huggingface/index.rst
@@ -12,4 +12,6 @@ the Mutable Torch-TensorRT Module.
    compile_hf_models
    Example: Compiling Stable Diffusion with torch.compile <../_rendered_examples/dynamo/torch_compile_stable_diffusion>
    Example: Compiling FLUX.1-dev with the dynamo backend <../_rendered_examples/dynamo/torch_export_flux_dev>
+   Example: FLUX.1-dev INT4 WOQ <../_rendered_examples/dynamo/torchao/torch_export_flux_int4_woq>
+   Example: Qwen3-8B INT4 WOQ <../_rendered_examples/dynamo/torchao/torch_export_qwen3_int4_woq>
    Example: Mutable Torch TensorRT Module <../_rendered_examples/dynamo/mutable_torchtrt_module_example>

--- a/docsrc/user_guide/shapes_precision/index.rst
+++ b/docsrc/user_guide/shapes_precision/index.rst
@@ -15,3 +15,6 @@ and reduce model size with INT8/FP8/FP4 quantization via ModelOpt or TorchAO.
    Example: TorchAO FP8 WOQ Linear <../../tutorials/_rendered_examples/dynamo/torchao/quantize_linear_fp8_woq>
    Example: TorchAO Static FP8 Linear <../../tutorials/_rendered_examples/dynamo/torchao/quantize_linear_fp8_static>
    Example: FLUX.1-dev FP8 WOQ <../../tutorials/_rendered_examples/dynamo/torchao/torch_export_flux_fp8_woq>
+   Example: TorchAO INT4 WOQ Linear <../../tutorials/_rendered_examples/dynamo/torchao/quantize_linear_int4_woq>
+   Example: FLUX.1-dev INT4 WOQ <../../tutorials/_rendered_examples/dynamo/torchao/torch_export_flux_int4_woq>
+   Example: Qwen3-8B INT4 WOQ <../../tutorials/_rendered_examples/dynamo/torchao/torch_export_qwen3_int4_woq>

--- a/docsrc/user_guide/shapes_precision/quantization.rst
+++ b/docsrc/user_guide/shapes_precision/quantization.rst
@@ -6,7 +6,7 @@ Quantization (INT8 / FP8 / FP4)
 Torch-TensorRT supports post-training quantization (PTQ) with **INT8**, **FP8**, and
 **FP4** precisions via NVIDIA's
 `ModelOpt <https://github.com/NVIDIA/TensorRT-Model-Optimizer>`_ library, and
-**FP8 weight-only** and **static FP8** quantization via
+**FP8 weight-only**, **static FP8**, and **INT4 weight-only** quantization via
 `TorchAO <https://github.com/pytorch/ao>`_. Quantizers insert
 quantize/dequantize (QDQ) nodes into the model graph; Torch-TensorRT then
 converts those nodes into TRT quantization layers and sets the appropriate builder flags.
@@ -27,6 +27,7 @@ Hardware requirements:
 
 * **INT8**: Any NVIDIA GPU with TensorRT support.
 * **FP8**: NVIDIA Hopper (H100) or newer.
+* **INT4 (TorchAO WOQ)**: TensorRT with INT4 constants (TRT ≥ 10.8); storage + DQ, not low-bit MMA.
 * **FP4 (NVFP4)**: NVIDIA Blackwell (B100/B200) or newer; requires TensorRT ≥ 10.8.
 
 ----
@@ -195,6 +196,57 @@ See :ref:`quantize_linear_fp8_woq` for a toy Linear model and
 
 ----
 
+TorchAO INT4 Weight-Only Quantization
+-------------------------------------
+
+TorchAO group-wise INT4 quantizes Linear weights to 4-bit integers while
+leaving activations in BF16. This is **weight-only storage**: TensorRT keeps an
+INT4 constant and dequantizes into a high-precision GEMM. It is not NVFP4
+Tensor Core MMA.
+
+TensorRT's ``IDequantizeLayer`` rejects nonzero zero-points, so examples use
+TorchAO's **symmetric** ``Int4Tensor.from_hp`` path (the float8-activation
+branch, then restore BF16 as the activation dtype). Default
+``Int4WeightOnlyConfig`` is asymmetric and will fail conversion.
+
+Parent ``Int4Tensor`` Linear dispatches to fused mslk kernels and never calls
+``dequantize()``. Promote weights to ``Int4TensorNonDecomposed`` so export emits
+``torch.ops.torchao.dequantize_affine``. The converter re-packs the unpacked
+int8 qdata into ``trt.DataType.INT4``. Blocked INT4 DQ currently uses an FP32
+DQ output, then a cast back to BF16.
+
+Compile with ``immutable_weights=True``. The converter packs INT4 at build
+time; engine refit would push the graph's int8 qdata at an INT4 prototype
+(``refit weights data type Int8 must equal to weights prototype Int4``).
+
+.. code-block:: python
+
+    quantize_linear_int4_symmetric(model, group_size=128)
+    model = pre_process_model_for_export(model)
+
+    with exclude_dq_from_constant_folding():
+        exp_program = torch.export.export(model, (example_input,), strict=True)
+
+    trt_model = torch_tensorrt.dynamo.compile(
+        exp_program,
+        inputs=[example_input],
+        min_block_size=1,
+        use_explicit_typing=True,
+        require_full_compilation=True,
+        immutable_weights=True,
+    )
+
+Hub checkpoints such as `pytorch/Qwen3-8B-INT4 <https://huggingface.co/pytorch/Qwen3-8B-INT4>`_
+may use HQQ or ``Int4TilePackedTo4dTensor``. Dequantize those weights to dense
+BF16, then re-pack with ``quantize_linear_int4_symmetric`` /
+``convert_hub_int4_to_symmetric_trt``.
+
+See :ref:`quantize_linear_int4_woq` for a toy Linear model,
+:ref:`torch_export_flux_int4_woq` for FLUX.1-dev, and
+:ref:`torch_export_qwen3_int4_woq` for Qwen3-8B.
+
+----
+
 TorchAO Static FP8 Quantization
 --------------------------------
 
@@ -232,8 +284,9 @@ graph (inserted by ModelOpt), the
 (e.g. Conv, Linear) to produce INT8 or FP8 kernel variants.
 
 For TorchAO weight-only graphs, ``torch.ops.torchao.dequantize_affine.default`` is
-mapped to ``IDequantizeLayer`` (weight constant stays FP8/INT, activations stay
-high precision).
+mapped to ``IDequantizeLayer`` (weight constant stays FP8 or INT4, activations stay
+high precision). Group-wise INT4 qdata is re-packed from unpacked int8 into a
+``trt.DataType.INT4`` constant.
 
 For TorchAO static FP8 graphs,
 ``quantize_affine_float8_non_decomposed`` / ``dequantize_affine_float8_non_decomposed``
@@ -281,6 +334,9 @@ Supported Precision / Hardware Matrix
    * - FP8
      - NVIDIA Hopper (H100+)
      - TRT ≥ 8.6
+   * - INT4 (TorchAO WOQ)
+     - Any TRT-capable GPU with INT4 support
+     - TRT ≥ 10.8
    * - FP4 (NVFP4)
      - NVIDIA Blackwell (B100+)
      - TRT ≥ 10.8
@@ -313,3 +369,14 @@ Troubleshooting
     Promote weights with ``pre_process_model_for_export`` and wrap export in
     ``exclude_dq_from_constant_folding`` as in :ref:`quantize_linear_fp8_woq`.
     Install ``torchao`` so the converter and constant-folding exclusion register.
+
+**TorchAO INT4 weights folded to BF16, or engine constants are Int8 not Int4**
+    The graph must keep ``dequantize_affine`` (same preprocess / constant-fold
+    exclusion as FP8 WOQ). Group-wise INT4 also requires the INT4 pack path in
+    the converter; per-channel INT8-style DQ will not emit ``Datatype: Int4``.
+    Use symmetric quantization (zero zero-point) and ``immutable_weights=True``.
+
+**"IDequantizeLayer rejects nonzero zero_point" / INT4 compile fails**
+    TorchAO's default INT4 config is asymmetric. Use
+    ``quantize_linear_int4_symmetric`` (or ``convert_hub_int4_to_symmetric_trt``
+    for Hub checkpoints) as in :ref:`quantize_linear_int4_woq`.

--- a/examples/dynamo/README.rst
+++ b/examples/dynamo/README.rst
@@ -28,6 +28,9 @@ Model Zoo
 * :ref:`quantize_linear_fp8_woq`: TorchAO FP8 weight-only quantization of a Linear layer (``examples/dynamo/torchao``)
 * :ref:`quantize_linear_fp8_static`: TorchAO static FP8 (act + weight) quantization of a Linear layer (``examples/dynamo/torchao``)
 * :ref:`torch_export_flux_fp8_woq`: Compiling FLUX.1-dev with TorchAO FP8 weight-only quantization (``examples/dynamo/torchao``)
+* :ref:`quantize_linear_int4_woq`: TorchAO INT4 weight-only quantization of a Linear layer (``examples/dynamo/torchao``)
+* :ref:`torch_export_flux_int4_woq`: Compiling FLUX.1-dev with TorchAO INT4 weight-only quantization (``examples/dynamo/torchao``)
+* :ref:`torch_export_qwen3_int4_woq`: Compiling Qwen3-8B with TorchAO INT4 weight-only quantization (``examples/dynamo/torchao``)
 * :ref:`debugger_example`: Debugging Torch-TensorRT Compilation
 * :ref:`torch_export_3d_rope`: Compiling a 3D RoPE video-transformer block with complex numerics support
 * :ref:`engine_converter_binding_names`: Naming input / output bindings when emitting a raw serialized TRT engine

--- a/examples/dynamo/torchao/README.rst
+++ b/examples/dynamo/torchao/README.rst
@@ -13,10 +13,17 @@ Static FP8 also quantizes activations. Calibrate observers, then export
 ``quantize_affine_float8_non_decomposed`` / ``dequantize_affine_float8_non_decomposed``
 so TensorRT can fuse Q/DQ into FP8 GEMMs.
 
+Weight-only INT4 is the same DQ pattern with packed 4-bit integer weights.
+Use **symmetric** group-wise INT4 (zero zero-point) and compile with
+``immutable_weights=True`` so engine constants stay ``Datatype: Int4``.
+
 .. code-block:: bash
 
     pip install -r ../requirements.txt
     python quantize_linear_fp8_woq.py
     python quantize_linear_fp8_static.py
     python torch_export_flux_fp8_woq.py
+    python quantize_linear_int4_woq.py
+    python torch_export_flux_int4_woq.py
+    python torch_export_qwen3_int4_woq.py
 """

--- a/examples/dynamo/torchao/int4_utils.py
+++ b/examples/dynamo/torchao/int4_utils.py
@@ -1,0 +1,251 @@
+"""Helpers for TorchAO INT4 weight-only quantization examples.
+
+TorchAO's default Int4Tensor Linear path uses fused mslk INT4 kernels and
+never emits dequantize_affine. Int4TensorNonDecomposed unpacks nibbles
+and dequantizes explicitly so Torch-TensorRT can map DQ to IDequantizeLayer
+and keep an INT4 weight constant.
+
+TensorRT's IDequantizeLayer rejects nonzero zero-points, so weights must be
+quantized with the symmetric Int4Tensor.from_hp path (float8-activation
+branch, then restore BF16 as the activation dtype).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torchao.quantization import dequantize_affine
+from torchao.quantization.quantize_.workflows.int4.int4_tensor import Int4Tensor
+
+aten = torch.ops.aten
+
+
+def unpack_int4(packed: torch.Tensor) -> torch.Tensor:
+    """Inverse of mslk pack_int4 (low nibble = even index, sign-extended)."""
+    low = torch.bitwise_right_shift(torch.bitwise_left_shift(packed, 4), 4)
+    high = torch.bitwise_right_shift(packed, 4)
+    return torch.stack([low, high], dim=-1).flatten(-2).contiguous()
+
+
+class Int4TensorNonDecomposed(Int4Tensor):
+    """Int4Tensor that dequantizes via explicit dequantize_affine.
+
+    Always emits zero_point=None. FP32 DQ output is what Myelin currently
+    accepts for INT4 blocked DQ; eager Linear casts back to the activation dtype.
+    """
+
+    def dequantize(self, output_dtype=None):
+        if output_dtype is None:
+            output_dtype = (
+                torch.bfloat16
+                if self.activation_dtype == torch.float8_e4m3fn
+                else self.activation_dtype
+            )
+
+        qdata = unpack_int4(self.qdata)
+        scale = self.scale.transpose(-2, -1).contiguous()
+        weight_hp = dequantize_affine(
+            qdata,
+            tuple(self.block_size),
+            scale,
+            None,
+            qdata.dtype,
+            output_dtype=torch.float32,
+        )
+        return weight_hp.to(output_dtype)
+
+
+implements = Int4TensorNonDecomposed.implements
+implements_torch_function = Int4TensorNonDecomposed.implements_torch_function
+
+
+@implements([aten.linear.default])
+@implements_torch_function([torch.nn.functional.linear])
+def _int4_non_decomposed_linear(func, types, args, kwargs):
+    """Run Linear as dequantize + F.linear so export sees dequantize_affine.
+
+    Parent Int4Tensor already owns Linear dispatch, but that path never
+    calls dequantize(). It feeds packed INT4 qdata into fused mslk kernels
+    (bf16i4bf16_rowwise). Export would then show an mslk op, which TensorRT
+    cannot map to IDequantizeLayer.
+
+    FP8 does not need this: Float8Tensor Linear already does
+    weight.dequantize() then matmul. INT4's parent never takes that branch,
+    so this handler steals Linear and calls our dequantize().
+    """
+    input_tensor = args[0]
+    weight_tensor = args[1]
+    bias = args[2] if len(args) > 2 else None
+
+    assert isinstance(weight_tensor, Int4TensorNonDecomposed)
+
+    weight_hp = weight_tensor.dequantize(output_dtype=input_tensor.dtype)
+    if bias is not None and bias.dtype != input_tensor.dtype:
+        bias = bias.to(dtype=input_tensor.dtype)
+    return torch.nn.functional.linear(input_tensor, weight_hp, bias)
+
+
+def _dequant_int4_tile_packed_to_4d(
+    weight: torch.Tensor,
+    compute_device: str,
+    chunk_size: int = 256,
+) -> torch.Tensor:
+    """Recover dense BF16 weights from Int4TilePackedTo4dTensor.
+
+    That subclass has no real dequantize() (Tensor.dequantize dispatches
+    to unimplemented aten.dequantize). Reconstruct via chunked
+    F.linear using the same tinygemm path as inference.
+    """
+    w = weight
+    if w.device.type != "cuda":
+        w = w.to(compute_device)
+    out_f, in_f = int(w.shape[0]), int(w.shape[1])
+    device = w.device
+    pieces: list[torch.Tensor] = []
+    for start in range(0, in_f, chunk_size):
+        end = min(start + chunk_size, in_f)
+        rows = end - start
+        x = torch.zeros(rows, in_f, dtype=torch.bfloat16, device=device)
+        x[
+            torch.arange(rows, device=device), torch.arange(start, end, device=device)
+        ] = 1
+        pieces.append(torch.nn.functional.linear(x, w))
+    return (
+        torch.cat(pieces, dim=0)
+        .T.contiguous()
+        .to(device=compute_device, dtype=torch.bfloat16)
+    )
+
+
+def _weight_to_bf16_hp(
+    weight: torch.Tensor, compute_device: str
+) -> tuple[torch.Tensor, torch.device]:
+    """Materialize a Linear weight as dense BF16 on compute_device.
+
+    Hub TorchAO checkpoints may use Int4TilePackedTo4dTensor, Int4Tensor,
+    AffineQuantizedTensor, etc. Prefer a class-defined dequantize; fall
+    back to the tile-packed linear reconstruct path. Do **not** call bare
+    Tensor.dequantize — it hits unimplemented aten.dequantize.
+    """
+    original_device = getattr(weight, "device", torch.device(compute_device))
+    cls_name = type(weight).__name__
+
+    qdata = getattr(weight, "qdata", None)
+    if cls_name == "Int4TilePackedTo4dTensor" or (
+        qdata is not None and getattr(qdata, "ndim", 0) == 4
+    ):
+        hp = _dequant_int4_tile_packed_to_4d(weight, compute_device)
+        return hp, original_device
+
+    dq = type(weight).__dict__.get("dequantize")
+    if callable(dq):
+        hp = dq(weight)
+        if not isinstance(hp, torch.Tensor):
+            raise TypeError(f"dequantize() returned {type(hp)}, expected torch.Tensor")
+        return (
+            hp.detach().to(device=compute_device, dtype=torch.bfloat16),
+            original_device,
+        )
+
+    hp = weight.detach().to(device=compute_device, dtype=torch.bfloat16)
+    return hp, original_device
+
+
+def quantize_linear_int4_symmetric(
+    model: torch.nn.Module,
+    group_size: int = 128,
+    verbose: bool = False,
+    compute_device: Optional[str] = None,
+) -> torch.nn.Module:
+    """Replace Linear weights with symmetric group-wise INT4 (TRT-compatible).
+
+    TorchAO's default Int4WeightOnlyConfig path for BF16 activations is
+    asymmetric (nonzero zero_point). TRT rejects that, so this uses TorchAO's
+    symmetric quantizer (float8-activation branch of Int4Tensor.from_hp) and
+    restores BF16 as the activation dtype for the DQ → Linear path.
+
+    Accepts dense BF16 weights **or** already-quantized Hub TorchAO weights
+    (dequantized first). Each layer is handled on compute_device then moved
+    back so VRAM stays bounded.
+    """
+    if compute_device is None:
+        compute_device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    quantized = 0
+    skipped = 0
+    for name, module in model.named_modules():
+        if not isinstance(module, torch.nn.Linear):
+            continue
+        weight = module.weight
+        if getattr(weight, "is_meta", False):
+            raise RuntimeError(
+                f"{name}.weight is on the meta device (no data to quantize). "
+                "Load the model without device_map/offloading before quantizing."
+            )
+
+        hp_weight, original_device = _weight_to_bf16_hp(weight, compute_device)
+        if hp_weight.shape[-1] % group_size != 0:
+            if verbose:
+                print(
+                    f"[skip] {name}: shape {tuple(hp_weight.shape)} not divisible "
+                    f"by group_size={group_size}"
+                )
+            module.weight = torch.nn.Parameter(
+                hp_weight.to(original_device), requires_grad=False
+            )
+            skipped += 1
+            continue
+
+        block_size = [1] * (hp_weight.ndim - 1) + [group_size]
+        qw = Int4Tensor.from_hp(
+            hp_weight,
+            block_size,
+            activation_dtype=torch.float8_e4m3fn,
+        )
+        qw.activation_dtype = torch.bfloat16
+        if not torch.all(qw.zero_point == 0).item():
+            raise AssertionError(f"{name}: expected symmetric INT4 (zero zero_point)")
+        if qw.device != original_device:
+            qw = qw.to(original_device)
+        module.weight = torch.nn.Parameter(qw, requires_grad=False)
+        quantized += 1
+        del hp_weight
+        if verbose:
+            print(
+                f"[int4] {name}: -> qdata {tuple(qw.qdata.shape)} "
+                f"(symmetric, group_size={group_size})"
+            )
+    if compute_device == "cuda":
+        torch.cuda.empty_cache()
+    if verbose:
+        print(
+            f"Quantized {quantized} Linear layers to symmetric INT4 "
+            f"(skipped {skipped})"
+        )
+    return model
+
+
+def convert_hub_int4_to_symmetric_trt(
+    model: torch.nn.Module,
+    group_size: int = 128,
+    verbose: bool = False,
+) -> torch.nn.Module:
+    """Hub INT4 (HQQ / tile-packed / asymmetric) → TRT-ready symmetric Int4Tensor."""
+    return quantize_linear_int4_symmetric(model, group_size=group_size, verbose=verbose)
+
+
+def convert_int4_to_int4_non_decomposed(model: torch.nn.Module) -> torch.nn.Module:
+    """Promote all Int4Tensor parameters to Int4TensorNonDecomposed."""
+    for param in model.parameters():
+        if isinstance(param, Int4Tensor) and not isinstance(
+            param, Int4TensorNonDecomposed
+        ):
+            param.__class__ = Int4TensorNonDecomposed
+            param.requires_grad_(False)
+    return model
+
+
+def pre_process_model_for_export(model: torch.nn.Module) -> torch.nn.Module:
+    """Promote Int4Tensor parameters so export emits dequantize_affine."""
+    return convert_int4_to_int4_non_decomposed(model)

--- a/examples/dynamo/torchao/quantize_linear_int4_woq.py
+++ b/examples/dynamo/torchao/quantize_linear_int4_woq.py
@@ -1,0 +1,92 @@
+"""
+.. _quantize_linear_int4_woq:
+
+TorchAO INT4 Weight-Only Quantization (Linear)
+==============================================
+
+This example quantizes a toy nn.Linear to **symmetric** group-wise INT4
+with TorchAO, keeps an explicit dequantize_affine in the exported graph,
+and compiles with the Torch-TensorRT Dynamo backend.
+
+The intended engine keeps an INT4 weight constant plus a DQ prologue into GEMM.
+TorchAO's default INT4 config is asymmetric (nonzero zero-point); TensorRT's
+IDequantizeLayer rejects that, so the helper uses TorchAO's symmetric
+quantizer. Parent Int4Tensor Linear uses fused mslk kernels and never calls
+dequantize(), so weights are promoted to Int4TensorNonDecomposed before
+export.
+
+This is 4-bit **integer** weight-only quantization (storage + DQ + high-precision
+GEMM), not NVFP4 Tensor Core MMA.
+
+Requirements:
+
+* NVIDIA GPU
+* torchao
+* torch-tensorrt with the INT4-aware torchao.dequantize_affine converter
+
+"""
+
+# %%
+# Imports
+# ^^^^^^^
+# This example lives in examples/dynamo/torchao/. Move that directory off
+# the front of sys.path so import torchao resolves the PyPI package
+# instead of this folder.
+
+import sys
+from pathlib import Path
+
+_EXAMPLE_DIR = str(Path(__file__).resolve().parent)
+if sys.path and Path(sys.path[0]).resolve() == Path(_EXAMPLE_DIR):
+    sys.path.pop(0)
+
+import torch
+import torch_tensorrt as torchtrt
+
+sys.path.insert(0, _EXAMPLE_DIR)
+from int4_utils import pre_process_model_for_export, quantize_linear_int4_symmetric
+from utils import exclude_dq_from_constant_folding
+
+# %%
+# Define a linear model and quantize weights to symmetric INT4
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+class LinearModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = torch.nn.Linear(3072, 4096)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+
+model = LinearModel().eval().to(dtype=torch.bfloat16, device="cuda")
+example_input = torch.randn(32, 3072, dtype=torch.bfloat16, device="cuda")
+
+quantize_linear_int4_symmetric(model, group_size=128)
+processed_model = pre_process_model_for_export(model)
+
+# %%
+# Export and compile
+# ^^^^^^^^^^^^^^^^^^
+# Wrap export in exclude_dq_from_constant_folding so inductor does not fold
+# dequantize_affine before Torch-TensorRT lowering. Use
+# immutable_weights=True: the converter re-packs int8 qdata into an INT4
+# constant at build time, and engine refit would push unpacked int8 at an INT4
+# prototype.
+
+with exclude_dq_from_constant_folding():
+    exp_program = torch.export.export(processed_model, (example_input,), strict=True)
+
+trt_model = torchtrt.dynamo.compile(
+    exp_program,
+    inputs=[example_input],
+    min_block_size=1,
+    use_explicit_typing=True,
+    require_full_compilation=True,
+    immutable_weights=True,
+)
+
+output = trt_model(example_input)
+print(output)

--- a/examples/dynamo/torchao/torch_export_flux_int4_woq.py
+++ b/examples/dynamo/torchao/torch_export_flux_int4_woq.py
@@ -1,0 +1,211 @@
+"""
+.. _torch_export_flux_int4_woq:
+
+Compiling FLUX.1-dev with TorchAO INT4 weight-only quantization
+===============================================================
+
+This example quantizes the transformer of
+`FLUX.1-dev <https://huggingface.co/black-forest-labs/FLUX.1-dev>`_ to
+**symmetric** group-wise INT4 with TorchAO, then compiles it with the
+Torch-TensorRT Dynamo backend.
+
+Weight-only INT4 keeps activations in BF16 and stores Linear weights as packed
+INT4 plus group-wise scales. After export, Torch-TensorRT maps
+dequantize_affine to TensorRT IDequantizeLayer and re-packs the
+unpacked int8 qdata into a trt.DataType.INT4 constant.
+
+You need access to FLUX.1-dev on Hugging Face. Quantization is done
+layer-by-layer on GPU so the rest of the pipeline can stay on CPU. Compile with
+immutable_weights=True (INT4 constants cannot be refit from int8 graph
+weights). On 32GB cards, park the text encoders during compile and generate
+from precomputed prompt embeddings so T5 and the TRT execution context are not
+resident together.
+
+.. code-block:: bash
+
+    pip install torchao diffusers transformers accelerate sentencepiece protobuf
+
+"""
+
+# %%
+# Imports
+# -------
+# This example lives in examples/dynamo/torchao/. Move that directory off
+# the front of sys.path so import torchao resolves the PyPI package
+# instead of this folder.
+
+import gc
+import os
+import sys
+from pathlib import Path
+
+_EXAMPLE_DIR = str(Path(__file__).resolve().parent)
+if sys.path and Path(sys.path[0]).resolve() == Path(_EXAMPLE_DIR):
+    sys.path.pop(0)
+
+import torch
+import torch_tensorrt
+from diffusers import FluxPipeline
+
+sys.path.insert(0, _EXAMPLE_DIR)
+from int4_utils import pre_process_model_for_export, quantize_linear_int4_symmetric
+from utils import exclude_dq_from_constant_folding
+
+DEVICE = "cuda:0"
+MODEL_ID = os.environ.get("FLUX_MODEL_ID", "black-forest-labs/FLUX.1-dev")
+GROUP_SIZE = int(os.environ.get("FLUX_INT4_GROUP_SIZE", "128"))
+PROMPT = (
+    "Baroque style, a lavish palace interior with ornate gilded ceilings, "
+    "intricate tapestries, and dramatic lighting over a grand staircase."
+)
+MAX_SEQUENCE_LENGTH = 512
+
+# %%
+# Load FLUX.1-dev and quantize the transformer
+# --------------------------------------------
+# Only the transformer is quantized and compiled. Text encoders and the VAE stay
+# BF16. Load on CPU, then quantize each Linear on GPU individually.
+
+pipe = FluxPipeline.from_pretrained(
+    MODEL_ID,
+    torch_dtype=torch.bfloat16,
+)
+config = pipe.transformer.config
+cache_context = getattr(pipe.transformer, "cache_context", None)
+
+quantize_linear_int4_symmetric(pipe.transformer, group_size=GROUP_SIZE)
+pipe.transformer = pre_process_model_for_export(pipe.transformer)
+
+# %%
+# Encode the prompt, then free the text encoders
+# ----------------------------------------------
+# The INT4 engine's execution context can reserve tens of GB. Compute embeddings
+# once, then drop CLIP/T5 so they are not resident during compile or generate.
+
+pipe.to(DEVICE)
+with torch.no_grad():
+    prompt_embeds, pooled_prompt_embeds, _ = pipe.encode_prompt(
+        prompt=PROMPT,
+        prompt_2=PROMPT,
+        device=torch.device(DEVICE),
+        max_sequence_length=MAX_SEQUENCE_LENGTH,
+    )
+pipe.text_encoder = None
+pipe.text_encoder_2 = None
+pipe.vae.to("cpu")
+gc.collect()
+torch.cuda.empty_cache()
+
+backbone = pipe.transformer.to(DEVICE)
+
+# %%
+# Export the quantized transformer
+# --------------------------------
+# Dummy inputs match the Flux transformer signature used by the BF16 / FP8 Flux
+# examples. exclude_dq_from_constant_folding keeps dequantize_affine in
+# the graph during torch.export.
+
+dummy_inputs = {
+    "hidden_states": torch.randn(1, 4096, 64, dtype=torch.bfloat16, device=DEVICE),
+    "encoder_hidden_states": torch.randn(
+        1, 512, 4096, dtype=torch.bfloat16, device=DEVICE
+    ),
+    "pooled_projections": torch.randn(1, 768, dtype=torch.bfloat16, device=DEVICE),
+    "timestep": torch.randn(1, dtype=torch.bfloat16, device=DEVICE),
+    "guidance": torch.randn(1, dtype=torch.float32, device=DEVICE),
+    "img_ids": torch.randn(4096, 3, dtype=torch.bfloat16, device=DEVICE),
+    "txt_ids": torch.randn(512, 3, dtype=torch.bfloat16, device=DEVICE),
+    "joint_attention_kwargs": {},
+    "return_dict": False,
+}
+
+with exclude_dq_from_constant_folding():
+    exp_program = torch.export.export(
+        backbone,
+        args=(),
+        kwargs=dummy_inputs,
+        strict=True,
+    )
+
+# %%
+# Compile with Torch-TensorRT
+# ---------------------------
+# .. note::
+#    Compilation of the 12B transformer takes on the order of 20–30 minutes.
+#    immutable_weights=True is required: the converter packs int8 qdata into
+#    INT4 at build time, and refit would push Int8 weights at an Int4 prototype.
+
+trt_gm = torch_tensorrt.dynamo.compile(
+    exp_program,
+    inputs=dummy_inputs,
+    truncate_double=True,
+    min_block_size=1,
+    use_explicit_typing=True,
+    require_full_compilation=True,
+    immutable_weights=True,
+    offload_module_to_cpu=True,
+)
+
+# %%
+# Swap the compiled transformer into the pipeline
+# -----------------------------------------------
+# Wrap the engine so Diffusers still sees a CUDA module after the text encoders
+# are dropped, and so TRT outputs are moved back to GPU if they land on CPU.
+
+
+class _TRTTransformerAdapter(torch.nn.Module):
+    def __init__(self, compiled, config, cache_context) -> None:
+        super().__init__()
+        self._compiled = compiled
+        self.config = config
+        self.cache_context = cache_context
+        self.register_buffer(
+            "_device_anchor", torch.empty(0, device=DEVICE), persistent=False
+        )
+
+    @property
+    def device(self) -> torch.device:
+        return self._device_anchor.device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return torch.bfloat16
+
+    def forward(self, *args, **kwargs):
+        def _to_cuda(x):
+            return x.to(DEVICE) if isinstance(x, torch.Tensor) else x
+
+        args = tuple(_to_cuda(a) for a in args)
+        kwargs = {k: _to_cuda(v) for k, v in kwargs.items()}
+        out = self._compiled(*args, **kwargs)
+        if isinstance(out, (tuple, list)):
+            return type(out)(_to_cuda(o) for o in out)
+        return _to_cuda(out)
+
+
+pipe.transformer = _TRTTransformerAdapter(trt_gm, config, cache_context)
+pipe.vae.to(DEVICE)
+del exp_program, backbone, trt_gm
+gc.collect()
+torch.cuda.empty_cache()
+
+# %%
+# Generate an image
+# -----------------
+
+
+def generate_image(pipe, image_name):
+    seed = 42
+    with torch.no_grad():
+        image = pipe(
+            prompt_embeds=prompt_embeds.to(DEVICE),
+            pooled_prompt_embeds=pooled_prompt_embeds.to(DEVICE),
+            output_type="pil",
+            num_inference_steps=20,
+            generator=torch.Generator("cuda").manual_seed(seed),
+        ).images[0]
+        image.save(f"{image_name}.png")
+        print(f"Image generated using {image_name} model saved as {image_name}.png")
+
+
+generate_image(pipe, "flux_int4_woq")

--- a/examples/dynamo/torchao/torch_export_qwen3_int4_woq.py
+++ b/examples/dynamo/torchao/torch_export_qwen3_int4_woq.py
@@ -1,0 +1,307 @@
+"""
+.. _torch_export_qwen3_int4_woq:
+
+Compiling Qwen3-8B with TorchAO INT4 weight-only quantization
+=============================================================
+
+This example loads
+`pytorch/Qwen3-8B-INT4 <https://huggingface.co/pytorch/Qwen3-8B-INT4>`_,
+converts Hub HQQ / tile-packed INT4 into TensorRT-compatible **symmetric**
+group-wise Int4Tensor weights, exports a logits-only wrapper, and compiles
+with the Torch-TensorRT Dynamo backend.
+
+Hub checkpoints are often asymmetric and may use Int4TilePackedTo4dTensor.
+Those layouts are dequantized to dense BF16, then re-packed with
+quantize_linear_int4_symmetric so IDequantizeLayer sees a zero
+zero-point and group-wise INT4 storage.
+
+The compiled engine is fixed to SEQ_LEN. Greedy decode pads or windows the
+growing sequence into that length (no KV cache), matching other Torch-TensorRT
+LLM examples.
+
+.. code-block:: bash
+
+    pip install torchao transformers accelerate
+
+    export QWEN3_INT4_MODEL=pytorch/Qwen3-8B-INT4
+    python torch_export_qwen3_int4_woq.py
+
+"""
+
+# %%
+# Imports
+# -------
+# This example lives in examples/dynamo/torchao/. Move that directory off
+# the front of sys.path so import torchao resolves the PyPI package
+# instead of this folder.
+
+from __future__ import annotations
+
+import copy
+import gc
+import os
+import sys
+from pathlib import Path
+
+_EXAMPLE_DIR = str(Path(__file__).resolve().parent)
+if sys.path and Path(sys.path[0]).resolve() == Path(_EXAMPLE_DIR):
+    sys.path.pop(0)
+
+import torch
+import torch_tensorrt as torchtrt
+from transformers import AutoConfig, AutoTokenizer, Qwen3ForCausalLM
+
+sys.path.insert(0, _EXAMPLE_DIR)
+from int4_utils import convert_hub_int4_to_symmetric_trt, pre_process_model_for_export
+from utils import exclude_dq_from_constant_folding
+
+MODEL_ID = os.environ.get("QWEN3_INT4_MODEL", "pytorch/Qwen3-8B-INT4")
+MAX_NEW_TOKENS = int(os.environ.get("QWEN3_MAX_NEW_TOKENS", "64"))
+GROUP_SIZE = int(os.environ.get("QWEN3_GROUP_SIZE", "128"))
+PROMPT = os.environ.get(
+    "QWEN3_PROMPT",
+    "Explain weight-only INT4 quantization in one short paragraph.",
+)
+SEQ_LEN = int(os.environ.get("QWEN3_SEQ_LEN", "128"))
+
+# %%
+# Sanitize Hub TorchAO config and load the model
+# ----------------------------------------------
+# Older checkpoints serialize layout=TensorCoreTiledLayout and other kwargs
+# removed in torchao>=0.17. Rewrite those onto int4_packing_format before
+# from_pretrained.
+
+
+def sanitize_torchao_quant_config(qc):
+    if qc is None:
+        return None
+    if hasattr(qc, "to_dict"):
+        d = qc.to_dict()
+    elif isinstance(qc, dict):
+        d = copy.deepcopy(qc)
+    else:
+        d = dict(qc)
+
+    qt = d.get("quant_type")
+    if isinstance(qt, dict) and "default" in qt:
+        entry = qt["default"]
+        data = entry.get("_data", entry)
+        layout = data.pop("layout", None)
+        if layout is not None and data.get("int4_packing_format") is None:
+            data["int4_packing_format"] = "tile_packed_to_4d"
+        if isinstance(layout, dict):
+            inner = (layout.get("_data") or {}).get("inner_k_tiles")
+            if inner is not None:
+                data["int4_tile_packed_ntile"] = inner
+        for k in ("use_hqq", "zero_point_domain", "preserve_zero", "layout"):
+            data.pop(k, None)
+        allowed = {
+            "group_size",
+            "set_inductor_config",
+            "int4_packing_format",
+            "int4_choose_qparams_algorithm",
+            "int4_tile_packed_ntile",
+        }
+        entry["_data"] = {k: v for k, v in data.items() if k in allowed}
+        qt["default"] = entry
+        d["quant_type"] = qt
+    return d
+
+
+class _LogitsWrapper(torch.nn.Module):
+    """CausalLM → logits only (export / TRT friendly)."""
+
+    def __init__(self, model: torch.nn.Module) -> None:
+        super().__init__()
+        self.model = model
+
+    def forward(
+        self, input_ids: torch.Tensor, position_ids: torch.Tensor
+    ) -> torch.Tensor:
+        return self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            use_cache=False,
+        ).logits
+
+
+def make_position_ids(seq_len: int, device: torch.device) -> torch.Tensor:
+    return torch.arange(seq_len, device=device).unsqueeze(0)
+
+
+print(f"Loading {MODEL_ID} ...")
+config = AutoConfig.from_pretrained(MODEL_ID, trust_remote_code=False)
+config.quantization_config = sanitize_torchao_quant_config(config.quantization_config)
+config.use_cache = False
+
+model = (
+    Qwen3ForCausalLM.from_pretrained(
+        MODEL_ID,
+        config=config,
+        dtype=torch.bfloat16,
+        attn_implementation="eager",
+        trust_remote_code=False,
+    )
+    .cuda()
+    .eval()
+)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, trust_remote_code=False)
+if tokenizer.pad_token_id is None:
+    tokenizer.pad_token = tokenizer.eos_token
+
+# %%
+# Convert Hub INT4 → symmetric Int4Tensor
+# ---------------------------------------
+
+convert_hub_int4_to_symmetric_trt(model, group_size=GROUP_SIZE, verbose=False)
+pre_process_model_for_export(model)
+
+# %%
+# Tokenize a fixed-length prompt
+# ------------------------------
+
+messages = [
+    {"role": "system", "content": "You are a helpful AI assistant."},
+    {"role": "user", "content": PROMPT},
+]
+templated = tokenizer.apply_chat_template(
+    messages,
+    tokenize=False,
+    add_generation_prompt=True,
+)
+encoded = tokenizer(
+    templated,
+    return_tensors="pt",
+    padding="max_length",
+    truncation=True,
+    max_length=SEQ_LEN,
+)
+input_ids = encoded["input_ids"].cuda()
+position_ids = make_position_ids(SEQ_LEN, input_ids.device)
+wrapper = _LogitsWrapper(model).eval()
+
+# %%
+# Greedy decode without KV cache
+# ------------------------------
+# The compiled engine is fixed to SEQ_LEN, so each step pads or windows the
+# growing sequence and reads logits at the last real (non-pad) position.
+
+
+def greedy_generate(
+    logits_fn,
+    input_ids: torch.Tensor,
+    max_new_tokens: int,
+    eos_token_id: int,
+    pad_token_id: int,
+) -> torch.Tensor:
+    nonempty = (input_ids[0] != pad_token_id).nonzero(as_tuple=False)
+    if nonempty.numel() == 0:
+        cur = input_ids.clone()
+    else:
+        cur = input_ids[:, : int(nonempty[-1]) + 1].clone()
+
+    for _ in range(max_new_tokens):
+        if cur.shape[1] >= SEQ_LEN:
+            window = cur[:, -SEQ_LEN:]
+            real_len = SEQ_LEN
+            start_pos = cur.shape[1] - SEQ_LEN
+            step_position_ids = torch.arange(
+                start_pos, start_pos + SEQ_LEN, device=cur.device
+            ).unsqueeze(0)
+        else:
+            pad = torch.full(
+                (cur.shape[0], SEQ_LEN - cur.shape[1]),
+                pad_token_id,
+                dtype=cur.dtype,
+                device=cur.device,
+            )
+            window = torch.cat([cur, pad], dim=1)
+            real_len = cur.shape[1]
+            step_position_ids = make_position_ids(SEQ_LEN, cur.device)
+
+        logits = logits_fn(window, step_position_ids)
+        if isinstance(logits, (tuple, list)):
+            logits = logits[0]
+        next_id = logits[:, real_len - 1, :].argmax(dim=-1, keepdim=True)
+        cur = torch.cat([cur, next_id], dim=-1)
+        if int(next_id.item()) == int(eos_token_id):
+            break
+    return cur
+
+
+# %%
+# Eager baseline
+# --------------
+
+with torch.no_grad():
+    eager_logits = wrapper(input_ids, position_ids)
+    eager_ids = greedy_generate(
+        wrapper,
+        input_ids,
+        max_new_tokens=MAX_NEW_TOKENS,
+        eos_token_id=tokenizer.eos_token_id,
+        pad_token_id=tokenizer.pad_token_id,
+    )
+print("eager:", tokenizer.decode(eager_ids[0], skip_special_tokens=True))
+
+# %%
+# Export and compile
+# ------------------
+# strict=False matches other Torch-TensorRT LLM examples (aotautograd).
+# immutable_weights=True is required for INT4 packed constants.
+
+processed = pre_process_model_for_export(wrapper)
+with exclude_dq_from_constant_folding():
+    exp_program = torch.export.export(
+        processed,
+        (input_ids, position_ids),
+        strict=False,
+    )
+
+compiled = torchtrt.dynamo.compile(
+    exp_program,
+    inputs=[input_ids, position_ids],
+    truncate_double=True,
+    require_full_compilation=True,
+    immutable_weights=True,
+    min_block_size=1,
+    use_explicit_typing=True,
+)
+
+del exp_program, processed
+gc.collect()
+torch.cuda.empty_cache()
+
+# %%
+# Torch-TensorRT inference
+# ------------------------
+
+with torch.no_grad():
+    trt_logits = compiled(input_ids, position_ids)
+if isinstance(trt_logits, (tuple, list)):
+    trt_logits = trt_logits[0]
+trt_logits = trt_logits.to(device=eager_logits.device, dtype=eager_logits.dtype)
+
+diff = (trt_logits.float() - eager_logits.float()).abs()
+print(f"max |Δlogits|:  {diff.max().item():.6g}")
+print(f"mean |Δlogits|: {diff.mean().item():.6g}")
+
+nonempty = (input_ids[0] != tokenizer.pad_token_id).nonzero(as_tuple=False)
+last_pos = int(nonempty[-1]) if nonempty.numel() else input_ids.shape[1] - 1
+eager_tok = eager_logits[0, last_pos].argmax()
+trt_tok = trt_logits[0, last_pos].argmax()
+print(
+    f"next-token argmax @ pos {last_pos}: "
+    f"eager={int(eager_tok)} trt={int(trt_tok)} "
+    f"match={bool(eager_tok == trt_tok)}"
+)
+
+with torch.no_grad():
+    trt_ids = greedy_generate(
+        compiled,
+        input_ids,
+        max_new_tokens=MAX_NEW_TOKENS,
+        eos_token_id=tokenizer.eos_token_id,
+        pad_token_id=tokenizer.pad_token_id,
+    )
+print("trt:", tokenizer.decode(trt_ids[0], skip_special_tokens=True))

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -1058,6 +1058,9 @@ else:
         if output_dtype is None:
             output_dtype = args[7] if len(args) > 7 else torch.float16
         input_dtype = args[4] if len(args) > 4 else None
+        zero_point = kwargs.get("zero_point")
+        if zero_point is None and len(args) > 3:
+            zero_point = args[3]
         return impl.quantize.dequantize_affine(
             ctx,
             target,
@@ -1068,6 +1071,7 @@ else:
             args[2],
             output_dtype,
             input_dtype=input_dtype,
+            zero_point=zero_point,
         )
 
 
@@ -1298,28 +1302,28 @@ def _index_copy_kv_eligible(
     *,
     input_node: Optional[Node] = None,
 ) -> bool:
-    """Validator for the KV-cache fast path of ``aten.index_copy.default``.
+    """Validator for the KV-cache fast path of aten.index_copy.default.
 
-    Returns True only for the narrow case our ``IKVCacheUpdateLayer``
+    Returns True only for the narrow case our IKVCacheUpdateLayer
     emitter can handle without a graph break:
 
     * Input is an FX placeholder (i.e. a network input — required for
       aliasing).
-    * Input has rank 4 and fully static shape ``[b, d, s_max, h]``.
-    * ``dim`` argument is exactly ``2``.
-    * Source tensor has rank 4 with ``shape[2] == 1`` (single-position
-      write; matches HF's per-step ``StaticCache.update`` call).
+    * Input has rank 4 and fully static shape [b, d, s_max, h].
+    * dim argument is exactly 2.
+    * Source tensor has rank 4 with shape[2] == 1 (single-position
+      write; matches HF's per-step StaticCache.update call).
     * Batch is 1 (avoids writeIndices broadcasting; trivially extensible
       to larger batches when needed).
 
     Cases that fail this validator fall through to
-    ``aten_ops_index_copy_fallback``.
+    aten_ops_index_copy_fallback.
 
-    ``input_node`` overrides which node the input checks are applied to. The
+    input_node overrides which node the input checks are applied to. The
     partitioner never passes it: by the time this runs as a capability validator,
     lowering has settled what the input is. The pre-conversion classifier in
-    ``lowering/_buffer_lifting.py`` runs before that and passes the node lowering
-    will leave behind, which is not always ``node.args[0]``.
+    lowering/_buffer_lifting.py runs before that and passes the node lowering
+    will leave behind, which is not always node.args[0].
     """
     # That same classifier marks a write it filed copy-back rather than KV, and its
     # value is a graph output by now. Aliasing it as well would hand the runtime an
@@ -1346,7 +1350,7 @@ def _index_copy_kv_eligible(
         return False  # batch > 1 deferred; see index_copy.index_copy_kv
 
     # IKVCacheUpdateLayer scatters along the sequence axis, which is axis 2 in
-    # the KV-cache layout it requires: ``[batch, num_heads, s_max, head_dim]``.
+    # the KV-cache layout it requires: [batch, num_heads, s_max, head_dim].
     # A write on any other axis is not a cache-position update and cannot be
     # expressed by the layer, so it must fall through to the scatter fallback.
     if dim != 2:

--- a/py/torch_tensorrt/dynamo/conversion/impl/quantize.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/quantize.py
@@ -14,6 +14,7 @@ from torch_tensorrt.dynamo.conversion.converter_utils import (
     get_trt_tensor,
     set_layer_name,
     to_torch,
+    to_trt_weights,
 )
 
 
@@ -153,6 +154,71 @@ def _block_size_as_ints(block_size: Sequence[object]) -> list[int]:
     return dims
 
 
+def _pack_int4_nibbles(qdata: torch.Tensor) -> torch.Tensor:
+    """Pack adjacent INT4 values into bytes (mslk / TensorRT nibble order).
+
+    Even columns go in the low nibble, odd columns in the high nibble.
+    """
+    if qdata.dtype != torch.int8:
+        raise ValueError(f"expected int8 qdata for INT4 packing, got {qdata.dtype}")
+    if qdata.shape[-1] % 2 != 0:
+        raise ValueError(
+            f"K dim must be even for INT4 packing, got {tuple(qdata.shape)}"
+        )
+    low = torch.bitwise_and(qdata[..., ::2], 0x0F)
+    high = torch.bitwise_left_shift(qdata[..., 1::2], 4)
+    return torch.bitwise_or(low, high).contiguous()
+
+
+def _is_groupwise_int4(
+    qdata: Union[torch.Tensor, TRTTensor],
+    block_size: Sequence[object],
+) -> bool:
+    """True when DQ is group-wise INT4 (blocked scale along the last dim).
+
+    Per-row INT8 uses block_size=[1, K] with K == qdata.shape[-1], which
+    also has block_size[-1] > 1. That is *not* INT4 groupwise.
+    """
+    if not isinstance(qdata, torch.Tensor) or qdata.dtype != torch.int8:
+        return False
+    try:
+        bs = _block_size_as_ints(block_size)
+    except TypeError:
+        return False
+    if not bs or bs[-1] <= 1:
+        return False
+    if bs[-1] >= qdata.shape[-1]:
+        return False
+    return True
+
+
+def _add_int4_constant(
+    ctx: ConversionContext, qdata: torch.Tensor, name: str
+) -> TRTTensor:
+    """Create a TRT constant with logical shape (N, K) and packed INT4 weights."""
+    packed = _pack_int4_nibbles(qdata.contiguous().cpu())
+    weights = to_trt_weights(
+        ctx,
+        packed,
+        name,
+        "CONSTANT",
+        "CONSTANT",
+        dtype=trt.DataType.INT4,
+        count=qdata.numel(),
+    )
+    constant = ctx.net.add_constant(list(qdata.shape), weights)
+    constant.name = name
+    return constant.get_output(0)
+
+
+def _zero_point_is_nonzero(zero_point: object) -> bool:
+    if zero_point is None:
+        return False
+    if isinstance(zero_point, torch.Tensor):
+        return bool(torch.any(zero_point != 0).item())
+    return True
+
+
 def dequantize_affine(
     ctx: ConversionContext,
     target: Target,
@@ -163,36 +229,60 @@ def dequantize_affine(
     scale: Union[np.ndarray, torch.Tensor, TRTTensor],
     output_dtype: torch.dtype,
     input_dtype: Optional[torch.dtype] = None,
+    zero_point: Optional[object] = None,
 ) -> TRTTensor:
-    """Map ``torchao.dequantize_affine`` to TensorRT ``IDequantizeLayer``.
+    """Map torchao.dequantize_affine to TensorRT IDequantizeLayer.
 
     Used by TorchAO weight-only quantization (FP8/INT8/INT4). The quantized
     weight stays a low-precision constant and is dequantized at the GEMM
     boundary so Myelin can fuse DQ into the matmul prologue instead of
     folding it into a dense high-precision weight.
-    """
-    qdata_trt = get_trt_tensor(ctx, qdata, f"{name}_qdata", dtype=input_dtype)
 
-    axis = None
-    if isinstance(scale, torch.Tensor):
-        scale_for_trt = scale.squeeze()
-        if scale_for_trt.numel() != 1:
-            # Per-channel axis is the dimension whose block size is 1
-            # (quantized independently per slice). Example: weight (3072, 64)
-            # with block_size [3072, 1] → axis 1.
-            bs = _block_size_as_ints(block_size)
-            try:
-                axis = next(i for i, dim in enumerate(bs) if dim == 1)
-            except StopIteration as exc:
-                raise ValueError(
-                    f"Unable to derive IDequantizeLayer axis from block_size={bs} "
-                    f"and scale shape {tuple(scale.shape)}"
-                ) from exc
-    else:
+    Group-wise INT4 WOQ unpacks to int8 in the PyTorch graph; this converter
+    re-packs those nibbles into a trt.DataType.INT4 constant. TensorRT
+    blocked INT4 DQ currently wants an FP32 DQ output (cast back to BF16
+    after). Nonzero zero-points are rejected for that path.
+    """
+    use_int4 = _is_groupwise_int4(qdata, block_size)
+
+    if use_int4:
+        if _zero_point_is_nonzero(zero_point):
+            raise RuntimeError(
+                "TensorRT IDequantizeLayer rejects nonzero zero_point; "
+                "group-wise INT4 WOQ must use symmetric quantization "
+                f"(got nonzero zero_point for '{name}')"
+            )
+        assert isinstance(qdata, torch.Tensor)
+        qdata_trt = _add_int4_constant(ctx, qdata, f"{name}_qdata_int4")
+        # Blocked along the group dimension (last dim of block_size > 1).
+        axis: Optional[int] = len(_block_size_as_ints(block_size)) - 1
         scale_for_trt = scale
+        # Myelin currently matches INT4 blocked DQ -> FP32, not BF16.
+        trt_output_dtype = trt.DataType.FLOAT
+    else:
+        qdata_trt = get_trt_tensor(ctx, qdata, f"{name}_qdata", dtype=input_dtype)
+
+        axis = None
+        if isinstance(scale, torch.Tensor):
+            scale_for_trt = scale.squeeze()
+            if scale_for_trt.numel() != 1:
+                # Per-channel axis is the dimension whose block size is 1
+                # (quantized independently per slice). Example: weight (3072, 64)
+                # with block_size [3072, 1] → axis 1.
+                bs = _block_size_as_ints(block_size)
+                try:
+                    axis = next(i for i, dim in enumerate(bs) if dim == 1)
+                except StopIteration as exc:
+                    raise ValueError(
+                        f"Unable to derive IDequantizeLayer axis from block_size={bs} "
+                        f"and scale shape {tuple(scale.shape)}"
+                    ) from exc
+        else:
+            scale_for_trt = scale
+
+        trt_output_dtype = _enums.dtype._from(output_dtype).to(trt.DataType)
 
     scale_trt = get_trt_tensor(ctx, scale_for_trt, f"{name}_scale", dtype=torch.float32)
-    trt_output_dtype = _enums.dtype._from(output_dtype).to(trt.DataType)
 
     dequantize_layer = ctx.net.add_dequantize(
         qdata_trt,
@@ -229,7 +319,7 @@ def quantize_affine_float8(
     input_tensor: Union[torch.Tensor, TRTTensor],
     scale: Union[np.ndarray, torch.Tensor, TRTTensor],
 ) -> TRTTensor:
-    """Map TorchAO ``quantize_affine_float8_non_decomposed`` to ``IQuantizeLayer``."""
+    """Map TorchAO quantize_affine_float8_non_decomposed to IQuantizeLayer."""
     input_trt = get_trt_tensor(ctx, input_tensor, f"{name}_input")
     scale_trt, axis = _fp8_scale_and_axis(ctx, scale, name)
     quantize_layer = ctx.net.add_quantize(input_trt, scale_trt, trt.DataType.FP8)
@@ -248,7 +338,7 @@ def dequantize_affine_float8(
     scale: Union[np.ndarray, torch.Tensor, TRTTensor],
     output_dtype: torch.dtype = torch.bfloat16,
 ) -> TRTTensor:
-    """Map TorchAO ``dequantize_affine_float8_non_decomposed`` to ``IDequantizeLayer``."""
+    """Map TorchAO dequantize_affine_float8_non_decomposed to IDequantizeLayer."""
     input_trt = get_trt_tensor(ctx, input_tensor, f"{name}_input")
     scale_trt, axis = _fp8_scale_and_axis(ctx, scale, name)
     trt_output_dtype = _enums.dtype._from(output_dtype).to(trt.DataType)

--- a/tests/py/dynamo/models/test_torchao_fp8_woq.py
+++ b/tests/py/dynamo/models/test_torchao_fp8_woq.py
@@ -170,3 +170,74 @@ def test_linear_fp8_static():
         ),
     )
     torch._dynamo.reset()
+
+
+@pytest.mark.unit
+@unittest.skipIf(importlib.util.find_spec("torchao") is None, "torchao not installed")
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+def test_linear_int4_woq():
+    import sys
+    from pathlib import Path
+
+    example_dir = (
+        Path(__file__).resolve().parents[4] / "examples" / "dynamo" / "torchao"
+    )
+    sys.path.insert(0, str(example_dir))
+    from int4_utils import pre_process_model_for_export, quantize_linear_int4_symmetric
+    from utils import exclude_dq_from_constant_folding
+
+    class LinearModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(64, 128)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.linear(x)
+
+    model = LinearModel().eval().to(dtype=torch.bfloat16, device="cuda")
+    example_input = torch.randn(8, 64, dtype=torch.bfloat16, device="cuda")
+    quantize_linear_int4_symmetric(model, group_size=32)
+    model = pre_process_model_for_export(model)
+    assertions.assertTrue(
+        torch.all(model.linear.weight.zero_point == 0).item(),
+        msg="INT4 WOQ test expected symmetric zero_point",
+    )
+
+    with exclude_dq_from_constant_folding():
+        exp_program = torch.export.export(model, (example_input,), strict=True)
+
+    dq_nodes = [
+        n
+        for n in exp_program.graph.nodes
+        if n.target == torch.ops.torchao.dequantize_affine.default
+    ]
+    assertions.assertTrue(
+        len(dq_nodes) >= 1,
+        msg="Exported graph is missing torchao.dequantize_affine",
+    )
+
+    trt_mod = torchtrt.dynamo.compile(
+        exp_program,
+        inputs=[example_input],
+        min_block_size=1,
+        use_explicit_typing=True,
+        require_full_compilation=True,
+        immutable_weights=True,
+        cache_built_engines=False,
+        reuse_cached_engines=False,
+    )
+
+    with torch.no_grad():
+        eager_out = model(example_input)
+        trt_out = trt_mod(example_input)
+    if isinstance(trt_out, (list, tuple)):
+        trt_out = trt_out[0]
+    cos_sim = cosine_similarity(eager_out, trt_out)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=(
+            "TorchAO INT4 WOQ TRT outputs don't match eager. "
+            f"Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}"
+        ),
+    )
+    torch._dynamo.reset()


### PR DESCRIPTION
## Summary
- Extend `torchao.dequantize_affine` so group-wise INT4 is re-packed to `trt.DataType.INT4` (symmetric zero-point; blocked DQ currently FP32 then cast).
- Add TorchAO INT4 WOQ gallery examples: toy Linear, FLUX.1-dev, and Qwen3-8B Hub (`pytorch/Qwen3-8B-INT4`).
- Document the path in the quantization user guide, troubleshooting, and example index.

Stacked on #4589 (TorchAO FP8). INT4 compile needs `immutable_weights=True`.

Replaces #4588 (same commits; reopened from `pytorch/TensorRT` branches so GitHub native Stacks work).

## Test plan
- [x] `tests/py/dynamo/models/test_torchao_fp8_woq.py::test_linear_int4_woq` (CUDA)
- [ ] `python examples/dynamo/torchao/quantize_linear_int4_woq.py`
- [ ] FLUX / Qwen3 examples on a GPU with enough VRAM