### PR TITLE
Added TorchAO MXFP4 (MXDynamicActivationMXWeightConfig) + Linear and FLUX examples

### DIFF
--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -104,7 +104,7 @@ sphinx_gallery_conf = {
         "tutorials/_rendered_examples/distributed_inference",
     ],
     # Exclude pure utility modules that aren't standalone runnable examples.
-    "ignore_pattern": r"(utils\.py|static_fp8_utils\.py|int4_utils\.py|rotary_embedding\.py|tensor_parallel_initialize_dist\.py)",
+    "ignore_pattern": r"(utils\.py|static_fp8_utils\.py|int4_utils\.py|nvfp4_utils\.py|mxfp4_utils\.py|rotary_embedding\.py|tensor_parallel_initialize_dist\.py)",
 }
 
 # Setup the breathe extension

--- a/docsrc/debugging/troubleshooting.rst
+++ b/docsrc/debugging/troubleshooting.rst
@@ -233,6 +233,11 @@ Accuracy / Performance Issues
     Export must keep ``dequantize_nvfp4`` so the engine can keep
     ``Datatype: FP4E2M1``.
 
+    For **MXFP4** with TorchAO (``MXDynamicActivationMXWeightConfig``; there is
+    no MXFP4 weight-only config), see :ref:`quantize_linear_mxfp4` and
+    :ref:`torch_export_flux_mxfp4`. Export must keep ``dequantize_mxfp4`` so
+    the engine can keep ``Datatype: FP4E2M1`` with E8M0 block scales.
+
 ----
 
 Distributed / Tensor-Parallel Issues

--- a/docsrc/tutorials/huggingface/index.rst
+++ b/docsrc/tutorials/huggingface/index.rst
@@ -14,5 +14,6 @@ the Mutable Torch-TensorRT Module.
    Example: Compiling FLUX.1-dev with the dynamo backend <../_rendered_examples/dynamo/torch_export_flux_dev>
    Example: FLUX.1-dev INT4 WOQ <../_rendered_examples/dynamo/torchao/torch_export_flux_int4_woq>
    Example: FLUX.1-dev NVFP4 WOQ <../_rendered_examples/dynamo/torchao/torch_export_flux_nvfp4_woq>
+   Example: FLUX.1-dev MXFP4 <../_rendered_examples/dynamo/torchao/torch_export_flux_mxfp4>
    Example: Qwen3-8B INT4 WOQ <../_rendered_examples/dynamo/torchao/torch_export_qwen3_int4_woq>
    Example: Mutable Torch TensorRT Module <../_rendered_examples/dynamo/mutable_torchtrt_module_example>

--- a/docsrc/user_guide/shapes_precision/index.rst
+++ b/docsrc/user_guide/shapes_precision/index.rst
@@ -20,3 +20,5 @@ and reduce model size with INT8/FP8/FP4 quantization via ModelOpt or TorchAO.
    Example: Qwen3-8B INT4 WOQ <../../tutorials/_rendered_examples/dynamo/torchao/torch_export_qwen3_int4_woq>
    Example: TorchAO NVFP4 WOQ Linear <../../tutorials/_rendered_examples/dynamo/torchao/quantize_linear_nvfp4_woq>
    Example: FLUX.1-dev NVFP4 WOQ <../../tutorials/_rendered_examples/dynamo/torchao/torch_export_flux_nvfp4_woq>
+   Example: TorchAO MXFP4 Linear <../../tutorials/_rendered_examples/dynamo/torchao/quantize_linear_mxfp4>
+   Example: FLUX.1-dev MXFP4 <../../tutorials/_rendered_examples/dynamo/torchao/torch_export_flux_mxfp4>

--- a/docsrc/user_guide/shapes_precision/quantization.rst
+++ b/docsrc/user_guide/shapes_precision/quantization.rst
@@ -6,8 +6,8 @@ Quantization (INT8 / FP8 / FP4)
 Torch-TensorRT supports post-training quantization (PTQ) with **INT8**, **FP8**, and
 **FP4** precisions via NVIDIA's
 `ModelOpt <https://github.com/NVIDIA/TensorRT-Model-Optimizer>`_ library, and
-**FP8 weight-only**, **static FP8**, **INT4 weight-only**, and **NVFP4
-weight-only** quantization via
+**FP8 weight-only**, **static FP8**, **INT4 weight-only**, **NVFP4
+weight-only**, and **MXFP4** (``MXDynamicActivationMXWeightConfig``) via
 `TorchAO <https://github.com/pytorch/ao>`_. Quantizers insert
 quantize/dequantize (QDQ) nodes into the model graph; Torch-TensorRT then
 converts those nodes into TRT quantization layers and sets the appropriate builder flags.
@@ -30,6 +30,7 @@ Hardware requirements:
 * **FP8**: NVIDIA Hopper (H100) or newer.
 * **INT4 (TorchAO WOQ)**: TensorRT with INT4 constants (TRT ≥ 10.8); storage + DQ, not low-bit MMA.
 * **NVFP4 (TorchAO WOQ)**: TensorRT with FP4 constants (TRT ≥ 10.8); packed FP4 storage + DQ, not native FP4 MMA.
+* **MXFP4 (TorchAO)**: TensorRT with FP4 + E8M0 constants (TRT ≥ 10.8); packed FP4 storage + DQ, not native MXFP4 MMA. There is no MXFP4 weight-only config.
 * **FP4 (ModelOpt NVFP4)**: NVIDIA Blackwell (B100/B200) or newer; requires TensorRT ≥ 10.8.
 
 ----
@@ -291,6 +292,49 @@ See :ref:`quantize_linear_nvfp4_woq` for a toy Linear model and
 
 ----
 
+TorchAO MXFP4 (Dynamic Activation + MX Weight)
+----------------------------------------------
+
+TorchAO MXFP4 stores Linear weights as packed FP4 E2M1 (two values per
+byte) with E8M0 block scales (block size 32). The public config is
+``MXDynamicActivationMXWeightConfig`` — there is no MXFP4 weight-only
+recipe (that is NVFP4 / ``NVFP4WeightOnlyConfig``). Native MXFP4xMXFP4
+kernels need B200/B300. This path uses emulated storage and a weight DQ
+prologue into a high-precision GEMM. Activations stay BF16.
+
+Last two weight dims must be divisible by 32. Parent ``MXTensor`` Linear
+does not emit a DQ op TensorRT can map. Promote weights to
+``MXTensorNonDecomposed`` so export emits
+``torch.ops.torchao_trt.dequantize_mxfp4``. The converter unswizzles TorchAO
+block scales, then builds an FP4 constant, an E8M0 block-scale constant, and
+``IDequantizeLayer``. Myelin accepts FP4 + E8M0 at block size 32; FP4 +
+float32 scales fail at that block size.
+
+Torch-TensorRT marks ``dequantize_mxfp4`` impure in constant folding so the
+packed FP4 weight is not folded into a dense BF16 constant. Compile with
+``immutable_weights=True``.
+
+.. code-block:: python
+
+    quantize_linear_mxfp4(model)
+    model = pre_process_model_for_export(model)
+
+    exp_program = torch.export.export(model, (example_input,), strict=True)
+
+    trt_model = torch_tensorrt.dynamo.compile(
+        exp_program,
+        inputs=[example_input],
+        min_block_size=1,
+        use_explicit_typing=True,
+        require_full_compilation=True,
+        immutable_weights=True,
+    )
+
+See :ref:`quantize_linear_mxfp4` for a toy Linear model and
+:ref:`torch_export_flux_mxfp4` for FLUX.1-dev.
+
+----
+
 TorchAO Static FP8 Quantization
 --------------------------------
 
@@ -341,6 +385,10 @@ For TorchAO NVFP4 weight-only graphs, ``torch.ops.torchao_trt.dequantize_nvfp4.d
 is mapped to two-level ``IDequantizeLayer`` (FP8 block scales restored with the
 global scale, then packed FP4 dequantized into the GEMM input type).
 
+For TorchAO MXFP4 graphs, ``torch.ops.torchao_trt.dequantize_mxfp4.default``
+is mapped to ``IDequantizeLayer`` (packed FP4 + logical E8M0 block scales at
+block size 32).
+
 For ModelOpt FP4, ``torch.ops.tensorrt.dynamic_block_quantize_op.default`` nodes
 are converted via the dynamic block quantize converter, which uses TRT's
 ``add_dynamic_quantize`` API (TRT ≥ 10.8).
@@ -387,6 +435,9 @@ Supported Precision / Hardware Matrix
      - TRT ≥ 10.8
    * - NVFP4 (TorchAO WOQ)
      - GPU with TRT FP4 constants
+     - TRT ≥ 10.8
+   * - MXFP4 (TorchAO)
+     - GPU with TRT FP4 + E8M0 constants
      - TRT ≥ 10.8
    * - FP4 (ModelOpt NVFP4)
      - NVIDIA Blackwell (B100+)
@@ -437,3 +488,10 @@ Troubleshooting
     ``pre_process_model_for_export`` as in :ref:`quantize_linear_nvfp4_woq`.
     Last two Linear dims must be divisible by 16. This path is weight-only DQ
     + BF16 GEMM, not ModelOpt ``dynamic_block_quantize_op``.
+
+**TorchAO MXFP4 weights folded to BF16, or engine has no FP4E2M1 constant**
+    The graph must keep ``torchao_trt.dequantize_mxfp4``. Promote weights with
+    ``pre_process_model_for_export`` as in :ref:`quantize_linear_mxfp4`.
+    Last two Linear dims must be divisible by 32. Pass E8M0 scales (not
+    float32) at block size 32. This is a weight DQ prologue, not native
+    MXFP4xMXFP4 MMA.

--- a/examples/dynamo/README.rst
+++ b/examples/dynamo/README.rst
@@ -33,6 +33,8 @@ Model Zoo
 * :ref:`torch_export_qwen3_int4_woq`: Compiling Qwen3-8B with TorchAO INT4 weight-only quantization (``examples/dynamo/torchao``)
 * :ref:`quantize_linear_nvfp4_woq`: TorchAO NVFP4 weight-only quantization of a Linear layer (``examples/dynamo/torchao``)
 * :ref:`torch_export_flux_nvfp4_woq`: Compiling FLUX.1-dev with TorchAO NVFP4 weight-only quantization (``examples/dynamo/torchao``)
+* :ref:`quantize_linear_mxfp4`: TorchAO MXFP4 (dyn-act + MX weight) quantization of a Linear layer (``examples/dynamo/torchao``)
+* :ref:`torch_export_flux_mxfp4`: Compiling FLUX.1-dev with TorchAO MXFP4 (``examples/dynamo/torchao``)
 * :ref:`debugger_example`: Debugging Torch-TensorRT Compilation
 * :ref:`torch_export_3d_rope`: Compiling a 3D RoPE video-transformer block with complex numerics support
 * :ref:`engine_converter_binding_names`: Naming input / output bindings when emitting a raw serialized TRT engine

--- a/examples/dynamo/torchao/README.rst
+++ b/examples/dynamo/torchao/README.rst
@@ -22,6 +22,11 @@ Export emits ``dequantize_nvfp4``, which Torch-TensorRT maps to two-level
 ``IDequantizeLayer`` so the engine can keep ``Datatype: FP4E2M1``. This is
 storage + DQ, not native FP4 MMA.
 
+MXFP4 uses TorchAO ``MXDynamicActivationMXWeightConfig`` (there is no MXFP4
+weight-only config). Export emits ``dequantize_mxfp4``, which Torch-TensorRT
+maps to FP4 + E8M0 ``IDequantizeLayer`` (block size 32). Activations stay
+BF16 in this path.
+
 .. code-block:: bash
 
     pip install -r ../requirements.txt
@@ -33,4 +38,6 @@ storage + DQ, not native FP4 MMA.
     python torch_export_qwen3_int4_woq.py
     python quantize_linear_nvfp4_woq.py
     python torch_export_flux_nvfp4_woq.py
+    python quantize_linear_mxfp4.py
+    python torch_export_flux_mxfp4.py
 """

--- a/examples/dynamo/torchao/mxfp4_utils.py
+++ b/examples/dynamo/torchao/mxfp4_utils.py
@@ -1,0 +1,158 @@
+"""Helpers for TorchAO MXFP4 (MXDynamicActivationMXWeightConfig) examples.
+
+TorchAO's default MXTensor Linear path dequantizes in Python and export would
+see an opaque weight. MXTensorNonDecomposed emits
+torchao_trt.dequantize_mxfp4 so Torch-TensorRT can map packed FP4 +
+swizzled E8M0 block scales to TensorRT constants and IDequantizeLayer.
+
+There is no TorchAO MXFP4 weight-only config. Last two weight dims must be
+divisible by 32. Native MXFP4xMXFP4 kernels need B200/B300; this path uses
+emulated storage and a weight DQ prologue into a BF16 GEMM.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch_tensorrt.dynamo.conversion.mxfp4_custom_op import dequantize_mxfp4
+from torchao.prototype.mx_formats.config import ScaleCalculationMode
+from torchao.prototype.mx_formats.mx_tensor import MXTensor, QuantizeTensorToMXKwargs
+from torchao.quantization.quantize_.common import KernelPreference
+from torchao.utils import _dispatch__torch_function__
+
+aten = torch.ops.aten
+
+MX_BLOCK_SIZE = 32
+
+
+class MXTensorNonDecomposed(MXTensor):
+    """MXTensor that dequantizes via explicit dequantize_mxfp4.
+
+    Parent MXTensor disables __torch_function__; re-enable it so
+    functional linear is intercepted before export treats the parameter as
+    opaque. Dynamic activation MX quant from the config is not lowered —
+    activations stay high precision so TensorRT can keep the FP4 weight.
+    """
+
+    __torch_function__ = classmethod(_dispatch__torch_function__)
+
+
+implements = MXTensorNonDecomposed.implements
+implements_torch_function = MXTensorNonDecomposed.implements_torch_function
+
+
+@implements([aten.linear.default])
+@implements_torch_function([torch.nn.functional.linear])
+def _mxfp4_non_decomposed_linear(func, types, args, kwargs):
+    """Run Linear as dequantize + F.linear so export sees dequantize_mxfp4."""
+    input_tensor = args[0]
+    weight_tensor = args[1]
+    bias = args[2] if len(args) > 2 else None
+
+    assert isinstance(weight_tensor, MXTensorNonDecomposed)
+    assert weight_tensor.elem_dtype == torch.float4_e2m1fn_x2
+    assert weight_tensor.is_swizzled_scales
+
+    rows, cols = weight_tensor.shape
+    weight_hp = dequantize_mxfp4(
+        weight_tensor.qdata,
+        weight_tensor.scale,
+        rows,
+        cols,
+        int(weight_tensor.block_size),
+        input_tensor.dtype,
+    )
+    if bias is not None and bias.dtype != input_tensor.dtype:
+        bias = bias.to(input_tensor.dtype)
+    return torch.nn.functional.linear(input_tensor, weight_hp, bias)
+
+
+def quantize_linear_mxfp4(
+    model: torch.nn.Module,
+    verbose: bool = False,
+    compute_device: Optional[str] = None,
+    block_size: int = MX_BLOCK_SIZE,
+) -> torch.nn.Module:
+    """Replace Linear weights with MXFP4 (packed FP4 E2M1 + E8M0 block scales).
+
+    Uses KernelPreference.EMULATED (AUTO needs B200/B300). Skips layers
+    whose last two dims are not divisible by block_size (default 32).
+    Each layer is quantized on compute_device then moved back.
+    """
+    if compute_device is None:
+        compute_device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    act_quant_kwargs = QuantizeTensorToMXKwargs(
+        elem_dtype=torch.float4_e2m1fn_x2,
+        block_size=block_size,
+        kernel_preference=KernelPreference.EMULATED,
+        is_swizzled_scales=True,
+        scaling_mode=ScaleCalculationMode.RCEIL,
+    )
+
+    quantized = 0
+    skipped = 0
+    for name, module in model.named_modules():
+        if not isinstance(module, torch.nn.Linear):
+            continue
+        weight = module.weight
+        if getattr(weight, "is_meta", False):
+            raise RuntimeError(
+                f"{name}.weight is on the meta device (no data to quantize). "
+                "Load the model without device_map/offloading before quantizing."
+            )
+
+        if weight.shape[-2] % block_size != 0 or weight.shape[-1] % block_size != 0:
+            if verbose:
+                print(
+                    f"[skip] {name}: shape {tuple(weight.shape)} "
+                    f"not divisible by {block_size}"
+                )
+            skipped += 1
+            continue
+
+        original_device = weight.device
+        hp = weight.detach().to(device=compute_device, dtype=torch.bfloat16)
+        qw = MXTensor.to_mx(
+            hp,
+            torch.float4_e2m1fn_x2,
+            block_size=block_size,
+            kernel_preference=KernelPreference.EMULATED,
+            act_quant_kwargs=act_quant_kwargs,
+            is_swizzled_scales=True,
+            scaling_mode=ScaleCalculationMode.RCEIL,
+        )
+        if qw.device != original_device:
+            qw = qw.to(original_device)
+        module.weight = torch.nn.Parameter(qw, requires_grad=False)
+        quantized += 1
+        del hp
+        if verbose:
+            print(
+                f"[mxfp4] {name}: {tuple(weight.shape)} "
+                f"-> qdata {tuple(qw.qdata.shape)} scale {tuple(qw.scale.shape)}"
+            )
+
+    if compute_device == "cuda":
+        torch.cuda.empty_cache()
+    if verbose:
+        print(
+            f"Quantized {quantized} Linear layers to MXFP4 "
+            f"(skipped {skipped}; block_size={block_size}, E8M0 scales, EMULATED)"
+        )
+    return model
+
+
+def convert_mxfp4_to_non_decomposed(model: torch.nn.Module) -> torch.nn.Module:
+    """Promote all MXTensor parameters to MXTensorNonDecomposed."""
+    for param in model.parameters():
+        if isinstance(param, MXTensor) and not isinstance(param, MXTensorNonDecomposed):
+            param.__class__ = MXTensorNonDecomposed
+            param.requires_grad_(False)
+    return model
+
+
+def pre_process_model_for_export(model: torch.nn.Module) -> torch.nn.Module:
+    """Promote MXTensor parameters so export emits dequantize_mxfp4."""
+    return convert_mxfp4_to_non_decomposed(model)

--- a/examples/dynamo/torchao/quantize_linear_mxfp4.py
+++ b/examples/dynamo/torchao/quantize_linear_mxfp4.py
@@ -1,0 +1,88 @@
+"""
+.. _quantize_linear_mxfp4:
+
+TorchAO MXFP4 Dynamic Activation + MX Weight (Linear)
+=====================================================
+
+This example quantizes a toy nn.Linear with TorchAO
+MXDynamicActivationMXWeightConfig-shaped MXFP4 storage (packed FP4 E2M1
+weights, E8M0 block scales, block size 32), keeps an explicit
+torchao_trt.dequantize_mxfp4 in the exported graph, and compiles with the
+Torch-TensorRT Dynamo backend.
+
+There is no TorchAO MXFP4 weight-only config. Native MXFP4xMXFP4 kernels
+need B200/B300. This path uses emulated storage and a weight DQ prologue
+into a high-precision GEMM — activations stay BF16.
+
+MXFP4 requires the last two weight dims to be divisible by 32. TorchAO's
+default MXTensor Linear path does not emit a DQ op TensorRT can map, so
+weights are promoted to MXTensorNonDecomposed before export.
+
+Requirements:
+
+* NVIDIA GPU with TensorRT FP4 and E8M0 constants (TRT ≥ 10.8)
+* torchao (prototype.mx_formats)
+* torch-tensorrt with the torchao_trt.dequantize_mxfp4 converter
+
+"""
+
+# %%
+# Imports
+# ^^^^^^^
+# This example lives in examples/dynamo/torchao/. Move that directory off
+# the front of sys.path so import torchao resolves the PyPI package
+# instead of this folder.
+
+import sys
+from pathlib import Path
+
+_EXAMPLE_DIR = str(Path(__file__).resolve().parent)
+if sys.path and Path(sys.path[0]).resolve() == Path(_EXAMPLE_DIR):
+    sys.path.pop(0)
+
+import torch
+import torch_tensorrt as torchtrt
+
+sys.path.insert(0, _EXAMPLE_DIR)
+from mxfp4_utils import pre_process_model_for_export, quantize_linear_mxfp4
+
+# %%
+# Define a linear model and quantize weights to MXFP4
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+class LinearModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        # K and N must be divisible by MX block_size=32.
+        self.linear = torch.nn.Linear(3072, 4096)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+
+model = LinearModel().eval().to(dtype=torch.bfloat16, device="cuda")
+example_input = torch.randn(32, 3072, dtype=torch.bfloat16, device="cuda")
+
+quantize_linear_mxfp4(model)
+processed_model = pre_process_model_for_export(model)
+
+# %%
+# Export and compile
+# ^^^^^^^^^^^^^^^^^^
+# Torch-TensorRT marks dequantize_mxfp4 impure in constant folding so the
+# packed FP4 weight is not folded into a dense BF16 constant.
+
+exp_program = torch.export.export(processed_model, (example_input,), strict=True)
+
+trt_model = torchtrt.dynamo.compile(
+    exp_program,
+    inputs=[example_input],
+    min_block_size=1,
+    use_explicit_typing=True,
+    require_full_compilation=True,
+    immutable_weights=True,
+)
+
+output = trt_model(example_input)
+print(output)

--- a/examples/dynamo/torchao/torch_export_flux_mxfp4.py
+++ b/examples/dynamo/torchao/torch_export_flux_mxfp4.py
@@ -1,0 +1,210 @@
+"""
+.. _torch_export_flux_mxfp4:
+
+Compiling FLUX.1-dev with TorchAO MXFP4
+=======================================
+
+This example quantizes the transformer of
+`FLUX.1-dev <https://huggingface.co/black-forest-labs/FLUX.1-dev>`_ with
+TorchAO MXFP4 (packed FP4 E2M1 + E8M0 block scales, block size 32), then
+compiles it with the Torch-TensorRT Dynamo backend.
+
+There is no TorchAO MXFP4 weight-only config; the public recipe is
+MXDynamicActivationMXWeightConfig. After export, Torch-TensorRT maps
+dequantize_mxfp4 to TensorRT IDequantizeLayer so the engine can keep
+an FP4 weight constant. Activations stay BF16 in this path (weight
+prologue, not native MXFP4xMXFP4 MMA). Layers whose last two dims are not
+divisible by 32 are left in BF16.
+
+You need access to FLUX.1-dev on Hugging Face. Quantization is done
+layer-by-layer on GPU so the rest of the pipeline can stay on CPU. Compile
+with immutable_weights=True. On 32GB cards, park the text encoders during
+compile and generate from precomputed prompt embeddings so T5 and the TRT
+execution context are not resident together.
+
+.. code-block:: bash
+
+    pip install torchao diffusers transformers accelerate sentencepiece protobuf
+
+"""
+
+# %%
+# Imports
+# -------
+# This example lives in examples/dynamo/torchao/. Move that directory off
+# the front of sys.path so import torchao resolves the PyPI package
+# instead of this folder.
+
+import gc
+import os
+import sys
+from pathlib import Path
+
+_EXAMPLE_DIR = str(Path(__file__).resolve().parent)
+if sys.path and Path(sys.path[0]).resolve() == Path(_EXAMPLE_DIR):
+    sys.path.pop(0)
+
+import torch
+import torch_tensorrt
+from diffusers import FluxPipeline
+
+sys.path.insert(0, _EXAMPLE_DIR)
+from mxfp4_utils import pre_process_model_for_export, quantize_linear_mxfp4
+
+DEVICE = "cuda:0"
+MODEL_ID = os.environ.get("FLUX_MODEL_ID", "black-forest-labs/FLUX.1-dev")
+PROMPT = (
+    "Baroque style, a lavish palace interior with ornate gilded ceilings, "
+    "intricate tapestries, and dramatic lighting over a grand staircase."
+)
+MAX_SEQUENCE_LENGTH = 512
+
+# %%
+# Load FLUX.1-dev and quantize the transformer
+# --------------------------------------------
+# Only the transformer is quantized and compiled. Text encoders and the VAE stay
+# BF16. Load on CPU, then quantize each Linear on GPU individually.
+
+pipe = FluxPipeline.from_pretrained(
+    MODEL_ID,
+    torch_dtype=torch.bfloat16,
+)
+config = pipe.transformer.config
+cache_context = getattr(pipe.transformer, "cache_context", None)
+
+quantize_linear_mxfp4(pipe.transformer)
+pipe.transformer = pre_process_model_for_export(pipe.transformer)
+
+# %%
+# Encode the prompt, then free the text encoders
+# ----------------------------------------------
+# The MXFP4 engine's execution context can reserve tens of GB. Compute
+# embeddings once, then drop CLIP/T5 so they are not resident during compile
+# or generate.
+
+pipe.to(DEVICE)
+with torch.no_grad():
+    prompt_embeds, pooled_prompt_embeds, _ = pipe.encode_prompt(
+        prompt=PROMPT,
+        prompt_2=PROMPT,
+        device=torch.device(DEVICE),
+        max_sequence_length=MAX_SEQUENCE_LENGTH,
+    )
+pipe.text_encoder = None
+pipe.text_encoder_2 = None
+pipe.vae.to("cpu")
+gc.collect()
+torch.cuda.empty_cache()
+
+backbone = pipe.transformer.to(DEVICE)
+
+# %%
+# Export the quantized transformer
+# --------------------------------
+# Dummy inputs match the Flux transformer signature used by the BF16 / FP8 /
+# INT4 / NVFP4 Flux examples. Torch-TensorRT constant folding keeps
+# dequantize_mxfp4 in the graph.
+
+dummy_inputs = {
+    "hidden_states": torch.randn(1, 4096, 64, dtype=torch.bfloat16, device=DEVICE),
+    "encoder_hidden_states": torch.randn(
+        1, 512, 4096, dtype=torch.bfloat16, device=DEVICE
+    ),
+    "pooled_projections": torch.randn(1, 768, dtype=torch.bfloat16, device=DEVICE),
+    "timestep": torch.randn(1, dtype=torch.bfloat16, device=DEVICE),
+    "guidance": torch.randn(1, dtype=torch.float32, device=DEVICE),
+    "img_ids": torch.randn(4096, 3, dtype=torch.bfloat16, device=DEVICE),
+    "txt_ids": torch.randn(512, 3, dtype=torch.bfloat16, device=DEVICE),
+    "joint_attention_kwargs": {},
+    "return_dict": False,
+}
+
+exp_program = torch.export.export(
+    backbone,
+    args=(),
+    kwargs=dummy_inputs,
+    strict=True,
+)
+
+# %%
+# Compile with Torch-TensorRT
+# ---------------------------
+# .. note::
+#    Compilation of the 12B transformer takes on the order of 20–30 minutes.
+#    immutable_weights=True keeps the packed FP4 constants from being
+#    refit as dense high-precision weights.
+
+trt_gm = torch_tensorrt.dynamo.compile(
+    exp_program,
+    inputs=dummy_inputs,
+    truncate_double=True,
+    min_block_size=1,
+    use_explicit_typing=True,
+    require_full_compilation=True,
+    immutable_weights=True,
+    offload_module_to_cpu=True,
+)
+
+# %%
+# Swap the compiled transformer into the pipeline
+# -----------------------------------------------
+# Wrap the engine so Diffusers still sees a CUDA module after the text encoders
+# are dropped, and so TRT outputs are moved back to GPU if they land on CPU.
+
+
+class _TRTTransformerAdapter(torch.nn.Module):
+    def __init__(self, compiled, config, cache_context) -> None:
+        super().__init__()
+        self._compiled = compiled
+        self.config = config
+        self.cache_context = cache_context
+        self.register_buffer(
+            "_device_anchor", torch.empty(0, device=DEVICE), persistent=False
+        )
+
+    @property
+    def device(self) -> torch.device:
+        return self._device_anchor.device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return torch.bfloat16
+
+    def forward(self, *args, **kwargs):
+        def _to_cuda(x):
+            return x.to(DEVICE) if isinstance(x, torch.Tensor) else x
+
+        args = tuple(_to_cuda(a) for a in args)
+        kwargs = {k: _to_cuda(v) for k, v in kwargs.items()}
+        out = self._compiled(*args, **kwargs)
+        if isinstance(out, (tuple, list)):
+            return type(out)(_to_cuda(o) for o in out)
+        return _to_cuda(out)
+
+
+pipe.transformer = _TRTTransformerAdapter(trt_gm, config, cache_context)
+pipe.vae.to(DEVICE)
+del exp_program, backbone, trt_gm
+gc.collect()
+torch.cuda.empty_cache()
+
+# %%
+# Generate an image
+# -----------------
+
+
+def generate_image(pipe, image_name):
+    seed = 42
+    with torch.no_grad():
+        image = pipe(
+            prompt_embeds=prompt_embeds.to(DEVICE),
+            pooled_prompt_embeds=pooled_prompt_embeds.to(DEVICE),
+            output_type="pil",
+            num_inference_steps=20,
+            generator=torch.Generator("cuda").manual_seed(seed),
+        ).images[0]
+        image.save(f"{image_name}.png")
+        print(f"Image generated using {image_name} model saved as {image_name}.png")
+
+
+generate_image(pipe, "flux_mxfp4")

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -1173,6 +1173,43 @@ else:
         )
 
 
+try:
+    from torch_tensorrt.dynamo.conversion import mxfp4_custom_op  # noqa: F401
+
+    assert torch.ops.torchao_trt.dequantize_mxfp4.default
+except Exception:
+    _LOGGER.debug(
+        "torchao MXFP4 custom op not available; skipping "
+        "torchao_trt.dequantize_mxfp4 converter. Install torchao with "
+        "prototype.mx_formats to compile TorchAO MXFP4 models."
+    )
+else:
+
+    @dynamo_tensorrt_converter(
+        torch.ops.torchao_trt.dequantize_mxfp4.default,
+        supports_dynamic_shapes=False,
+    )
+    def aten_ops_torchao_dequantize_mxfp4(
+        ctx: ConversionContext,
+        target: Target,
+        args: Tuple[Argument, ...],
+        kwargs: Dict[str, Argument],
+        name: str,
+    ) -> Union[TRTTensor, Sequence[TRTTensor]]:
+        return impl.quantize.dequantize_mxfp4(
+            ctx,
+            target,
+            SourceIR.ATEN,
+            name,
+            args[0],
+            args[1],
+            args[2],
+            args[3],
+            args[4],
+            args[5],
+        )
+
+
 @dynamo_tensorrt_converter(torch.ops.aten.squeeze.dim, supports_dynamic_shapes=True)
 @dynamo_tensorrt_converter(torch.ops.aten.squeeze.dims, supports_dynamic_shapes=True)
 def aten_ops_squeeze(

--- a/py/torch_tensorrt/dynamo/conversion/impl/quantize.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/quantize.py
@@ -329,6 +329,12 @@ def quantize_affine_float8(
     return quantize_layer.get_output(0)
 
 
+def _as_dim_int(value: Union[int, torch.Tensor]) -> int:
+    if isinstance(value, torch.Tensor):
+        return int(value.item())
+    return value
+
+
 def dequantize_nvfp4(
     ctx: ConversionContext,
     target: Target,
@@ -344,7 +350,7 @@ def dequantize_nvfp4(
     """Map torchao_trt.dequantize_nvfp4 to two-level TensorRT dequantize.
 
     TorchAO stores NVFP4 block scales in a padded/swizzled layout. TensorRT
-    wants the logical ``[N, K/16]`` FP8 block-scale tensor, an FP4 weight
+    wants the logical [N, K/16] FP8 block-scale tensor, an FP4 weight
     constant, and a FP32 global scale. Activations stay high precision; this
     is weight-only storage, not native FP4 MMA.
     """
@@ -354,11 +360,6 @@ def dequantize_nvfp4(
         raise ValueError("NVFP4 weight DQ requires constant qdata and scales")
 
     from torchao.prototype.mx_formats.utils import from_blocked
-
-    def _as_dim_int(value: Union[int, torch.Tensor]) -> int:
-        if isinstance(value, torch.Tensor):
-            return int(value.item())
-        return value
 
     rows_i = _as_dim_int(rows)
     cols_i = _as_dim_int(cols)
@@ -398,6 +399,88 @@ def dequantize_nvfp4(
     data_dq = ctx.net.add_dequantize(
         qdata_trt,
         scale_dq.get_output(0),
+        output_type=trt_output_dtype,
+    )
+    data_dq.axis = -1
+    set_layer_name(data_dq, target, f"{name}_dequantize_data", source_ir)
+    return data_dq.get_output(0)
+
+
+def _e8m0_constant(
+    ctx: ConversionContext,
+    scale_e8m0: torch.Tensor,
+    name: str,
+) -> TRTTensor:
+    """Create a TRT E8M0 constant from TorchAO float8_e8m0fnu scales."""
+    # get_trt_tensor maps uint8 to FP4; build E8M0 weights directly and
+    # record the torch buffer so the data_ptr stays alive through build.
+    u8 = scale_e8m0.detach().contiguous().view(torch.uint8).cpu()
+    weights = to_trt_weights(
+        ctx,
+        u8,
+        name,
+        "CONSTANT",
+        "CONSTANT",
+        dtype=trt.DataType.E8M0,
+    )
+    constant = ctx.net.add_constant(tuple(u8.shape), weights)
+    constant.name = name
+    return constant.get_output(0)
+
+
+def dequantize_mxfp4(
+    ctx: ConversionContext,
+    target: Target,
+    source_ir: Optional[SourceIR],
+    name: str,
+    qdata: Union[torch.Tensor, TRTTensor],
+    block_scale_e8m0: Union[torch.Tensor, TRTTensor],
+    rows: Union[int, torch.Tensor],
+    cols: Union[int, torch.Tensor],
+    block_size: Union[int, torch.Tensor],
+    output_dtype: torch.dtype,
+) -> TRTTensor:
+    """Map torchao_trt.dequantize_mxfp4 to TensorRT dequantize.
+
+    TorchAO stores MX scales in a padded/swizzled layout. TensorRT wants
+    logical [N, K/block_size] E8M0 scales, an FP4 weight constant, and
+    IDequantizeLayer. Myelin accepts FP4 + E8M0 at block size 32; it
+    rejects FP4 + float32 scales at that block size. Activations stay high
+    precision; this is MXFP4 weight storage, not native MXFP4xMXFP4 MMA.
+    """
+    if not all(isinstance(x, torch.Tensor) for x in (qdata, block_scale_e8m0)):
+        raise ValueError("MXFP4 weight DQ requires constant qdata and scales")
+
+    from torchao.prototype.mx_formats.utils import from_blocked
+
+    rows_i = _as_dim_int(rows)
+    cols_i = _as_dim_int(cols)
+    block_size_i = _as_dim_int(block_size)
+    if cols_i % block_size_i != 0:
+        raise ValueError(
+            f"cols ({cols_i}) must be divisible by block_size ({block_size_i})"
+        )
+    n_blocks = cols_i // block_size_i
+
+    with unset_fake_temporarily():
+        logical_e8m0 = from_blocked(block_scale_e8m0, rows_i, n_blocks).contiguous()
+
+    qdata_trt = get_trt_tensor(
+        ctx,
+        qdata,
+        f"{name}_qdata_fp4",
+        target_quantized_type=trt.DataType.FP4,
+    )
+    block_scale_trt = _e8m0_constant(
+        ctx,
+        logical_e8m0,
+        f"{name}_block_scale_e8m0",
+    )
+    trt_output_dtype = _enums.dtype._from(output_dtype).to(trt.DataType)
+
+    data_dq = ctx.net.add_dequantize(
+        qdata_trt,
+        block_scale_trt,
         output_type=trt_output_dtype,
     )
     data_dq.axis = -1

--- a/py/torch_tensorrt/dynamo/conversion/mxfp4_custom_op.py
+++ b/py/torch_tensorrt/dynamo/conversion/mxfp4_custom_op.py
@@ -1,0 +1,76 @@
+"""Register torchao_trt.dequantize_mxfp4 when TorchAO MX kernels exist.
+
+TorchAO MXTensor does not emit a single DQ op that TensorRT can map.
+This custom op keeps packed FP4 qdata and swizzled E8M0 block scales visible
+through torch.export so the converter can emit TensorRT FP4 / E8M0 constants
+and IDequantizeLayer.
+
+MXFP4 uses block size 32 (NVFP4 uses 16) and E8M0 scales (NVFP4 uses FP8
+E4M3 plus a per-tensor scale). There is no TorchAO MXFP4 weight-only config;
+the public recipe is MXDynamicActivationMXWeightConfig. This op only
+dequantizes weights so TensorRT can keep an FP4 constant.
+"""
+
+from __future__ import annotations
+
+import torch
+
+try:
+    from torchao.prototype.mx_formats.kernels import f4_unpacked_to_f32, unpack_uint4
+    from torchao.prototype.mx_formats.mx_tensor import get_fp_scale
+    from torchao.prototype.mx_formats.utils import from_blocked
+
+    _MXFP4_KERNELS_AVAILABLE = True
+except Exception:
+    _MXFP4_KERNELS_AVAILABLE = False
+
+
+if _MXFP4_KERNELS_AVAILABLE:
+
+    @torch.library.custom_op(  # type: ignore[misc]
+        "torchao_trt::dequantize_mxfp4", mutates_args=()
+    )
+    def dequantize_mxfp4(
+        qdata: torch.Tensor,
+        block_scale_e8m0: torch.Tensor,
+        rows: int,
+        cols: int,
+        block_size: int,
+        output_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """Dequantize packed FP4 + swizzled E8M0 block scales for eager validation."""
+        if cols % block_size != 0:
+            raise ValueError(
+                f"cols ({cols}) must be divisible by block_size ({block_size})"
+            )
+        n_blocks = cols // block_size
+
+        unpacked = unpack_uint4(qdata.contiguous().view(torch.uint8))
+        data_f32 = f4_unpacked_to_f32(unpacked).view(rows, n_blocks, block_size)
+
+        scale = from_blocked(block_scale_e8m0, rows, n_blocks)
+        scale_f32 = get_fp_scale(scale).to(torch.float32)
+        return (
+            (data_f32 * scale_f32.view(rows, n_blocks, 1))
+            .view(rows, cols)
+            .to(output_dtype)
+        )
+
+    @dequantize_mxfp4.register_fake  # type: ignore[misc]
+    def _dequantize_mxfp4_fake(
+        qdata: torch.Tensor,
+        block_scale_e8m0: torch.Tensor,
+        rows: int,
+        cols: int,
+        block_size: int,
+        output_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        return torch.empty((rows, cols), device=qdata.device, dtype=output_dtype)
+
+else:
+
+    def dequantize_mxfp4(*_args: object, **_kwargs: object) -> torch.Tensor:
+        raise RuntimeError(
+            "torchao_trt.dequantize_mxfp4 requires torchao MX kernels "
+            "(torchao.prototype.mx_formats)"
+        )

--- a/py/torch_tensorrt/dynamo/lowering/passes/constant_folding.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/constant_folding.py
@@ -108,8 +108,9 @@ class _TorchTensorRTConstantFolder(ConstantFolder):  # type: ignore[misc]
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         # Quantization ops excluded from constant folding so TRT sees QDQ
-        # (ModelOpt tensorrt.quantize_op, TorchAO dequantize_affine, and
-        # TorchAO NVFP4 dequantize_nvfp4 when that custom op is registered).
+        # (ModelOpt tensorrt.quantize_op, TorchAO dequantize_affine, TorchAO
+        # NVFP4 dequantize_nvfp4, and TorchAO MXFP4 dequantize_mxfp4 when
+        # those custom ops are registered).
         self.quantization_ops: Set[torch._ops.OpOverload] = set()
         try:
             # modelopt import ensures torch.ops.tensorrt.quantize_op.default is registered
@@ -152,6 +153,14 @@ class _TorchTensorRTConstantFolder(ConstantFolder):  # type: ignore[misc]
 
             assert torch.ops.torchao_trt.dequantize_nvfp4.default
             self.quantization_ops.add(torch.ops.torchao_trt.dequantize_nvfp4.default)
+        except Exception:
+            pass
+
+        try:
+            from torch_tensorrt.dynamo.conversion import mxfp4_custom_op  # noqa: F401
+
+            assert torch.ops.torchao_trt.dequantize_mxfp4.default
+            self.quantization_ops.add(torch.ops.torchao_trt.dequantize_mxfp4.default)
         except Exception:
             pass
 

--- a/tests/py/dynamo/models/test_torchao_fp8_woq.py
+++ b/tests/py/dynamo/models/test_torchao_fp8_woq.py
@@ -319,3 +319,83 @@ def test_linear_nvfp4_woq():
         ),
     )
     torch._dynamo.reset()
+
+
+def _has_mxfp4_support() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    try:
+        import tensorrt as trt
+        from torchao.prototype.mx_formats.mx_tensor import MXTensor  # noqa: F401
+
+        return hasattr(trt.DataType, "FP4") and hasattr(trt.DataType, "E8M0")
+    except Exception:
+        return False
+
+
+@pytest.mark.unit
+@unittest.skipIf(importlib.util.find_spec("torchao") is None, "torchao not installed")
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+@unittest.skipIf(
+    not _has_mxfp4_support(), "TensorRT FP4 and E8M0 DataTypes are required"
+)
+def test_linear_mxfp4():
+    import sys
+    from pathlib import Path
+
+    example_dir = (
+        Path(__file__).resolve().parents[4] / "examples" / "dynamo" / "torchao"
+    )
+    sys.path.insert(0, str(example_dir))
+    from mxfp4_utils import pre_process_model_for_export, quantize_linear_mxfp4
+
+    class LinearModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(64, 128)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.linear(x)
+
+    model = LinearModel().eval().to(dtype=torch.bfloat16, device="cuda")
+    example_input = torch.randn(8, 64, dtype=torch.bfloat16, device="cuda")
+    quantize_linear_mxfp4(model)
+    model = pre_process_model_for_export(model)
+
+    exp_program = torch.export.export(model, (example_input,), strict=True)
+
+    dq_nodes = [
+        n
+        for n in exp_program.graph.nodes
+        if n.target == torch.ops.torchao_trt.dequantize_mxfp4.default
+    ]
+    assertions.assertTrue(
+        len(dq_nodes) >= 1,
+        msg="Exported graph is missing torchao_trt.dequantize_mxfp4",
+    )
+
+    trt_mod = torchtrt.dynamo.compile(
+        exp_program,
+        inputs=[example_input],
+        min_block_size=1,
+        use_explicit_typing=True,
+        require_full_compilation=True,
+        immutable_weights=True,
+        cache_built_engines=False,
+        reuse_cached_engines=False,
+    )
+
+    with torch.no_grad():
+        eager_out = model(example_input)
+        trt_out = trt_mod(example_input)
+    if isinstance(trt_out, (list, tuple)):
+        trt_out = trt_out[0]
+    cos_sim = cosine_similarity(eager_out, trt_out)
+    assertions.assertTrue(
+        cos_sim > COSINE_THRESHOLD,
+        msg=(
+            "TorchAO MXFP4 TRT outputs don't match eager. "
+            f"Cosine sim score: {cos_sim} Threshold: {COSINE_THRESHOLD}"
+        ),
+    )
+    torch._dynamo.reset()


### PR DESCRIPTION
# Description

Adds TorchAO **MXFP4** support on the Dynamo path (`MXDynamicActivationMXWeightConfig`). There is no TorchAO MXFP4 weight-only config — that recipe is NVFP4 (`NVFP4WeightOnlyConfig`, #4593). This layer registers `torchao_trt.dequantize_mxfp4`, maps it to TensorRT `IDequantizeLayer` (packed FP4 E2M1 + E8M0 block scales, block size 32), and marks the op impure in constant folding so DQ is not folded into dense BF16.

Native MXFP4×MXFP4 kernels need B200/B300. This path uses emulated MX storage and a **weight DQ prologue** into a high-precision GEMM; activations stay BF16. Last two Linear dims must be divisible by 32. Parent `MXTensor` does not emit a DQ op TensorRT can map — examples promote to `MXTensorNonDecomposed` before export. Compile with `immutable_weights=True`. Myelin accepts FP4 + E8M0 at block size 32; FP4 + float32 scales fail.

Examples: toy `nn.Linear` and FLUX.1-dev. User-guide, troubleshooting, and gallery docs are updated. HTML under `docs/` is left to the post-merge docgen bot.

**Dependencies:** `torchao` (`prototype.mx_formats`). TensorRT with FP4 and E8M0 constants (TRT ≥ 10.8).

Stacked on #4593 (NVFP4 WOQ) → #4590 (INT4) → #4589 (FP8). Stack: https://github.com/pytorch/TensorRT/stack/4591

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] `test_linear_mxfp4` compiles a 64×128 Linear locally (max abs diff vs eager: 0)
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified