### PR TITLE
Added TorchAO NVFP4 weight-only quantization + Linear and FLUX examples

### DIFF
--- a/docsrc/debugging/troubleshooting.rst
+++ b/docsrc/debugging/troubleshooting.rst
@@ -228,6 +228,11 @@ Accuracy / Performance Issues
     :ref:`torch_export_qwen3_int4_woq`. Use symmetric INT4 (zero zero-point)
     and ``immutable_weights=True`` so engine constants stay ``Datatype: Int4``.
 
+    For **NVFP4 weight-only** quantization with TorchAO, see
+    :ref:`quantize_linear_nvfp4_woq` and :ref:`torch_export_flux_nvfp4_woq`.
+    Export must keep ``dequantize_nvfp4`` so the engine can keep
+    ``Datatype: FP4E2M1``.
+
 ----
 
 Distributed / Tensor-Parallel Issues

--- a/docsrc/tutorials/huggingface/index.rst
+++ b/docsrc/tutorials/huggingface/index.rst
@@ -13,5 +13,6 @@ the Mutable Torch-TensorRT Module.
    Example: Compiling Stable Diffusion with torch.compile <../_rendered_examples/dynamo/torch_compile_stable_diffusion>
    Example: Compiling FLUX.1-dev with the dynamo backend <../_rendered_examples/dynamo/torch_export_flux_dev>
    Example: FLUX.1-dev INT4 WOQ <../_rendered_examples/dynamo/torchao/torch_export_flux_int4_woq>
+   Example: FLUX.1-dev NVFP4 WOQ <../_rendered_examples/dynamo/torchao/torch_export_flux_nvfp4_woq>
    Example: Qwen3-8B INT4 WOQ <../_rendered_examples/dynamo/torchao/torch_export_qwen3_int4_woq>
    Example: Mutable Torch TensorRT Module <../_rendered_examples/dynamo/mutable_torchtrt_module_example>

--- a/docsrc/user_guide/shapes_precision/index.rst
+++ b/docsrc/user_guide/shapes_precision/index.rst
@@ -18,3 +18,5 @@ and reduce model size with INT8/FP8/FP4 quantization via ModelOpt or TorchAO.
    Example: TorchAO INT4 WOQ Linear <../../tutorials/_rendered_examples/dynamo/torchao/quantize_linear_int4_woq>
    Example: FLUX.1-dev INT4 WOQ <../../tutorials/_rendered_examples/dynamo/torchao/torch_export_flux_int4_woq>
    Example: Qwen3-8B INT4 WOQ <../../tutorials/_rendered_examples/dynamo/torchao/torch_export_qwen3_int4_woq>
+   Example: TorchAO NVFP4 WOQ Linear <../../tutorials/_rendered_examples/dynamo/torchao/quantize_linear_nvfp4_woq>
+   Example: FLUX.1-dev NVFP4 WOQ <../../tutorials/_rendered_examples/dynamo/torchao/torch_export_flux_nvfp4_woq>

--- a/docsrc/user_guide/shapes_precision/quantization.rst
+++ b/docsrc/user_guide/shapes_precision/quantization.rst
@@ -6,7 +6,8 @@ Quantization (INT8 / FP8 / FP4)
 Torch-TensorRT supports post-training quantization (PTQ) with **INT8**, **FP8**, and
 **FP4** precisions via NVIDIA's
 `ModelOpt <https://github.com/NVIDIA/TensorRT-Model-Optimizer>`_ library, and
-**FP8 weight-only**, **static FP8**, and **INT4 weight-only** quantization via
+**FP8 weight-only**, **static FP8**, **INT4 weight-only**, and **NVFP4
+weight-only** quantization via
 `TorchAO <https://github.com/pytorch/ao>`_. Quantizers insert
 quantize/dequantize (QDQ) nodes into the model graph; Torch-TensorRT then
 converts those nodes into TRT quantization layers and sets the appropriate builder flags.
@@ -28,7 +29,8 @@ Hardware requirements:
 * **INT8**: Any NVIDIA GPU with TensorRT support.
 * **FP8**: NVIDIA Hopper (H100) or newer.
 * **INT4 (TorchAO WOQ)**: TensorRT with INT4 constants (TRT ≥ 10.8); storage + DQ, not low-bit MMA.
-* **FP4 (NVFP4)**: NVIDIA Blackwell (B100/B200) or newer; requires TensorRT ≥ 10.8.
+* **NVFP4 (TorchAO WOQ)**: TensorRT with FP4 constants (TRT ≥ 10.8); packed FP4 storage + DQ, not native FP4 MMA.
+* **FP4 (ModelOpt NVFP4)**: NVIDIA Blackwell (B100/B200) or newer; requires TensorRT ≥ 10.8.
 
 ----
 
@@ -247,6 +249,48 @@ See :ref:`quantize_linear_int4_woq` for a toy Linear model,
 
 ----
 
+TorchAO NVFP4 Weight-Only Quantization
+--------------------------------------
+
+TorchAO NVFP4 quantizes Linear weights to packed FP4 E2M1 (two values per
+byte) with FP8 E4M3 block scales (block size 16) and an FP32 per-tensor
+global scale. Activations stay BF16. This is **weight-only storage**:
+TensorRT keeps an FP4 constant and dequantizes into a high-precision GEMM.
+It is not native FP4 Tensor Core MMA, and it is a different graph from
+ModelOpt ``NVFP4_DEFAULT_CFG`` (``dynamic_block_quantize_op``).
+
+Last two weight dims must be divisible by 16. Parent ``NVFP4Tensor`` Linear
+does not emit a DQ op TensorRT can map. Promote weights to
+``NVFP4TensorNonDecomposed`` so export emits
+``torch.ops.torchao_trt.dequantize_nvfp4``. The converter unswizzles TorchAO
+block scales, then builds an FP4 constant, an FP8 block-scale constant, and
+two-level ``IDequantizeLayer``.
+
+Torch-TensorRT marks ``dequantize_nvfp4`` impure in constant folding so the
+packed FP4 weight is not folded into a dense BF16 constant. Compile with
+``immutable_weights=True``.
+
+.. code-block:: python
+
+    quantize_linear_nvfp4(model)
+    model = pre_process_model_for_export(model)
+
+    exp_program = torch.export.export(model, (example_input,), strict=True)
+
+    trt_model = torch_tensorrt.dynamo.compile(
+        exp_program,
+        inputs=[example_input],
+        min_block_size=1,
+        use_explicit_typing=True,
+        require_full_compilation=True,
+        immutable_weights=True,
+    )
+
+See :ref:`quantize_linear_nvfp4_woq` for a toy Linear model and
+:ref:`torch_export_flux_nvfp4_woq` for FLUX.1-dev.
+
+----
+
 TorchAO Static FP8 Quantization
 --------------------------------
 
@@ -293,8 +337,12 @@ For TorchAO static FP8 graphs,
 map to ``IQuantizeLayer`` / ``IDequantizeLayer`` so both activations and weights
 participate in FP8 GEMM fusion.
 
-For FP4, ``torch.ops.tensorrt.dynamic_block_quantize_op.default`` nodes are converted
-via the dynamic block quantize converter, which uses TRT's
+For TorchAO NVFP4 weight-only graphs, ``torch.ops.torchao_trt.dequantize_nvfp4.default``
+is mapped to two-level ``IDequantizeLayer`` (FP8 block scales restored with the
+global scale, then packed FP4 dequantized into the GEMM input type).
+
+For ModelOpt FP4, ``torch.ops.tensorrt.dynamic_block_quantize_op.default`` nodes
+are converted via the dynamic block quantize converter, which uses TRT's
 ``add_dynamic_quantize`` API (TRT ≥ 10.8).
 
 The ``constant_folding`` lowering pass explicitly marks quantization ops as *impure* to
@@ -337,7 +385,10 @@ Supported Precision / Hardware Matrix
    * - INT4 (TorchAO WOQ)
      - Any TRT-capable GPU with INT4 support
      - TRT ≥ 10.8
-   * - FP4 (NVFP4)
+   * - NVFP4 (TorchAO WOQ)
+     - GPU with TRT FP4 constants
+     - TRT ≥ 10.8
+   * - FP4 (ModelOpt NVFP4)
      - NVIDIA Blackwell (B100+)
      - TRT ≥ 10.8
 
@@ -380,3 +431,9 @@ Troubleshooting
     TorchAO's default INT4 config is asymmetric. Use
     ``quantize_linear_int4_symmetric`` (or ``convert_hub_int4_to_symmetric_trt``
     for Hub checkpoints) as in :ref:`quantize_linear_int4_woq`.
+
+**TorchAO NVFP4 weights folded to BF16, or engine has no FP4E2M1 constant**
+    The graph must keep ``torchao_trt.dequantize_nvfp4``. Promote weights with
+    ``pre_process_model_for_export`` as in :ref:`quantize_linear_nvfp4_woq`.
+    Last two Linear dims must be divisible by 16. This path is weight-only DQ
+    + BF16 GEMM, not ModelOpt ``dynamic_block_quantize_op``.

--- a/examples/dynamo/README.rst
+++ b/examples/dynamo/README.rst
@@ -31,6 +31,8 @@ Model Zoo
 * :ref:`quantize_linear_int4_woq`: TorchAO INT4 weight-only quantization of a Linear layer (``examples/dynamo/torchao``)
 * :ref:`torch_export_flux_int4_woq`: Compiling FLUX.1-dev with TorchAO INT4 weight-only quantization (``examples/dynamo/torchao``)
 * :ref:`torch_export_qwen3_int4_woq`: Compiling Qwen3-8B with TorchAO INT4 weight-only quantization (``examples/dynamo/torchao``)
+* :ref:`quantize_linear_nvfp4_woq`: TorchAO NVFP4 weight-only quantization of a Linear layer (``examples/dynamo/torchao``)
+* :ref:`torch_export_flux_nvfp4_woq`: Compiling FLUX.1-dev with TorchAO NVFP4 weight-only quantization (``examples/dynamo/torchao``)
 * :ref:`debugger_example`: Debugging Torch-TensorRT Compilation
 * :ref:`torch_export_3d_rope`: Compiling a 3D RoPE video-transformer block with complex numerics support
 * :ref:`engine_converter_binding_names`: Naming input / output bindings when emitting a raw serialized TRT engine

--- a/examples/dynamo/torchao/README.rst
+++ b/examples/dynamo/torchao/README.rst
@@ -17,6 +17,11 @@ Weight-only INT4 is the same DQ pattern with packed 4-bit integer weights.
 Use **symmetric** group-wise INT4 (zero zero-point) and compile with
 ``immutable_weights=True`` so engine constants stay ``Datatype: Int4``.
 
+Weight-only NVFP4 stores packed FP4 E2M1 weights with FP8 block scales.
+Export emits ``dequantize_nvfp4``, which Torch-TensorRT maps to two-level
+``IDequantizeLayer`` so the engine can keep ``Datatype: FP4E2M1``. This is
+storage + DQ, not native FP4 MMA.
+
 .. code-block:: bash
 
     pip install -r ../requirements.txt
@@ -26,4 +31,6 @@ Use **symmetric** group-wise INT4 (zero zero-point) and compile with
     python quantize_linear_int4_woq.py
     python torch_export_flux_int4_woq.py
     python torch_export_qwen3_int4_woq.py
+    python quantize_linear_nvfp4_woq.py
+    python torch_export_flux_nvfp4_woq.py
 """

--- a/examples/dynamo/torchao/nvfp4_utils.py
+++ b/examples/dynamo/torchao/nvfp4_utils.py
@@ -1,0 +1,144 @@
+"""Helpers for TorchAO NVFP4 weight-only quantization examples.
+
+TorchAO's default NVFP4 Linear path dequantizes in Python and export would
+see an opaque weight. NVFP4TensorNonDecomposed emits
+``torchao_trt.dequantize_nvfp4`` so Torch-TensorRT can map packed FP4 +
+swizzled FP8 block scales to TensorRT constants and IDequantizeLayer.
+
+NVFP4 requires the last two weight dims to be divisible by 16.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch_tensorrt.dynamo.conversion.nvfp4_custom_op import dequantize_nvfp4
+from torchao.prototype.mx_formats.nvfp4_tensor import (
+    NVFP4Tensor,
+    per_tensor_amax_to_scale,
+)
+from torchao.utils import _dispatch__torch_function__
+
+aten = torch.ops.aten
+
+
+class NVFP4TensorNonDecomposed(NVFP4Tensor):
+    """NVFP4Tensor that dequantizes via explicit ``dequantize_nvfp4``.
+
+    Parent NVFP4Tensor disables ``__torch_function__``; re-enable it so
+    functional linear is intercepted before export treats the parameter as
+    opaque.
+    """
+
+    __torch_function__ = classmethod(_dispatch__torch_function__)
+
+
+implements = NVFP4TensorNonDecomposed.implements
+implements_torch_function = NVFP4TensorNonDecomposed.implements_torch_function
+
+
+@implements([aten.linear.default])
+@implements_torch_function([torch.nn.functional.linear])
+def _nvfp4_non_decomposed_linear(func, types, args, kwargs):
+    """Run Linear as dequantize + F.linear so export sees dequantize_nvfp4."""
+    input_tensor = args[0]
+    weight_tensor = args[1]
+    bias = args[2] if len(args) > 2 else None
+
+    assert isinstance(weight_tensor, NVFP4TensorNonDecomposed)
+    assert weight_tensor.per_tensor_scale is not None
+    assert weight_tensor.is_swizzled_scales
+
+    rows, cols = weight_tensor.shape
+    weight_hp = dequantize_nvfp4(
+        weight_tensor.qdata,
+        weight_tensor.scale,
+        weight_tensor.per_tensor_scale,
+        rows,
+        cols,
+        input_tensor.dtype,
+    )
+    if bias is not None and bias.dtype != input_tensor.dtype:
+        bias = bias.to(input_tensor.dtype)
+    return torch.nn.functional.linear(input_tensor, weight_hp, bias)
+
+
+def quantize_linear_nvfp4(
+    model: torch.nn.Module,
+    verbose: bool = False,
+    compute_device: Optional[str] = None,
+) -> torch.nn.Module:
+    """Replace Linear weights with NVFP4 (packed FP4 E2M1 + FP8 block scales).
+
+    Skips layers whose last two dims are not divisible by 16. Each layer is
+    quantized on ``compute_device`` then moved back so VRAM stays bounded.
+    """
+    if compute_device is None:
+        compute_device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    quantized = 0
+    skipped = 0
+    for name, module in model.named_modules():
+        if not isinstance(module, torch.nn.Linear):
+            continue
+        weight = module.weight
+        if getattr(weight, "is_meta", False):
+            raise RuntimeError(
+                f"{name}.weight is on the meta device (no data to quantize). "
+                "Load the model without device_map/offloading before quantizing."
+            )
+
+        if weight.shape[-2] % 16 != 0 or weight.shape[-1] % 16 != 0:
+            if verbose:
+                print(
+                    f"[skip] {name}: shape {tuple(weight.shape)} " "not divisible by 16"
+                )
+            skipped += 1
+            continue
+
+        original_device = weight.device
+        hp = weight.detach().to(device=compute_device, dtype=torch.bfloat16)
+        tensor_amax = torch.max(torch.abs(hp))
+        per_tensor_scale = per_tensor_amax_to_scale(tensor_amax)
+        qw = NVFP4Tensor.to_nvfp4(
+            hp,
+            per_tensor_scale=per_tensor_scale,
+            is_swizzled_scales=True,
+            act_quant_kwargs=None,
+        )
+        if qw.device != original_device:
+            qw = qw.to(original_device)
+        module.weight = torch.nn.Parameter(qw, requires_grad=False)
+        quantized += 1
+        del hp
+        if verbose:
+            print(
+                f"[nvfp4] {name}: {tuple(weight.shape)} "
+                f"-> qdata {tuple(qw.qdata.shape)} scale {tuple(qw.scale.shape)}"
+            )
+
+    if compute_device == "cuda":
+        torch.cuda.empty_cache()
+    if verbose:
+        print(
+            f"Quantized {quantized} Linear layers to NVFP4 "
+            f"(skipped {skipped}; block_size=16, swizzled FP8 scales)"
+        )
+    return model
+
+
+def convert_nvfp4_to_non_decomposed(model: torch.nn.Module) -> torch.nn.Module:
+    """Promote all NVFP4Tensor parameters to NVFP4TensorNonDecomposed."""
+    for param in model.parameters():
+        if isinstance(param, NVFP4Tensor) and not isinstance(
+            param, NVFP4TensorNonDecomposed
+        ):
+            param.__class__ = NVFP4TensorNonDecomposed
+            param.requires_grad_(False)
+    return model
+
+
+def pre_process_model_for_export(model: torch.nn.Module) -> torch.nn.Module:
+    """Promote NVFP4Tensor parameters so export emits dequantize_nvfp4."""
+    return convert_nvfp4_to_non_decomposed(model)

--- a/examples/dynamo/torchao/quantize_linear_nvfp4_woq.py
+++ b/examples/dynamo/torchao/quantize_linear_nvfp4_woq.py
@@ -1,0 +1,86 @@
+"""
+.. _quantize_linear_nvfp4_woq:
+
+TorchAO NVFP4 Weight-Only Quantization (Linear)
+===============================================
+
+This example quantizes a toy ``nn.Linear`` to NVFP4 with TorchAO (packed
+FP4 E2M1 weights, FP8 E4M3 block scales, FP32 global scale), keeps an
+explicit ``torchao_trt.dequantize_nvfp4`` in the exported graph, and compiles
+with the Torch-TensorRT Dynamo backend.
+
+The intended engine keeps an FP4 weight constant plus a two-level DQ
+prologue into a high-precision GEMM. This is 4-bit **weight-only storage**,
+not native FP4 Tensor Core MMA — activations stay BF16.
+
+NVFP4 requires the last two weight dims to be divisible by 16. TorchAO's
+default NVFP4 Linear path does not emit a DQ op TensorRT can map, so weights
+are promoted to ``NVFP4TensorNonDecomposed`` before export.
+
+Requirements:
+
+* NVIDIA GPU with TensorRT FP4 constants (TRT ≥ 10.8)
+* torchao (``prototype.mx_formats``)
+* torch-tensorrt with the ``torchao_trt.dequantize_nvfp4`` converter
+
+"""
+
+# %%
+# Imports
+# ^^^^^^^
+# This example lives in examples/dynamo/torchao/. Move that directory off
+# the front of sys.path so import torchao resolves the PyPI package
+# instead of this folder.
+
+import sys
+from pathlib import Path
+
+_EXAMPLE_DIR = str(Path(__file__).resolve().parent)
+if sys.path and Path(sys.path[0]).resolve() == Path(_EXAMPLE_DIR):
+    sys.path.pop(0)
+
+import torch
+import torch_tensorrt as torchtrt
+
+sys.path.insert(0, _EXAMPLE_DIR)
+from nvfp4_utils import pre_process_model_for_export, quantize_linear_nvfp4
+
+# %%
+# Define a linear model and quantize weights to NVFP4
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+class LinearModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = torch.nn.Linear(3072, 4096)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+
+model = LinearModel().eval().to(dtype=torch.bfloat16, device="cuda")
+example_input = torch.randn(32, 3072, dtype=torch.bfloat16, device="cuda")
+
+quantize_linear_nvfp4(model)
+processed_model = pre_process_model_for_export(model)
+
+# %%
+# Export and compile
+# ^^^^^^^^^^^^^^^^^^
+# Torch-TensorRT marks ``dequantize_nvfp4`` impure in constant folding so the
+# packed FP4 weight is not folded into a dense BF16 constant.
+
+exp_program = torch.export.export(processed_model, (example_input,), strict=True)
+
+trt_model = torchtrt.dynamo.compile(
+    exp_program,
+    inputs=[example_input],
+    min_block_size=1,
+    use_explicit_typing=True,
+    require_full_compilation=True,
+    immutable_weights=True,
+)
+
+output = trt_model(example_input)
+print(output)

--- a/examples/dynamo/torchao/torch_export_flux_nvfp4_woq.py
+++ b/examples/dynamo/torchao/torch_export_flux_nvfp4_woq.py
@@ -1,0 +1,211 @@
+"""
+.. _torch_export_flux_nvfp4_woq:
+
+Compiling FLUX.1-dev with TorchAO NVFP4 weight-only quantization
+================================================================
+
+This example quantizes the transformer of
+`FLUX.1-dev <https://huggingface.co/black-forest-labs/FLUX.1-dev>`_ to NVFP4
+with TorchAO (packed FP4 E2M1 + FP8 block scales), then compiles it with the
+Torch-TensorRT Dynamo backend.
+
+Weight-only NVFP4 keeps activations in BF16 and stores Linear weights as
+packed FP4 plus swizzled FP8 block scales and a global scale. After export,
+Torch-TensorRT maps ``dequantize_nvfp4`` to two-level TensorRT
+``IDequantizeLayer`` so the engine can keep an FP4 weight constant.
+
+This is **not** native FP4 Tensor Core MMA. Layers whose last two dims are
+not divisible by 16 are left in BF16.
+
+You need access to FLUX.1-dev on Hugging Face. Quantization is done
+layer-by-layer on GPU so the rest of the pipeline can stay on CPU. Compile
+with ``immutable_weights=True``. On 32GB cards, park the text encoders during
+compile and generate from precomputed prompt embeddings so T5 and the TRT
+execution context are not resident together.
+
+.. code-block:: bash
+
+    pip install torchao diffusers transformers accelerate sentencepiece protobuf
+
+"""
+
+# %%
+# Imports
+# -------
+# This example lives in examples/dynamo/torchao/. Move that directory off
+# the front of sys.path so import torchao resolves the PyPI package
+# instead of this folder.
+
+import gc
+import os
+import sys
+from pathlib import Path
+
+_EXAMPLE_DIR = str(Path(__file__).resolve().parent)
+if sys.path and Path(sys.path[0]).resolve() == Path(_EXAMPLE_DIR):
+    sys.path.pop(0)
+
+import torch
+import torch_tensorrt
+from diffusers import FluxPipeline
+
+sys.path.insert(0, _EXAMPLE_DIR)
+from nvfp4_utils import pre_process_model_for_export, quantize_linear_nvfp4
+
+DEVICE = "cuda:0"
+MODEL_ID = os.environ.get("FLUX_MODEL_ID", "black-forest-labs/FLUX.1-dev")
+PROMPT = (
+    "Baroque style, a lavish palace interior with ornate gilded ceilings, "
+    "intricate tapestries, and dramatic lighting over a grand staircase."
+)
+MAX_SEQUENCE_LENGTH = 512
+
+# %%
+# Load FLUX.1-dev and quantize the transformer
+# --------------------------------------------
+# Only the transformer is quantized and compiled. Text encoders and the VAE stay
+# BF16. Load on CPU, then quantize each Linear on GPU individually.
+
+pipe = FluxPipeline.from_pretrained(
+    MODEL_ID,
+    torch_dtype=torch.bfloat16,
+)
+config = pipe.transformer.config
+cache_context = getattr(pipe.transformer, "cache_context", None)
+
+quantize_linear_nvfp4(pipe.transformer)
+pipe.transformer = pre_process_model_for_export(pipe.transformer)
+
+# %%
+# Encode the prompt, then free the text encoders
+# ----------------------------------------------
+# The NVFP4 engine's execution context can reserve tens of GB. Compute
+# embeddings once, then drop CLIP/T5 so they are not resident during compile
+# or generate.
+
+pipe.to(DEVICE)
+with torch.no_grad():
+    prompt_embeds, pooled_prompt_embeds, _ = pipe.encode_prompt(
+        prompt=PROMPT,
+        prompt_2=PROMPT,
+        device=torch.device(DEVICE),
+        max_sequence_length=MAX_SEQUENCE_LENGTH,
+    )
+pipe.text_encoder = None
+pipe.text_encoder_2 = None
+pipe.vae.to("cpu")
+gc.collect()
+torch.cuda.empty_cache()
+
+backbone = pipe.transformer.to(DEVICE)
+
+# %%
+# Export the quantized transformer
+# --------------------------------
+# Dummy inputs match the Flux transformer signature used by the BF16 / FP8 /
+# INT4 Flux examples. Torch-TensorRT constant folding keeps
+# ``dequantize_nvfp4`` in the graph.
+
+dummy_inputs = {
+    "hidden_states": torch.randn(1, 4096, 64, dtype=torch.bfloat16, device=DEVICE),
+    "encoder_hidden_states": torch.randn(
+        1, 512, 4096, dtype=torch.bfloat16, device=DEVICE
+    ),
+    "pooled_projections": torch.randn(1, 768, dtype=torch.bfloat16, device=DEVICE),
+    "timestep": torch.randn(1, dtype=torch.bfloat16, device=DEVICE),
+    "guidance": torch.randn(1, dtype=torch.float32, device=DEVICE),
+    "img_ids": torch.randn(4096, 3, dtype=torch.bfloat16, device=DEVICE),
+    "txt_ids": torch.randn(512, 3, dtype=torch.bfloat16, device=DEVICE),
+    "joint_attention_kwargs": {},
+    "return_dict": False,
+}
+
+exp_program = torch.export.export(
+    backbone,
+    args=(),
+    kwargs=dummy_inputs,
+    strict=True,
+)
+
+# %%
+# Compile with Torch-TensorRT
+# ---------------------------
+# .. note::
+#    Compilation of the 12B transformer takes on the order of 20–30 minutes.
+#    ``immutable_weights=True`` keeps the packed FP4 constants from being
+#    refit as dense high-precision weights.
+
+trt_gm = torch_tensorrt.dynamo.compile(
+    exp_program,
+    inputs=dummy_inputs,
+    truncate_double=True,
+    min_block_size=1,
+    use_explicit_typing=True,
+    require_full_compilation=True,
+    immutable_weights=True,
+    offload_module_to_cpu=True,
+)
+
+# %%
+# Swap the compiled transformer into the pipeline
+# -----------------------------------------------
+# Wrap the engine so Diffusers still sees a CUDA module after the text encoders
+# are dropped, and so TRT outputs are moved back to GPU if they land on CPU.
+
+
+class _TRTTransformerAdapter(torch.nn.Module):
+    def __init__(self, compiled, config, cache_context) -> None:
+        super().__init__()
+        self._compiled = compiled
+        self.config = config
+        self.cache_context = cache_context
+        self.register_buffer(
+            "_device_anchor", torch.empty(0, device=DEVICE), persistent=False
+        )
+
+    @property
+    def device(self) -> torch.device:
+        return self._device_anchor.device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return torch.bfloat16
+
+    def forward(self, *args, **kwargs):
+        def _to_cuda(x):
+            return x.to(DEVICE) if isinstance(x, torch.Tensor) else x
+
+        args = tuple(_to_cuda(a) for a in args)
+        kwargs = {k: _to_cuda(v) for k, v in kwargs.items()}
+        out = self._compiled(*args, **kwargs)
+        if isinstance(out, (tuple, list)):
+            return type(out)(_to_cuda(o) for o in out)
+        return _to_cuda(out)
+
+
+pipe.transformer = _TRTTransformerAdapter(trt_gm, config, cache_context)
+pipe.vae.to(DEVICE)
+del exp_program, backbone, trt_gm
+gc.collect()
+torch.cuda.empty_cache()
+
+# %%
+# Generate an image
+# -----------------
+
+
+def generate_image(pipe, image_name):
+    seed = 42
+    with torch.no_grad():
+        image = pipe(
+            prompt_embeds=prompt_embeds.to(DEVICE),
+            pooled_prompt_embeds=pooled_prompt_embeds.to(DEVICE),
+            output_type="pil",
+            num_inference_steps=20,
+            generator=torch.Generator("cuda").manual_seed(seed),
+        ).images[0]
+        image.save(f"{image_name}.png")
+        print(f"Image generated using {image_name} model saved as {image_name}.png")
+
+
+generate_image(pipe, "flux_nvfp4_woq")

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -1136,6 +1136,43 @@ else:
         )
 
 
+try:
+    from torch_tensorrt.dynamo.conversion import nvfp4_custom_op  # noqa: F401
+
+    assert torch.ops.torchao_trt.dequantize_nvfp4.default
+except Exception:
+    _LOGGER.debug(
+        "torchao NVFP4 custom op not available; skipping "
+        "torchao_trt.dequantize_nvfp4 converter. Install torchao with "
+        "prototype.mx_formats to compile TorchAO NVFP4 weight-only models."
+    )
+else:
+
+    @dynamo_tensorrt_converter(
+        torch.ops.torchao_trt.dequantize_nvfp4.default,
+        supports_dynamic_shapes=False,
+    )
+    def aten_ops_torchao_dequantize_nvfp4(
+        ctx: ConversionContext,
+        target: Target,
+        args: Tuple[Argument, ...],
+        kwargs: Dict[str, Argument],
+        name: str,
+    ) -> Union[TRTTensor, Sequence[TRTTensor]]:
+        return impl.quantize.dequantize_nvfp4(
+            ctx,
+            target,
+            SourceIR.ATEN,
+            name,
+            args[0],
+            args[1],
+            args[2],
+            args[3],
+            args[4],
+            args[5],
+        )
+
+
 @dynamo_tensorrt_converter(torch.ops.aten.squeeze.dim, supports_dynamic_shapes=True)
 @dynamo_tensorrt_converter(torch.ops.aten.squeeze.dims, supports_dynamic_shapes=True)
 def aten_ops_squeeze(

--- a/py/torch_tensorrt/dynamo/conversion/impl/quantize.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/quantize.py
@@ -329,6 +329,82 @@ def quantize_affine_float8(
     return quantize_layer.get_output(0)
 
 
+def dequantize_nvfp4(
+    ctx: ConversionContext,
+    target: Target,
+    source_ir: Optional[SourceIR],
+    name: str,
+    qdata: Union[torch.Tensor, TRTTensor],
+    block_scale: Union[torch.Tensor, TRTTensor],
+    per_tensor_scale: Union[torch.Tensor, TRTTensor],
+    rows: Union[int, torch.Tensor],
+    cols: Union[int, torch.Tensor],
+    output_dtype: torch.dtype,
+) -> TRTTensor:
+    """Map torchao_trt.dequantize_nvfp4 to two-level TensorRT dequantize.
+
+    TorchAO stores NVFP4 block scales in a padded/swizzled layout. TensorRT
+    wants the logical ``[N, K/16]`` FP8 block-scale tensor, an FP4 weight
+    constant, and a FP32 global scale. Activations stay high precision; this
+    is weight-only storage, not native FP4 MMA.
+    """
+    if not all(
+        isinstance(x, torch.Tensor) for x in (qdata, block_scale, per_tensor_scale)
+    ):
+        raise ValueError("NVFP4 weight DQ requires constant qdata and scales")
+
+    from torchao.prototype.mx_formats.utils import from_blocked
+
+    def _as_dim_int(value: Union[int, torch.Tensor]) -> int:
+        if isinstance(value, torch.Tensor):
+            return int(value.item())
+        return value
+
+    rows_i = _as_dim_int(rows)
+    cols_i = _as_dim_int(cols)
+
+    with unset_fake_temporarily():
+        logical_scale = from_blocked(block_scale, rows_i, cols_i // 16).contiguous()
+
+    qdata_trt = get_trt_tensor(
+        ctx,
+        qdata,
+        f"{name}_qdata_fp4",
+        target_quantized_type=trt.DataType.FP4,
+    )
+    block_scale_trt = get_trt_tensor(
+        ctx,
+        logical_scale,
+        f"{name}_block_scale_fp8",
+        target_quantized_type=trt.DataType.FP8,
+    )
+    global_scale_trt = get_trt_tensor(
+        ctx,
+        per_tensor_scale.float(),
+        f"{name}_global_scale",
+        dtype=torch.float32,
+        min_rank=0,
+    )
+    trt_output_dtype = _enums.dtype._from(output_dtype).to(trt.DataType)
+
+    scale_dq = ctx.net.add_dequantize(
+        block_scale_trt,
+        global_scale_trt,
+        output_type=trt_output_dtype,
+    )
+    scale_dq.axis = -1
+    set_layer_name(scale_dq, target, f"{name}_dequantize_scale", source_ir)
+
+    data_dq = ctx.net.add_dequantize(
+        qdata_trt,
+        scale_dq.get_output(0),
+        output_type=trt_output_dtype,
+    )
+    data_dq.axis = -1
+    set_layer_name(data_dq, target, f"{name}_dequantize_data", source_ir)
+    return data_dq.get_output(0)
+
+
 def dequantize_affine_float8(
     ctx: ConversionContext,
     target: Target,

--- a/py/torch_tensorrt/dynamo/conversion/nvfp4_custom_op.py
+++ b/py/torch_tensorrt/dynamo/conversion/nvfp4_custom_op.py
@@ -1,0 +1,65 @@
+"""Register ``torchao_trt.dequantize_nvfp4`` when TorchAO NVFP4 kernels exist.
+
+TorchAO ``NVFP4Tensor`` does not emit a single DQ op that TensorRT can map.
+This custom op keeps packed FP4 qdata, swizzled FP8 block scales, and the
+global scale visible through ``torch.export`` so the converter can emit
+TensorRT FP4 / FP8 constants and two-level ``IDequantizeLayer``.
+"""
+
+from __future__ import annotations
+
+import torch
+
+try:
+    from torchao.prototype.mx_formats.kernels import f4_unpacked_to_f32, unpack_uint4
+    from torchao.prototype.mx_formats.utils import from_blocked
+
+    _NVFP4_KERNELS_AVAILABLE = True
+except Exception:
+    _NVFP4_KERNELS_AVAILABLE = False
+
+
+if _NVFP4_KERNELS_AVAILABLE:
+
+    @torch.library.custom_op(  # type: ignore[misc]
+        "torchao_trt::dequantize_nvfp4", mutates_args=()
+    )
+    def dequantize_nvfp4(
+        qdata: torch.Tensor,
+        block_scale: torch.Tensor,
+        per_tensor_scale: torch.Tensor,
+        rows: int,
+        cols: int,
+        output_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """Dequantize packed FP4 + swizzled FP8 scales for eager validation."""
+        unpacked = unpack_uint4(qdata.contiguous().view(torch.uint8))
+        data_f32 = f4_unpacked_to_f32(unpacked)
+        data_f32 = data_f32.view(rows, cols // 16, 16)
+
+        scale = from_blocked(block_scale, rows, cols // 16)
+        scale = scale.to(torch.float32) * per_tensor_scale.to(torch.float32)
+        return (
+            (data_f32 * scale.view(rows, cols // 16, 1))
+            .view(rows, cols)
+            .to(output_dtype)
+        )
+
+    @dequantize_nvfp4.register_fake  # type: ignore[misc]
+    def _dequantize_nvfp4_fake(
+        qdata: torch.Tensor,
+        block_scale: torch.Tensor,
+        per_tensor_scale: torch.Tensor,
+        rows: int,
+        cols: int,
+        output_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        return torch.empty((rows, cols), device=qdata.device, dtype=output_dtype)
+
+else:
+
+    def dequantize_nvfp4(*_args: object, **_kwargs: object) -> torch.Tensor:
+        raise RuntimeError(
+            "torchao_trt.dequantize_nvfp4 requires torchao NVFP4 kernels "
+            "(torchao.prototype.mx_formats)"
+        )

--- a/py/torch_tensorrt/dynamo/lowering/passes/constant_folding.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/constant_folding.py
@@ -108,7 +108,8 @@ class _TorchTensorRTConstantFolder(ConstantFolder):  # type: ignore[misc]
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         # Quantization ops excluded from constant folding so TRT sees QDQ
-        # (ModelOpt tensorrt.quantize_op and TorchAO dequantize_affine).
+        # (ModelOpt tensorrt.quantize_op, TorchAO dequantize_affine, and
+        # TorchAO NVFP4 dequantize_nvfp4 when that custom op is registered).
         self.quantization_ops: Set[torch._ops.OpOverload] = set()
         try:
             # modelopt import ensures torch.ops.tensorrt.quantize_op.default is registered
@@ -143,6 +144,14 @@ class _TorchTensorRTConstantFolder(ConstantFolder):  # type: ignore[misc]
             self.quantization_ops.add(
                 torch.ops.torchao.dequantize_affine_float8_non_decomposed.default
             )
+        except Exception:
+            pass
+
+        try:
+            from torch_tensorrt.dynamo.conversion import nvfp4_custom_op  # noqa: F401
+
+            assert torch.ops.torchao_trt.dequantize_nvfp4.default
+            self.quantization_ops.add(torch.ops.torchao_trt.dequantize_nvfp4.default)
         except Exception:
             pass
 

--- a/tests/py/dynamo/models/test_torchao_fp8_woq.py
+++ b/tests/py/dynamo/models/test_torchao_fp8_woq.py
@@ -241,3 +241,81 @@ def test_linear_int4_woq():
         ),
     )
     torch._dynamo.reset()
+
+
+def _has_nvfp4_support() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    try:
+        import tensorrt as trt
+        from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor  # noqa: F401
+
+        return hasattr(trt.DataType, "FP4")
+    except Exception:
+        return False
+
+
+@pytest.mark.unit
+@unittest.skipIf(importlib.util.find_spec("torchao") is None, "torchao not installed")
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+@unittest.skipIf(not _has_nvfp4_support(), "TensorRT FP4 DataType is required")
+def test_linear_nvfp4_woq():
+    import sys
+    from pathlib import Path
+
+    example_dir = (
+        Path(__file__).resolve().parents[4] / "examples" / "dynamo" / "torchao"
+    )
+    sys.path.insert(0, str(example_dir))
+    from nvfp4_utils import pre_process_model_for_export, quantize_linear_nvfp4
+
+    class LinearModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(64, 128)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.linear(x)
+
+    model = LinearModel().eval().to(dtype=torch.bfloat16, device="cuda")
+    example_input = torch.randn(8, 64, dtype=torch.bfloat16, device="cuda")
+    quantize_linear_nvfp4(model)
+    model = pre_process_model_for_export(model)
+
+    exp_program = torch.export.export(model, (example_input,), strict=True)
+
+    dq_nodes = [
+        n
+        for n in exp_program.graph.nodes
+        if n.target == torch.ops.torchao_trt.dequantize_nvfp4.default
+    ]
+    assertions.assertTrue(
+        len(dq_nodes) >= 1,
+        msg="Exported graph is missing torchao_trt.dequantize_nvfp4",
+    )
+
+    trt_mod = torchtrt.dynamo.compile(
+        exp_program,
+        inputs=[example_input],
+        min_block_size=1,
+        use_explicit_typing=True,
+        require_full_compilation=True,
+        immutable_weights=True,
+        cache_built_engines=False,
+        reuse_cached_engines=False,
+    )
+
+    with torch.no_grad():
+        eager_out = model(example_input)
+        trt_out = trt_mod(example_input)
+    if isinstance(trt_out, (list, tuple)):
+        trt_out = trt_out[0]
+    cos_sim = cosine_similarity(eager_out, trt_out)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=(
+            "TorchAO NVFP4 WOQ TRT outputs don't match eager. "
+            f"Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}"
+        ),
+    )
+    torch._dynamo.reset()


### PR DESCRIPTION
# Description

Adds TorchAO **NVFP4 weight-only** support on the Dynamo path (`NVFP4WeightOnlyConfig`). Registers `torchao_trt.dequantize_nvfp4`, maps it to two-level TensorRT `IDequantizeLayer` (packed FP4 E2M1 + swizzled FP8 E4M3 block scales at block size 16 + FP32 per-tensor scale), and marks the op impure in constant folding so DQ is not folded into dense BF16.

This is **weight-only storage**, not native FP4 Tensor Core MMA — activations stay BF16. It is a different graph from ModelOpt `NVFP4_DEFAULT_CFG` (`dynamic_block_quantize_op`). Last two Linear dims must be divisible by 16. Parent `NVFP4Tensor` does not emit a DQ op TensorRT can map — examples promote to `NVFP4TensorNonDecomposed` before export. Compile with `immutable_weights=True`.

Examples: toy `nn.Linear` and FLUX.1-dev. User-guide, troubleshooting, and gallery docs are updated. HTML under `docs/` is left to the post-merge docgen bot.

**Dependencies:** `torchao` (`prototype.mx_formats`). TensorRT with FP4 constants (TRT ≥ 10.8).

Stacked on #4590 (INT4 WOQ) → #4589 (FP8). MXFP4 follow-up is #4595. Stack: https://github.com/pytorch/TensorRT/stack/4591

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified