### PR TITLE
perf(executorch): opt-in shared per-device activation-scratch pool

### DIFF
--- a/.github/workflows/executorch-test-linux.yml
+++ b/.github/workflows/executorch-test-linux.yml
@@ -125,9 +125,6 @@ jobs:
           fi
           export LD_LIBRARY_PATH="${_dir}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
         done
-        bazel test //tests/cpp/executorch:executorch_backend_tests \
-          --compilation_mode opt --config=linux --test_output=errors \
-          --test_env=LD_LIBRARY_PATH
         executorch_cmake_location="$(bazel query @executorch//:executorch/CMakeLists.txt --output=location)"
         export EXECUTORCH_SOURCE_DIR="$(dirname "${executorch_cmake_location%%:*}")"
         export EXECUTORCH_ROOT="${EXECUTORCH_SOURCE_DIR}"
@@ -143,3 +140,33 @@ jobs:
           "${RUNNER_TEMP}/torchtrt-coalesced.pte"
         python examples/executorch_reference_runner/load_model.py \
           --model_path="${RUNNER_TEMP}/torchtrt-python.pte" --num_runs=1
+        # The backend C++ suite runs here, at the end, and not next to the Bazel
+        # build above, because `set -e` ends this script at the first failure and
+        # everything between the two would be traded away for it: the three
+        # exports, verify-executorch-reference-runner.sh -- which unpacks the
+        # release archive and builds the packaged CMake backend out of it, and so
+        # is what says the archive still carries every header that backend needs
+        # -- and load_model.py. Run last, a suite that fails because the device
+        # went missing or flaky costs none of them.
+        #
+        # --test_summary=detailed names every case that skipped, in Bazel's own
+        # summary rather than in the test log, which --test_output=errors prints
+        # nothing of for a target that passes. Cases in that suite skip for reasons
+        # the variable below does not cover -- its own coverage note lists them --
+        # and without those names a run in which the pool's growth and
+        # allocation-failure paths never executed looks like one in which they did.
+        #
+        # TORCHTRT_EXECUTORCH_REQUIRE_CUDA turns a case that skips for want of a
+        # CUDA device into a failure. Every row of this job's matrix is a CUDA row
+        # -- filter-matrix.py drops any whose desired_cuda is not a TensorRT CUDA
+        # version -- and linux-test.yml starts the container with `--gpus all` for
+        # those, so a skip here means the device went missing rather than that the
+        # runner never had one. Without the variable every case that needs a
+        # device skips, its target exits zero and is reported as a passing target
+        # that covered nothing -- 27 of the suite's 96 cases, the whole of
+        # test_shared_scratch_backend.
+        bazel test //tests/cpp/executorch:executorch_backend_tests \
+          --compilation_mode opt --config=linux --test_output=errors \
+          --test_summary=detailed \
+          --test_env=LD_LIBRARY_PATH \
+          --test_env=TORCHTRT_EXECUTORCH_REQUIRE_CUDA=1

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -191,6 +191,122 @@ cc_library(
     ],
 )
 
+# Implementation detail of :tensorrt_executorch_backend, so the header sits under
+# src/ and ships with the sources rather than in the installed API set. A caller
+# turning the pool on needs only the option key, which is in TensorRTBackend.h.
+cc_library(
+    name = "tensorrt_executorch_shared_scratch_pool",
+    hdrs = [
+        "src/torch_tensorrt/executorch/SharedScratchPool.h",
+    ],
+    strip_include_prefix = "src",
+    target_compatible_with = select({
+        ":linux_x86_64": [],
+        ":sbsa": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = select({
+        ":linux_x86_64": [
+            "@cuda//:cuda_headers",
+        ],
+        ":sbsa": [
+            "@cuda//:cuda_headers",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+# The one internal entry point of :tensorrt_executorch_backend that its test calls
+# directly. Under src/ for the same reason as the pool header above: it is an
+# implementation detail of execute(), and an installed header declaring it would
+# make it API from the next release.
+#
+# It carries the definition and not only the declaration, so the target stands on
+# its own: a header target whose symbol another target defines links only for a
+# consumer that happens to depend on that one too.
+cc_library(
+    name = "tensorrt_executorch_pooled_scratch_install",
+    srcs = [
+        "src/torch_tensorrt/executorch/PooledScratchInstall.cpp",
+    ],
+    hdrs = [
+        "src/torch_tensorrt/executorch/PooledScratchInstall.h",
+    ],
+    strip_include_prefix = "src",
+    target_compatible_with = select({
+        ":linux_x86_64": [],
+        ":sbsa": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = select({
+        ":linux_x86_64": [
+            "@executorch//:executorch_headers",
+            "@tensorrt//:nvinfer",
+        ],
+        ":sbsa": [
+            "@executorch//:executorch_headers",
+            "@tensorrt_sbsa//:nvinfer",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+# The body of the pool's test-only reset. testonly and under src/, so it is in
+# neither the packaged include tree nor executorch_backend_source_files below: a
+# release build has no definition of it anywhere. SharedScratchPool.h keeps only
+# the friend declaration that lets this reach the registry's internals.
+cc_library(
+    name = "tensorrt_executorch_shared_scratch_pool_reset",
+    testonly = True,
+    hdrs = [
+        "src/torch_tensorrt/executorch/SharedScratchPoolReset.h",
+    ],
+    strip_include_prefix = "src",
+    target_compatible_with = select({
+        ":linux_x86_64": [],
+        ":sbsa": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        ":tensorrt_executorch_shared_scratch_pool",
+    ],
+)
+
+# The pool's test-only entry points. A separate target, and testonly, so the
+# released archive -- Bazel's :tensorrt_executorch_backend and CMake's
+# executorch_trt_backend, neither of which compiles this source -- carries no
+# definition of them and exports no symbol for them. One of them frees the live
+# pool with no wait for work in flight, which is not something a release build
+# should offer a caller.
+cc_library(
+    name = "tensorrt_executorch_shared_scratch_pool_test_hooks",
+    testonly = True,
+    srcs = [
+        "src/torch_tensorrt/executorch/SharedScratchPoolTestHooks.cpp",
+    ],
+    hdrs = [
+        "src/torch_tensorrt/executorch/SharedScratchPoolTestHooks.h",
+    ],
+    strip_include_prefix = "src",
+    target_compatible_with = select({
+        ":linux_x86_64": [],
+        ":sbsa": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        ":tensorrt_executorch_shared_scratch_pool",
+        ":tensorrt_executorch_shared_scratch_pool_reset",
+    ] + select({
+        ":linux_x86_64": [
+            "@cuda//:cudart",
+        ],
+        ":sbsa": [
+            "@cuda//:cudart",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
 cc_library(
     name = "tensorrt_executorch_backend",
     srcs = [
@@ -211,6 +327,8 @@ cc_library(
     deps = [
         ":tensorrt_executorch_binding_names",
         ":tensorrt_executorch_blob_header",
+        ":tensorrt_executorch_pooled_scratch_install",
+        ":tensorrt_executorch_shared_scratch_pool",
         ":tensorrt_executorch_weight_streaming_budget",
     ] + select({
         ":linux_x86_64": [
@@ -234,7 +352,10 @@ filegroup(
     name = "executorch_backend_source_files",
     srcs = [
         "src/torch_tensorrt/executorch/CMakeLists.txt",
+        "src/torch_tensorrt/executorch/PooledScratchInstall.cpp",
+        "src/torch_tensorrt/executorch/PooledScratchInstall.h",
         "src/torch_tensorrt/executorch/README.md",
+        "src/torch_tensorrt/executorch/SharedScratchPool.h",
         "src/torch_tensorrt/executorch/TensorRTBackend.cpp",
         "src/torch_tensorrt/executorch/TensorRTBlobHeader.cpp",
         "src/torch_tensorrt/executorch/WeightStreamingBudget.cpp",

--- a/cpp/include/torch_tensorrt/executorch/TensorRTBackend.h
+++ b/cpp/include/torch_tensorrt/executorch/TensorRTBackend.h
@@ -17,6 +17,7 @@
 
 #include <executorch/runtime/backend/interface.h>
 
+#include <cstddef>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -75,6 +76,23 @@ struct EngineHandle {
   size_t num_aliased_outputs = 0;
   int device_id = 0;
   bool unified_memory = false;
+  // Whether exec_ctx was created kUSER_MANAGED, because
+  // kSharedActivationScratchKey was on at this engine's load. Such a context takes
+  // its activation scratch from the shared per-device pool on every call, unless
+  // claims_pooled_scratch below is false, in which case the engine needs none and
+  // never claims from the pool at all.
+  bool shared_scratch = false;
+  // Whether this handle takes its activation scratch from the pool. Set at init
+  // only where shared_scratch above is on, and then only where the engine reports
+  // needing activation scratch under some shape; a handle loaded with the option
+  // off keeps this false and says nothing about what its engine needs, because it
+  // has its own kSTATIC scratch either way. It is a predicate and not a size
+  // because the size is never the right amount to install: enqueueV3 refuses a
+  // kUSER_MANAGED context with no device memory once the engine needs any, however
+  // little the shapes bound to a given call need, so execute() must hand such a
+  // call some buffer -- but the engine's own figure covers every shape in the
+  // profile, and installing it would size the pool for the largest of them.
+  bool claims_pooled_scratch = false;
   std::mutex mu;
   // Makes the skip-sync fast path safe to reuse: TensorRT forbids reconfiguring or
   // destroying an execution context while one of its enqueues is in flight, so when
@@ -86,6 +104,15 @@ struct EngineHandle {
 
   ~EngineHandle();
 };
+
+// Runtime backend option that backs execution-context activation scratch with a
+// shared per-device pool instead of giving every context its own. Boolean,
+// default false. Read by TensorRTBackend::set_option below, and delivered as
+//   executorch::runtime::set_option("TensorRTBackend", options.view())
+// A context's allocation strategy is fixed when the context is created, so a
+// later call governs only the engines loaded after it, and a pooled context and
+// a private-scratch one coexist in one process.
+inline constexpr char kSharedActivationScratchKey[] = "use_shared_activation_scratch";
 
 class TensorRTBackend final : public ::executorch::runtime::BackendInterface {
  public:
@@ -102,12 +129,101 @@ class TensorRTBackend final : public ::executorch::runtime::BackendInterface {
   // past return, order any other stream against this one, and synchronize the stream
   // before reading device-resident outputs. The selected stream must be on the engine's
   // device, and calls on one handle must not overlap each other or its destruction.
-  // Note that other CUDA delegates sharing the same guard may instead synchronize before
+  // Other CUDA delegates sharing the same guard may instead synchronize before
   // returning, so do not assume results are ready on return from this one.
+  // With the shared activation scratch pool (kSharedActivationScratchKey) one
+  // buffer per device backs every context created while the option was on. Calls
+  // on two such handles on one device may overlap: a per-device lock held across
+  // the enqueue serializes them, so they do not run concurrently on the device. A
+  // handle whose context was created while the option was off keeps its own
+  // scratch and is not subject to this, nor is one whose engine reports needing no
+  // activation scratch under any shape, which is left out of the pool. For the
+  // handles that do draw on it, five further consequences:
+  //   - A call needing more scratch than the pool holds grows it, and the growth
+  //     has to get rid of the buffer it replaces before it returns, or the bytes
+  //     of every size the pool ever grew to stay resident at once. Where that
+  //     buffer has an enqueue recorded against it, the disposal begins with a host
+  //     wait for that enqueue -- a whole inference, with no upper bound, paid
+  //     whatever kind of call the growth is and whether or not it goes on to fail.
+  //     Unbounded is meant literally: if that enqueue is itself waiting on
+  //     something only this thread supplies once execute() returns -- a host
+  //     function it will release, a copy it will enqueue next -- the call does not
+  //     return, and the thread that would unblock it is the one inside the wait. A
+  //     growth that reached its own enqueue therefore comes back with that engine
+  //     work finished rather than in flight, since the event it waits on names that
+  //     enqueue too. What the growth does not wait for is the rest of the device:
+  //     the free is queued on a stream the pool owns and synchronizes itself, so
+  //     work on streams this call never submitted to is not in the wait, and the
+  //     bytes are back before it returns. Three things make the free a device-wide
+  //     cudaFree instead, and then the call does block until the device is idle: a
+  //     device with no stream-ordered allocator, where cudaFreeAsync reports
+  //     cudaErrorNotSupported rather than freeing; any other code it reports, since
+  //     a queued free that did not happen is not a free; and a disposal stream the
+  //     pool could not create at all. Which calls grow the pool is not knowable
+  //     from here; see the README.
+  //   - A call that synchronizes the stream waits, through the handoff, for every
+  //     pooled enqueue submitted before it on that device. That is what one buffer
+  //     costs, and it is another unbounded wait: park a host function ahead of a
+  //     pooled enqueue and release it only after a later execute() returns, and
+  //     the later call is the one that does not return.
+  //   - Capturing a CUDA graph around this delegate is not supported, with the
+  //     option on or off. With it on, a call whose selected stream is capturing is
+  //     refused with Error::NotSupported, ahead of every CUDA call it makes that a
+  //     capture cannot take -- only the device query and the device switch run
+  //     first. The pool's event handoff waits on an event recorded outside the
+  //     capture, which invalidates it under every capture mode, and a growth's
+  //     allocation and its disposal of the buffer it replaces invalidate it under
+  //     every mode but cudaStreamCaptureModeRelaxed. The alternative to refusing is
+  //     a capture that silently comes back invalidated. Where the query cannot be
+  //     answered the call is not told it is capturing: cudaStreamIsCapturing also
+  //     hands back a sticky fault left by earlier work on the device, and a call
+  //     that meets one fails with that fault's own message and
+  //     Error::InvalidProgram instead. Only a capture on the selected stream is
+  //     caught; one running on any other stream under cudaStreamCaptureModeGlobal,
+  //     or under cudaStreamCaptureModeThreadLocal from this thread, is invalidated
+  //     by the same calls and is not refused, because CUDA offers no query for it.
+  //     Do not run a pooled engine while capturing anywhere in the process. With
+  //     the option off nothing refuses, because the check is inside the pooled
+  //     path, but capture is unsupported there too: no call shape is built or
+  //     tested for it. The README states this in full.
+  //   - cudaDeviceReset() invalidates the pool without emptying it. The buffer,
+  //     the handoff event and the disposal stream it still holds are destroyed
+  //     with the primary context, and the next call on that device uses all three.
+  //     There is no guard: do not reset a device this backend has run a pooled
+  //     engine on.
+  //   - The pool adds failure points to a call, on top of Error::NotSupported for
+  //     the capture above. Only Error::Internal is its own: a pooled call returns
+  //     it when the device's handoff event cannot be created, and an unpooled call
+  //     never returns it at all. The rest reuse codes an unpooled call already
+  //     returns from elsewhere in execute(), so the code alone does not say the
+  //     pool was involved -- the log line does, and every one of them logs at Error
+  //     first. Error::MemoryAllocationFailed if the shared buffer cannot be
+  //     allocated or grown; Error::InvalidState if the wait ordering this call
+  //     behind the previous enqueue fails, if TensorRT refuses the installed
+  //     buffer, or if this call's enqueue cannot be recorded for the next claimant;
+  //     Error::InvalidProgram if the capture query fails for a reason that is not a
+  //     capture, or if the disposal's host wait fails -- and that last one leaks
+  //     the retired buffer rather than freeing it under an enqueue that may still
+  //     be reading it. The record and the disposal are the only two reached after
+  //     this call's enqueue is submitted, and both synchronize the stream before
+  //     returning, so neither leaves engine work in flight. Separately, a pooled
+  //     call that staged a host-resident input synchronizes the stream on any error
+  //     return it makes after that copy: the copy reads the caller's own memory and
+  //     the caller owns that memory again the moment execute() returns. That too is
+  //     a whole-stream wait, so it covers work the caller queued before calling. An
+  //     unpooled call makes no such wait -- its error returns can leave that copy
+  //     running, which is what they have always done.
   ::executorch::runtime::Error execute(
       ::executorch::runtime::BackendExecutionContext& context,
       ::executorch::runtime::DelegateHandle* handle,
       ::executorch::runtime::Span<::executorch::runtime::EValue*> args) const override;
+
+  // Applies the runtime backend options a caller passes to
+  // executorch::runtime::set_option("TensorRTBackend", ...). The only key read is
+  // kSharedActivationScratchKey, a boolean.
+  ::executorch::runtime::Error set_option(
+      ET_UNUSED ::executorch::runtime::BackendOptionContext& context,
+      const ::executorch::runtime::Span<::executorch::runtime::BackendOption>& backend_options) override;
 
   void destroy(::executorch::runtime::DelegateHandle* handle) const override;
 };

--- a/cpp/src/torch_tensorrt/executorch/CMakeLists.txt
+++ b/cpp/src/torch_tensorrt/executorch/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(CUDAToolkit REQUIRED)
 find_package(Threads REQUIRED)
 
 set(_torchtrt_executorch_sources
+    "${CMAKE_CURRENT_LIST_DIR}/PooledScratchInstall.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/TensorRTBackend.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/TensorRTBlobHeader.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/WeightStreamingBudget.cpp"
@@ -36,6 +37,13 @@ set_target_properties(executorch_trt_backend
 target_include_directories(executorch_trt_backend
     PUBLIC
         "${CMAKE_CURRENT_LIST_DIR}/../../../include"
+    PRIVATE
+        # SharedScratchPool.h and PooledScratchInstall.h are implementation
+        # details, so they sit beside the sources instead of in the installed
+        # include tree. This directory is
+        # .../torch_tensorrt/executorch in both the repository and the released
+        # package, so two levels up is the root its #include path is relative to.
+        "${CMAKE_CURRENT_LIST_DIR}/../.."
 )
 
 get_filename_component(_torchtrt_repo_root "${CMAKE_CURRENT_LIST_DIR}/../../../.." ABSOLUTE)

--- a/cpp/src/torch_tensorrt/executorch/PooledScratchInstall.cpp
+++ b/cpp/src/torch_tensorrt/executorch/PooledScratchInstall.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "torch_tensorrt/executorch/PooledScratchInstall.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <NvInfer.h>
+
+#include <executorch/runtime/platform/log.h>
+
+namespace torch_tensorrt {
+namespace executorch_backend {
+namespace {
+
+// Collects what TensorRT reports while it is attached. Attaching it is
+// ScopedRecorderAttachment's below; this is only the sink.
+class CollectingErrorRecorder final : public nvinfer1::IErrorRecorder {
+ public:
+  int32_t getNbErrors() const noexcept override {
+    return static_cast<int32_t>(errors_.size());
+  }
+  nvinfer1::ErrorCode getErrorCode(int32_t index) const noexcept override {
+    return in_range(index) ? errors_[static_cast<size_t>(index)].first : nvinfer1::ErrorCode::kSUCCESS;
+  }
+  ErrorDesc getErrorDesc(int32_t index) const noexcept override {
+    return in_range(index) ? errors_[static_cast<size_t>(index)].second.c_str() : "";
+  }
+  bool hasOverflowed() const noexcept override {
+    return overflowed_;
+  }
+  void clear() noexcept override {
+    errors_.clear();
+  }
+  bool reportError(nvinfer1::ErrorCode code, ErrorDesc desc) noexcept override {
+    // noexcept, and a throwing push_back here would terminate: an allocation
+    // failure while reporting an error costs the description, not the process.
+    try {
+      errors_.emplace_back(code, std::string(desc == nullptr ? "" : desc));
+    } catch (...) {
+      overflowed_ = true;
+    }
+    return false; // false asks TensorRT to keep going; the caller decides
+  }
+  RefCount incRefCount() noexcept override {
+    return ++refs_;
+  }
+  RefCount decRefCount() noexcept override {
+    return --refs_;
+  }
+
+  bool anything_reported() const {
+    return !errors_.empty() || overflowed_;
+  }
+
+ private:
+  bool in_range(int32_t index) const {
+    return index >= 0 && static_cast<size_t>(index) < errors_.size();
+  }
+
+  std::vector<std::pair<nvinfer1::ErrorCode, std::string>> errors_;
+  bool overflowed_ = false;
+  RefCount refs_ = 1;
+};
+
+// Attaches `recorder` to `ctx` for the length of one TensorRT call and puts back
+// whatever the caller had attached before.
+//
+// The restore is a destructor rather than a statement after the call. `recorder`
+// is a stack object and `ctx` outlives the call, so a return added between the
+// attach and the restore would leave TensorRT holding a pointer into a dead
+// frame. Nor is the restore tidiness: while a recorder is attached TensorRT
+// reports to it *instead of* to the ILogger, so one left in place would divert
+// the diagnostics for setInputShape, setTensorAddress and enqueueV3 away from the
+// backend's logger.
+//
+// It takes a reference of its own on the recorder it displaces and holds it
+// across the swap. TensorRT drops a reference on the recorder it replaces and
+// takes one again on the restore, so a recorder whose only reference is
+// TensorRT's reaches zero on the way in: measured on a real execution context on
+// TensorRT 11.2.1 and 10.16.1.11, the replaced recorder's count goes to 0 at the
+// attach and incRefCount is then called on it again at the restore. Destroying an
+// error recorder once its count reaches zero is what IErrorRecorder's own
+// documentation describes and what TensorRT's samples do, so without this
+// reference such a caller's recorder is freed at the attach and re-registered
+// dangling at the restore, once per pooled call.
+class ScopedRecorderAttachment {
+ public:
+  ScopedRecorderAttachment(nvinfer1::IExecutionContext& ctx, nvinfer1::IErrorRecorder& recorder)
+      : ctx_(ctx), previous_(ctx.getErrorRecorder()) {
+    if (previous_ != nullptr) {
+      previous_->incRefCount();
+    }
+    ctx_.setErrorRecorder(&recorder);
+  }
+  ScopedRecorderAttachment(const ScopedRecorderAttachment&) = delete;
+  ScopedRecorderAttachment& operator=(const ScopedRecorderAttachment&) = delete;
+
+  ~ScopedRecorderAttachment() {
+    ctx_.setErrorRecorder(previous_);
+    if (previous_ != nullptr) {
+      previous_->decRefCount();
+    }
+  }
+
+ private:
+  nvinfer1::IExecutionContext& ctx_;
+  nvinfer1::IErrorRecorder* previous_;
+};
+
+} // namespace
+
+// Declared in PooledScratchInstall.h. See that header for why the install is
+// checked rather than made and trusted.
+bool install_pooled_scratch(nvinfer1::IExecutionContext& ctx, void* buffer, std::size_t bytes, int device_id) {
+  CollectingErrorRecorder recorder;
+  {
+    const ScopedRecorderAttachment attached(ctx, recorder);
+    ctx.setDeviceMemoryV2(buffer, static_cast<int64_t>(bytes));
+  }
+
+  if (!recorder.anything_reported()) {
+    return true;
+  }
+  ET_LOG(
+      Error,
+      "TensorRTBackend::execute: TensorRT refused the %zu-byte shared activation scratch buffer for device %d: %s",
+      bytes,
+      device_id,
+      recorder.getNbErrors() > 0 ? recorder.getErrorDesc(0) : "the refusal could not be recorded");
+  return false;
+}
+
+} // namespace executorch_backend
+} // namespace torch_tensorrt

--- a/cpp/src/torch_tensorrt/executorch/PooledScratchInstall.h
+++ b/cpp/src/torch_tensorrt/executorch/PooledScratchInstall.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// The one step of execute()'s pooled path that the backend's test drives
+// directly, declared beside the source that defines it rather than in the
+// installed header set: it is an implementation detail of execute(), and a
+// declaration in an installed header is API the next release has to keep.
+// SharedScratchPool.h sits here for the same reason.
+
+#include <NvInfer.h>
+
+#include <cstddef>
+
+namespace torch_tensorrt {
+namespace executorch_backend {
+
+// Installs `bytes` of `buffer` as the activation scratch of `ctx`, a
+// kUSER_MANAGED context, and reports whether TensorRT accepted it. Logs the
+// refusal, naming `device_id`, when it did not.
+//
+// The check is the point. setDeviceMemoryV2 returns void and refuses a buffer
+// smaller than the bound shapes need, so a caller that does not ask cannot tell an
+// accepted install from a refused one -- and a refused one leaves the context
+// pointed at the buffer it was last given, which a shared-scratch pool growth may
+// since have freed. The engine then reads and writes freed memory with enqueueV3
+// reporting success. The refusal is read back through an IErrorRecorder scoped to
+// this one call, the only channel that hands it to the caller: with no recorder
+// attached TensorRT writes it to the runtime's ILogger and this function has
+// nothing to return.
+//
+// The backend's own test calls it over the same TensorRT call to cover a refusal
+// that cannot be induced through execute().
+bool install_pooled_scratch(nvinfer1::IExecutionContext& ctx, void* buffer, std::size_t bytes, int device_id);
+
+} // namespace executorch_backend
+} // namespace torch_tensorrt

--- a/cpp/src/torch_tensorrt/executorch/README.md
+++ b/cpp/src/torch_tensorrt/executorch/README.md
@@ -68,8 +68,7 @@ type.
 The upstream `CallerStreamGuard` documents the generic contract (per-thread,
 nested scoping; the caller owns the stream for the guard's lifetime; the caller
 manages host-data lifetime for async work). The TensorRT backend adds these
-requirements, which previously lived on
-the removed `CudaStreamGuard`:
+requirements, which previously lived on the removed `CudaStreamGuard`:
 
 - The selected stream must be on the TensorRT engine's device.
 - Calls using one delegate handle must not overlap, and must not overlap with
@@ -85,6 +84,18 @@ the removed `CudaStreamGuard`:
   complete, order any cross-stream producers/consumers with their own events,
   and synchronize the stream before reading outputs on the host.
 - With no guard active, the backend falls back to `cudaStreamPerThread`.
+- With the `use_shared_activation_scratch` backend option enabled, one buffer
+  per device backs the activation scratch of every execution context created
+  while it was on, so no two enqueues against it may overlap. The backend
+  enforces this itself: it holds a per-device lock from the claim on the buffer
+  through the enqueue and the completion event recorded on it, so two
+  `execute()` calls on one device are serialized at submission and the second's
+  stream waits on the first's enqueue. They may run on one stream or on two, and
+  they may be submitted concurrently from two threads, but they will not run
+  concurrently on the device, so the pool costs the parallelism between them.
+  Contexts created while the option was off keep their own scratch and are
+  unaffected, and so is a context whose engine needs no activation scratch under
+  any shape: that one is left out of the pool and serializes against nothing.
 - The reference-runner smoke test runs inference inside a caller-stream guard on
   the discrete-GPU CI configuration, where all inputs and outputs are host-backed
   and therefore take the synchronized staging path. CI separately asserts that the
@@ -103,6 +114,264 @@ the removed `CudaStreamGuard`:
   the method inputs and outputs are host-backed, so the device-resident
   asynchronous return described above is still uncovered and the interaction
   between a green context and the internal completion event remains untested.
+
+## Shared activation scratch
+
+A TensorRT execution context allocates its own activation scratch and holds it
+for as long as the context lives, so a model lowered to N single-layer engines
+pays N copies and can run out of device memory on the layer count alone. The
+`use_shared_activation_scratch` backend option (a boolean, off by default)
+instead backs a device's contexts from one buffer, grown to the largest
+requirement any call on that device has asked for. Which contexts: those created
+while the option was on, less any whose engine needs no scratch under any shape,
+which are left out of the pool entirely. The two exceptions are spelled out
+below.
+
+```cpp
+#include <executorch/runtime/backend/interface.h>
+
+executorch::runtime::Error enable_shared_activation_scratch() {
+  executorch::runtime::BackendOptions<1> options;
+  // Returns Error::InvalidArgument when the object has no room left. One key in a
+  // BackendOptions<1> always fits, so this cannot fail as written; the check is
+  // what keeps it honest when a second key is added beside it.
+  const executorch::runtime::Error stored =
+      options.set_option("use_shared_activation_scratch", true);
+  if (stored != executorch::runtime::Error::Ok) {
+    return stored;
+  }
+  // Nothing was set if this fails: every context still allocates its own scratch.
+  return executorch::runtime::set_option("TensorRTBackend", options.view());
+}
+```
+
+`Error::NotFound` means no backend is registered under that name, which is what a
+binary that has not linked the backend archive gets. Nothing forces the check: the
+free `executorch::runtime::set_option` is not `ET_NODISCARD`, so dropping its
+return compiles.
+
+N per-engine copies collapse to one, so the reclaimed memory is the sum of the N
+requirements less the largest of them. Set the option before loading the methods
+whose engines should use the pool, and read the `use_shared_activation_scratch`
+bullet of the caller-stream contract above: engines sharing a buffer do not run
+concurrently on the device. The pool never shrinks, so the largest scratch it was
+ever asked for stays allocated until the process exits.
+
+A call that asks for nothing never grows a pool that already holds a buffer: it is
+handed that buffer, whatever size it is. Against an empty pool it does allocate,
+which the paragraph after next is about. It is not handed the pool's size with it
+either: what the context is told it owns is the figure this call asked for, so a
+zero becomes the one-byte minimum below and TensorRT is told the buffer is one
+byte, whatever the pool's capacity is. Two of the things a zero from the per-shape
+query can mean reach this point, and are indistinguishable where it is read: the
+shapes bound to this call need none -- an empty batch inside a profile that admits
+one -- or the query failed. Neither wants a buffer of its own.
+
+Such a call cannot be left with no buffer at all. `enqueueV3` refuses a
+`kUSER_MANAGED` context with no device memory installed as soon as the engine
+reports needing some under *any* shape, however little the shapes actually bound
+need. So where the pool holds nothing yet, a zero allocates the smallest buffer
+that satisfies that check, and the first call with a real requirement grows it.
+Standing the engine's own figure in for the zero would satisfy the check too, but
+that figure covers the whole profile: on the dynamic engine the tests use it is
+4 MiB against the 128 KiB the next call needs, and the pool never shrinks.
+
+Only one of the two causes is safe to hand a buffer that small, and the install is
+what separates them. `setDeviceMemoryV2` refuses a buffer smaller than the bound
+shapes need, and it returns `void`: where the shapes genuinely need nothing the
+expected size is zero and the one-byte buffer is accepted, but where the query
+failed the engine expects what it always did, the install is refused, and the
+context keeps the buffer it was last given -- which a growth may already have
+freed, so the enqueue would read and write memory the pool no longer owns while
+`enqueueV3` reports success. The backend reads the refusal back through a TensorRT
+`IErrorRecorder` scoped to that one call and fails with `Error::InvalidState`
+rather than enqueueing. Nothing reaches `enqueueV3` on an install TensorRT
+rejected.
+
+What each call installs is its own requirement, not the capacity the pool holds,
+which is larger whenever an earlier call asked for more. Handing a context the
+larger figure would say it owns bytes that belong to whatever ran before it, and
+the pool never clears the buffer between users -- activation scratch is written
+before it is read, so a context that stays inside its own requirement never sees
+those bytes, and one that runs past it sees another engine's activations rather
+than zeros. The smaller figure also keeps the refusal above sharp: after a growth
+the capacity may well cover what a failed query concealed, and an install sized
+from it would be accepted.
+
+The third thing a zero can mean is an engine that needs no scratch under *any*
+shape, and that one is settled before a call is ever made: such an engine is left
+out of the pool entirely, so it takes no per-device lock and does not serialize
+against the engines that do.
+
+The buffer grows when a call asks for more than every call before it did, and the
+growth has to get rid of the buffer it replaces *before `execute()` returns*.
+Not disposing of it inside the call is not an option: the pool grows monotonically,
+so a run that let each retired buffer outlive its growth would end up holding the
+sum of every size the pool was ever grown to rather than the largest of them.
+
+Every growth gets rid of it the same way, and none of the three steps reads
+anything about the call the growth was made from: wait on the host for the enqueue
+the handoff event names, queue a `cudaFreeAsync` on a stream the pool owns for that
+device, and synchronize that stream, which is what returns the bytes. All three are
+made with the per-device lock dropped, so none of them is serialized behind the
+pool's own lock and none holds the next claimant off while it runs: two pooled calls
+serialize at submission, as the caller-stream contract above says, and a growth is
+not an exception to it.
+
+**The host wait is the thing to know about**, because it is what a growth pays
+whenever the buffer it replaces has an enqueue recorded against it. It is a whole
+inference, and it has no upper bound: whatever the enqueue is waiting for holds it
+too, so if a host function ahead of that enqueue will be released only by this
+thread once `execute()` returns, the growing call does not return and the thread
+that would release it is the one inside the wait.
+
+The event it waits on is the handoff, and a call that reached its own enqueue has
+recorded that enqueue there before it releases the claim, so the wait covers this
+call's inference as well as the one before it. A growth therefore returns with its
+engine work finished rather than in flight, however asynchronous the caller-stream
+contract above lets a call that does not grow the pool be, and anything `execute()`
+queues after the release -- an aliased reflect, a D2H copy -- goes behind a
+completed enqueue rather than a running one. Only a growth pays that; a call with
+nothing retired makes no CUDA call in the release at all. A growth whose retired
+buffer never had an enqueue recorded against it does not pay it either: the
+handoff carries no recording, so there is nothing to wait for and the disposal
+goes straight to the free. A pooled call that returned between taking the buffer
+and recording its enqueue -- a refused install, a refused `enqueueV3` -- is what
+leaves the pool in that state.
+
+Sharing one buffer has an unbounded wait of its own, growth or no growth. A call
+that synchronizes waits, through the handoff, for every pooled enqueue submitted
+before it on that device. Park a host function ahead of one pooled call's enqueue
+and release it only once a later pooled call has returned, and the later call is
+the one that never returns.
+
+What a growth does *not* wait for is the rest of the device, and that is what the
+pool's own stream buys. A device-wide `cudaFree` waits for everything queued on the
+device rather than for the work that touched the buffer. Measured on an A100 with
+CUDA 13.0 and driver 13.0, freeing a 512 MiB buffer behind a 10 ms enqueue with a
+host function parked for 1500 ms on a stream nothing else in the measurement
+submitted to: 1500.8-1501.4 ms device-wide against 10.6-11.7 ms on the pool's
+stream, both with every byte back by the time the disposal returned. That wait is
+not hypothetical: the backend's own tests deadlocked on the device-wide free once,
+when a change of test order turned a case that parks a host function on its own
+stream into the one that grew the pool.
+
+The stream has to be the pool's rather than the calling engine's. A `cudaFreeAsync`
+of a `cudaMalloc`'d pointer -- which is what this pool holds -- hands the bytes
+back at the next `cudaStreamSynchronize` of the stream it was queued on and at no
+point before it. Measured on the same machine: it returns `cudaSuccess` and defers
+the free, a stream `cudaStreamQuery` reports as drained still holds the bytes,
+`cudaMemGetInfo` does not move, and a `cudaMalloc` of the same size fails with out
+of memory until the synchronize. So whoever queues the free has to be able to
+promise that synchronize, and only the pool can. Queuing it on the caller's stream
+costs the disposal nothing, 0.0 ms in the same measurement, because all it does is
+queue; the
+whole 512 MiB was still resident when it returned, and the caller's own synchronize
+is what gives it back. Where the caller makes one, that is no faster overall:
+10.4-11.8 ms to the same point. Where it does not -- the caller-stream,
+device-resident case, which is the one this option exists for -- the bytes never
+come back at all: nothing this backend does will ever synchronize that stream, and
+the stream is the caller's to destroy. Measured, a 4 GiB block queued
+that way and then abandoned with the stream is gone for the life of the process, on
+a device with tens of gigabytes still free: not at `cudaStreamDestroy`, not at
+`cudaDeviceSynchronize`, not from another stream, and not at `cudaMemPoolTrimTo`.
+Replaying the pool's own growth sequence on one such stream -- 8, 16, 24 and 32 GiB,
+no synchronize between them -- four growths that all succeed when the disposal
+returns the bytes fail on the fourth with out of memory, free stuck at 30.83 GiB
+on a device that started with 78.83 GiB of it.
+
+That last is a property of the pointer rather than of stream-ordered frees in
+general, so it is worth saying which one this pool holds. Replayed with
+`cudaMallocAsync` on both sides of the same never-synchronized stream, all four
+growths succeed: the free moves from 54.83 to 38.83 GiB for the 24 GiB request,
+the retired 16 GiB reused with nobody having synchronized anything. Those bytes go
+back to the device's memory pool rather than to the driver, and the next
+allocation can take them from there. The pool allocates with `cudaMalloc`, so the
+shape above is the one it is in, and the disposal stream is what that shape costs.
+
+Which calls do synchronize their stream is knowable, and the disposal does not ask.
+It is a claim about what the caller has still to do rather than about anything the
+pool holds, and three defects on this path in a row were a disposal getting that
+claim wrong -- the last of them a call that failed after the growth and so had no
+synchronization left to make, having recorded at the claim that it would make one.
+So the disposal takes no argument: there is nothing to record when the buffer is
+retired and nothing a later return can leave stale.
+
+A device-wide `cudaFree`, and the wait for the whole device that comes with it, is
+still the fallback. It is what a growth makes where the device has no
+stream-ordered allocator (`cudaDevAttrMemoryPoolsSupported`) and `cudaFreeAsync`
+reports `cudaErrorNotSupported` instead of freeing -- and on any other code it
+reports, since a queued free that did not happen is not a free -- and where the
+pool's stream could not be created at all. A program that parks work across an
+`execute()` has to keep such growths away from it, and the paragraph below on how
+often the pool grows is what says whether a run order can do that.
+
+What an engine answers when asked how much it needs is decided when it is built,
+not when it runs. The builder's `kRUNTIME_ACTIVATION_RESIZE_10_10` preview feature
+makes an engine report what the shapes just bound need; without it, whether an
+engine does that or reports its profile maximum depends on how TensorRT planned
+it. Either way the pool can settle well above the live data, and nothing the
+runtime does changes it.
+
+How often the pool grows follows from that. The backend asks afresh on every
+`execute()`, after the input shapes are bound, so an engine whose answer does not
+vary with the bound shapes grows the pool at most once, on its first run. For a
+program built only from such engines, running the largest one first leaves the
+pool with a single allocation. An engine whose answer does vary can grow it on any
+call whose shapes need more than every call before them, so with one of those in
+the program no run order bounds the number of allocations. One engine over a
+`[1..4, 512, 512]` profile is either, depending on how it was built.
+
+### CUDA graph capture is not supported
+
+A pooled call whose selected stream is capturing is refused with
+`Error::NotSupported`. The handoff between one enqueue and the next waits on an
+event recorded outside the capture, and `cudaStreamWaitEvent` on such an event
+fails with `cudaErrorStreamCaptureIsolation` and invalidates the capture under
+every capture mode, `cudaStreamCaptureModeRelaxed` included. A growth adds more of
+the same: its `cudaMalloc`, and the host wait its disposal of the replaced buffer
+begins with, invalidate the capture under `Global` and `ThreadLocal`, and under
+`Relaxed` are permitted but run uncaptured. Left to run, the caller learns of any
+of it only when `cudaStreamEndCapture` hands back
+`cudaErrorStreamCaptureInvalidated` and a null graph, long after the call that
+caused it.
+
+The check sits ahead of everything `execute()` does that a capture cannot take,
+not merely ahead of the pool's own calls: the wait on a previous enqueue and the
+`cudaMalloc` that grows a host-input staging buffer come before those and, outside
+`Relaxed`, would invalidate the capture first. Only the device query and the
+device switch run before the check, and a capture takes both.
+
+Where the query fails for a reason that is not a capture, the call is not told it
+is capturing. `cudaStreamIsCapturing` also hands back a sticky fault left by
+earlier work on the device -- measured on an A100 with CUDA 12.8, after an illegal
+memory access it returns that fault with the capture status still
+`cudaStreamCaptureStatusNone` -- and a call that meets one fails with
+`Error::InvalidProgram` under that fault's own message instead. The one query
+failure that does still mean a capture, `cudaErrorStreamCaptureImplicit`, is
+refused with the rest.
+
+Only the selected stream is checked. A capture running on another stream under
+`Global`, or under `ThreadLocal` from the calling thread, is invalidated by the
+same calls and is not refused, because CUDA has no query for "is a capture live in
+this process". So that much is the caller's to keep: do not run a pooled engine
+while any capture is open anywhere in the process. Turning the option off removes
+the refusal, since the check lives inside the pooled path, but this delegate does
+not support capture with the option off either. No call shape here is built or
+tested for it, and the completion event `execute()` records so that the next call
+can wait for an enqueue that outlived the return would become a node of the graph
+rather than an event the host can wait on.
+
+### cudaDeviceReset() is not survivable
+
+The pool is not guarded against it: it holds its buffer, its handoff event and the
+stream its growths dispose on for the process lifetime, and a reset destroys the
+primary context under all three. The next pooled `execute()` on that device then
+waits on a destroyed event and hands the engine a pointer that is no longer a
+device allocation, and the next growth after that queues its free on a stream that
+no longer exists. Guarding this would mean revalidating all three on every call,
+and the check that would catch it is as expensive as the work it protects. Treat a
+device the backend has run a pooled engine on as one that must not be reset.
 
 ## Standalone Backend Archive
 

--- a/cpp/src/torch_tensorrt/executorch/SharedScratchPool.h
+++ b/cpp/src/torch_tensorrt/executorch/SharedScratchPool.h
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// Bookkeeping for the TensorRT backend's shared per-device activation-scratch
+// pool: the grow/reuse policy, the enqueue-handoff rule, the stream a growth
+// disposes on, and the lock that scopes them to a single device.
+// Allocation, event creation and stream creation arrive as callables rather than
+// being made here.
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <mutex>
+#include <unordered_map>
+
+namespace torch_tensorrt {
+namespace executorch_backend {
+
+// Per-device handoff marker for the shared scratch buffer: the pool-owned CUDA
+// event that the last enqueue against the buffer was recorded on.
+struct SharedScratchMarker {
+  // Nothing in the normal path destroys this event; only the test-only reset
+  // hands it to a disposer that does.
+  cudaEvent_t event = nullptr;
+  bool pending = false; // an enqueue against the buffer has been recorded on `event`
+};
+
+// What a caller about to enqueue against a device's shared scratch has to do:
+// when `needs_wait`, make its stream wait on `event` first; once the enqueue is
+// submitted, record it on `event`. `event` is null only when the slot has no
+// event and one could not be created.
+struct SharedScratchHandoff {
+  cudaEvent_t event = nullptr;
+  bool needs_wait = false;
+};
+
+// One device's shared scratch buffer and the marker ordering its handoff, behind
+// the lock that covers both.
+//
+// A claimant holds `mu` from the wait on the previous enqueue through its own
+// enqueue and the record of that enqueue on the marker. Holding it that far is
+// what makes the marker a complete account of who is using the buffer. Anything
+// less leaves an enqueue live in a window the marker does not cover, and a
+// claimant entering that window is handed the same buffer with nothing ordering
+// the two. `mu` covers one device, so a growth holds no lock a claim on
+// another device has to acquire.
+struct SharedScratchDevice {
+  std::mutex mu;
+  void* buffer = nullptr;
+  std::size_t capacity = 0;
+  SharedScratchMarker marker;
+  // The stream a growth queues its free of the buffer it replaced on. Created on
+  // the first growth that has one to dispose of; nothing in the normal path
+  // destroys it, only the test-only reset hands it to a disposer that does.
+  cudaStream_t disposal_stream = nullptr;
+};
+
+class SharedScratchPool;
+
+// Defined in SharedScratchPoolReset.h; see the friend declaration inside
+// SharedScratchPool for why the body is not here.
+template <typename Dispose>
+std::size_t reset_shared_scratch_pool_slots(SharedScratchPool& pool, Dispose dispose);
+
+// Holds one SharedScratchDevice per device id.
+//
+// `get` locks only long enough to find or create the entry, and the reference it
+// returns stays usable once that lock is dropped: std::unordered_map keeps
+// references to elements valid across rehashing, and entries are never erased.
+// This one lock is shared by every device, so holding it couples every device to
+// whoever holds it: it covers the lookup, and in the test-only reset a snapshot
+// of which slots exist, and nothing else. Nothing is made under it that waits --
+// no CUDA call, and no wait for a device's own lock.
+class SharedScratchPool {
+ public:
+  SharedScratchDevice& get(int device_id) {
+    std::lock_guard<std::mutex> lk(mu_);
+    return devices_[device_id];
+  }
+
+ private:
+  // The reset is test-only and its body is not here: it frees everything the live
+  // pool holds without waiting for work in flight against it, which is not a thing
+  // this header should hand a consumer of the released source package -- and this
+  // header does ship with those sources. The body is in SharedScratchPoolReset.h,
+  // which is testonly and ships nowhere, so a release build can reach the grant and
+  // nothing else, and reaching the pool that way means writing the traversal, the
+  // locks and the deadline again.
+  //
+  // It is an open door and not a lock. The grant is on a template, so it admits any
+  // definition of that name a consumer writes in this namespace, and such a
+  // definition reaches both members below -- including erasing entries a live `get`
+  // reference points into, which the stability rule above forbids. C++ offers
+  // nothing narrower: a non-template friend admits a definition of its own just the
+  // same.
+  template <typename Dispose>
+  friend std::size_t reset_shared_scratch_pool_slots(SharedScratchPool& pool, Dispose dispose);
+
+  std::mutex mu_;
+  std::unordered_map<int, SharedScratchDevice> devices_;
+};
+
+// The process-wide per-device pool the TensorRT backend runs on. One buffer per
+// device, grown to the largest requirement any call on that device has asked
+// for, serves every kUSER_MANAGED context on it that needs activation scratch --
+// a context whose engine needs none under any shape claims nothing here -- instead
+// of each of N layer-engines pinning its own scratch, which makes device memory
+// scale with the layer count and OOMs multi-layer models.
+//
+// ORDERING: a context reads and writes its scratch for the whole enqueue, which
+// can still be in flight when execute() returns, so two enqueues must never hold
+// one buffer at the same time. A device's lock is what enforces that -- see the
+// backend's SharedScratchClaim -- and it is held from the claim through the
+// enqueue and the record of it, so two execute() calls on one device are
+// serialized at submission. The lock does not couple two devices: each carries
+// its own, and no CUDA call is made under the one lock the registry itself holds.
+//
+// The buffers, the events and the disposal streams are intentionally never
+// released at teardown, and the C++ object is never destroyed either. Nothing here
+// runs a CUDA call at process exit, which keeps the pool clear of teardown-order
+// hazards against anything else holding device memory; and static destruction
+// would destroy the registry's mutex, every device's mutex and the map nodes a
+// live reference points into while a thread between the lookup and the release of
+// its device lock still holds them. Leaking it costs one allocation.
+//
+// Inline, so the pool's test hooks can reach the same instance from the
+// translation unit that defines them without the backend having to export an
+// accessor for them; see SharedScratchPoolTestHooks.h. One instance still, for
+// the usual reason a function-local static in an inline function is one.
+inline SharedScratchPool& scratch_pool() {
+  static SharedScratchPool* const pool = new SharedScratchPool();
+  return *pool;
+}
+
+// Claims a device's handoff for a caller about to enqueue against its shared
+// scratch, creating the marker's event on first use. Call with `dev.mu` held.
+//
+// `create_event` returns a CUDA event, or nullptr if one could not be created,
+// in which case the slot stays empty and the next call retries.
+//
+// The ordering between one enqueue and the next is carried by an event rather
+// than by the stream the previous enqueue used, because a stream handle cannot
+// carry it: synchronizing on a handle whose stream the caller has since
+// destroyed is a crash rather than an error return, CUDA recycles handle values
+// so a genuinely different stream can compare equal to the recorded one, and the
+// NULL stream is both a legal stream a caller can select and the only available
+// "no previous user" sentinel. An event names the work instead of the queue --
+// it stays valid after the stream that recorded it is destroyed, and waiting on
+// it from the stream that recorded it is already satisfied, so the common
+// single-stream case costs a host call and no device stall.
+template <typename CreateEvent>
+SharedScratchHandoff shared_scratch_claim_event(SharedScratchDevice& dev, CreateEvent create_event) {
+  if (dev.marker.event == nullptr) {
+    dev.marker.event = create_event();
+  }
+  // A slot with no event is never marked, so a failed creation reports nothing to
+  // wait for rather than a wait the caller has no event to perform.
+  return {dev.marker.event, dev.marker.pending};
+}
+
+// Call with `dev.mu` held.
+//
+// The mark precedes the record, so a failed record leaves the slot claiming an
+// enqueue the event does not cover -- the caller must then synchronize the stream
+// itself before returning the error.
+inline cudaEvent_t shared_scratch_mark_in_flight(SharedScratchDevice& dev) {
+  if (dev.marker.event != nullptr) {
+    dev.marker.pending = true;
+  }
+  return dev.marker.event;
+}
+
+// The stream this device's growths queue their frees on, creating it on first
+// use. Call with `dev.mu` held.
+//
+// `create_stream` returns a CUDA stream, or nullptr if one could not be created,
+// in which case the slot stays empty and the next growth retries.
+//
+// It is the pool's own stream and not the claimant's: a cudaFreeAsync of a
+// cudaMalloc'd pointer, which is what this pool holds, hands the bytes back only at
+// the next synchronize of the stream it was queued on, and only the pool can
+// promise that synchronize -- a claimant on the path this pool exists for never
+// synchronizes its stream and is free to destroy it the moment the call returns.
+// The pool makes that synchronize itself, in the same call that queued the free.
+template <typename CreateStream>
+cudaStream_t shared_scratch_disposal_stream(SharedScratchDevice& dev, CreateStream create_stream) {
+  if (dev.disposal_stream == nullptr) {
+    dev.disposal_stream = create_stream();
+  }
+  return dev.disposal_stream;
+}
+
+// A buffer a growth replaced, handed back for the caller to dispose of.
+//
+// A non-null `wait_for` is the marker's event, on which an enqueue that may still
+// be reading and writing `buffer` has been recorded; the caller must not free the
+// buffer ahead of that enqueue. A null `wait_for` means nothing was ever recorded
+// against it, so nothing is using it.
+//
+// One event covers every enqueue the buffer ever served, but only because each of
+// them claims the handoff before enqueueing -- which orders its stream after the
+// event -- and records on the event afterwards, so the latest recording completes
+// only once all the earlier ones have. An enqueue that reaches the buffer without
+// doing both is ordered against nothing here.
+//
+// The disposal belongs outside `dev.mu`: it waits on the host for that enqueue,
+// and under the lock that wait is one an unrelated claim on this device would sit
+// through for nothing.
+struct RetiredScratch {
+  void* buffer = nullptr;
+  cudaEvent_t wait_for = nullptr;
+};
+
+// Bookkeeping for a device's scratch buffer, which grows monotonically to the
+// largest requested size. Call with `dev.mu` held.
+//
+// `alloc` returns nullptr on failure; the buffer is then left untouched.
+// Allocating before releasing is what makes that true, and it costs peak
+// residency: while the buffer grows, the old and the new one are both resident.
+//
+// A growth reports the buffer it displaced through `out_retired`; see
+// RetiredScratch for what the caller owes it. Nothing is freed here, so a caller
+// that ignores `out_retired` leaks rather than frees a buffer an enqueue may
+// still be using. Every path clears `out_retired` first, so a caller reusing one
+// across calls is not handed a buffer an earlier call already disposed of.
+//
+// What the buffer ended up sized at is `dev.capacity`, which the caller holds the
+// lock for anyway. It is not reported separately, because a caller reading it
+// would be reading what an earlier call grew the pool to and not its own request:
+// the only figure that belongs on a caller's execution context is the one it
+// asked for here.
+template <typename Alloc>
+void* shared_scratch_get_or_grow(SharedScratchDevice& dev, std::size_t need, Alloc alloc, RetiredScratch& out_retired) {
+  out_retired = RetiredScratch{};
+  if (dev.buffer != nullptr && dev.capacity >= need) {
+    return dev.buffer;
+  }
+  void* p = alloc(need);
+  if (p == nullptr) {
+    return nullptr;
+  }
+  if (dev.buffer != nullptr) {
+    out_retired.buffer = dev.buffer;
+    out_retired.wait_for = dev.marker.pending ? dev.marker.event : nullptr;
+  }
+  dev.buffer = p;
+  dev.capacity = need;
+  return p;
+}
+
+} // namespace executorch_backend
+} // namespace torch_tensorrt

--- a/cpp/src/torch_tensorrt/executorch/SharedScratchPoolReset.h
+++ b/cpp/src/torch_tensorrt/executorch/SharedScratchPoolReset.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// The body of the shared scratch pool's test-only reset.
+//
+// It lives here rather than in SharedScratchPool.h because that header ships in
+// the released source package and this operation frees everything the live pool
+// holds without waiting for work in flight against it. This file is carried by a
+// testonly Bazel target, is in neither the packaged include tree nor the packaged
+// source set, and is compiled by nothing a release build produces. What
+// SharedScratchPool leaves reachable is the friend declaration alone, so a
+// consumer of the released sources who wants this has to write it.
+//
+// Safe only with no claim outstanding and no enqueue in flight against a pooled
+// buffer; the caller earns that by synchronizing every stream it submitted on and
+// joining every thread that called execute(). "No claim outstanding" covers a
+// claim whose release is still disposing of a buffer a growth retired: that
+// disposal runs with the device's lock dropped and is still reading the marker
+// event and the disposal stream, both of which this destroys.
+
+#include "torch_tensorrt/executorch/SharedScratchPool.h"
+
+#include <chrono>
+#include <cstddef>
+#include <mutex>
+#include <thread>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace torch_tensorrt {
+namespace executorch_backend {
+
+// How long a reset waits, in total, for the device locks. A test calls the reset
+// between cases with nothing claimed, so anything held is a leak the run has
+// already failed over; the wait only has to outlast a claim still winding down.
+//
+// Here rather than on SharedScratchPool, which ships in the released source
+// package and has nothing that reads this.
+inline constexpr std::chrono::seconds kResetLockWait{5};
+
+// Returns every device's slot to the state it had before anything claimed it,
+// handing what the slot held to `dispose(device_id, buffer, event, disposal_stream)`
+// so the caller can release it. Entries stay in the map, so a reference `get`
+// handed out remains valid.
+//
+// Answers with the number of devices whose lock it could not take within
+// kResetLockWait. A lock that never comes free is a leaked claim, and taking the
+// locks unconditionally would hang on exactly that defect, in a fixture that
+// resets both before and after every case, so the run would end in a target
+// timeout with nothing said about the cause. The caller reports it instead.
+//
+// The deadline covers the whole reset rather than each device, so a leaked lock
+// costs the same however many devices the pool has seen. What a leak must not do
+// is spend the budget on behalf of the slots after it: the retry below sweeps
+// every slot it has not taken yet on each pass, so a slot whose claim is merely
+// winding down is tried again inside the window it is free, rather than once at
+// whatever instant a leaked neighbour leaves in the budget.
+//
+// The registry's lock covers one snapshot of which slots exist, and nothing else.
+// Every pooled call on every device goes through that lock to find its slot, so a
+// reset that held it across the retry below -- which sleeps between passes and
+// can run to the whole deadline -- would hold off devices it never touches for
+// that long. Dropping it is what the registry's own stability rule licenses:
+// entries are never erased and references stay valid, so a slot pointer taken
+// under the lock is still good without it. A slot created after the snapshot is
+// not reset, which is a caller claiming from a pool this is only safe to reset
+// when nothing is claiming from it.
+//
+// Each slot is then emptied under its own device lock, and what came out of it is
+// disposed of afterwards with that dropped as well, because the disposer frees
+// device memory and a device-wide free blocks on everything queued on that device
+// -- a parked host function included -- which under the device's lock would hold
+// off that device's next claimant.
+//
+// Nothing here waits for an enqueue: the buffer it frees may still be in use by
+// one, and the caller is responsible for there being none.
+template <typename Dispose>
+std::size_t reset_shared_scratch_pool_slots(SharedScratchPool& pool, Dispose dispose) {
+  std::vector<std::pair<int, SharedScratchDevice*>> not_taken_yet;
+  {
+    std::lock_guard<std::mutex> lk(pool.mu_);
+    not_taken_yet.reserve(pool.devices_.size());
+    for (auto& entry : pool.devices_) {
+      not_taken_yet.emplace_back(entry.first, &entry.second);
+    }
+  }
+
+  std::vector<std::tuple<int, void*, cudaEvent_t, cudaStream_t>> taken;
+  taken.reserve(not_taken_yet.size());
+  const auto deadline = std::chrono::steady_clock::now() + kResetLockWait;
+  while (!not_taken_yet.empty()) {
+    std::vector<std::pair<int, SharedScratchDevice*>> still_to_try;
+    for (const auto& slot : not_taken_yet) {
+      SharedScratchDevice& dev = *slot.second;
+      if (!dev.mu.try_lock()) {
+        still_to_try.push_back(slot);
+        continue;
+      }
+      std::lock_guard<std::mutex> dev_lk(dev.mu, std::adopt_lock);
+      taken.emplace_back(slot.first, dev.buffer, dev.marker.event, dev.disposal_stream);
+      dev.buffer = nullptr;
+      dev.capacity = 0;
+      dev.marker.event = nullptr;
+      dev.marker.pending = false;
+      dev.disposal_stream = nullptr;
+    }
+    not_taken_yet.swap(still_to_try);
+    if (not_taken_yet.empty() || std::chrono::steady_clock::now() >= deadline) {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  const std::size_t left_alone = not_taken_yet.size();
+
+  for (const auto& slot : taken) {
+    dispose(std::get<0>(slot), std::get<1>(slot), std::get<2>(slot), std::get<3>(slot));
+  }
+  return left_alone;
+}
+
+} // namespace executorch_backend
+} // namespace torch_tensorrt

--- a/cpp/src/torch_tensorrt/executorch/SharedScratchPoolTestHooks.cpp
+++ b/cpp/src/torch_tensorrt/executorch/SharedScratchPoolTestHooks.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "torch_tensorrt/executorch/SharedScratchPoolTestHooks.h"
+
+#include "torch_tensorrt/executorch/SharedScratchPool.h"
+#include "torch_tensorrt/executorch/SharedScratchPoolReset.h"
+
+#include <cuda_runtime.h>
+
+#include <mutex>
+
+namespace torch_tensorrt {
+namespace executorch_backend {
+
+std::size_t shared_scratch_capacity_for_testing(int device_id) {
+  SharedScratchDevice& dev = scratch_pool().get(device_id);
+  std::lock_guard<std::mutex> lk(dev.mu);
+  return dev.capacity;
+}
+
+bool reset_shared_scratch_pool_for_testing() {
+  int restore_to = 0;
+  const bool have_current = cudaGetDevice(&restore_to) == cudaSuccess;
+  const std::size_t left_alone = reset_shared_scratch_pool_slots(
+      scratch_pool(), [](int device_id, void* buffer, cudaEvent_t event, cudaStream_t disposal_stream) {
+        if (buffer == nullptr && event == nullptr && disposal_stream == nullptr) {
+          return;
+        }
+        // cudaFree, cudaEventDestroy and cudaStreamDestroy all act on the current
+        // device, and a slot is keyed by the device its buffer came from.
+        if (cudaSetDevice(device_id) != cudaSuccess) {
+          return;
+        }
+        if (buffer != nullptr) {
+          (void)cudaFree(buffer);
+        }
+        if (event != nullptr) {
+          (void)cudaEventDestroy(event);
+        }
+        if (disposal_stream != nullptr) {
+          (void)cudaStreamDestroy(disposal_stream);
+        }
+        // Clears a non-sticky error so a reset does not leave one for the next call to
+        // report. A sticky one survives the clear, and no cleanup here recovers it.
+        (void)cudaGetLastError();
+      });
+  if (have_current) {
+    (void)cudaSetDevice(restore_to);
+  }
+  return left_alone == 0;
+}
+
+} // namespace executorch_backend
+} // namespace torch_tensorrt

--- a/cpp/src/torch_tensorrt/executorch/SharedScratchPoolTestHooks.h
+++ b/cpp/src/torch_tensorrt/executorch/SharedScratchPoolTestHooks.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// Views of the shared activation-scratch pool that only a test has any business
+// calling: one reads the pool's capacity, the other frees everything it holds
+// with no wait for work in flight against it.
+//
+// They live in this header and SharedScratchPoolTestHooks.cpp rather than beside
+// the pool, and neither file is compiled into libexecutorch_trt_backend or
+// shipped in the source package, so a released build contains no definition of
+// either and exports no symbol for them. The Bazel target that carries them is
+// testonly. Reaching the pool from a separate translation unit is what
+// scratch_pool() is inline in SharedScratchPool.h for.
+//
+// Both are safe only with no claim outstanding and no enqueue in flight against a
+// pooled buffer; a test earns that by synchronizing every stream it submitted on
+// and joining every thread that called execute(). A claim is still outstanding
+// while its release disposes of a buffer a growth retired: that disposal runs with
+// the device's lock dropped and goes on reading the marker event and the disposal
+// stream, both of which the reset destroys. The reset also frees what the pool
+// holds, so a test should destroy its delegate handles before calling it.
+
+#include <cstddef>
+
+namespace torch_tensorrt {
+namespace executorch_backend {
+
+// The bytes the pool holds for `device_id` right now; zero if it holds nothing.
+std::size_t shared_scratch_capacity_for_testing(int device_id);
+
+// Frees every device's buffer, destroys its handoff event and its disposal
+// stream, and clears the marker, so one test does not inherit a pool an earlier
+// one grew.
+//
+// False when a device's slot still had its lock held at the end of the pool's
+// reset deadline; that slot is left as it was. A caller should report it rather
+// than carry on, and must not wait for the lock itself -- a lock held for that
+// long is a claim that was never released, so nothing is going to release it.
+bool reset_shared_scratch_pool_for_testing();
+
+} // namespace executorch_backend
+} // namespace torch_tensorrt

--- a/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
+++ b/cpp/src/torch_tensorrt/executorch/TensorRTBackend.cpp
@@ -6,10 +6,13 @@
  */
 
 #include "torch_tensorrt/executorch/TensorRTBackend.h"
+#include "torch_tensorrt/executorch/PooledScratchInstall.h"
+#include "torch_tensorrt/executorch/SharedScratchPool.h"
 #include "torch_tensorrt/executorch/TensorRTBindingNames.h"
 #include "torch_tensorrt/executorch/TensorRTBlobHeader.h"
 #include "torch_tensorrt/executorch/WeightStreamingBudget.h"
 
+#include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <memory>
@@ -17,6 +20,7 @@
 #include <string>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <NvInfer.h>
@@ -34,6 +38,8 @@ using ::executorch::aten::SizesType;
 using ::executorch::runtime::ArrayRef;
 using ::executorch::runtime::BackendExecutionContext;
 using ::executorch::runtime::BackendInitContext;
+using ::executorch::runtime::BackendOption;
+using ::executorch::runtime::BackendOptionContext;
 using ::executorch::runtime::CompileSpec;
 using ::executorch::runtime::DelegateHandle;
 using ::executorch::runtime::Error;
@@ -85,7 +91,9 @@ EngineHandle::~EngineHandle() {
       cudaError_t err = cudaEventSynchronize(inflight_event);
       if (err != cudaSuccess) {
         ET_LOG(Error, "EngineHandle::~EngineHandle: cudaEventSynchronize failed: %s", cudaGetErrorString(err));
-        cudaGetLastError(); // clear sticky error; tear down regardless
+        // Clears a non-sticky error so it does not resurface under the name of the
+        // next call here; a sticky one survives the clear. Tear down regardless.
+        cudaGetLastError();
       }
       inflight_pending = false;
     }
@@ -151,6 +159,16 @@ bool infer_binding_names(
   return true;
 }
 
+// The setting behind kSharedActivationScratchKey: whether an execution context
+// created subsequently draws its activation scratch from the shared per-device
+// pool rather than allocating its own.
+//
+// execute() must read EngineHandle::claims_pooled_scratch, never this. This can
+// have moved since the engine was loaded, and what the engine can do about it
+// cannot: its context's allocation strategy was fixed when the context was
+// created. initialize_engine_io below is the one place this is read.
+std::atomic<bool> scratch_enabled{false};
+
 Error initialize_engine_io(EngineHandle& handle) {
   if (handle.input_binding_names.empty() && handle.output_binding_names.empty() &&
       !infer_binding_names(handle.engine.get(), handle.input_binding_names, handle.output_binding_names)) {
@@ -161,9 +179,24 @@ Error initialize_engine_io(EngineHandle& handle) {
   handle.num_inputs = handle.input_binding_names.size();
   handle.num_outputs = handle.output_binding_names.size();
 
-  handle.exec_ctx.reset(handle.engine->createExecutionContext());
+  // kSTATIC gives the context its own activation scratch; kUSER_MANAGED makes it
+  // allocate none and take a buffer from execute() instead. The strategy is fixed
+  // at creation, so it is captured on the handle here rather than read per call.
+  handle.shared_scratch = scratch_enabled.load(std::memory_order_relaxed);
+  const auto strategy = handle.shared_scratch ? nvinfer1::ExecutionContextAllocationStrategy::kUSER_MANAGED
+                                              : nvinfer1::ExecutionContextAllocationStrategy::kSTATIC;
+  handle.exec_ctx.reset(handle.engine->createExecutionContext(strategy));
   TORCHTRT_ET_CHECK_NOT_NULL(
       handle.exec_ctx, Error::InvalidProgram, "TensorRTBackend::init: failed to create TensorRT execution context");
+
+  if (handle.shared_scratch) {
+    // Gated so an engine loaded with the option off pays no TensorRT call for a
+    // pool it will never claim from. Read after the weight streaming budget is
+    // applied, which the caller does before this runs because TensorRT forbids
+    // moving the budget once a context exists -- and the budget is the one thing
+    // that moves this figure.
+    handle.claims_pooled_scratch = handle.engine->getDeviceMemorySizeV2() > 0;
+  }
 
   return Error::Ok;
 }
@@ -202,6 +235,427 @@ bool is_cuda_accessible_ptr(const void* ptr) {
     return false;
   }
   return attrs.type == cudaMemoryTypeDevice || attrs.type == cudaMemoryTypeManaged;
+}
+
+// A caller's hold on one device's shared scratch: the device lock, plus the
+// buffer a growth displaced, freed once that lock is dropped.
+//
+// The lock spans the enqueue, not just the choice of buffer. A claimant that
+// released it as soon as it had a buffer would leave its enqueue live for a
+// window the marker's event does not yet cover, and a second claimant entering
+// that window is handed the same buffer and told to wait for the enqueue before
+// it -- so nothing orders the two and both write the same scratch. The failure
+// is silent: wrong output, no CUDA error, no TensorRT error.
+//
+// This lock nests inside the per-handle EngineHandle::mu, which already spans
+// the enqueue, and is never taken in the other order.
+class SharedScratchClaim {
+ public:
+  SharedScratchClaim() = default;
+  SharedScratchClaim(const SharedScratchClaim&) = delete;
+  SharedScratchClaim& operator=(const SharedScratchClaim&) = delete;
+  ~SharedScratchClaim() {
+    // A claim that still holds a retired buffer here was never released, so
+    // execute() returned between the claim and the release below -- a refused
+    // install, a refused enqueue, or a failed record of one already submitted.
+    // The disposal it makes is the one every other path makes, and it has the
+    // bytes back before it returns, so a bail-out after a growth costs the
+    // retired buffer and not the whole pool.
+    //
+    // The return is the caller's to report, and on this path there is no caller
+    // left to report it to: an execute() that returned early has already failed.
+    (void)release();
+  }
+
+  SharedScratchDevice& hold(int device_id) {
+    dev_ = &scratch_pool().get(device_id);
+    device_id_ = device_id;
+    lock_ = std::unique_lock<std::mutex>(dev_->mu);
+    return *dev_;
+  }
+
+  // Null until hold() runs and null again after release(): non-null exactly while
+  // this claim holds the device's lock.
+  SharedScratchDevice* device() const {
+    return dev_;
+  }
+
+  // Takes ownership of a buffer a growth displaced, to be freed by release().
+  // `wait_for` is the marker event the enqueues that used it were recorded on, or
+  // null if none were; `disposal_stream` is the pool's own stream for this device,
+  // or null if one could not be created.
+  void retire(void* buffer, cudaEvent_t wait_for, cudaStream_t disposal_stream) {
+    retired_ = buffer;
+    retired_wait_ = wait_for;
+    disposal_stream_ = disposal_stream;
+  }
+
+  // Drops the lock, and the device pointer with it so device() cannot hand out a
+  // pointer this claim no longer holds the lock for. Then disposes of whatever a
+  // growth displaced, after the unlock, because that disposal waits for an enqueue
+  // another pooled engine on this device has nothing to do with.
+  //
+  // The disposal reads nothing the caller supplies and asks nothing about it: wait
+  // on the host for the enqueue the marker names, queue the free on the pool's own
+  // stream for this device, and synchronize that stream, which is what has the
+  // bytes back before this returns. It is the same three steps on every path,
+  // including the destructor's, so a return added between the claim and the
+  // release cannot change what the disposal does. Deciding instead from what the
+  // calling execute() has still to do is a claim about the caller, and three
+  // defects on this path in a row were a disposal getting that claim wrong.
+  //
+  // The free is stream-ordered, and on the pool's own stream, for two reasons. A
+  // device-wide cudaFree waits for everything queued on the device rather than for
+  // the work that touched the buffer, and that wait has no upper bound. And a
+  // cudaFreeAsync of a cudaMalloc'd pointer, which is what the pool holds, hands
+  // the bytes back at the next synchronize of the stream it was queued on and at
+  // no point before it, so whoever queues the free has to be able to promise that
+  // synchronize -- which a caller on the path this pool exists for cannot, since it
+  // never synchronizes its stream and is free to destroy it the moment execute()
+  // returns. The README's shared activation scratch section has the measurements
+  // behind both.
+  //
+  // cudaFreeAsync needs the device's stream-ordered allocator, which not every
+  // platform has. Where it is missing, or the pool's stream could not be created,
+  // the free is device-wide instead and blocks until the device is idle.
+  //
+  // Returns false when the wait for the enqueue failed, which leaves the buffer
+  // leaked rather than freed under a live enqueue; the caller reports it. Frees on
+  // the current device, which must still be the buffer's.
+  bool release() {
+    void* const retired = retired_;
+    const cudaEvent_t wait_for = retired_wait_;
+    const cudaStream_t disposal_stream = disposal_stream_;
+    // Clearing the pointer is what stops the destructor's release from disposing
+    // of the same buffer twice.
+    retired_ = nullptr;
+    if (lock_.owns_lock()) {
+      lock_.unlock();
+    }
+    dev_ = nullptr;
+    if (retired == nullptr) {
+      return true;
+    }
+    if (!wait_for_the_enqueue_that_used_it(wait_for)) {
+      return false;
+    }
+    if (disposal_stream == nullptr || !free_on_the_pools_stream(retired, disposal_stream)) {
+      free_device_wide(retired);
+    }
+    return true;
+  }
+
+ private:
+  // Waits for the enqueue that last used the retired buffer, so the free below is
+  // not made under one still reading it. `wait_for` is the device's handoff marker,
+  // so where the calling execute() has already recorded its own enqueue there, the
+  // wait covers that one as well. Unbounded either way -- it is a whole inference,
+  // and the execute() contract says as much.
+  bool wait_for_the_enqueue_that_used_it(cudaEvent_t wait_for) {
+    if (wait_for == nullptr) {
+      return true;
+    }
+    const cudaError_t wait_err = cudaEventSynchronize(wait_for);
+    if (wait_err != cudaSuccess) {
+      // This wait is the only thing keeping the free off a buffer an enqueue may
+      // still be reading, so a failed wait leaks it instead. What it reports is
+      // usually an asynchronous fault raised by earlier work on this device.
+      ET_LOG(
+          Error,
+          "TensorRTBackend::execute: waiting for the enqueue on the replaced shared activation scratch on device %d failed (%s), which for a wait on device work is usually an earlier asynchronous fault on this device surfacing here; leaking that buffer rather than freeing it under a live enqueue",
+          device_id_,
+          cudaGetErrorString(wait_err));
+      cudaGetLastError();
+      return false;
+    }
+    return true;
+  }
+
+  // Queues the free on the pool's stream for this device and synchronizes it,
+  // which is what returns the bytes. Reports whether the buffer was freed, so a
+  // refusal falls back to the device-wide free; a synchronize that fails after the
+  // free was accepted is not one, and freeing again would be freeing twice.
+  bool free_on_the_pools_stream(void* retired, cudaStream_t disposal_stream) {
+    const cudaError_t free_err = cudaFreeAsync(retired, disposal_stream);
+    if (free_err != cudaSuccess) {
+      // The error is this call's own, so it is cleared here rather than left for
+      // the next CUDA call in execute() to report under its own name.
+      cudaGetLastError();
+      if (free_err == cudaErrorNotSupported) {
+        ET_LOG(
+            Info,
+            "TensorRTBackend::execute: device %d has no stream-ordered allocator, so the free of the shared activation scratch buffer a pool growth replaced falls back to a device-wide free, which blocks this call until the device is idle",
+            device_id_);
+      } else {
+        // Any other code is a fault on a device that does have the allocator, so
+        // this does not say the platform lacks one.
+        ET_LOG(
+            Info,
+            "TensorRTBackend::execute: the stream-ordered free of the shared activation scratch buffer a pool growth replaced on device %d returned %s, so it falls back to a device-wide free, which blocks this call until the device is idle",
+            device_id_,
+            cudaGetErrorString(free_err));
+      }
+      return false;
+    }
+
+    const cudaError_t sync_err = cudaStreamSynchronize(disposal_stream);
+    if (sync_err != cudaSuccess) {
+      // Nothing was on this stream but the free, and the enqueue it had to follow
+      // was already waited for, so a failure here is a fault this device was
+      // already in. Whether the bytes came back is not knowable from it.
+      ET_LOG(
+          Error,
+          "TensorRTBackend::execute: synchronizing the shared activation scratch pool's disposal stream on device %d reported %s, so the free of the buffer a growth replaced may not have returned its bytes",
+          device_id_,
+          cudaGetErrorString(sync_err));
+      cudaGetLastError();
+    }
+    return true;
+  }
+
+  void free_device_wide(void* retired) {
+    const cudaError_t err = cudaFree(retired);
+    if (err != cudaSuccess) {
+      // cudaFree synchronizes, so what it reports is more often an earlier
+      // asynchronous fault on this device than a fault in the free -- which is
+      // why the message does not call it one.
+      ET_LOG(
+          Error,
+          "TensorRTBackend::execute: freeing the shared activation scratch buffer that a pool growth replaced on device %d reported %s; a device-wide free reports whatever fault this device is already in, so this need not be the pool's",
+          device_id_,
+          cudaGetErrorString(err));
+      // Clears a non-sticky error so it does not resurface under the name of the
+      // next CUDA call in execute(). A sticky one survives the clear and will
+      // resurface anyway; the caller learns of it from that call.
+      cudaGetLastError();
+    }
+  }
+
+  SharedScratchDevice* dev_ = nullptr;
+  int device_id_ = -1;
+  std::unique_lock<std::mutex> lock_;
+  void* retired_ = nullptr;
+  cudaEvent_t retired_wait_ = nullptr;
+  cudaStream_t disposal_stream_ = nullptr;
+};
+
+// What a call needing no activation scratch is given when the pool holds nothing
+// yet. It cannot be given nothing: enqueueV3 refuses a kUSER_MANAGED context with
+// no device memory installed as soon as the engine reports needing any under some
+// shape, whatever the shapes actually bound need. So the pool starts at the
+// smallest allocation that satisfies that check and the first call with a real
+// requirement grows it -- as against standing the engine's profile-wide figure in
+// for the zero, which would pin the pool at the largest shape the engine admits
+// on the strength of a call that uses none of it.
+constexpr size_t kMinPooledScratchBytes = 1;
+
+// Refuses a pooled call whose stream is capturing a CUDA graph.
+//
+// The handoff's event wait is on an event recorded outside the capture:
+// cudaStreamWaitEvent fails it with cudaErrorStreamCaptureIsolation and
+// invalidates the capture under every capture mode. A growth's cudaMalloc and its
+// disposal of the buffer it replaces invalidate it under every mode but
+// cudaStreamCaptureModeRelaxed, and under Relaxed run uncaptured, leaving a replay
+// pointed at a buffer the pool may since have freed. None of that fails cleanly:
+// the caller learns of it only when cudaStreamEndCapture hands back an error and a
+// null graph. Refusing names the cause instead.
+//
+// execute() calls this ahead of every CUDA call it makes that a capture cannot
+// take, not just the pool's own: the cudaEventSynchronize on a previous enqueue,
+// the cudaMalloc that grows a host-input staging buffer, and the
+// cudaStreamSynchronize that ends a call this backend does not let return early.
+// Any of them leaves a refusal made after it nothing to save. Only the device
+// query and the device switch run earlier, and a capture takes both.
+//
+// It sees only `stream`, and there is no query for "is any capture live in this
+// process": a capture on another stream under Global, or under ThreadLocal from
+// this thread, is invalidated by the pool's calls just the same and is not caught.
+// The header and the README say so.
+//
+// The query fails in two ways, and they are not the same answer.
+// cudaErrorStreamCaptureImplicit -- `stream` is the legacy stream and some other
+// stream is capturing -- is a capture, so it is refused with the rest. Any other
+// code is not a capture at all: cudaStreamIsCapturing also hands back a sticky
+// fault left by earlier work on this device, measured on an A100 with CUDA 12.8
+// after an illegal memory access, returning that fault with the status still
+// cudaStreamCaptureStatusNone. Answering that with the capture refusal names a
+// cause that is not there and buries the one that is, so it is reported as itself.
+Error refuse_pooled_call_on_a_capturing_stream(cudaStream_t stream, int device_id) {
+  cudaStreamCaptureStatus capture = cudaStreamCaptureStatusNone;
+  const cudaError_t capture_err = cudaStreamIsCapturing(stream, &capture);
+  if (capture_err != cudaSuccess && capture_err != cudaErrorStreamCaptureImplicit) {
+    ET_LOG(
+        Error,
+        "TensorRTBackend::execute: could not tell whether the selected stream is capturing a CUDA graph, because cudaStreamIsCapturing on device %d reported %s. That code is not a capture, and it need not be this call's doing: cudaStreamIsCapturing also hands back a sticky fault left by earlier work on this device. The shared activation scratch pool reports it because it is the first thing here to ask the device a question.",
+        device_id,
+        cudaGetErrorString(capture_err));
+    // The query's own failure is this call's, not the next one's; a sticky fault
+    // survives the clear and resurfaces on whatever this thread calls next, which
+    // is where an unpooled call would have reported it.
+    cudaGetLastError();
+    return Error::InvalidProgram;
+  }
+  if (capture_err == cudaSuccess && capture == cudaStreamCaptureStatusNone) {
+    return Error::Ok;
+  }
+  ET_LOG(
+      Error,
+      "TensorRTBackend::execute: the selected stream is capturing a CUDA graph (%s), which the shared activation scratch pool on device %d does not support. Loading the engine with '%s' off removes this refusal, but this delegate does not support capture that way either. The capture section of the backend README has the detail.",
+      capture_err == cudaSuccess ? "capture in progress" : cudaGetErrorString(capture_err),
+      device_id,
+      kSharedActivationScratchKey);
+  if (capture_err != cudaSuccess) {
+    // cudaErrorStreamCaptureImplicit, the one failure that still reports a
+    // capture. Its error is the query's own, so it is cleared here rather than
+    // left for the next CUDA call to report under its own name. Not on the
+    // ordinary refusal: there the query succeeded, so anything pending on this
+    // thread was left by earlier work and belongs to whoever calls CUDA next.
+    cudaGetLastError();
+  }
+  return Error::NotSupported;
+}
+
+// Sets out_ptr to a buffer of at least `need` bytes on `device_id`, with `stream`
+// ordered after the enqueue that last used the buffer. Returns with `claim`
+// holding the device's lock: the caller must submit its enqueue, call
+// record_shared_scratch_enqueue, and only then release the claim.
+//
+// The buffer's capacity is not reported, because no caller has any use for it:
+// what a call installs on its context is its own requirement, not whatever the
+// pool grew to for someone else.
+//
+// `need` is a real request and never zero -- execute() substitutes
+// kMinPooledScratchBytes for a zero before calling, so that the size the pool
+// guarantees and the size the context is told it owns are one figure and not two.
+//
+// The caller must already have refused a capturing `stream`: the handoff's wait
+// invalidates a capture under every mode, a growth's allocation under every mode
+// but Relaxed, and a growth's disposal of the buffer it replaces under every mode
+// but Relaxed as well.
+//
+// Must be called with `device_id` already current: cudaEventCreateWithFlags and
+// cudaMalloc both act on the *current* device and nothing in here sets it.
+Error claim_shared_scratch(SharedScratchClaim& claim, int device_id, size_t need, cudaStream_t stream, void*& out_ptr) {
+  SharedScratchDevice& dev = claim.hold(device_id);
+
+  const SharedScratchHandoff handoff = shared_scratch_claim_event(dev, []() -> cudaEvent_t {
+    cudaEvent_t event = nullptr;
+    // Blocking-sync so the host yields instead of busy-spinning. The only host
+    // wait ever made on this event is the one a growth's disposal makes in
+    // SharedScratchClaim::release(), and it waits for a whole inference; spinning
+    // would burn a core for that time and be no faster. Nothing on a call that
+    // does not grow the pool waits on it from the host, and the flag costs
+    // nothing there.
+    if (cudaEventCreateWithFlags(&event, cudaEventDisableTiming | cudaEventBlockingSync) != cudaSuccess) {
+      // The pool's own failure, cleared where it is made: the caller is told by
+      // the return, and leaving it pending would surface it under the name of
+      // whatever this thread calls next.
+      cudaGetLastError();
+      return nullptr;
+    }
+    return event;
+  });
+  if (handoff.event == nullptr) {
+    ET_LOG(
+        Error,
+        "TensorRTBackend::execute: failed to create the shared activation scratch handoff event on device %d",
+        device_id);
+    return Error::Internal;
+  }
+  if (handoff.needs_wait) {
+    const cudaError_t err = cudaStreamWaitEvent(stream, handoff.event, 0);
+    if (err != cudaSuccess) {
+      ET_LOG(
+          Error,
+          "TensorRTBackend::execute: waiting for the enqueue that last used the shared activation scratch failed: %s",
+          cudaGetErrorString(err));
+      cudaGetLastError();
+      return Error::InvalidState;
+    }
+  }
+
+  const bool first_buffer = dev.buffer == nullptr;
+  RetiredScratch retired;
+  void* const buffer = shared_scratch_get_or_grow(
+      dev,
+      need,
+      [device_id, first_buffer](size_t bytes) -> void* {
+        void* p = nullptr;
+        if (cudaMalloc(&p, bytes) != cudaSuccess) {
+          cudaGetLastError();
+          return nullptr;
+        }
+        ET_LOG(
+            Info,
+            "TensorRTBackend::execute: shared scratch pool (device %d) %s %zu bytes",
+            device_id,
+            first_buffer ? "allocated" : "grew to",
+            bytes);
+        return p;
+      },
+      retired);
+  if (buffer == nullptr) {
+    ET_LOG(
+        Error,
+        "TensorRTBackend::execute: failed to allocate %zu bytes of shared activation scratch on device %d",
+        need,
+        device_id);
+    return Error::MemoryAllocationFailed;
+  }
+
+  // The retired buffer is disposed of at release(), with the device's lock
+  // dropped; see SharedScratchClaim::release() for what that costs. Nothing here
+  // makes a CUDA call that blocks on device work under that lock -- the stream is
+  // created and not waited on, and only a growth that displaced a buffer creates
+  // one at all.
+  if (retired.buffer != nullptr) {
+    const cudaStream_t disposal_stream = shared_scratch_disposal_stream(dev, [device_id]() -> cudaStream_t {
+      cudaStream_t stream_for_disposals = nullptr;
+      // Non-blocking, so a free queued here is not ordered against the legacy
+      // default stream: the disposal waits for the enqueue that used the buffer
+      // and for nothing else, and the legacy stream would add whatever any other
+      // library on this device happens to have queued on it.
+      if (cudaStreamCreateWithFlags(&stream_for_disposals, cudaStreamNonBlocking) != cudaSuccess) {
+        // The pool's own failure, cleared where it is made: the disposal falls
+        // back to a device-wide free and says so, and leaving this pending would
+        // surface it under the name of whatever this thread calls next.
+        cudaGetLastError();
+        ET_LOG(
+            Info,
+            "TensorRTBackend::execute: could not create the shared activation scratch pool's disposal stream on device %d, so this growth's free of the buffer it replaced is device-wide",
+            device_id);
+        return nullptr;
+      }
+      return stream_for_disposals;
+    });
+    claim.retire(retired.buffer, retired.wait_for, disposal_stream);
+  }
+
+  out_ptr = buffer;
+  return Error::Ok;
+}
+
+// Records the enqueue now in flight on `stream` against the claimed device's
+// shared scratch, so the next call to claim_shared_scratch waits for it.
+//
+// Call on a `claim` that claim_shared_scratch returned Error::Ok on and that
+// still holds the device's lock. Both halves matter, and together they are why
+// neither the device nor the event below is checked: a claim's device is non-null
+// exactly while it holds the lock, and claim_shared_scratch has already failed the
+// call with Error::Internal if the marker had no event, which only the test-only
+// reset clears again and that needs the lock this claim is holding.
+Error record_shared_scratch_enqueue(SharedScratchClaim& claim, cudaStream_t stream) {
+  const cudaEvent_t event = shared_scratch_mark_in_flight(*claim.device());
+  const cudaError_t err = cudaEventRecord(event, stream);
+  if (err != cudaSuccess) {
+    ET_LOG(
+        Error,
+        "TensorRTBackend::execute: recording the completion event for the shared activation scratch enqueue failed: %s",
+        cudaGetErrorString(err));
+    cudaGetLastError();
+    return Error::InvalidState;
+  }
+  return Error::Ok;
 }
 
 } // namespace
@@ -611,6 +1065,30 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
   nvinfer1::IExecutionContext* ctx = engine->exec_ctx.get();
   TORCHTRT_ET_CHECK_NOT_NULL(ctx, Error::InvalidState, "TensorRTBackend::execute: backend is not initialized");
 
+  const auto caller_stream = ::executorch::extension::cuda::getCallerStream();
+  const bool caller_stream_set = caller_stream.has_value();
+  cudaStream_t stream = caller_stream.value_or(cudaStreamPerThread);
+
+  // Settled at init: the option was on at this engine's load and the engine needs
+  // scratch under some shape. An engine that needs none is left out of the pool
+  // entirely -- enqueueV3 accepts it with no device memory installed, so it need
+  // not claim the device and does not serialize against the engines that do.
+  const bool pooled_scratch = engine->claims_pooled_scratch;
+
+  // Refused here, ahead of every call this function makes that a capture cannot
+  // take. The pool's own are not the only ones: the wait on a previous enqueue just
+  // below, and the cudaMalloc that grows a host-input staging buffer further down,
+  // are prohibited under every mode but cudaStreamCaptureModeRelaxed, so outside
+  // that mode they would invalidate the capture before the pooled path was ever
+  // reached and a refusal any later would arrive after the thing it exists to
+  // protect was gone.
+  if (pooled_scratch) {
+    const Error capture_err = refuse_pooled_call_on_a_capturing_stream(stream, engine->device_id);
+    if (capture_err != Error::Ok) {
+      return capture_err;
+    }
+  }
+
   // A prior fast-path execute() may have returned with its enqueue still in flight
   // on the shared exec_ctx. Wait for it before reconfiguring the context below:
   // TensorRT forbids mutating a context while one of its enqueues is in flight, and
@@ -623,11 +1101,43 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
       return Error::InvalidProgram;
     }
   }
-  const auto caller_stream = ::executorch::extension::cuda::getCallerStream();
-  const bool caller_stream_set = caller_stream.has_value();
-  cudaStream_t stream = caller_stream.value_or(cudaStreamPerThread);
   bool output_staged_to_host = false;
   bool input_staged_from_host = false;
+
+  // A host-resident input is staged with an asynchronous copy that reads the
+  // caller's own memory, and that copy must not still be running when execute()
+  // returns: the caller is free to write that buffer again, and a copy from
+  // pinned memory has not read it yet -- measured, every byte the device
+  // received was the value written after the return. The success path already
+  // synchronizes whenever anything was staged (must_sync below); this covers the
+  // returns between the copy and that point, which would otherwise leave it live.
+  //
+  // Scoped to the pooled path, by the call rather than by the return: on a pooled
+  // call it covers every error return past the copy, and on an unpooled one it
+  // covers none, so an engine loaded with the option off waits nowhere it did not
+  // already wait. The hazard is reachable on an unpooled call too, and closing it
+  // there is a fix of its own rather than this option's to make: it would change
+  // what a default-off call does on every error return it makes after that copy.
+  // The capture refusal sits inside the pooled path for the same reason.
+  //
+  // The wait it makes is a whole-stream one and not a wait on the copy alone, so
+  // an error return that staged a host input can block on work the caller queued
+  // before calling. Waiting for the copy alone would mean recording an event after
+  // the last staging copy of every call that makes one, which costs a per-call
+  // event record on the success path to narrow a wait only error returns make.
+  // Staging already implies must_sync, so no successful call reaches the
+  // destructor with this pending.
+  struct StagedInputDrain {
+    cudaStream_t stream;
+    bool pooled;
+    const bool& staged;
+    bool done = false;
+    ~StagedInputDrain() {
+      if (pooled && staged && !done) {
+        (void)cudaStreamSynchronize(stream);
+      }
+    }
+  } staged_input_drain{stream, pooled_scratch, input_staged_from_host};
 
   if (engine->cached_input_ptrs.empty()) {
     engine->cached_input_ptrs.resize(num_inputs, nullptr);
@@ -905,8 +1415,80 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
     }
   }
 
+  // Whether this call ends by waiting for its own enqueue. Settled here, the first
+  // point everything it reads is final: the two staging flags and the aliased
+  // reflects are set while the bindings are built above, and whether a caller
+  // stream is active was read at the top.
+  //
+  //   must_sync = an output is staged to host (the caller reads the D2H result on
+  //   return), an input was staged from host (its async H2D read the caller's host
+  //   buffer, which the caller may reuse once we return), an aliased reflect is
+  //   queued (ExecuTorch's buffer-mutation copy_ reads that EValue after execute()
+  //   returns, so the reflect must complete first), or no caller stream is active
+  //   (preserve the historical "results ready on return" behavior).
+  //
+  // Otherwise -- caller stream, all I/O device-resident, no alias -- the engine
+  // work is left enqueued so it composes with the caller's later GPU work, and a
+  // completion event is recorded instead so the next execute() and the destructor
+  // wait before reusing or freeing exec_ctx.
+  const bool aliased_reflect_pending = !aliased_reflects.empty();
+  const bool must_sync =
+      output_staged_to_host || input_staged_from_host || aliased_reflect_pending || !caller_stream_set;
+
   // ------------------------------------------------------------------
-  // 4. Enqueue inference on the current CUDA stream
+  // 4. Back activation scratch with the shared per-device pool
+  // ------------------------------------------------------------------
+  // The query requires every input shape to be bound, which they are by here, and
+  // whatever it answers is binding rather than advisory: an engine backed by less
+  // than it asked for writes past the end. The buffer is installed on every call,
+  // not once, because any call needing more than the pool holds -- this engine on
+  // other shapes, or another one -- grows it and moves it. A kSTATIC context owns
+  // its private scratch, so the install must not be made on one.
+  //
+  // A reported zero has two causes that reach here and nothing distinguishes them:
+  // bound shapes that genuinely need none -- an empty input inside a profile that
+  // admits one -- and a query that failed. Neither sizes the pool: a zero asks for
+  // kMinPooledScratchBytes, which any live buffer already covers. The install is
+  // what tells the two apart, because setDeviceMemoryV2 refuses a buffer smaller
+  // than the bound shapes need, so a call whose query failed ends here rather than
+  // enqueueing against whatever pointer the context was last given, which a growth
+  // may since have freed. The README's shared activation scratch section says why
+  // the minimum rather than the engine's profile-wide figure.
+  //
+  // What is installed is this call's own requirement and not the capacity the pool
+  // holds, which is larger whenever an earlier call asked for more. The larger
+  // figure would tell TensorRT it owns bytes holding another engine's activations
+  // -- the pool never clears the buffer -- and would blunt the refusal above,
+  // since after a growth the capacity may well cover what a failed query
+  // concealed.
+  //
+  // The claim holds the device's pool lock from here through the record of the
+  // enqueue below; see SharedScratchClaim for why it spans that far. Every return
+  // in between drops it through the destructor, which runs ahead of the device
+  // restore above, so its free lands on the right device.
+  SharedScratchClaim scratch_claim;
+  if (pooled_scratch) {
+    const size_t need = ctx->updateDeviceMemorySizeForShapes();
+    // The substitution for a zero is made here and once: the same figure has to
+    // be the size the pool guarantees and the size the context is told it owns,
+    // and nothing downstream checks that two copies of it still agree --
+    // setDeviceMemoryV2 refuses an install smaller than the bound shapes need and
+    // says nothing about one that is larger. A context whose engine needs scratch
+    // under some shape has to be given a buffer whatever this call's shapes need,
+    // or enqueueV3 refuses it.
+    const size_t scratch_bytes = need == 0 ? kMinPooledScratchBytes : need;
+    void* pool = nullptr;
+    const Error scratch_err = claim_shared_scratch(scratch_claim, engine->device_id, scratch_bytes, stream, pool);
+    if (scratch_err != Error::Ok) {
+      return scratch_err;
+    }
+    if (!install_pooled_scratch(*ctx, pool, scratch_bytes, engine->device_id)) {
+      return Error::InvalidState;
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // 5. Enqueue inference on the current CUDA stream
   // ------------------------------------------------------------------
   if (!ctx->enqueueV3(stream)) {
     ET_LOG(
@@ -918,6 +1500,52 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
     return Error::InvalidState;
   }
 
+  // What every early return past this point owes. The enqueue is submitted and
+  // this handle's completion marker is not armed -- it is armed at the end of
+  // execute(), below every one of the lambda's call sites -- so a return that left
+  // the enqueue running would have a later execute() or ~EngineHandle reconfigure
+  // or free exec_ctx underneath it, which TensorRT forbids. That is also why the
+  // lambda clears no marker: wherever it is called there is none to clear. Where
+  // the pool is in play the same wait is what keeps the next claimant from
+  // overwriting scratch this enqueue is still using. The drain guard's flag is
+  // cleared, since this wait covers a staged input's copy as well.
+  const auto drain_the_enqueue = [&]() {
+    (void)cudaStreamSynchronize(stream);
+    staged_input_drain.done = true;
+  };
+
+  // Pairs with claim_shared_scratch: the next claimant waits on this event.
+  if (pooled_scratch) {
+    const Error mark_err = record_shared_scratch_enqueue(scratch_claim, stream);
+    if (mark_err != Error::Ok) {
+      // Nothing will wait for this enqueue otherwise: the record that would have
+      // put it on the marker is the call that just failed.
+      //
+      // The wait is made with the device's pool lock still held -- the claim is
+      // released below -- which is the one place a pooled call holds it across a
+      // host wait, so another pooled engine on this device waits out this
+      // inference. Releasing first would be worse: it would hand the buffer to a
+      // claimant with nothing ordering it against the enqueue this call just
+      // submitted, which is the silent-corruption case the lock exists for.
+      drain_the_enqueue();
+      return mark_err;
+    }
+  }
+  // The enqueue is now on the marker's event, so the device's pool is safe to
+  // hand to the next claimant. Released here rather than at the end of the
+  // function so the rest of execute() -- the aliased reflects, the D2H copies and
+  // their synchronizations -- does not hold up another engine on this device.
+  // The release is also where a growth disposes of the buffer it replaced, with
+  // the lock dropped; this is the only place that release is made rather than
+  // left to the claim's destructor.
+  if (!scratch_claim.release()) {
+    // The only failure it reports is its wait for the enqueue on the buffer a
+    // growth retired, which for a wait on device work means this device is
+    // already in a faulted state.
+    drain_the_enqueue();
+    return Error::InvalidProgram;
+  }
+
   // Caller-owned KV: reflect each engine in-place update into its delegate output
   // EValue (D2D on the same stream, after the engine work).
   for (const auto& r : aliased_reflects) {
@@ -925,34 +1553,19 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
     if (cuda_err != cudaSuccess) {
       ET_LOG(
           Error, "TensorRTBackend::execute: aliased-output reflect D2D copy failed: %s", cudaGetErrorString(cuda_err));
-      // enqueueV3 already submitted engine work to `stream`, and inflight_pending
-      // is not armed until the end of the happy path -- drain now so a later
-      // execute() or the destructor never reconfigures/frees exec_ctx while this
-      // enqueue is still running.
-      (void)cudaStreamSynchronize(stream);
-      engine->inflight_pending = false;
+      drain_the_enqueue();
       return Error::InvalidProgram;
     }
   }
 
-  // The engine work is now in flight on `stream`. Decide whether to wait for it:
-  //   must_sync = an output is staged to host (the caller reads the D2H result on
-  //   return), an input was staged from host (its async H2D read the caller's host
-  //   buffer, which the caller may reuse once we return), or no caller stream is
-  //   active (preserve the historical "results ready on return" behavior).
-  // Otherwise (caller stream + all I/O device-resident) leave the work enqueued so
-  // it composes with the caller's later GPU work, and record inflight_event so the
-  // next execute() and the destructor wait before reusing/freeing exec_ctx. The D2H
-  // copies live in the must_sync branch: an output staged to host always sets
+  // The engine work is on `stream` -- still in flight, unless a growth's disposal
+  // above waited out the enqueue -- and must_sync says whether to wait for it. The
+  // D2H copies live in this branch: an output staged to host always sets
   // output_staged_to_host, so outputs_needing_copy is empty on the skip path.
-  // An aliased reflect enqueues the engine's in-place update into the delegate
-  // output EValue on `stream`; ExecuTorch's buffer-mutation copy_ reads that EValue
-  // after execute() returns, so the reflect must complete first. A model with
-  // aliased outputs therefore always syncs here.
-  const bool aliased_reflect_pending = !aliased_reflects.empty();
-  const bool must_sync =
-      output_staged_to_host || input_staged_from_host || aliased_reflect_pending || !caller_stream_set;
   if (must_sync) {
+    // Every return from here on is behind the cudaStreamSynchronize below, so
+    // the staging drain has nothing left to do.
+    staged_input_drain.done = true;
     Error copy_err = Error::Ok;
     for (auto& output : outputs_needing_copy) {
       exec_aten::Tensor et_out = args[output.first]->toTensor();
@@ -964,7 +1577,7 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
             "TensorRTBackend::execute: D2H copy failed for output %zu: %s",
             output.first,
             cudaGetErrorString(cuda_err));
-        // The enqueue already succeeded, so the engine is still running on the
+        // The enqueue already succeeded, so the engine may still be running on the
         // stream. Drain below before returning, or the next call mutates a live
         // execution context, which TensorRT forbids.
         copy_err = Error::InvalidProgram;
@@ -983,14 +1596,43 @@ Error TensorRTBackend::execute(BackendExecutionContext& context, DelegateHandle*
   } else {
     cuda_err = cudaEventRecord(engine->inflight_event, stream);
     if (cuda_err != cudaSuccess) {
-      // Could not arm the completion marker; drain now so a later execute() or the
-      // destructor never reconfigures or frees exec_ctx while this enqueue runs.
+      // Could not arm the completion marker, so nothing downstream would wait.
       ET_LOG(Error, "TensorRTBackend::execute: cudaEventRecord failed: %s", cudaGetErrorString(cuda_err));
-      (void)cudaStreamSynchronize(stream);
-      engine->inflight_pending = false;
+      drain_the_enqueue();
       return Error::InvalidProgram;
     }
     engine->inflight_pending = true;
+  }
+  return Error::Ok;
+}
+
+// ---------------------------------------------------------------------------
+// set_option
+// ---------------------------------------------------------------------------
+Error TensorRTBackend::set_option(ET_UNUSED BackendOptionContext& context, const Span<BackendOption>& backend_options) {
+  // The whole span is read before anything is stored. A span is one request, so a
+  // caller told it was refused must not find part of it applied -- and the part
+  // that would be applied here is process-wide and governs every engine loaded
+  // after it. Where a span names this key more than once the last one wins, which
+  // is what applying each in turn did.
+  bool requested = false;
+  bool have_request = false;
+  for (const auto& option : backend_options) {
+    // A caller may address one option span to several backends, so a key this
+    // backend does not read is skipped rather than refused.
+    if (std::strcmp(option.key, kSharedActivationScratchKey) == 0) {
+      const bool* const val = std::get_if<bool>(&option.value);
+      if (val == nullptr) {
+        ET_LOG(Error, "TensorRTBackend::set_option: option '%s' must be a boolean", kSharedActivationScratchKey);
+        return Error::InvalidArgument;
+      }
+      requested = *val;
+      have_request = true;
+    }
+  }
+
+  if (have_request) {
+    scratch_enabled.store(requested, std::memory_order_relaxed);
   }
   return Error::Ok;
 }

--- a/py/torch-tensorrt-executorch-runtime/native/CMakeLists.txt
+++ b/py/torch-tensorrt-executorch-runtime/native/CMakeLists.txt
@@ -173,6 +173,9 @@ target_compile_definitions(torch_tensorrt_executorch_backend
 target_include_directories(torch_tensorrt_executorch_backend PRIVATE
   "${TORCH_TENSORRT_SOURCE_DIR}"
   "${TORCH_TENSORRT_SOURCE_DIR}/cpp/include"
+  # Headers the backend sources include but that are not part of the installed
+  # API, such as SharedScratchPool.h.
+  "${TORCH_TENSORRT_SOURCE_DIR}/cpp/src"
   "${EXECUTORCH_SOURCE_DIR}/.."
   "${EXECUTORCH_SOURCE_DIR}/runtime/core/portable_type/c10")
 if(NOT TARGET extension_cuda)

--- a/tests/cpp/BUILD
+++ b/tests/cpp/BUILD
@@ -62,16 +62,6 @@ test_suite(
     ],
 )
 
-test_suite(
-    name = "executorch_backend_tests",
-    tests = [
-        "//tests/cpp/executorch:test_caller_stream",
-        "//tests/cpp/executorch:test_executorch_binding_names",
-        "//tests/cpp/executorch:test_executorch_blob_header",
-        "//tests/cpp/executorch:test_executorch_weight_streaming_budget",
-    ],
-)
-
 cc_test(
     name = "test_default_input_types",
     srcs = ["test_default_input_types.cpp"],

--- a/tests/cpp/executorch/BUILD
+++ b/tests/cpp/executorch/BUILD
@@ -9,6 +9,8 @@ test_suite(
         ":test_executorch_binding_names",
         ":test_executorch_blob_header",
         ":test_executorch_weight_streaming_budget",
+        ":test_shared_scratch_backend",
+        ":test_shared_scratch_pool",
     ],
 )
 
@@ -46,4 +48,58 @@ cc_test(
         "//cpp:tensorrt_executorch_weight_streaming_budget",
         "@googletest//:gtest_main",
     ],
+)
+
+# The long timeout is what makes the fork case's per-child deadline mean anything:
+# it reaps 24 children at 30 s each, so the path where they wedge budgets 720 s
+# against Bazel's 300 s default for a target that names neither size nor timeout.
+# Two source files because one of them is how the target sees that scratch_pool()
+# is one registry across translation units; see the second file's comment.
+cc_test(
+    name = "test_shared_scratch_pool",
+    timeout = "long",
+    srcs = [
+        "test_shared_scratch_pool.cpp",
+        "test_shared_scratch_pool_other_tu.cpp",
+    ],
+    deps = [
+        "//cpp:tensorrt_executorch_shared_scratch_pool",
+        "//cpp:tensorrt_executorch_shared_scratch_pool_reset",
+        "@googletest//:gtest_main",
+    ],
+)
+
+# exclusive because the memory comparison reads device-wide free memory, which
+# any other GPU target running at the same time would move.
+cc_test(
+    name = "test_shared_scratch_backend",
+    timeout = "long",
+    srcs = ["test_shared_scratch_backend.cpp"],
+    tags = ["exclusive"],
+    target_compatible_with = select({
+        "//cpp:linux_x86_64": [],
+        "//cpp:sbsa": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        "//cpp:tensorrt_executorch_backend",
+        "//cpp:tensorrt_executorch_blob_header",
+        "//cpp:tensorrt_executorch_pooled_scratch_install",
+        "//cpp:tensorrt_executorch_shared_scratch_pool",
+        "//cpp:tensorrt_executorch_shared_scratch_pool_test_hooks",
+        "@executorch//:executorch_core",
+        "@executorch//:executorch_headers",
+        "@executorch//:extension_cuda",
+        "@googletest//:gtest_main",
+    ] + select({
+        "//cpp:linux_x86_64": [
+            "@cuda//:cudart",
+            "@tensorrt//:nvinfer",
+        ],
+        "//cpp:sbsa": [
+            "@cuda//:cudart",
+            "@tensorrt_sbsa//:nvinfer",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/tests/cpp/executorch/test_shared_scratch_backend.cpp
+++ b/tests/cpp/executorch/test_shared_scratch_backend.cpp
@@ -1,0 +1,2849 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Exercises the shared activation-scratch pool through the delegate that uses
+// it: the runtime option that turns it on, the per-engine capture of that
+// option, and the pooled execute() path -- the kUSER_MANAGED context, the
+// updateDeviceMemorySizeForShapes/setDeviceMemoryV2 pair, the enqueue handoff
+// between two caller streams, the growth a larger engine forces on a pool a
+// smaller one already allocated, two of the three things that make the per-shape
+// query answer zero -- the third, a failed query, cannot be induced from inside
+// this process -- and two threads submitting against one pooled buffer at once.
+// It also covers the one place this branch could have moved the option-off path
+// without meaning to, and where it says it did not: the error returns of an
+// unpooled call.
+//
+// The TensorRT engine is built here rather than loaded from a .pte so the target
+// carries no exported artifact, at the cost of a few seconds of builder time.
+//
+// COVERAGE LIMIT: every test below needs a CUDA device and a TensorRT that can
+// build an engine. Without one the whole suite skips and covers nothing, so a
+// green run on a host with no GPU says nothing about the pool -- and a skipped
+// gtest case exits zero, which Bazel reports as a passing target. A run that is
+// meant to have a device says so through TORCHTRT_EXECUTORCH_REQUIRE_CUDA, and
+// then the missing device is a failure instead, which each failing case says for
+// itself. Where that variable is unset, a count of the cases that skipped for that
+// reason is printed at the end of the suite.
+//
+// That variable covers the missing device and nothing else. Cases also skip for a
+// second reason: the device would not fill, its memory would not stay still, or it
+// has no stream-ordered allocator. None of those is a state a test can insist on
+// while sharing the device with other processes. Those skips stand whether the
+// variable is set or not, so a green required-CUDA run says every case ran, not
+// that every case covered what it is named for. No count is given here, because a
+// skip written in a fixture helper belongs to every case that calls it and moves
+// the moment one is added; the suite counts these separately from the missing
+// device and lists them by name and reason at the end of the suite, whether or not
+// the variable is set. That list is in the test log, which --test_output=errors
+// prints nothing of for a target that passes; the CI invocation therefore also
+// passes --test_summary=detailed, which names every skipped case in Bazel's own
+// summary.
+//
+// SHARED-DEVICE WARNING: the three cases that need the device full take it to
+// essentially zero free bytes for as long as they hold their DeviceMemoryHog --
+// measured, 16 MiB free of 81151 MiB, with a neighbour process getting
+// out-of-memory on 256 MiB allocations throughout the window. That is the only way
+// to reach the pool's allocation-failure path from inside this process: nothing in
+// the delegate takes an allocator a test could substitute, and the other early
+// returns on that path need TensorRT or CUDA to fail a call that is correct as
+// made. Bazel's exclusive tag keeps other actions in the same build off this
+// device; it cannot keep anything else off it.
+//
+// The CI invocation in .github/workflows/executorch-test-linux.yml passes that
+// variable, and the job it sits in asks for a GPU runner and starts its container
+// with every GPU attached. The ExecuTorch job's own gate in ci-linux-x86_64.yml
+// does not keep these cases off an ordinary pull-request push: it sits out only
+// when the lane is skip or the backend is RTX, and _decide.yml resolves an
+// unlabelled pull_request to lane=fast and backend=standard. What does drop the
+// job is the standard channel having been cancelled, which the same workflow
+// already carries a comment about.
+
+#include "torch_tensorrt/executorch/PooledScratchInstall.h"
+#include "torch_tensorrt/executorch/SharedScratchPool.h"
+#include "torch_tensorrt/executorch/SharedScratchPoolTestHooks.h"
+#include "torch_tensorrt/executorch/TensorRTBackend.h"
+#include "torch_tensorrt/executorch/TensorRTBlobHeader.h"
+
+#include <NvInfer.h>
+#include <cuda_runtime.h>
+
+#include <executorch/extension/cuda/caller_stream.h>
+#include <executorch/runtime/backend/interface.h>
+#include <executorch/runtime/backend/options.h>
+#include <executorch/runtime/core/evalue.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/freeable_buffer.h>
+#include <executorch/runtime/core/memory_allocator.h>
+#include <executorch/runtime/core/span.h>
+#include <executorch/runtime/platform/runtime.h>
+
+#include "gtest/gtest.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace torch_tensorrt {
+namespace executorch_backend {
+namespace {
+
+using ::executorch::aten::ScalarType;
+using ::executorch::aten::SizesType;
+using ::executorch::runtime::ArrayRef;
+using ::executorch::runtime::BackendExecutionContext;
+using ::executorch::runtime::BackendInitContext;
+using ::executorch::runtime::BackendOption;
+using ::executorch::runtime::BackendOptionContext;
+using ::executorch::runtime::CompileSpec;
+using ::executorch::runtime::DelegateHandle;
+using ::executorch::runtime::Error;
+using ::executorch::runtime::EValue;
+using ::executorch::runtime::FreeableBuffer;
+using ::executorch::runtime::MemoryAllocator;
+using ::executorch::runtime::Span;
+
+// Spelled out rather than taken from TensorRTBackend.h: a test that reads the
+// key through the production constant cannot pin the key's value.
+constexpr char kOptionKey[] = "use_shared_activation_scratch";
+
+constexpr int kRows = 2048;
+constexpr int kCols = 2048;
+constexpr std::size_t kElems = static_cast<std::size_t>(kRows) * static_cast<std::size_t>(kCols);
+constexpr std::size_t kBytes = kElems * sizeof(float);
+
+// A second scratch-needing engine, four times the elements of the one above, so
+// loading it after that one drives the pool's growth path. Every other engine in
+// this file asks for the same size, which is why nothing else reaches it.
+constexpr int kBigRows = 4096;
+constexpr int kBigCols = 4096;
+
+// A dynamic-batch engine whose profile admits an empty batch. Binding one is a
+// valid call that needs no activation scratch, from an engine that needs some,
+// which is one of the three things a zero from updateDeviceMemorySizeForShapes
+// can mean. The dimensions are small because no test compares this engine's
+// memory against a figure; only whether each answer it gives is zero matters.
+constexpr int kDynRows = 64;
+constexpr int kDynCols = 64;
+constexpr int kDynMaxBatch = 128;
+// Inside the same profile and not empty, so one engine covers both answers.
+constexpr int kDynBatch = 4;
+
+// Engines loaded together in the memory test. Four is enough for the private
+// case to cost 4x the scratch and the pooled case 1x.
+constexpr int kEngineCount = 4;
+
+// A value neither network below can produce, so an output comparison cannot be
+// satisfied by an execute() that never reached the engine.
+constexpr float kSentinel = -7.0f;
+
+// Below this the memory comparison cannot see past allocator granularity, so the
+// test reports that its network stopped producing measurable scratch instead of
+// passing on a difference it cannot resolve.
+constexpr std::size_t kMinMeasurableScratch = 4u << 20;
+
+// ---------------------------------------------------------------------------
+// A TensorRT engine, built here, wrapped in the delegate's blob wire format
+// ---------------------------------------------------------------------------
+
+constexpr char kMagic[4] = {'T', 'R', '0', '1'};
+constexpr std::uint32_t kMetadataOffsetField = 4;
+constexpr std::uint32_t kMetadataSizeField = 8;
+constexpr std::uint32_t kEngineOffsetField = 12;
+constexpr std::uint32_t kEngineSizeField = 16;
+constexpr std::uint32_t kHeaderSize = 32;
+constexpr std::uint32_t kEngineAlignment = 16;
+
+class BuilderLogger : public nvinfer1::ILogger {
+ public:
+  void log(Severity severity, const char* msg) noexcept override {
+    if (severity <= Severity::kWARNING) {
+      std::fprintf(stderr, "[TensorRT] %s\n", msg);
+    }
+  }
+};
+
+template <typename T>
+void write_field(std::vector<std::uint8_t>& blob, std::size_t offset, T value) {
+  std::memcpy(blob.data() + offset, &value, sizeof(value));
+}
+
+std::size_t align_up(std::size_t value, std::size_t alignment) {
+  return ((value + alignment - 1) / alignment) * alignment;
+}
+
+// Two softmaxes over different axes sit between the pointwise layers so the
+// chain cannot collapse into a single pass, which is what keeps the engine's
+// activation requirement large enough for the memory comparison to resolve.
+bool add_scratch_needing_net(nvinfer1::INetworkDefinition& network, nvinfer1::ITensor& input) {
+  static const float kAddend = 0.125f;
+  static const float kScale = 1.5f;
+
+  nvinfer1::IConstantLayer* addend =
+      network.addConstant(nvinfer1::Dims3{1, 1, 1}, nvinfer1::Weights{nvinfer1::DataType::kFLOAT, &kAddend, 1});
+  nvinfer1::IConstantLayer* scale =
+      network.addConstant(nvinfer1::Dims3{1, 1, 1}, nvinfer1::Weights{nvinfer1::DataType::kFLOAT, &kScale, 1});
+  if (addend == nullptr || scale == nullptr) {
+    return false;
+  }
+
+  nvinfer1::IElementWiseLayer* shifted =
+      network.addElementWise(input, *addend->getOutput(0), nvinfer1::ElementWiseOperation::kSUM);
+  nvinfer1::ISoftMaxLayer* over_cols = network.addSoftMax(*shifted->getOutput(0));
+  over_cols->setAxes(1u << 2);
+  nvinfer1::ISoftMaxLayer* over_rows = network.addSoftMax(*over_cols->getOutput(0));
+  over_rows->setAxes(1u << 1);
+  nvinfer1::IElementWiseLayer* scaled =
+      network.addElementWise(*over_rows->getOutput(0), *scale->getOutput(0), nvinfer1::ElementWiseOperation::kPROD);
+  scaled->getOutput(0)->setName("output_0");
+  network.markOutput(*scaled->getOutput(0));
+  return true;
+}
+
+// TensorRT routes a pointwise chain through the I/O tensors alone, so this
+// engine's activation requirement is zero -- the same answer it gives for a
+// failed query. Every layer is parameterless, because a default alpha or beta
+// can collapse a chain to a constant and make an output comparison vacuous.
+bool add_scratch_free_net(nvinfer1::INetworkDefinition& network, nvinfer1::ITensor& input) {
+  static const nvinfer1::ActivationType kChain[] = {
+      nvinfer1::ActivationType::kSIGMOID,
+      nvinfer1::ActivationType::kTANH,
+      nvinfer1::ActivationType::kSOFTSIGN,
+      nvinfer1::ActivationType::kSIGMOID,
+      nvinfer1::ActivationType::kTANH,
+      nvinfer1::ActivationType::kSOFTSIGN,
+  };
+  nvinfer1::ITensor* t = &input;
+  for (const nvinfer1::ActivationType op : kChain) {
+    nvinfer1::IActivationLayer* layer = network.addActivation(*t, op);
+    if (layer == nullptr) {
+      return false;
+    }
+    t = layer->getOutput(0);
+  }
+  t->setName("output_0");
+  network.markOutput(*t);
+  return true;
+}
+
+// Wraps a serialized engine in the delegate's blob wire format.
+std::vector<std::uint8_t> wrap_engine_plan(const nvinfer1::IHostMemory& plan) {
+  const std::string metadata =
+      R"({"io_bindings":[{"name":"input_0","is_input":true},{"name":"output_0","is_input":false}],)"
+      R"("hardware_compatible":false,"device_id":0})";
+  const auto metadata_offset = static_cast<std::uint32_t>(kHeaderSize);
+  const auto metadata_size = static_cast<std::uint32_t>(metadata.size());
+  const auto engine_offset = static_cast<std::uint32_t>(align_up(metadata_offset + metadata_size, kEngineAlignment));
+
+  std::vector<std::uint8_t> blob(static_cast<std::size_t>(engine_offset) + plan.size(), 0);
+  std::memcpy(blob.data(), kMagic, sizeof(kMagic));
+  write_field(blob, kMetadataOffsetField, metadata_offset);
+  write_field(blob, kMetadataSizeField, metadata_size);
+  write_field(blob, kEngineOffsetField, engine_offset);
+  write_field(blob, kEngineSizeField, static_cast<std::uint64_t>(plan.size()));
+  std::memcpy(blob.data() + metadata_offset, metadata.data(), metadata.size());
+  std::memcpy(blob.data() + engine_offset, plan.data(), plan.size());
+  return blob;
+}
+
+std::vector<std::uint8_t> build_engine_blob(bool needs_scratch, int rows = kRows, int cols = kCols) {
+  static BuilderLogger logger;
+
+  TRTUniquePtr<nvinfer1::IBuilder> builder(nvinfer1::createInferBuilder(logger));
+  if (builder == nullptr) {
+    return {};
+  }
+  TRTUniquePtr<nvinfer1::INetworkDefinition> network(builder->createNetworkV2(0));
+  if (network == nullptr) {
+    return {};
+  }
+
+  nvinfer1::ITensor* input = network->addInput("input_0", nvinfer1::DataType::kFLOAT, nvinfer1::Dims3{1, rows, cols});
+  if (input == nullptr) {
+    return {};
+  }
+  const bool built = needs_scratch ? add_scratch_needing_net(*network, *input) : add_scratch_free_net(*network, *input);
+  if (!built) {
+    return {};
+  }
+
+  TRTUniquePtr<nvinfer1::IBuilderConfig> config(builder->createBuilderConfig());
+  if (config == nullptr) {
+    return {};
+  }
+  nvinfer1::IOptimizationProfile* profile = builder->createOptimizationProfile();
+  const nvinfer1::Dims3 shape{1, rows, cols};
+  profile->setDimensions("input_0", nvinfer1::OptProfileSelector::kMIN, shape);
+  profile->setDimensions("input_0", nvinfer1::OptProfileSelector::kOPT, shape);
+  profile->setDimensions("input_0", nvinfer1::OptProfileSelector::kMAX, shape);
+  config->addOptimizationProfile(profile);
+
+  TRTUniquePtr<nvinfer1::IHostMemory> plan(builder->buildSerializedNetwork(*network, *config));
+  if (plan == nullptr) {
+    return {};
+  }
+  return wrap_engine_plan(*plan);
+}
+
+// The scratch-needing network again, over a leading dimension the caller chooses
+// per call, with an empty batch as the profile minimum.
+std::vector<std::uint8_t> build_dynamic_batch_engine_blob() {
+  static BuilderLogger logger;
+
+  TRTUniquePtr<nvinfer1::IBuilder> builder(nvinfer1::createInferBuilder(logger));
+  if (builder == nullptr) {
+    return {};
+  }
+  TRTUniquePtr<nvinfer1::INetworkDefinition> network(builder->createNetworkV2(0));
+  if (network == nullptr) {
+    return {};
+  }
+
+  nvinfer1::ITensor* input =
+      network->addInput("input_0", nvinfer1::DataType::kFLOAT, nvinfer1::Dims3{-1, kDynRows, kDynCols});
+  if (input == nullptr || !add_scratch_needing_net(*network, *input)) {
+    return {};
+  }
+
+  TRTUniquePtr<nvinfer1::IBuilderConfig> config(builder->createBuilderConfig());
+  if (config == nullptr) {
+    return {};
+  }
+  nvinfer1::IOptimizationProfile* profile = builder->createOptimizationProfile();
+  profile->setDimensions("input_0", nvinfer1::OptProfileSelector::kMIN, nvinfer1::Dims3{0, kDynRows, kDynCols});
+  profile->setDimensions("input_0", nvinfer1::OptProfileSelector::kOPT, nvinfer1::Dims3{kDynBatch, kDynRows, kDynCols});
+  profile->setDimensions(
+      "input_0", nvinfer1::OptProfileSelector::kMAX, nvinfer1::Dims3{kDynMaxBatch, kDynRows, kDynCols});
+  config->addOptimizationProfile(profile);
+
+  TRTUniquePtr<nvinfer1::IHostMemory> plan(builder->buildSerializedNetwork(*network, *config));
+  if (plan == nullptr) {
+    return {};
+  }
+  return wrap_engine_plan(*plan);
+}
+
+// The activation scratch one context of `blob`'s engine needs for the given
+// shape, read the way execute() reads it. Zero if the engine could not be
+// measured, which is also what an empty batch answers, so a caller reading a zero
+// as meaningful has to rule the failure out by some other measurement.
+std::size_t measure_engine_scratch(
+    const std::vector<std::uint8_t>& blob,
+    int rows = kRows,
+    int cols = kCols,
+    int batch = 1) {
+  static BuilderLogger logger;
+  TensorRTBlobHeader header;
+  if (!TensorRTBlobHeader::parse(blob.data(), blob.size(), header)) {
+    return 0;
+  }
+  TRTUniquePtr<nvinfer1::IRuntime> runtime(nvinfer1::createInferRuntime(logger));
+  if (runtime == nullptr) {
+    return 0;
+  }
+  TRTUniquePtr<nvinfer1::ICudaEngine> engine(
+      runtime->deserializeCudaEngine(TensorRTBlobHeader::engine_data(blob.data(), header), header.engine_size));
+  if (engine == nullptr) {
+    return 0;
+  }
+  // kUSER_MANAGED so the probe context itself allocates no scratch to measure.
+  TRTUniquePtr<nvinfer1::IExecutionContext> ctx(
+      engine->createExecutionContext(nvinfer1::ExecutionContextAllocationStrategy::kUSER_MANAGED));
+  if (ctx == nullptr) {
+    return 0;
+  }
+  if (!ctx->setInputShape("input_0", nvinfer1::Dims3{batch, rows, cols})) {
+    return 0;
+  }
+  return ctx->updateDeviceMemorySizeForShapes();
+}
+
+// What the engine reports it needs, read the way init() reads it. A negative
+// result means the blob could not be opened, which no engine reports and which
+// no test may mistake for a scratch-free engine.
+std::int64_t engine_scratch_requirement(const std::vector<std::uint8_t>& blob) {
+  static BuilderLogger logger;
+  TensorRTBlobHeader header;
+  if (!TensorRTBlobHeader::parse(blob.data(), blob.size(), header)) {
+    return -1;
+  }
+  TRTUniquePtr<nvinfer1::IRuntime> runtime(nvinfer1::createInferRuntime(logger));
+  if (runtime == nullptr) {
+    return -1;
+  }
+  TRTUniquePtr<nvinfer1::ICudaEngine> engine(
+      runtime->deserializeCudaEngine(TensorRTBlobHeader::engine_data(blob.data(), header), header.engine_size));
+  if (engine == nullptr) {
+    return -1;
+  }
+  return engine->getDeviceMemorySizeV2();
+}
+
+// ---------------------------------------------------------------------------
+// One loaded delegate handle plus the device-resident I/O its execute() needs
+// ---------------------------------------------------------------------------
+
+// Reproducible on both sides and non-uniform: a constant input would make the
+// softmaxes uniform and stop the output depending on the tensor under test.
+float pattern(std::size_t index, std::uint32_t seed) {
+  std::uint32_t h = static_cast<std::uint32_t>(index) * 2654435761u + seed * 40503u;
+  h ^= h >> 15;
+  return static_cast<float>(h % 1000u) / 500.0f - 1.0f;
+}
+
+class LoadedEngine {
+ public:
+  LoadedEngine() = default;
+  LoadedEngine(const LoadedEngine&) = delete;
+  LoadedEngine& operator=(const LoadedEngine&) = delete;
+
+  ~LoadedEngine() {
+    if (handle_ != nullptr) {
+      backend_.destroy(handle_);
+    }
+    cudaFree(device_in_);
+    cudaFree(device_out_);
+  }
+
+  // Loads the blob through the backend, capturing whatever the shared-scratch
+  // option is set to at this moment. `batch`/`rows`/`cols` must be a shape the
+  // blob's profile admits; `batch` may be 0, which allocates nothing and leaves
+  // both device pointers null, a state an empty ExecuTorch tensor can arrive in.
+  Error load(
+      const std::vector<std::uint8_t>& blob,
+      std::uint32_t seed,
+      int rows = kRows,
+      int cols = kCols,
+      int batch = 1) {
+    batch_ = static_cast<SizesType>(batch);
+    rows_ = static_cast<SizesType>(rows);
+    cols_ = static_cast<SizesType>(cols);
+    std::vector<float> host_in(elems());
+    for (std::size_t i = 0; i < elems(); ++i) {
+      host_in[i] = pattern(i, seed);
+    }
+    if (bytes() > 0) {
+      if (cudaMalloc(&device_in_, bytes()) != cudaSuccess || cudaMalloc(&device_out_, bytes()) != cudaSuccess) {
+        return Error::MemoryAllocationFailed;
+      }
+      if (cudaMemcpy(device_in_, host_in.data(), bytes(), cudaMemcpyHostToDevice) != cudaSuccess) {
+        return Error::Internal;
+      }
+    }
+
+    arena_storage_.resize(kArenaBytes);
+    arena_ = std::make_unique<MemoryAllocator>(static_cast<std::uint32_t>(kArenaBytes), arena_storage_.data());
+    BackendInitContext init_context(arena_.get());
+    FreeableBuffer processed(blob.data(), blob.size(), nullptr);
+    const auto result = backend_.init(init_context, &processed, ArrayRef<CompileSpec>{});
+    if (!result.ok()) {
+      return result.error();
+    }
+    handle_ = result.get();
+    return Error::Ok;
+  }
+
+  bool fill_output(float value) {
+    if (bytes() == 0) {
+      return true;
+    }
+    const std::vector<float> host(elems(), value);
+    return cudaMemcpy(device_out_, host.data(), bytes(), cudaMemcpyHostToDevice) == cudaSuccess;
+  }
+
+  // Runs one inference on `stream`. Returns without waiting for the enqueue,
+  // which is the state the pool's handoff exists to order.
+  Error run(cudaStream_t stream) {
+    return run_with_input(stream, device_in_);
+  }
+
+  // The same run with no CallerStreamGuard, which is one of the four things that
+  // make execute() synchronize the stream before returning. It is the one a memory
+  // measurement can use: the other three each need a buffer this fixture does not
+  // otherwise allocate -- a host-backed input or output, which execute() stages
+  // through a device buffer of its own, or an extra output EValue for an aliased
+  // output -- and the growth measurement would read those alongside the pool. The
+  // enqueue goes on cudaStreamPerThread, which is not ordered against any stream
+  // created cudaStreamNonBlocking.
+  Error run_on_the_synchronized_path() {
+    return run_with_input(nullptr, device_in_, /*scope_a_caller_stream=*/false);
+  }
+
+  // The same run with the input bound to caller-owned host memory, which
+  // execute() stages through a device buffer of its own instead of binding
+  // directly. The output stays device-resident, so the only staging is the
+  // input's. `host_in` must hold bytes() bytes.
+  Error run_from_host_input(cudaStream_t stream, void* host_in) {
+    return run_with_input(stream, host_in);
+  }
+
+  // The same run with the output bound to caller-owned host memory as well, which
+  // execute() also stages through a device buffer of its own -- and allocates that
+  // buffer on the first call that needs it -- which, with the device full, is the
+  // only failure this suite can force after the input's staging copy has been
+  // queued. Both pointers must hold bytes() bytes.
+  Error run_from_host_input_to_host_output(cudaStream_t stream, void* host_in, void* host_out) {
+    return run_with_input(stream, host_in, /*scope_a_caller_stream=*/true, host_out);
+  }
+
+  // Where execute() staged this handle's input, or null if it never had to.
+  void* staging_buffer_for_input_0() const {
+    const EngineHandle* const h = handle();
+    return h->cached_input_ptrs.empty() ? nullptr : h->cached_input_ptrs[0];
+  }
+
+  std::vector<float> read_output() const {
+    std::vector<float> host_out(elems());
+    if (bytes() > 0 && cudaMemcpy(host_out.data(), device_out_, bytes(), cudaMemcpyDeviceToHost) != cudaSuccess) {
+      host_out.clear();
+    }
+    return host_out;
+  }
+
+  const EngineHandle* handle() const {
+    return static_cast<const EngineHandle*>(handle_);
+  }
+
+  // The execution context execute() configures and enqueues on, so a test can
+  // watch what the delegate does to it.
+  nvinfer1::IExecutionContext* context() const {
+    return static_cast<EngineHandle*>(handle_)->exec_ctx.get();
+  }
+
+  std::size_t elems() const {
+    return static_cast<std::size_t>(batch_) * static_cast<std::size_t>(rows_) * static_cast<std::size_t>(cols_);
+  }
+
+  std::size_t bytes() const {
+    return elems() * sizeof(float);
+  }
+
+ private:
+  // With `scope_a_caller_stream` false no CallerStreamGuard is scoped and `stream`
+  // is unread: execute() then finds no caller stream, enqueues on
+  // cudaStreamPerThread and synchronizes before returning. A null `out_ptr` means
+  // this handle's own device-resident output.
+  Error run_with_input(cudaStream_t stream, void* in_ptr, bool scope_a_caller_stream = true, void* out_ptr = nullptr) {
+    // Separate arrays: execute() resizes the output tensor to the shape TensorRT
+    // inferred, which writes through whichever array that tensor was given.
+    SizesType in_sizes[3] = {batch_, rows_, cols_};
+    SizesType out_sizes[3] = {batch_, rows_, cols_};
+    ::executorch::aten::TensorImpl in_impl(ScalarType::Float, 3, in_sizes, in_ptr);
+    ::executorch::aten::TensorImpl out_impl(
+        ScalarType::Float, 3, out_sizes, out_ptr != nullptr ? out_ptr : device_out_);
+    ::executorch::aten::Tensor in_tensor(&in_impl);
+    ::executorch::aten::Tensor out_tensor(&out_impl);
+    EValue in_value(in_tensor);
+    EValue out_value(out_tensor);
+    EValue* args[2] = {&in_value, &out_value};
+
+    BackendExecutionContext exec_context;
+    if (!scope_a_caller_stream) {
+      return backend_.execute(exec_context, handle_, Span<EValue*>(args, 2));
+    }
+    ::executorch::extension::cuda::CallerStreamGuard guard(stream);
+    return backend_.execute(exec_context, handle_, Span<EValue*>(args, 2));
+  }
+
+  // EngineHandle is placement-newed into this arena by init(), and the arena is
+  // never reset, so it only has to hold one instance.
+  static constexpr std::size_t kArenaBytes = 4096;
+
+  TensorRTBackend backend_;
+  std::vector<std::uint8_t> arena_storage_;
+  std::unique_ptr<MemoryAllocator> arena_;
+  DelegateHandle* handle_ = nullptr;
+  void* device_in_ = nullptr;
+  void* device_out_ = nullptr;
+  SizesType batch_ = 1;
+  SizesType rows_ = kRows;
+  SizesType cols_ = kCols;
+};
+
+// Sets `out` to the device-wide bytes in use, or returns false leaving it alone.
+// It reports the failure rather than substituting a figure because both callers
+// subtract two of these: a zero for the first reading of a pair makes the second
+// look like the whole cost of what was measured between them, which is a pass.
+bool device_bytes_in_use(std::size_t& out) {
+  std::size_t free_bytes = 0;
+  std::size_t total_bytes = 0;
+  if (cudaMemGetInfo(&free_bytes, &total_bytes) != cudaSuccess) {
+    return false;
+  }
+  out = total_bytes - free_bytes;
+  return true;
+}
+
+// Takes device memory until an allocation of the size a caller names can no longer
+// succeed, and gives it all back when it goes out of scope. The only way to reach
+// an allocation failure inside execute() -- the pool's, or a staging buffer's --
+// from inside the process, and the reason it is held for as short a window as
+// possible: while it is up, every other process on this device is out of memory
+// too.
+class DeviceMemoryHog {
+ public:
+  DeviceMemoryHog() = default;
+  DeviceMemoryHog(const DeviceMemoryHog&) = delete;
+  DeviceMemoryHog& operator=(const DeviceMemoryHog&) = delete;
+
+  ~DeviceMemoryHog() {
+    release();
+  }
+
+  // Chunked from large to small, so a device with tens of gigabytes free is filled
+  // in a few dozen allocations rather than thousands.
+  bool leave_less_free_than(std::size_t bytes) {
+    for (std::size_t chunk = std::size_t{1} << 30; chunk >= (std::size_t{1} << 20); chunk /= 4) {
+      while (free_bytes_above(bytes)) {
+        void* block = nullptr;
+        if (cudaMalloc(&block, chunk) != cudaSuccess) {
+          cudaGetLastError();
+          break;
+        }
+        blocks_.push_back(block);
+      }
+    }
+    return !free_bytes_above(bytes);
+  }
+
+  void release() {
+    for (void* block : blocks_) {
+      cudaFree(block);
+    }
+    blocks_.clear();
+  }
+
+ private:
+  static bool free_bytes_above(std::size_t bytes) {
+    std::size_t free_bytes = 0;
+    std::size_t total_bytes = 0;
+    return cudaMemGetInfo(&free_bytes, &total_bytes) == cudaSuccess && free_bytes > bytes;
+  }
+
+  std::vector<void*> blocks_;
+};
+
+// Opens a live kUSER_MANAGED context over `blob`'s engine with one shape bound,
+// the state execute() installs a scratch buffer into. Held by the caller, unlike
+// measure_engine_scratch's, which is gone by the time it returns its figure.
+struct LiveContext {
+  TRTUniquePtr<nvinfer1::IRuntime> runtime;
+  TRTUniquePtr<nvinfer1::ICudaEngine> engine;
+  TRTUniquePtr<nvinfer1::IExecutionContext> ctx;
+};
+
+bool open_user_managed_context(const std::vector<std::uint8_t>& blob, int rows, int cols, int batch, LiveContext& out) {
+  static BuilderLogger logger;
+  TensorRTBlobHeader header;
+  if (!TensorRTBlobHeader::parse(blob.data(), blob.size(), header)) {
+    return false;
+  }
+  out.runtime.reset(nvinfer1::createInferRuntime(logger));
+  if (out.runtime == nullptr) {
+    return false;
+  }
+  out.engine.reset(
+      out.runtime->deserializeCudaEngine(TensorRTBlobHeader::engine_data(blob.data(), header), header.engine_size));
+  if (out.engine == nullptr) {
+    return false;
+  }
+  out.ctx.reset(out.engine->createExecutionContext(nvinfer1::ExecutionContextAllocationStrategy::kUSER_MANAGED));
+  if (out.ctx == nullptr) {
+    return false;
+  }
+  return out.ctx->setInputShape("input_0", nvinfer1::Dims3{batch, rows, cols});
+}
+
+// Counts the reference-count calls TensorRT makes on a recorder as it attaches
+// and detaches one, which is how a test attached to the delegate's own context
+// sees install_pooled_scratch scope its recorder over the install.
+//
+// TensorRT documents setErrorRecorder as calling incRefCount on the recorder it
+// takes and decRefCount on the one it replaces, and it does. That makes the count
+// this starts at load-bearing rather than incidental: it starts at zero, so the
+// reference TensorRT takes at the attach is the only one, which is the shape
+// IErrorRecorder's documentation describes and TensorRT's own samples use -- a
+// recorder handed to TensorRT and destroyed when the count returns to zero. A
+// recorder that kept a reference of its own would never reach zero however the
+// install swapped it, and `reached_zero` below would report nothing.
+class CountingErrorRecorder final : public nvinfer1::IErrorRecorder {
+ public:
+  int32_t getNbErrors() const noexcept override {
+    return 0;
+  }
+  nvinfer1::ErrorCode getErrorCode(int32_t) const noexcept override {
+    return nvinfer1::ErrorCode::kSUCCESS;
+  }
+  ErrorDesc getErrorDesc(int32_t) const noexcept override {
+    return "";
+  }
+  bool hasOverflowed() const noexcept override {
+    return false;
+  }
+  void clear() noexcept override {}
+  bool reportError(nvinfer1::ErrorCode, ErrorDesc) noexcept override {
+    reported.fetch_add(1);
+    return false;
+  }
+  RefCount incRefCount() noexcept override {
+    reattached.fetch_add(1);
+    return ++refs_;
+  }
+  RefCount decRefCount() noexcept override {
+    detached.fetch_add(1);
+    const RefCount remaining = --refs_;
+    if (remaining <= 0) {
+      reached_zero.store(true);
+    }
+    return remaining;
+  }
+
+  void forget() {
+    reattached.store(0);
+    detached.store(0);
+    reported.store(0);
+    reached_zero.store(false);
+  }
+
+  std::atomic<int> reattached{0};
+  std::atomic<int> detached{0};
+  std::atomic<int> reported{0};
+  // Whether TensorRT ever left this recorder with no references. A recorder that
+  // deletes itself there -- the shape the interface documents -- would be gone.
+  std::atomic<bool> reached_zero{false};
+
+ private:
+  RefCount refs_ = 0;
+};
+
+// Set by a run that is supposed to have a GPU. A skip is then a failure, rather
+// than a green target that covered nothing.
+constexpr char kRequireCudaEnvVar[] = "TORCHTRT_EXECUTORCH_REQUIRE_CUDA";
+
+bool cuda_device_is_required() {
+  const char* const value = std::getenv(kRequireCudaEnvVar);
+  return value != nullptr && value[0] != '\0' && std::strcmp(value, "0") != 0;
+}
+
+Error set_shared_scratch(TensorRTBackend& backend, bool enabled) {
+  BackendOption option;
+  std::strncpy(option.key, kOptionKey, sizeof(option.key) - 1);
+  option.value = enabled;
+  BackendOption options[1] = {option};
+  BackendOptionContext context;
+  return backend.set_option(context, Span<BackendOption>(options, 1));
+}
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+class SharedScratchBackendTest : public ::testing::Test {
+ protected:
+  // Building the engine dominates the runtime of this target, so it is built
+  // once and every test loads the same blob.
+  static void SetUpTestSuite() {
+    ::executorch::runtime::runtime_init();
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+      return;
+    }
+    blob_ = build_engine_blob(true);
+    scratch_free_blob_ = build_engine_blob(false);
+    big_blob_ = build_engine_blob(true, kBigRows, kBigCols);
+    dynamic_blob_ = build_dynamic_batch_engine_blob();
+    if (blob_.empty() || scratch_free_blob_.empty() || big_blob_.empty() || dynamic_blob_.empty()) {
+      return;
+    }
+    scratch_bytes_ = measure_engine_scratch(blob_);
+    big_scratch_bytes_ = measure_engine_scratch(big_blob_, kBigRows, kBigCols);
+    empty_batch_scratch_bytes_ = measure_engine_scratch(dynamic_blob_, kDynRows, kDynCols, 0);
+    dynamic_batch_scratch_bytes_ = measure_engine_scratch(dynamic_blob_, kDynRows, kDynCols, kDynBatch);
+    scratch_free_engine_bytes_ = engine_scratch_requirement(scratch_free_blob_);
+    dynamic_engine_bytes_ = engine_scratch_requirement(dynamic_blob_);
+  }
+
+  static void TearDownTestSuite() {
+    report_the_second_reason_skips();
+    if (skipped_for_no_device_ == 0) {
+      return;
+    }
+    // Nothing skipped when the requirement is on -- SetUp counts the missing device
+    // and then fails the case. Printing here would put a skip banner under those
+    // failures and tell the reader to set the very variable that produced them.
+    if (cuda_device_is_required()) {
+      return;
+    }
+    const ::testing::TestSuite* const suite = ::testing::UnitTest::GetInstance()->current_test_suite();
+    std::fprintf(
+        stderr,
+        "[  SKIPPED ] %d of %d cases in this file: no CUDA device. Nothing here ran, so this target passing says "
+        "nothing about the shared activation scratch pool. Set %s=1 on a run that is meant to have a device and a "
+        "skip becomes a failure.\n",
+        skipped_for_no_device_,
+        suite == nullptr ? skipped_for_no_device_ : suite->total_test_count(),
+        kRequireCudaEnvVar);
+  }
+
+  void SetUp() override {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+      ++skipped_for_no_device_;
+      this_case_skipped_for_no_device_ = true;
+      if (cuda_device_is_required()) {
+        FAIL() << "no CUDA device, and " << kRequireCudaEnvVar
+               << " says this run must have one. Every case in this file needs a device, so without one the binary "
+                  "would exit zero having covered nothing.";
+      }
+      GTEST_SKIP() << "no CUDA device: the shared-scratch backend path is not covered by this run";
+    }
+    ASSERT_FALSE(blob_.empty()) << "TensorRT could not build the fixture engine";
+    ASSERT_FALSE(scratch_free_blob_.empty()) << "TensorRT could not build the scratch-free fixture engine";
+    ASSERT_FALSE(big_blob_.empty()) << "TensorRT could not build the larger fixture engine";
+    ASSERT_FALSE(dynamic_blob_.empty()) << "TensorRT could not build the dynamic-batch fixture engine";
+    ASSERT_EQ(set_shared_scratch(backend_, false), Error::Ok);
+    // The pool outlives every test in this file, and most of them depend on what
+    // it holds when they start: one expects a growth, one expects none, one
+    // expects a first allocation. Leaving it alone makes each of those depend on
+    // which cases ran before it, so the suite passes in declaration order and in
+    // no other -- running the empty-input case first turns the handoff test's
+    // first run into a growth, which is not the state that case is written for.
+    //
+    // Reported rather than waited out: a slot still in use here was left that way
+    // by the case before, and this case cannot run without the reset, so it fails
+    // now and says which state it found.
+    ASSERT_TRUE(reset_shared_scratch_pool_for_testing())
+        << "a device's pool slot still had its lock held when this case started, so an earlier case returned with a "
+           "claim outstanding and the pool could not be reset";
+  }
+
+  void TearDown() override {
+    record_a_second_reason_skip();
+    set_shared_scratch(backend_, false);
+    // Also here, so a buffer this test grew is not still resident while the next
+    // one measures device-wide memory.
+    ASSERT_TRUE(reset_shared_scratch_pool_for_testing())
+        << "this case left a device's pool slot with its lock held, so the pool could not be reset for the next one";
+  }
+
+  const std::vector<std::uint8_t>& blob() const {
+    return blob_;
+  }
+
+  const std::vector<std::uint8_t>& scratch_free_blob() const {
+    return scratch_free_blob_;
+  }
+
+  const std::vector<std::uint8_t>& big_blob() const {
+    return big_blob_;
+  }
+
+  const std::vector<std::uint8_t>& dynamic_blob() const {
+    return dynamic_blob_;
+  }
+
+  // Defined below, next to the cases that call them.
+  void run_a_growth_and_bound_what_it_cost(bool synchronized_path);
+  void run_a_growth_beside_parked_work(bool synchronized_path);
+
+  // A case can also skip for a reason the device being present says nothing about
+  // -- the device would not fill, its memory would not stay still, it has no
+  // stream-ordered allocator. Those skips are the difference between a green
+  // target and a run that covered what the cases are named for, and with
+  // --test_output=errors a passing target prints not one of them. So they are
+  // collected here and printed at the end whether or not the CUDA requirement is
+  // armed, which is the case the missing-device banner cannot cover.
+  void record_a_second_reason_skip() {
+    if (this_case_skipped_for_no_device_ || !::testing::Test::IsSkipped()) {
+      return;
+    }
+    const ::testing::TestInfo* const info = ::testing::UnitTest::GetInstance()->current_test_info();
+    if (info == nullptr) {
+      return;
+    }
+    std::string reason;
+    const ::testing::TestResult* const result = info->result();
+    for (int i = 0; result != nullptr && i < result->total_part_count(); ++i) {
+      const ::testing::TestPartResult& part = result->GetTestPartResult(i);
+      if (part.type() == ::testing::TestPartResult::kSkip) {
+        reason = part.summary();
+        break;
+      }
+    }
+    // The reason a case gives usually wraps, and one line per skip is what makes
+    // the report below readable.
+    for (char& c : reason) {
+      if (c == '\n') {
+        c = ' ';
+      }
+    }
+    while (!reason.empty() && reason.back() == ' ') {
+      reason.pop_back();
+    }
+    if (reason.empty()) {
+      reason = "no reason recorded";
+    }
+    second_reason_skips_.emplace_back(info->name(), reason);
+  }
+
+  static void report_the_second_reason_skips() {
+    if (second_reason_skips_.empty()) {
+      return;
+    }
+    const ::testing::TestSuite* const suite = ::testing::UnitTest::GetInstance()->current_test_suite();
+    std::fprintf(
+        stderr,
+        "[  SKIPPED ] %zu of %d cases in this file ran on a device but did not cover what they are named for, so this "
+        "target passing does not say the pool's growth, allocation-failure and queued-free paths were exercised:\n",
+        second_reason_skips_.size(),
+        suite == nullptr ? static_cast<int>(second_reason_skips_.size()) : suite->total_test_count());
+    for (const auto& skip : second_reason_skips_) {
+      std::fprintf(stderr, "[  SKIPPED ]   %s: %s\n", skip.first.c_str(), skip.second.c_str());
+    }
+  }
+
+  TensorRTBackend backend_;
+  static std::vector<std::uint8_t> blob_;
+  static std::vector<std::uint8_t> scratch_free_blob_;
+  static std::vector<std::uint8_t> big_blob_;
+  static std::vector<std::uint8_t> dynamic_blob_;
+  static std::size_t scratch_bytes_;
+  static std::size_t big_scratch_bytes_;
+  static std::size_t empty_batch_scratch_bytes_;
+  static std::size_t dynamic_batch_scratch_bytes_;
+  static std::int64_t scratch_free_engine_bytes_;
+  static std::int64_t dynamic_engine_bytes_;
+  static int skipped_for_no_device_;
+  static std::vector<std::pair<std::string, std::string>> second_reason_skips_;
+  bool this_case_skipped_for_no_device_ = false;
+};
+
+std::vector<std::uint8_t> SharedScratchBackendTest::blob_;
+std::vector<std::uint8_t> SharedScratchBackendTest::scratch_free_blob_;
+std::vector<std::uint8_t> SharedScratchBackendTest::big_blob_;
+std::vector<std::uint8_t> SharedScratchBackendTest::dynamic_blob_;
+std::size_t SharedScratchBackendTest::scratch_bytes_ = 0;
+std::size_t SharedScratchBackendTest::big_scratch_bytes_ = 0;
+std::size_t SharedScratchBackendTest::empty_batch_scratch_bytes_ = 0;
+std::size_t SharedScratchBackendTest::dynamic_batch_scratch_bytes_ = 0;
+std::int64_t SharedScratchBackendTest::scratch_free_engine_bytes_ = -1;
+std::int64_t SharedScratchBackendTest::dynamic_engine_bytes_ = -1;
+int SharedScratchBackendTest::skipped_for_no_device_ = 0;
+std::vector<std::pair<std::string, std::string>> SharedScratchBackendTest::second_reason_skips_;
+
+// ---------------------------------------------------------------------------
+// set_option
+// ---------------------------------------------------------------------------
+
+// The foreign key is sent from both settings, because from one of them the test
+// cannot tell a key that is ignored from a key that resets the setting to that
+// value.
+TEST_F(SharedScratchBackendTest, SetOptionAcceptsAKeyThisBackendDoesNotRead) {
+  BackendOption foreign;
+  std::strncpy(foreign.key, "some_other_backends_option", sizeof(foreign.key) - 1);
+  foreign.value = 7;
+  BackendOption options[1] = {foreign};
+  BackendOptionContext context;
+
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+  EXPECT_EQ(backend_.set_option(context, Span<BackendOption>(options, 1)), Error::Ok);
+  LoadedEngine after_on;
+  ASSERT_EQ(after_on.load(blob(), 1), Error::Ok);
+  EXPECT_TRUE(after_on.handle()->shared_scratch) << "a foreign key turned the shared-scratch setting off";
+
+  ASSERT_EQ(set_shared_scratch(backend_, false), Error::Ok);
+  EXPECT_EQ(backend_.set_option(context, Span<BackendOption>(options, 1)), Error::Ok);
+  LoadedEngine after_off;
+  ASSERT_EQ(after_off.load(blob(), 12), Error::Ok);
+  EXPECT_FALSE(after_off.handle()->shared_scratch) << "a foreign key turned the shared-scratch setting on";
+}
+
+TEST_F(SharedScratchBackendTest, SetOptionStoresTheBooleanItIsGiven) {
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+  LoadedEngine pooled;
+  ASSERT_EQ(pooled.load(blob(), 2), Error::Ok);
+  EXPECT_TRUE(pooled.handle()->shared_scratch);
+
+  ASSERT_EQ(set_shared_scratch(backend_, false), Error::Ok);
+  LoadedEngine priv;
+  ASSERT_EQ(priv.load(blob(), 3), Error::Ok);
+  EXPECT_FALSE(priv.handle()->shared_scratch);
+}
+
+TEST_F(SharedScratchBackendTest, SetOptionRejectsANonBooleanAndLeavesTheSettingAlone) {
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+
+  BackendOption wrong_type;
+  std::strncpy(wrong_type.key, kOptionKey, sizeof(wrong_type.key) - 1);
+  // The int has to coerce to the opposite of the setting above: one that coerced
+  // to the same value would leave the setting exactly where the assertion at the
+  // end expects to find it, whether it was rejected or not.
+  wrong_type.value = 0;
+  BackendOption options[1] = {wrong_type};
+  BackendOptionContext context;
+  EXPECT_EQ(backend_.set_option(context, Span<BackendOption>(options, 1)), Error::InvalidArgument);
+
+  LoadedEngine engine;
+  ASSERT_EQ(engine.load(blob(), 4), Error::Ok);
+  EXPECT_TRUE(engine.handle()->shared_scratch) << "a rejected option still moved the shared-scratch setting";
+}
+
+// The case above sends the bad entry on its own, where returning before the store
+// and storing before the return look the same. A span carrying a good entry ahead
+// of a bad one tells them apart, and it is the span a caller writes when it sets
+// several options at once.
+TEST_F(SharedScratchBackendTest, SetOptionRejectsASpanWithoutApplyingTheEntriesBeforeTheBadOne) {
+  ASSERT_EQ(set_shared_scratch(backend_, false), Error::Ok);
+
+  BackendOption turn_on;
+  std::strncpy(turn_on.key, kOptionKey, sizeof(turn_on.key) - 1);
+  turn_on.value = true;
+  // The same key again, so what the span asks for is unambiguous: this entry
+  // cannot be read as addressed to some other backend.
+  BackendOption wrong_type;
+  std::strncpy(wrong_type.key, kOptionKey, sizeof(wrong_type.key) - 1);
+  wrong_type.value = 1;
+  BackendOption options[2] = {turn_on, wrong_type};
+  BackendOptionContext context;
+
+  EXPECT_EQ(backend_.set_option(context, Span<BackendOption>(options, 2)), Error::InvalidArgument);
+
+  LoadedEngine engine;
+  ASSERT_EQ(engine.load(blob(), 28), Error::Ok);
+  EXPECT_FALSE(engine.handle()->shared_scratch)
+      << "a span that was refused still turned the pool on for every engine loaded after it";
+}
+
+// A context's allocation strategy is fixed when the context is created, so the
+// option cannot be re-read per call.
+TEST_F(SharedScratchBackendTest, EachEngineCapturesTheSettingInEffectAtItsOwnLoad) {
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+  LoadedEngine pooled;
+  ASSERT_EQ(pooled.load(blob(), 5), Error::Ok);
+
+  ASSERT_EQ(set_shared_scratch(backend_, false), Error::Ok);
+  LoadedEngine priv;
+  ASSERT_EQ(priv.load(blob(), 6), Error::Ok);
+
+  EXPECT_TRUE(pooled.handle()->shared_scratch);
+  EXPECT_FALSE(priv.handle()->shared_scratch);
+
+  cudaStream_t stream = nullptr;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+  EXPECT_EQ(pooled.run(stream), Error::Ok);
+  EXPECT_EQ(priv.run(stream), Error::Ok);
+  EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  EXPECT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+}
+
+// ---------------------------------------------------------------------------
+// The pooled execute() path
+// ---------------------------------------------------------------------------
+
+TEST_F(SharedScratchBackendTest, APooledEngineProducesWhatAPrivateScratchEngineProduces) {
+  cudaStream_t stream = nullptr;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+  LoadedEngine priv;
+  ASSERT_EQ(priv.load(blob(), 7), Error::Ok);
+  // Two arms on the same setting produce the same bytes whichever setting that
+  // is, so the comparison at the end is worth nothing unless each arm is pinned
+  // to the side it stands for.
+  ASSERT_FALSE(priv.handle()->shared_scratch);
+  ASSERT_EQ(priv.run(stream), Error::Ok);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  const std::vector<float> expected = priv.read_output();
+
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+  LoadedEngine pooled;
+  ASSERT_EQ(pooled.load(blob(), 7), Error::Ok);
+  ASSERT_TRUE(pooled.handle()->shared_scratch);
+  ASSERT_EQ(pooled.run(stream), Error::Ok);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  const std::vector<float> actual = pooled.read_output();
+
+  ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+
+  ASSERT_EQ(expected.size(), kElems);
+  ASSERT_EQ(actual.size(), kElems);
+  // A degenerate output would make the comparison above pass without depending
+  // on the engine having run.
+  bool varies = false;
+  for (std::size_t i = 1; i < kElems && !varies; ++i) {
+    varies = expected[i] != expected[0];
+  }
+  EXPECT_TRUE(varies) << "the reference output is constant, so the comparison proves nothing";
+  EXPECT_EQ(std::memcmp(expected.data(), actual.data(), kBytes), 0);
+}
+
+TEST_F(SharedScratchBackendTest, PooledEnginesShareOneActivationScratchAllocation) {
+  ASSERT_GE(scratch_bytes_, kMinMeasurableScratch)
+      << "the fixture engine reports " << scratch_bytes_
+      << " bytes of activation scratch, too little for the memory comparison to resolve";
+
+  cudaStream_t stream = nullptr;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+  // One load and run first, so the one-time TensorRT runtime and CUDA module
+  // allocations land outside both measurements.
+  {
+    LoadedEngine warmup;
+    ASSERT_EQ(warmup.load(blob(), 8), Error::Ok);
+    ASSERT_EQ(warmup.run(stream), Error::Ok);
+    ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  }
+
+  std::size_t private_cost = 0;
+  {
+    std::size_t before = 0;
+    ASSERT_TRUE(device_bytes_in_use(before)) << "cudaMemGetInfo failed, so this test measured nothing";
+    std::vector<std::unique_ptr<LoadedEngine>> engines;
+    for (int i = 0; i < kEngineCount; ++i) {
+      engines.push_back(std::make_unique<LoadedEngine>());
+      ASSERT_EQ(engines.back()->load(blob(), 9), Error::Ok);
+      ASSERT_EQ(engines.back()->run(stream), Error::Ok);
+    }
+    ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+    std::size_t after = 0;
+    ASSERT_TRUE(device_bytes_in_use(after)) << "cudaMemGetInfo failed, so this test measured nothing";
+    // The subtraction is unsigned, so a fall in device-wide usage would wrap it
+    // to a number that satisfies the comparison at the end for free.
+    ASSERT_GE(after, before) << "device-wide memory in use fell across the private-scratch measurement, so "
+                                "something outside this test is releasing memory on this device";
+    private_cost = after - before;
+  }
+
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+  std::size_t pooled_cost = 0;
+  {
+    std::size_t before = 0;
+    ASSERT_TRUE(device_bytes_in_use(before)) << "cudaMemGetInfo failed, so this test measured nothing";
+    std::vector<std::unique_ptr<LoadedEngine>> engines;
+    for (int i = 0; i < kEngineCount; ++i) {
+      engines.push_back(std::make_unique<LoadedEngine>());
+      ASSERT_EQ(engines.back()->load(blob(), 9), Error::Ok);
+      ASSERT_EQ(engines.back()->run(stream), Error::Ok);
+    }
+    ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+    std::size_t after = 0;
+    ASSERT_TRUE(device_bytes_in_use(after)) << "cudaMemGetInfo failed, so this test measured nothing";
+    ASSERT_GE(after, before) << "device-wide memory in use fell across the pooled measurement, so "
+                                "something outside this test is releasing memory on this device";
+    pooled_cost = after - before;
+  }
+
+  ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+
+  // Half the ideal saving, which leaves room for allocator granularity without
+  // admitting a run in which every context still carries its own scratch.
+  const std::size_t expected_saving = (kEngineCount - 1) * scratch_bytes_ / 2;
+  EXPECT_GE(private_cost, pooled_cost + expected_saving)
+      << kEngineCount << " engines cost " << private_cost << " bytes with private scratch and " << pooled_cost
+      << " pooled, against " << scratch_bytes_ << " bytes of scratch each";
+}
+
+// ---------------------------------------------------------------------------
+// Growing the pool
+// ---------------------------------------------------------------------------
+
+// Runs a four-times-larger engine after a smaller one to reach the growth path,
+// which nothing else in this file does, and bounds what the growth cost the
+// device.
+//
+// The reading is taken the moment execute() returns and *before* any synchronize
+// of this test's, which is what makes the upper bound mean something. A
+// stream-ordered free hands the bytes back only at the next synchronize of the
+// stream it was queued on, so a synchronize in between is exactly what would hide
+// a disposal that queued the free and left it. Measured on an A100 with CUDA 13.0:
+// cudaFreeAsync on a cudaMalloc'd pointer returns cudaSuccess and defers the free,
+// and the bytes come back at that synchronize and at no point before it -- a
+// stream cudaStreamQuery reports as drained still holds them. So a growth that
+// queued the free and returned costs the whole new buffer here rather than the
+// difference, and the upper bound below fails.
+//
+// The lower bound also fails if the pool were already large enough for the second
+// engine, which is how this test could otherwise pass vacuously. The fixture
+// empties the pool before each test, so it is the smaller engine's run below that
+// establishes the size the growth has to exceed.
+//
+// `synchronized_path` picks which kind of call grows the pool. The disposal is the
+// same either way and this is the same measurement pointed at each, which is the
+// point: the bound holds on a call whose own synchronize would have covered for a
+// free the pool did not finish, and on one that makes no synchronize at all.
+void SharedScratchBackendTest::run_a_growth_and_bound_what_it_cost(bool synchronized_path) {
+  ASSERT_GE(big_scratch_bytes_, scratch_bytes_ + kMinMeasurableScratch)
+      << "the two fixture engines ask for " << scratch_bytes_ << " and " << big_scratch_bytes_
+      << " bytes of activation scratch, too close for the growth to be measurable";
+
+  cudaStream_t stream = nullptr;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+  const auto run_one = [synchronized_path, stream](LoadedEngine& engine) {
+    return synchronized_path ? engine.run_on_the_synchronized_path() : engine.run(stream);
+  };
+
+  // Private-scratch references for both engines, and the run that pays the larger
+  // engine's one-time TensorRT and CUDA module costs so they land outside the
+  // measurement below.
+  std::vector<float> small_expected;
+  std::vector<float> big_expected;
+  {
+    LoadedEngine small_priv;
+    LoadedEngine big_priv;
+    ASSERT_EQ(small_priv.load(blob(), 15), Error::Ok);
+    ASSERT_EQ(big_priv.load(big_blob(), 16, kBigRows, kBigCols), Error::Ok);
+    ASSERT_FALSE(small_priv.handle()->shared_scratch);
+    ASSERT_FALSE(big_priv.handle()->shared_scratch);
+    ASSERT_EQ(run_one(small_priv), Error::Ok);
+    ASSERT_EQ(run_one(big_priv), Error::Ok);
+    ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+    small_expected = small_priv.read_output();
+    big_expected = big_priv.read_output();
+  }
+
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+  LoadedEngine small;
+  ASSERT_EQ(small.load(blob(), 15), Error::Ok);
+  ASSERT_TRUE(small.handle()->shared_scratch);
+  ASSERT_EQ(run_one(small), Error::Ok);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+  // Loaded before the measurement starts: its weights and its I/O are not part of
+  // what the growth costs.
+  LoadedEngine big;
+  ASSERT_EQ(big.load(big_blob(), 16, kBigRows, kBigCols), Error::Ok);
+  ASSERT_TRUE(big.handle()->shared_scratch);
+
+  std::size_t before = 0;
+  ASSERT_TRUE(device_bytes_in_use(before)) << "cudaMemGetInfo failed, so this test measured nothing";
+  const auto measurement_began = std::chrono::steady_clock::now();
+  ASSERT_EQ(run_one(big), Error::Ok);
+  // No synchronize between the growth and this reading: see the note above. The
+  // allocation and the whole disposal are host calls execute() makes and returns
+  // from, so what this reads is settled whether or not the enqueue has finished.
+  std::size_t after = 0;
+  ASSERT_TRUE(device_bytes_in_use(after)) << "cudaMemGetInfo failed, so this test measured nothing";
+  // A control window of the same length as the measurement, with nothing of this
+  // test's running in it. It is sampled before the synchronize below for the same
+  // reason the reading above is: a synchronize releases a free the growth only
+  // queued, so one taken inside this window would move `settled` away from `after`
+  // and turn the failure the bounds are meant to report into a skip. On a device
+  // this test has to itself, device-wide usage does not move across it; anything
+  // else means another process is moving memory on the same timescale as the
+  // growth, which is what makes the bounds below report a figure the pool did not
+  // produce. The same length matters: two readings taken back to back would sample
+  // microseconds against the growth's milliseconds and would miss almost
+  // everything. It is still a sample of a different window, so it narrows the
+  // misdiagnosis rather than removing it, and the upper bound names the cause as
+  // well. The exclusive tag keeps other Bazel actions off this device, not other
+  // processes.
+  //
+  // What counts as quiet is what the bounds below can absorb, rather than exact
+  // equality, which threw the whole measurement away for a byte. The tighter of
+  // the two bounds allows scratch_bytes_/2 of slack, so a control window that
+  // moved by at most half of that cannot turn what they report into something
+  // else, while anything large enough to matter still skips. The tolerance is for
+  // allocator granularity and not for a busy device: on a device this suite had to
+  // itself the window was measured moving 0 bytes against a tolerance of 8 MiB for
+  // these fixture engines, and a neighbour allocating at the scale they do moves it
+  // by far more than that.
+  std::this_thread::sleep_for(std::chrono::steady_clock::now() - measurement_began);
+  std::size_t settled = 0;
+  ASSERT_TRUE(device_bytes_in_use(settled)) << "cudaMemGetInfo failed, so this test measured nothing";
+  const std::size_t quiet_tolerance = scratch_bytes_ / 4;
+  const std::size_t control_window_moved_by = settled > after ? settled - after : after - settled;
+  const bool device_was_quiet = control_window_moved_by <= quiet_tolerance;
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  // Only something outside this test can make device-wide usage fall across a
+  // growth: the growth allocates the larger buffer before it disposes of the
+  // smaller one. It belongs with the skip below rather than being a failure of its
+  // own, for the reason that skip exists -- and it has to be answered before the
+  // subtraction, which is unsigned.
+  const bool device_gave_memory_back = after < before;
+  const std::size_t difference = big_scratch_bytes_ - scratch_bytes_;
+
+  // The pool must still serve the smaller engine after the growth moved the
+  // buffer: its context holds the address it was given on its previous call, and
+  // that address has been freed. This run is also the one place the suite installs
+  // a size below the pool's capacity, since that is what this engine's shapes
+  // need, so a size TensorRT refuses fails here.
+  ASSERT_TRUE(small.fill_output(kSentinel));
+  ASSERT_EQ(run_one(small), Error::Ok);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  const std::vector<float> small_actual = small.read_output();
+  const std::vector<float> big_actual = big.read_output();
+
+  ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+
+  ASSERT_EQ(big_expected.size(), big_actual.size());
+  ASSERT_FALSE(big_expected.empty());
+  EXPECT_EQ(std::memcmp(big_expected.data(), big_actual.data(), big_expected.size() * sizeof(float)), 0)
+      << "the engine that grew the pool did not produce what it produces with its own scratch";
+
+  ASSERT_EQ(small_expected.size(), kElems);
+  ASSERT_EQ(small_actual.size(), kElems);
+  EXPECT_NE(small_expected[0], kSentinel) << "the reference output is the sentinel, so a skipped enqueue would pass";
+  EXPECT_EQ(std::memcmp(small_expected.data(), small_actual.data(), kBytes), 0)
+      << "the smaller engine stopped producing its own output once the growth moved the shared buffer";
+
+  // Last, so the output comparisons above are made either way.
+  if (device_gave_memory_back) {
+    GTEST_SKIP() << "device-wide memory in use fell from " << before << " to " << after
+                 << " bytes across the growth, which a growth cannot do, so another process released memory on this "
+                    "device and the two bounds below would measure it rather than the growth";
+  }
+  if (!device_was_quiet) {
+    GTEST_SKIP() << "device-wide memory in use moved from " << after << " to " << settled << " bytes -- "
+                 << control_window_moved_by << " against a " << quiet_tolerance
+                 << "-byte tolerance -- with nothing of this test's running in between, so another process is "
+                    "allocating on this device and the two bounds below would measure it rather than the growth";
+  }
+  const std::size_t growth_cost = after - before;
+  EXPECT_GE(growth_cost, difference / 2) << "the larger engine cost " << growth_cost << " bytes against a "
+                                         << difference
+                                         << "-byte difference in requirement, so the pool did not grow for it";
+  EXPECT_LE(growth_cost, difference + scratch_bytes_ / 2)
+      << "the larger engine cost " << growth_cost << " bytes, about the whole " << big_scratch_bytes_
+      << "-byte buffer rather than the " << difference
+      << "-byte difference, so the buffer it replaced was still resident when execute() returned -- a free the growth "
+         "only queued, or none at all -- unless another process allocated on this device across the measurement, "
+         "which the control window above samples for and cannot rule out";
+}
+
+// The path this option exists for: a caller stream with device-resident I/O, so
+// execute() never synchronizes the stream. Nothing this test or the caller does
+// would ever release a free the pool left queued, so the bound here is the one
+// that says the pool finished it.
+TEST_F(SharedScratchBackendTest, ALargerEngineGrowsThePoolAndFreesTheBufferItReplaces) {
+  run_a_growth_and_bound_what_it_cost(/*synchronized_path=*/false);
+}
+
+// The other path, where execute() ends by synchronizing the stream. The bytes have
+// to be back by the time the call returns here too, and the same bound says so --
+// what this case adds is a growth beside a synchronize the disposal does not lean
+// on, since the disposal returns the bytes itself and runs before it.
+TEST_F(SharedScratchBackendTest, AGrowthOnASynchronizedCallFreesTheBufferItReplaces) {
+  run_a_growth_and_bound_what_it_cost(/*synchronized_path=*/true);
+}
+
+// ---------------------------------------------------------------------------
+// An engine that needs no activation scratch
+// ---------------------------------------------------------------------------
+
+// The pooled path branches on this flag, and it must separate the two fixture
+// networks or the branch is only ever taken one way below.
+TEST_F(SharedScratchBackendTest, EachEngineRecordsWhetherItClaimsFromThePool) {
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+  LoadedEngine needing;
+  LoadedEngine scratch_free;
+  ASSERT_EQ(needing.load(blob(), 12), Error::Ok);
+  ASSERT_EQ(scratch_free.load(scratch_free_blob(), 13), Error::Ok);
+
+  EXPECT_TRUE(needing.handle()->claims_pooled_scratch)
+      << "the two-softmax network reports no activation scratch of its own, so no test here reaches the pooled path";
+  EXPECT_FALSE(scratch_free.handle()->claims_pooled_scratch)
+      << "the pointwise chain reports activation scratch, so it no longer covers the scratch-free case";
+}
+
+// Turning the pool on must not turn an engine that legitimately needs no
+// activation scratch into a failure. Such an engine skips the pool altogether,
+// which is what the capacity check below pins.
+TEST_F(SharedScratchBackendTest, AnEngineNeedingNoActivationScratchRunsWithThePoolEnabled) {
+  ASSERT_EQ(scratch_free_engine_bytes_, 0) << "the fixture engine needs scratch, so this test covers nothing";
+
+  cudaStream_t stream = nullptr;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+  LoadedEngine priv;
+  ASSERT_EQ(priv.load(scratch_free_blob(), 14), Error::Ok);
+  ASSERT_TRUE(priv.fill_output(kSentinel));
+  ASSERT_EQ(priv.run(stream), Error::Ok);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  const std::vector<float> expected = priv.read_output();
+
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+  LoadedEngine pooled;
+  ASSERT_EQ(pooled.load(scratch_free_blob(), 14), Error::Ok);
+  ASSERT_TRUE(pooled.handle()->shared_scratch);
+  ASSERT_TRUE(pooled.fill_output(kSentinel));
+  EXPECT_EQ(pooled.run(stream), Error::Ok) << "the pool rejected an engine that needs no activation scratch";
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  EXPECT_EQ(shared_scratch_capacity_for_testing(pooled.handle()->device_id), 0u)
+      << "an engine that needs no activation scratch under any shape claimed the pool anyway";
+  const std::vector<float> actual = pooled.read_output();
+
+  ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+
+  ASSERT_EQ(expected.size(), kElems);
+  ASSERT_EQ(actual.size(), kElems);
+  // Without these two the comparison would be satisfied by an execute() that
+  // wrote nothing, and by a network whose output does not depend on its input.
+  EXPECT_NE(expected[0], kSentinel) << "the reference output is the sentinel, so a skipped enqueue would pass";
+  bool varies = false;
+  for (std::size_t i = 1; i < kElems && !varies; ++i) {
+    varies = expected[i] != expected[0];
+  }
+  EXPECT_TRUE(varies) << "the reference output is constant, so the comparison proves nothing";
+  EXPECT_EQ(std::memcmp(expected.data(), actual.data(), kBytes), 0);
+}
+
+// ---------------------------------------------------------------------------
+// An empty input to an engine that does need activation scratch
+// ---------------------------------------------------------------------------
+
+// An empty batch inside the profile is a valid call, and the per-shape query
+// answers it with the same zero it gives for a failed query, from an engine whose
+// own requirement is not zero. The three assertions at the top are what make this
+// the empty-input case rather than either of the others: an engine that needs
+// nothing would fail the second, and a measurement that could not read the engine
+// at all would fail the third.
+//
+// What the empty call must not do is size the pool for itself. The engine's own
+// profile-wide requirement, `dynamic_engine_bytes_`, is the figure a zero invites
+// installing, and it stands far above the `dynamic_batch_scratch_bytes_` the next
+// call actually needs; the pool never shrinks, so installing it would pin the pool
+// at many times that for the rest of the process. The empty call is therefore
+// checked twice, once against an empty pool and once against a pool holding a real
+// requirement, and neither may leave the pool above what a non-empty call asked
+// for. The capacity is read directly rather than inferred from device-wide
+// memory, which cannot resolve the difference reliably.
+TEST_F(SharedScratchBackendTest, AnEmptyInputRunsWithThePoolEnabled) {
+  ASSERT_EQ(empty_batch_scratch_bytes_, 0u)
+      << "an empty batch reports " << empty_batch_scratch_bytes_
+      << " bytes of activation scratch, so this test no longer covers a call whose per-shape query answers zero";
+  ASSERT_GT(dynamic_engine_bytes_, 0)
+      << "the dynamic fixture engine reports no activation scratch of its own, so the zero above is the "
+         "scratch-free case rather than the empty-input one";
+  ASSERT_GT(dynamic_batch_scratch_bytes_, 0u) << "the same engine reports no activation scratch at batch " << kDynBatch
+                                              << " either, so the zero above says nothing about the batch being empty";
+
+  cudaStream_t stream = nullptr;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+  // The non-empty reference is taken with private scratch, so the pooled run
+  // below has something to be compared against that the pool did not produce.
+  LoadedEngine priv;
+  ASSERT_EQ(priv.load(dynamic_blob(), 19, kDynRows, kDynCols, kDynBatch), Error::Ok);
+  ASSERT_FALSE(priv.handle()->shared_scratch);
+  ASSERT_TRUE(priv.fill_output(kSentinel));
+  ASSERT_EQ(priv.run(stream), Error::Ok);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  const std::vector<float> expected = priv.read_output();
+
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+  LoadedEngine empty;
+  ASSERT_EQ(empty.load(dynamic_blob(), 19, kDynRows, kDynCols, 0), Error::Ok);
+  ASSERT_TRUE(empty.handle()->shared_scratch);
+  const int device = empty.handle()->device_id;
+  ASSERT_EQ(shared_scratch_capacity_for_testing(device), 0u)
+      << "the fixture left the pool holding something, so an empty call adding nothing to it proves nothing";
+  EXPECT_EQ(empty.run(stream), Error::Ok) << "the pool rejected an empty input to an engine that needs scratch";
+  EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  // Not zero: enqueueV3 refuses this context with no device memory installed
+  // whatever the bound shapes need, so the pool has to allocate something. What it
+  // must not do is take the engine's word for how much.
+  const std::size_t after_empty = shared_scratch_capacity_for_testing(device);
+  // Pinned to the exact figure rather than bounded below the 131072 bytes the next
+  // call needs, because a bound that loose is met by any minimum up to 128 KiB and
+  // the point of the minimum is that it is the smallest thing enqueueV3 accepts.
+  EXPECT_EQ(after_empty, 1u) << "an empty call against an empty pool took " << after_empty
+                             << " bytes rather than the one-byte kMinPooledScratchBytes; a zero means no buffer was "
+                                "installed, which TensorRT refuses for this engine, and anything larger means the "
+                                "call sized the pool from a figure of its own";
+
+  // The same engine on a shape that does need scratch, after the empty call, so a
+  // pool the empty call left in an unusable state is not left untested.
+  LoadedEngine pooled;
+  ASSERT_EQ(pooled.load(dynamic_blob(), 19, kDynRows, kDynCols, kDynBatch), Error::Ok);
+  ASSERT_TRUE(pooled.handle()->shared_scratch);
+  ASSERT_TRUE(pooled.fill_output(kSentinel));
+  EXPECT_EQ(pooled.run(stream), Error::Ok);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  const std::vector<float> actual = pooled.read_output();
+  const std::size_t after_non_empty = shared_scratch_capacity_for_testing(device);
+  EXPECT_EQ(after_non_empty, dynamic_batch_scratch_bytes_)
+      << "the pool holds " << after_non_empty << " bytes after a call needing " << dynamic_batch_scratch_bytes_
+      << ", so it was not sized to what that call asked for";
+
+  // A second empty call, now that the pool holds a real requirement: it must be
+  // handed that buffer rather than grow the pool to the engine's profile-wide one.
+  ASSERT_EQ(empty.run(stream), Error::Ok);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  EXPECT_EQ(shared_scratch_capacity_for_testing(device), after_non_empty)
+      << "the empty call grew the pool from " << after_non_empty << " bytes, against the " << dynamic_engine_bytes_
+      << " bytes this engine reports over its whole profile";
+
+  ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+
+  const std::size_t dyn_elems =
+      static_cast<std::size_t>(kDynBatch) * static_cast<std::size_t>(kDynRows) * static_cast<std::size_t>(kDynCols);
+  ASSERT_EQ(expected.size(), dyn_elems);
+  ASSERT_EQ(actual.size(), dyn_elems);
+  // Without these two the comparison would be satisfied by an execute() that
+  // wrote nothing, and by a network whose output does not depend on its input.
+  EXPECT_NE(expected[0], kSentinel) << "the reference output is the sentinel, so a skipped enqueue would pass";
+  bool varies = false;
+  for (std::size_t i = 1; i < dyn_elems && !varies; ++i) {
+    varies = expected[i] != expected[0];
+  }
+  EXPECT_TRUE(varies) << "the reference output is constant, so the comparison proves nothing";
+  EXPECT_EQ(std::memcmp(expected.data(), actual.data(), dyn_elems * sizeof(float)), 0);
+}
+
+// The install is what separates the two causes of a zero from the per-shape
+// query. Both reach execute() as a zero and neither is asked to size the pool, so
+// both can be handed a buffer as small as one byte; only one of them is safe with
+// it. Where the bound shapes genuinely need nothing the engine expects nothing
+// and the one-byte buffer is accepted. Where the query failed the engine expects what it
+// always did, TensorRT refuses the install through a call that returns void, and
+// the context keeps the buffer it was last given -- which a growth may already
+// have freed, and enqueueV3 then reports success while the engine reads and
+// writes memory the pool no longer owns.
+//
+// The failed query itself cannot be induced from inside this process, so what is
+// pinned here is the check that catches its consequence, over the same TensorRT
+// call execute() makes.
+TEST_F(SharedScratchBackendTest, AnUndersizedScratchInstallIsSeenAsRefused) {
+  LiveContext needs_scratch;
+  ASSERT_TRUE(open_user_managed_context(blob(), kRows, kCols, 1, needs_scratch))
+      << "could not open a user-managed context over the fixture engine";
+  const std::size_t need = needs_scratch.ctx->updateDeviceMemorySizeForShapes();
+  ASSERT_GT(need, 1u) << "the fixture engine needs no more than one byte of activation scratch for this shape, so an "
+                         "undersized install cannot be built out of it";
+
+  void* enough = nullptr;
+  ASSERT_EQ(cudaMalloc(&enough, need), cudaSuccess);
+  EXPECT_TRUE(install_pooled_scratch(*needs_scratch.ctx, enough, need, 0))
+      << "a buffer of exactly what the bound shapes need was reported as refused, which would fail every pooled call";
+
+  void* one_byte = nullptr;
+  ASSERT_EQ(cudaMalloc(&one_byte, 1), cudaSuccess);
+  EXPECT_FALSE(install_pooled_scratch(*needs_scratch.ctx, one_byte, 1, 0))
+      << "TensorRT refused a one-byte buffer for a context expecting " << need
+      << " bytes and the backend read the install as accepted, so the enqueue would run on the buffer installed "
+         "before it";
+
+  // The safe cause, which has to keep working: an empty batch expects nothing, so
+  // the one-byte buffer is accepted and no refusal may be invented for it.
+  LiveContext empty_batch;
+  ASSERT_TRUE(open_user_managed_context(dynamic_blob(), kDynRows, kDynCols, 0, empty_batch));
+  ASSERT_EQ(empty_batch.ctx->updateDeviceMemorySizeForShapes(), 0u)
+      << "an empty batch does not answer zero for this engine, so this half covers nothing";
+  EXPECT_TRUE(install_pooled_scratch(*empty_batch.ctx, one_byte, 1, 0))
+      << "the one-byte buffer an empty call is handed was reported as refused, which would fail a call that is safe";
+
+  EXPECT_EQ(cudaFree(enough), cudaSuccess);
+  EXPECT_EQ(cudaFree(one_byte), cudaSuccess);
+}
+
+// The recorder the install swaps out is the caller's, and swapping it must not
+// destroy it. TensorRT drops a reference on the recorder it replaces and takes
+// one again on the restore, so a recorder whose only reference is TensorRT's
+// reaches zero in between -- and destroying an error recorder once its count
+// reaches zero is what IErrorRecorder's documentation describes and what
+// TensorRT's samples do. Such a recorder is freed by the install and
+// re-registered dangling by the restore, once per pooled call, with nothing
+// reported by either TensorRT or the delegate.
+//
+// Driven over install_pooled_scratch rather than through execute() because what
+// has to hold is a property of the swap rather than of the call around it, and
+// every pooled call makes exactly this one swap.
+TEST_F(SharedScratchBackendTest, AnInstallKeepsAReferenceOnTheRecorderItSwapsOut) {
+  // Declared before the context so it outlives it: the context drops its
+  // reference on this recorder as it is destroyed.
+  CountingErrorRecorder recorder;
+  LiveContext live;
+  ASSERT_TRUE(open_user_managed_context(blob(), kRows, kCols, 1, live))
+      << "could not open a user-managed context over the fixture engine";
+  const std::size_t need = live.ctx->updateDeviceMemorySizeForShapes();
+  ASSERT_GT(need, 0u) << "the fixture engine needs no activation scratch for this shape, so there is no install to "
+                         "swap a recorder around";
+
+  void* buffer = nullptr;
+  ASSERT_EQ(cudaMalloc(&buffer, need), cudaSuccess);
+
+  live.ctx->setErrorRecorder(&recorder);
+  ASSERT_EQ(recorder.reattached.load(), 1)
+      << "TensorRT did not take a reference on the recorder it was handed, so this recorder does not stand in for one "
+         "whose only reference is TensorRT's and nothing below means anything";
+  recorder.forget();
+
+  EXPECT_TRUE(install_pooled_scratch(*live.ctx, buffer, need, 0))
+      << "a buffer of exactly what the bound shapes need was reported as refused";
+
+  ASSERT_GT(recorder.detached.load(), 0)
+      << "the install never displaced the recorder attached to the context, so it made no swap for this case to watch";
+  EXPECT_FALSE(recorder.reached_zero.load())
+      << "the install left the caller's recorder with no references before putting it back, so a recorder of the shape "
+         "TensorRT documents deletes itself at the install and the restore then re-registers freed memory -- once per "
+         "pooled call";
+
+  EXPECT_EQ(cudaFree(buffer), cudaSuccess);
+}
+
+// The two cases above drive install_pooled_scratch directly, which leaves
+// execute() free to stop calling it: replacing the checked call with a bare
+// setDeviceMemoryV2 installs the same buffer, produces the same output and drops
+// only the refusal, so every other case here stays green.
+//
+// Forcing the refusal itself through execute() is not available. The size
+// execute() installs is what the per-shape query just returned, over a buffer the
+// pool has grown to at least that, so the installed size is never short of what
+// the context expects. Only a failed query makes the two disagree, and that
+// cannot be induced from inside this process.
+//
+// Nor is the choice between that size and the pool's capacity observable through
+// TensorRT: an install larger than the context expects is accepted in silence, so
+// no black-box case here can tell the two apart, and the argument for the smaller
+// one is the hazard it removes rather than anything a test can read back. What the
+// suite does see is the other direction -- ALargerEngineGrowsThePoolAndFreesTheBufferItReplaces
+// runs the smaller engine again after the growth, so its install is smaller than
+// the capacity, and a size TensorRT would not accept fails that case.
+//
+// What is observable is the recorder. install_pooled_scratch attaches one for
+// the duration of the install and restores the previous one after, because that
+// is the only channel TensorRT reports a refusal on. A recorder this test leaves
+// on the delegate's context therefore sees itself replaced and put back exactly
+// once per pooled run, and sees nothing at all if the install stops going
+// through the helper.
+TEST_F(SharedScratchBackendTest, ExecuteInstallsPooledScratchThroughTheCheckedHelper) {
+  // Declared before the engine so it outlives the context TensorRT attaches it
+  // to: the context decrements this recorder's count as it is destroyed.
+  CountingErrorRecorder recorder;
+
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+  cudaStream_t stream = nullptr;
+  ASSERT_EQ(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), cudaSuccess);
+
+  LoadedEngine pooled;
+  ASSERT_EQ(pooled.load(blob(), 25), Error::Ok);
+  ASSERT_TRUE(pooled.handle()->shared_scratch);
+  ASSERT_TRUE(pooled.handle()->claims_pooled_scratch)
+      << "this engine skips the pool, so its execute() makes no install for this case to watch";
+  pooled.context()->setErrorRecorder(&recorder);
+
+  recorder.forget();
+  ASSERT_EQ(pooled.run(stream), Error::Ok);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+  // Two of each and not one: TensorRT drops a reference on the recorder it
+  // replaces and takes it again on the restore, and the install holds one of its
+  // own across the swap so that the caller's recorder cannot reach zero in
+  // between -- AnInstallKeepsAReferenceOnTheRecorderItSwapsOut is that half.
+  EXPECT_EQ(recorder.detached.load(), 2)
+      << "a pooled execute() did not replace the context's error recorder, so its activation-scratch install was not "
+         "the checked one and a refusal by TensorRT would go unread";
+  EXPECT_EQ(recorder.reattached.load(), 2)
+      << "the recorder the caller had attached was not put back after the install, so TensorRT's diagnostics for the "
+         "rest of the call go somewhere the caller did not ask for";
+  EXPECT_EQ(pooled.context()->getErrorRecorder(), &recorder)
+      << "execute() left an error recorder of its own attached to the context";
+  EXPECT_EQ(recorder.reported.load(), 0)
+      << "TensorRT reported an error to the caller's recorder during a run that succeeded";
+
+  ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+}
+
+// Every pooled path out of execute() that is not the happy one returns while the
+// claim still holds the device's lock, and leaves the claim's destructor to drop
+// it. Nothing else here takes one of those paths, and the failure a regression
+// there produces is not a wrong answer: it is every later pooled call on the
+// device blocking forever with nothing logged.
+//
+// Only one of them can be reached from inside the process. A refused install needs
+// the pool to hold less than the context expects, which it never does; a failed
+// enqueue and a failed completion record need TensorRT or CUDA to fail a call that
+// is correct as made. The pool's own allocation can be made to fail by taking the
+// device's memory first, and it returns through the same destructor as the others.
+//
+// What it reaches is the lock the destructor drops, not the buffer it disposes
+// of: an allocation that failed retired nothing, so this case leaves the
+// destructor with none to free. Nothing in this suite reaches a bail-out that
+// still holds a retired buffer, since the two returns that can are the two named
+// above. What keeps that path right is the shape of release() rather than a case:
+// it takes no argument, and the disposal is the same three steps on every path --
+// wait on the host for the enqueue the handoff event names, cudaFreeAsync on the
+// pool's stream, synchronize that stream. It never asks what kind of call it is,
+// so a bail-out gets the same disposal as a happy return and there is no promise
+// recorded at the claim for a later return to leave stale.
+TEST_F(SharedScratchBackendTest, AFailedPooledAllocationLeavesTheDeviceLockFreeAndNothingPending) {
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+
+  cudaStream_t stream = nullptr;
+  ASSERT_EQ(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), cudaSuccess);
+
+  LoadedEngine pooled;
+  ASSERT_EQ(pooled.load(blob(), 31), Error::Ok);
+  ASSERT_TRUE(pooled.handle()->shared_scratch);
+  ASSERT_TRUE(pooled.handle()->claims_pooled_scratch) << "this engine skips the pool, so it never allocates from it";
+  const int device_id = pooled.handle()->device_id;
+  ASSERT_EQ(shared_scratch_capacity_for_testing(device_id), 0u)
+      << "the pool already holds a buffer, so this call would reuse it rather than allocate";
+
+  Error failed_run = Error::Ok;
+  cudaError_t pending_after_the_failure = cudaSuccess;
+  {
+    DeviceMemoryHog hog;
+    if (!hog.leave_less_free_than(scratch_bytes_)) {
+      ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+      GTEST_SKIP() << "could not take the device below the " << scratch_bytes_
+                   << " bytes this engine's scratch needs, so its allocation would have succeeded";
+    }
+    // The hog clears the last failed allocation of its own, and nothing else has
+    // made a CUDA call since, so whatever is pending after the run below was left
+    // by the run.
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess) << "something before the call under test left a CUDA error pending";
+    failed_run = pooled.run(stream);
+    pending_after_the_failure = cudaPeekAtLastError();
+  }
+
+  if (failed_run == Error::Ok) {
+    ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+    ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+    GTEST_SKIP() << "the pooled allocation succeeded with the device full, so this run did not take the path under "
+                    "test";
+  }
+  ASSERT_EQ(failed_run, Error::MemoryAllocationFailed)
+      << "the run failed somewhere other than the pool's allocation, so it says nothing about that path";
+
+  SharedScratchDevice& dev = scratch_pool().get(device_id);
+  const bool lock_free = dev.mu.try_lock();
+  if (lock_free) {
+    dev.mu.unlock();
+  }
+  ASSERT_TRUE(lock_free) << "a pooled call that returned early left the device's pool lock held, so every later pooled "
+                            "call on this device blocks forever";
+
+  // The failure is reported by the return value, so the CUDA error the pool's own
+  // cudaMalloc left has to be cleared where it was made. Left pending it is
+  // collected by whichever caller makes the next CUDA call on this thread and
+  // reported under that call's name -- which is what the capture refusal has its
+  // own case for, from the other direction.
+  EXPECT_EQ(pending_after_the_failure, cudaSuccess)
+      << "the pooled call left '" << cudaGetErrorString(pending_after_the_failure)
+      << "' pending on this thread after reporting the failure through its return value, so the next CUDA call any "
+         "caller makes collects the pool's error as its own";
+  cudaGetLastError();
+
+  // And the slot is still usable, not merely unlocked: with the memory back, the
+  // next call allocates and runs.
+  ASSERT_TRUE(pooled.fill_output(kSentinel));
+  EXPECT_EQ(pooled.run(stream), Error::Ok) << "the pool was left unusable by a call whose allocation failed";
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  const std::vector<float> actual = pooled.read_output();
+  ASSERT_EQ(actual.size(), kElems);
+  EXPECT_NE(actual[0], kSentinel) << "the engine did not write its output, so the run above did not reach it";
+
+  ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+}
+
+// ---------------------------------------------------------------------------
+// Stream capture
+// ---------------------------------------------------------------------------
+
+// The refusal clears the CUDA error state only when the capture query itself
+// failed, because then the error is the query's own. On the ordinary refusal --
+// the query succeeded and reported a capture -- whatever is pending was left by
+// earlier work on this thread, and clearing it takes it away from the caller,
+// which learns of it from no later call either: the error is not sticky.
+TEST_F(SharedScratchBackendTest, ARefusedPooledCallLeavesTheCallersPendingCudaErrorAlone) {
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+
+  cudaStream_t stream = nullptr;
+  ASSERT_EQ(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), cudaSuccess);
+
+  LoadedEngine pooled;
+  ASSERT_EQ(pooled.load(blob(), 32), Error::Ok);
+  ASSERT_TRUE(pooled.handle()->shared_scratch);
+
+  // An error of the caller's own, unread. Nothing but cudaGetLastError clears one,
+  // so it is still there when the refused call returns unless that call took it.
+  void* impossible = nullptr;
+  ASSERT_EQ(cudaMalloc(&impossible, static_cast<std::size_t>(1) << 62), cudaErrorMemoryAllocation);
+
+  ASSERT_EQ(cudaStreamBeginCapture(stream, cudaStreamCaptureModeRelaxed), cudaSuccess);
+  const Error refused = pooled.run(stream);
+  cudaGraph_t graph = nullptr;
+  const cudaError_t end_err = cudaStreamEndCapture(stream, &graph);
+  if (graph != nullptr) {
+    cudaGraphDestroy(graph);
+  }
+  // Read here, before any assertion can return early with it still pending and
+  // hand it to the next case.
+  const cudaError_t pending = cudaGetLastError();
+
+  ASSERT_EQ(refused, Error::NotSupported) << "the run was not refused, so it did not take the path under test";
+  EXPECT_EQ(end_err, cudaSuccess) << "the refused run invalidated the capture: " << cudaGetErrorString(end_err);
+  EXPECT_EQ(pending, cudaErrorMemoryAllocation)
+      << "the refusal cleared an error this backend did not cause, so the caller never sees it: got "
+      << cudaGetErrorString(pending);
+
+  ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+}
+
+// That execute() refuses a capturing stream, and where in execute() it does it.
+// Under the default Global mode the host wait on the previous enqueue, and further
+// down the cudaMalloc that grows a host-input staging buffer, are prohibited and
+// invalidate the capture where they stand. A refusal after either is a clean error
+// handed to a caller whose capture is already dead, which is the outcome the guard
+// exists to prevent. Relaxed mode could not tell the two apart: it permits
+// everything execute() does before it reaches the pool, so a guard sitting
+// anywhere ahead of the pool would look the same.
+//
+// The first run is what arms that wait -- it returns with its enqueue still in
+// flight, and the next call waits for it before touching the context. It also
+// leaves the pool holding a buffer with an enqueue recorded against it, so the
+// handoff wait the refusal protects is one this call would really have made.
+TEST_F(SharedScratchBackendTest, APooledEngineRefusesACaptureBeforeAnythingCanInvalidateIt) {
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+
+  cudaStream_t stream = nullptr;
+  ASSERT_EQ(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), cudaSuccess);
+  // A node of the caller's own, so a null graph below means the capture was
+  // invalidated rather than that nothing was ever captured.
+  void* captured_target = nullptr;
+  ASSERT_EQ(cudaMalloc(&captured_target, 16), cudaSuccess);
+
+  LoadedEngine pooled;
+  ASSERT_EQ(pooled.load(blob(), 21), Error::Ok);
+  ASSERT_TRUE(pooled.handle()->shared_scratch);
+  ASSERT_EQ(pooled.run(stream), Error::Ok);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  ASSERT_TRUE(pooled.handle()->inflight_pending)
+      << "the first run left no enqueue in flight, so the next call makes no host wait and this case pins nothing";
+  ASSERT_GT(shared_scratch_capacity_for_testing(pooled.handle()->device_id), 0u)
+      << "the pool holds nothing, so the run below has no handoff to wait on and the capture it is refused for was "
+         "never at risk";
+
+  ASSERT_EQ(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal), cudaSuccess);
+  ASSERT_EQ(cudaMemsetAsync(captured_target, 0, 16, stream), cudaSuccess);
+  const Error captured = pooled.run(stream);
+  cudaGraph_t graph = nullptr;
+  const cudaError_t end_err = cudaStreamEndCapture(stream, &graph);
+  const bool have_graph = graph != nullptr;
+  if (have_graph) {
+    cudaGraphDestroy(graph);
+  }
+
+  EXPECT_EQ(captured, Error::NotSupported)
+      << "execute() did not refuse a pooled run on a stream capturing in the default mode";
+  EXPECT_EQ(end_err, cudaSuccess) << "the refused run had already made a call the capture could not take: "
+                                  << cudaGetErrorString(end_err);
+  EXPECT_TRUE(have_graph) << "the capture ended with no graph, so the run invalidated it before refusing";
+
+  EXPECT_EQ(cudaFree(captured_target), cudaSuccess);
+  ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+}
+
+// ---------------------------------------------------------------------------
+// The enqueue handoff, single-threaded, two caller streams
+// ---------------------------------------------------------------------------
+
+struct StreamGate {
+  std::mutex mu;
+  std::condition_variable cv;
+  bool open = false;
+  // Set when the watchdog, not the test, had to open the gate.
+  std::atomic<bool> forced_open{false};
+};
+
+void CUDART_CB hold_stream(void* user_data) {
+  StreamGate* gate = static_cast<StreamGate*>(user_data);
+  std::unique_lock<std::mutex> lock(gate->mu);
+  gate->cv.wait(lock, [gate] { return gate->open; });
+}
+
+// Long enough to tell a wait on the stream carrying it from no wait at all, short
+// enough not to lengthen the suite.
+constexpr std::chrono::milliseconds kHostWorkOnTheCallerStream{1500};
+
+// Host work that runs on its own and needs no releasing, unlike hold_stream: what
+// it is for is measuring whether something waited for the stream carrying it, in
+// a place where a gate nothing opened would deadlock the teardown instead.
+void CUDART_CB sleep_on_the_stream(void*) {
+  std::this_thread::sleep_for(kHostWorkOnTheCallerStream);
+}
+
+// Long enough that the wait the test performs while the gate is shut, and the
+// two enqueues before it, are nowhere near it.
+constexpr std::chrono::seconds kGateWatchdog{60};
+
+// Opens the gate and waits for the held work to drain, by two routes because two
+// different things can go wrong. A held stream outlives any assertion that
+// returns early, and every teardown path below -- cudaFree, the delegate
+// destructor -- blocks on it, so the destructor opens the gate for a test that
+// does not reach its end. That is no help if a delegate call blocks on the held
+// stream instead of returning, since the calling thread then never runs the
+// destructor either: the watchdog covers that, and records that it had to, so
+// the outcome is a failure naming the cause rather than a process that never
+// exits.
+class GateRelease {
+ public:
+  GateRelease(StreamGate& gate, cudaStream_t stream)
+      : gate_(gate), stream_(stream), deadline_(std::chrono::steady_clock::now() + kGateWatchdog) {
+    watchdog_ = std::thread([this] {
+      std::unique_lock<std::mutex> lock(gate_.mu);
+      if (!gate_.cv.wait_until(lock, deadline_, [this] { return gate_.open; })) {
+        gate_.open = true;
+        gate_.forced_open.store(true);
+        lock.unlock();
+        gate_.cv.notify_all();
+      }
+    });
+  }
+
+  ~GateRelease() {
+    release();
+    watchdog_.join();
+  }
+
+  void release() {
+    if (released_) {
+      return;
+    }
+    released_ = true;
+    {
+      std::lock_guard<std::mutex> lock(gate_.mu);
+      gate_.open = true;
+    }
+    gate_.cv.notify_all();
+    cudaStreamSynchronize(stream_);
+  }
+
+ private:
+  StreamGate& gate_;
+  cudaStream_t stream_;
+  std::chrono::steady_clock::time_point deadline_;
+  std::thread watchdog_;
+  bool released_ = false;
+};
+
+// A thread that is joined however the case leaves its scope, so an assertion that
+// returns early does not leave one joinable and take the process down with it.
+class JoinAtScopeExit {
+ public:
+  explicit JoinAtScopeExit(std::thread t) : t_(std::move(t)) {}
+  JoinAtScopeExit(const JoinAtScopeExit&) = delete;
+  JoinAtScopeExit& operator=(const JoinAtScopeExit&) = delete;
+
+  ~JoinAtScopeExit() {
+    join();
+  }
+
+  void join() {
+    if (t_.joinable()) {
+      t_.join();
+    }
+  }
+
+ private:
+  std::thread t_;
+};
+
+// Two engines on one device share one scratch buffer, so the second engine's
+// enqueue must not start before the first one's has finished with it. The two
+// run on different streams, which is what the README permits and what the event
+// handoff is for: nothing but the handoff orders them.
+TEST_F(SharedScratchBackendTest, ASecondPooledEnqueueWaitsForTheFirstOnAnotherStream) {
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+
+  cudaStream_t first_stream = nullptr;
+  cudaStream_t second_stream = nullptr;
+  ASSERT_EQ(cudaStreamCreateWithFlags(&first_stream, cudaStreamNonBlocking), cudaSuccess);
+  ASSERT_EQ(cudaStreamCreateWithFlags(&second_stream, cudaStreamNonBlocking), cudaSuccess);
+
+  LoadedEngine first;
+  LoadedEngine second;
+  ASSERT_EQ(first.load(blob(), 10), Error::Ok);
+  ASSERT_EQ(second.load(blob(), 11), Error::Ok);
+  ASSERT_TRUE(first.handle()->shared_scratch);
+  ASSERT_TRUE(second.handle()->shared_scratch);
+
+  // Held work at the head of the first stream, so the first enqueue and the
+  // completion event recorded after it stay pending for as long as the test
+  // wants them to.
+  StreamGate gate;
+  ASSERT_EQ(cudaLaunchHostFunc(first_stream, hold_stream, &gate), cudaSuccess);
+  GateRelease gate_release(gate, first_stream);
+
+  // Held for the checks below, which take the watchdog flag first: a call that
+  // blocks on the held stream comes back with an error once the watchdog opens
+  // the gate, and that error on its own does not say so.
+  const Error first_error = first.run(first_stream);
+  const Error second_error = second.run(second_stream);
+
+  bool second_finished_early = false;
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (cudaStreamQuery(second_stream) == cudaSuccess) {
+      second_finished_early = true;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  ASSERT_FALSE(gate.forced_open.load())
+      << "the watchdog had to open the gate: a call blocked on the held stream rather than returning, "
+         "so nothing below was measured under the conditions it describes";
+  ASSERT_EQ(first_error, Error::Ok);
+  ASSERT_EQ(second_error, Error::Ok);
+
+  gate_release.release();
+  ASSERT_EQ(cudaStreamSynchronize(first_stream), cudaSuccess);
+  // Rules out the second engine's work having failed rather than been held,
+  // which would leave the check below false for the wrong reason.
+  ASSERT_EQ(cudaStreamSynchronize(second_stream), cudaSuccess);
+
+  EXPECT_FALSE(second_finished_early)
+      << "the second engine ran to completion while the first one's enqueue was still holding the shared buffer";
+
+  const std::vector<float> first_output = first.read_output();
+  const std::vector<float> second_output = second.read_output();
+  ASSERT_EQ(first_output.size(), kElems);
+  ASSERT_EQ(second_output.size(), kElems);
+  EXPECT_NE(std::memcmp(first_output.data(), second_output.data(), kBytes), 0)
+      << "the two engines were given different inputs but produced the same output";
+
+  ASSERT_EQ(cudaStreamDestroy(first_stream), cudaSuccess);
+  ASSERT_EQ(cudaStreamDestroy(second_stream), cudaSuccess);
+}
+
+// ---------------------------------------------------------------------------
+// What a growth waits for
+// ---------------------------------------------------------------------------
+
+// A growth's disposal of the buffer it replaces waits for one thing and not the
+// other, and these three cases park each of them in turn.
+//
+// It waits for the enqueue against the buffer it retires, because freeing under a
+// live enqueue is what the marker event is there to stop; the third case pins that
+// it waits rather than freeing under it. It does not wait for anything else the
+// device is running, because the free is queued on a stream the pool owns rather
+// than made device-wide; the first two pin that, one on each kind of call. Both
+// kinds, because what kind of call it is must not decide which disposal it gets.
+//
+// Each measures what the call came back before through the gate's watchdog, which
+// is the only other thing that can open a gate: if a call waited when it should
+// not have, the watchdog would have had to open the gate to end the test, and the
+// case says so.
+
+// Nothing the growing engine or the pool ever submitted to runs on the parked
+// stream, so only a device-wide free has any reason to wait for it.
+//
+// Gated on the device's stream-ordered allocator, and gated before the gate is
+// parked so a device without one costs milliseconds rather than the watchdog
+// interval. Where there is none, cudaFreeAsync reports cudaErrorNotSupported, the
+// backend correctly falls back to a device-wide free, and this assertion would
+// report a defect that is not there -- the target is built for sbsa as well as
+// x86_64, and nothing in the delegate asks the device about memory pools, so the
+// fallback is what a whole platform would take.
+//
+// On a device that does have one, nothing in this suite covers that fallback.
+// Reaching it needs cudaFreeAsync to fail a call that is correct as made, or the
+// pool's stream creation to fail, and neither can be induced from inside this
+// process.
+void SharedScratchBackendTest::run_a_growth_beside_parked_work(bool synchronized_path) {
+  ASSERT_GE(big_scratch_bytes_, scratch_bytes_ + kMinMeasurableScratch)
+      << "the two fixture engines ask for " << scratch_bytes_ << " and " << big_scratch_bytes_
+      << " bytes of activation scratch, too close for the second to be sure of growing the pool";
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+
+  cudaStream_t stream = nullptr;
+  cudaStream_t unrelated = nullptr;
+  ASSERT_EQ(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), cudaSuccess);
+  ASSERT_EQ(cudaStreamCreateWithFlags(&unrelated, cudaStreamNonBlocking), cudaSuccess);
+
+  // `stream` is unread on the synchronized path: with no CallerStreamGuard
+  // execute() enqueues on cudaStreamPerThread and synchronizes before returning.
+  const auto run_one = [synchronized_path, stream](LoadedEngine& engine) {
+    return synchronized_path ? engine.run_on_the_synchronized_path() : engine.run(stream);
+  };
+
+  LoadedEngine small;
+  LoadedEngine big;
+  ASSERT_EQ(small.load(blob(), 26), Error::Ok);
+  ASSERT_EQ(big.load(big_blob(), 27, kBigRows, kBigCols), Error::Ok);
+  ASSERT_TRUE(small.handle()->shared_scratch);
+  ASSERT_TRUE(big.handle()->shared_scratch);
+  const int device_id = big.handle()->device_id;
+
+  int memory_pools = 0;
+  ASSERT_EQ(cudaDeviceGetAttribute(&memory_pools, cudaDevAttrMemoryPoolsSupported, device_id), cudaSuccess);
+  if (memory_pools == 0) {
+    GTEST_SKIP() << "device " << device_id
+                 << " reports no stream-ordered allocator (cudaDevAttrMemoryPoolsSupported = 0), so a growth here "
+                    "correctly falls back to a device-wide free, which does wait for work parked anywhere on the "
+                    "device";
+  }
+
+  // Without this the larger engine allocates rather than grows, and a growth that
+  // retires nothing disposes of nothing. Drained, so the only enqueue the growth's
+  // wait can be held by is the one it submits itself, which nothing here parks;
+  // the parked stream is the only other thing that could hold the growth up.
+  ASSERT_EQ(run_one(small), Error::Ok);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  const std::size_t before = shared_scratch_capacity_for_testing(device_id);
+  ASSERT_GT(before, 0u) << "the smaller engine left the pool empty, so the larger one has nothing to retire";
+
+  StreamGate gate;
+  ASSERT_EQ(cudaLaunchHostFunc(unrelated, hold_stream, &gate), cudaSuccess);
+  GateRelease gate_release(gate, unrelated);
+
+  ASSERT_TRUE(big.fill_output(kSentinel));
+  const Error growth_error = run_one(big);
+  const bool came_back_with_the_device_held = !gate.forced_open.load();
+
+  gate_release.release();
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+  EXPECT_EQ(growth_error, Error::Ok);
+  EXPECT_GT(shared_scratch_capacity_for_testing(device_id), before)
+      << "the pool did not grow, so no buffer was retired and nothing was disposed of";
+  {
+    // The slot has the pool's own stream for this device, which only a growth
+    // with a buffer to dispose of ever asks for. What this does not say is which
+    // stream the free was queued on: the stream is created in the claim, so it is
+    // here whatever the disposal went on to do with it.
+    // AGrowthsDisposalDoesNotSynchronizeTheCallersStream below is what pins that.
+    SharedScratchDevice& dev = scratch_pool().get(device_id);
+    std::lock_guard<std::mutex> lock(dev.mu);
+    EXPECT_NE(dev.disposal_stream, nullptr)
+        << "the growth disposed of the buffer it retired without the pool's own stream for this device";
+  }
+  const std::vector<float> grown_output = big.read_output();
+  ASSERT_FALSE(grown_output.empty());
+  EXPECT_NE(grown_output[0], kSentinel)
+      << "the growing engine did not write its output, so it never reached the engine";
+
+  EXPECT_TRUE(came_back_with_the_device_held)
+      << "the growing call did not return until the watchdog released a host function parked on a stream it never "
+         "submitted to, so its disposal of the retired buffer waits for the whole device";
+
+  ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+  ASSERT_EQ(cudaStreamDestroy(unrelated), cudaSuccess);
+}
+
+// With no caller stream, execute() ends by synchronizing its own stream.
+TEST_F(SharedScratchBackendTest, AGrowthDoesNotWaitForUnrelatedWorkQueuedOnTheDevice) {
+  run_a_growth_beside_parked_work(/*synchronized_path=*/true);
+}
+
+// The path this option exists for, and the one a disposal that read the caller
+// could not serve: nothing on it ever synchronizes the caller's stream, so a free
+// queued there would never come back and the only alternative to the pool's own
+// stream is a device-wide free. This case is that difference -- the growth here
+// returns while a host function is still parked on an unrelated stream, which a
+// device-wide free waits out.
+TEST_F(SharedScratchBackendTest, AGrowthOnACallerStreamDoesNotWaitForUnrelatedWorkQueuedOnTheDevice) {
+  run_a_growth_beside_parked_work(/*synchronized_path=*/false);
+}
+
+// The wait the disposal does make. Freeing the retired buffer while an enqueue is
+// still reading it corrupts that engine's output and reports nothing, so the
+// disposal waits on the marker event first, and what has to hold is that it waits
+// rather than freeing under the enqueue.
+//
+// The smaller engine's own enqueue is parked behind a host function, and a thread
+// releases it a short while after the growing call starts. A growth that waited
+// comes back after that release; one that freed the retired buffer under the live
+// enqueue comes back before it.
+//
+// The smaller engine's output is checked against the same engine run with private
+// scratch, because it is the one whose buffer was retired underneath it: a free
+// that landed early would take its activations with it.
+TEST_F(SharedScratchBackendTest, AGrowthOnACallerStreamWaitsForTheEnqueueOnTheBufferItRetires) {
+  ASSERT_GE(big_scratch_bytes_, scratch_bytes_ + kMinMeasurableScratch)
+      << "the two fixture engines ask for " << scratch_bytes_ << " and " << big_scratch_bytes_
+      << " bytes of activation scratch, too close for the second to be sure of growing the pool";
+
+  // Long enough that the growing call cannot come back after it by accident, short
+  // enough not to lengthen the suite.
+  constexpr std::chrono::milliseconds kHoldTheEnqueueFor{500};
+
+  cudaStream_t held = nullptr;
+  cudaStream_t growing = nullptr;
+  ASSERT_EQ(cudaStreamCreateWithFlags(&held, cudaStreamNonBlocking), cudaSuccess);
+  ASSERT_EQ(cudaStreamCreateWithFlags(&growing, cudaStreamNonBlocking), cudaSuccess);
+
+  // Loaded with the option off, so this one keeps its own scratch and its output
+  // is what the pooled run below has to reproduce.
+  LoadedEngine reference;
+  ASSERT_EQ(set_shared_scratch(backend_, false), Error::Ok);
+  ASSERT_EQ(reference.load(blob(), 29), Error::Ok);
+  ASSERT_FALSE(reference.handle()->shared_scratch);
+  ASSERT_EQ(reference.run(held), Error::Ok);
+  ASSERT_EQ(cudaStreamSynchronize(held), cudaSuccess);
+  const std::vector<float> expected = reference.read_output();
+  ASSERT_EQ(expected.size(), kElems);
+
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+  LoadedEngine small;
+  LoadedEngine big;
+  ASSERT_EQ(small.load(blob(), 29), Error::Ok);
+  ASSERT_EQ(big.load(big_blob(), 30, kBigRows, kBigCols), Error::Ok);
+  ASSERT_TRUE(small.handle()->shared_scratch);
+  ASSERT_TRUE(big.handle()->shared_scratch);
+  const int device_id = big.handle()->device_id;
+  ASSERT_TRUE(small.fill_output(kSentinel));
+
+  // Parked ahead of the smaller engine's enqueue, so that enqueue and the event
+  // recorded after it both stay pending for as long as this test wants them to.
+  StreamGate gate;
+  ASSERT_EQ(cudaLaunchHostFunc(held, hold_stream, &gate), cudaSuccess);
+  GateRelease gate_release(gate, held);
+
+  ASSERT_EQ(small.run(held), Error::Ok);
+  const std::size_t before = shared_scratch_capacity_for_testing(device_id);
+  ASSERT_GT(before, 0u) << "the smaller engine left the pool empty, so the larger one has nothing to retire";
+
+  // Opens the gate, without the stream synchronization GateRelease::release() also
+  // makes: that one runs on this thread at scope exit, after the join below, so the
+  // two never touch GateRelease at once.
+  std::atomic<bool> the_enqueue_was_released{false};
+  JoinAtScopeExit opener{std::thread([&] {
+    std::this_thread::sleep_for(kHoldTheEnqueueFor);
+    the_enqueue_was_released.store(true);
+    {
+      std::lock_guard<std::mutex> lock(gate.mu);
+      gate.open = true;
+    }
+    gate.cv.notify_all();
+  })};
+
+  const Error growth_error = big.run(growing);
+  const bool waited_for_the_parked_enqueue = the_enqueue_was_released.load();
+  opener.join();
+
+  gate_release.release();
+  ASSERT_EQ(cudaStreamSynchronize(held), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(growing), cudaSuccess);
+
+  EXPECT_EQ(growth_error, Error::Ok);
+  ASSERT_FALSE(gate.forced_open.load())
+      << "the watchdog had to open the gate, so the growing call blocked for the whole watchdog interval rather than "
+         "for the enqueue it had to wait for";
+  EXPECT_TRUE(waited_for_the_parked_enqueue)
+      << "the growing call returned while the enqueue against the buffer it retired was still parked, so it freed that "
+         "buffer under a live enqueue";
+  EXPECT_GT(shared_scratch_capacity_for_testing(device_id), before)
+      << "the pool did not grow, so no buffer was retired and there was nothing to wait for";
+  const std::vector<float> small_output = small.read_output();
+  ASSERT_EQ(small_output.size(), kElems);
+  EXPECT_EQ(std::memcmp(expected.data(), small_output.data(), kBytes), 0)
+      << "the engine whose scratch buffer the growth retired did not produce what the same engine produces with "
+         "private scratch, so the buffer went away while its enqueue was still using it";
+
+  ASSERT_EQ(cudaStreamDestroy(held), cudaSuccess);
+  ASSERT_EQ(cudaStreamDestroy(growing), cudaSuccess);
+}
+
+// None of the growth cases above can see whether the disposal is made with the
+// device's lock held: each runs its growth alone, so a lock held across it holds
+// nothing up and they all stay green with the unlock moved below the disposal.
+// This one is what covers that.
+//
+// It matters because the disposal waits on the host for the enqueue against the
+// buffer it retires, which is a whole inference. Under the lock, that wait is one
+// every other pooled engine on the device has to sit through before it can even
+// submit, which is the serialization the execute() contract says a pooled call
+// does not impose past its own submission.
+//
+// So: park a host function ahead of the growing engine's own enqueue, which is
+// what that wait is for, then check the pool lock while the growth is still inside
+// it. The capacity read under that same try_lock is what stops the case passing on
+// a lock that is free because the growth has not started -- past a growth it is
+// above what the smaller engine left, and the growth has not returned.
+TEST_F(SharedScratchBackendTest, AGrowthOnACallerStreamDisposesWithTheDeviceLockDropped) {
+  ASSERT_GE(big_scratch_bytes_, scratch_bytes_ + kMinMeasurableScratch)
+      << "the two fixture engines ask for " << scratch_bytes_ << " and " << big_scratch_bytes_
+      << " bytes of activation scratch, too close for the second to be sure of growing the pool";
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+
+  cudaStream_t stream = nullptr;
+  ASSERT_EQ(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), cudaSuccess);
+
+  LoadedEngine small;
+  LoadedEngine big;
+  ASSERT_EQ(small.load(blob(), 32), Error::Ok);
+  ASSERT_EQ(big.load(big_blob(), 33, kBigRows, kBigCols), Error::Ok);
+  ASSERT_TRUE(small.handle()->shared_scratch);
+  ASSERT_TRUE(big.handle()->shared_scratch);
+  const int device_id = big.handle()->device_id;
+
+  // Without this the larger engine allocates rather than grows, and a growth that
+  // retires nothing frees nothing. Drained, so the only enqueue the growth's wait
+  // can be held by is the one it submits itself, below the gate.
+  ASSERT_EQ(small.run(stream), Error::Ok);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  const std::size_t before = shared_scratch_capacity_for_testing(device_id);
+  ASSERT_GT(before, 0u) << "the smaller engine left the pool empty, so the larger one has nothing to retire";
+
+  // Ahead of the growing engine's enqueue, so that enqueue and the marker recorded
+  // after it stay pending and the disposal's wait for them does too.
+  StreamGate gate;
+  ASSERT_EQ(cudaLaunchHostFunc(stream, hold_stream, &gate), cudaSuccess);
+  GateRelease gate_release(gate, stream);
+
+  std::atomic<bool> growth_returned{false};
+  Error growth_error = Error::Internal;
+  JoinAtScopeExit grower{std::thread([&] {
+    growth_error = big.run(stream);
+    growth_returned.store(true);
+  })};
+
+  SharedScratchDevice& dev = scratch_pool().get(device_id);
+  bool lock_free_during_the_disposal = false;
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (!growth_returned.load() && std::chrono::steady_clock::now() < deadline) {
+    if (dev.mu.try_lock()) {
+      const std::size_t capacity_now = dev.capacity;
+      dev.mu.unlock();
+      if (capacity_now > before && !growth_returned.load()) {
+        lock_free_during_the_disposal = true;
+        break;
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  const bool still_inside_execute = !growth_returned.load();
+
+  gate_release.release();
+  grower.join();
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+
+  ASSERT_FALSE(gate.forced_open.load())
+      << "the watchdog had to open the gate rather than this test, so more than the watchdog interval passed between "
+         "parking the host function ahead of the growing engine's enqueue and releasing it, and nothing here was "
+         "measured under the conditions it describes";
+  ASSERT_EQ(growth_error, Error::Ok);
+  ASSERT_TRUE(still_inside_execute)
+      << "the growing call returned before the gate opened, so its disposal never stalled and there was no window in "
+         "which to observe the lock";
+  ASSERT_GT(shared_scratch_capacity_for_testing(device_id), before)
+      << "the pool did not grow, so no buffer was retired and nothing was disposed of";
+  EXPECT_TRUE(lock_free_during_the_disposal)
+      << "the device's pool lock stayed held for the whole of a stalled growth disposal, so every other pooled engine "
+         "on this device waits out an inference it has nothing to do with before it can submit";
+}
+
+// Which stream the disposal queues its free on and synchronizes, which none of
+// the cases above can see. The pool's stream carries that free and nothing else,
+// so synchronizing it waits for the free. The caller's carries whatever the caller
+// put there, so synchronizing that waits for work this delegate never submitted --
+// the same hazard the staged-input drain's contract names, arriving by another
+// route. Every other case in this file stays green with the free and its
+// synchronize moved onto the caller's stream.
+//
+// What tells the two apart is work queued on the caller's stream *after* the
+// growing call recorded its own enqueue, because that is the only work on that
+// stream the disposal's wait for the retired buffer's enqueue does not already
+// cover -- the wait is on the handoff marker, and the growing call has recorded
+// itself there. So: park the growing engine's enqueue behind a gate, wait until
+// the slot counts its disposal, which is raised after that enqueue and its
+// marker record are both queued, queue host work on the same stream behind them,
+// and then let the enqueue go. A disposal on the pool's stream comes back while
+// that host work is still running. One on the caller's stream waits it out.
+TEST_F(SharedScratchBackendTest, AGrowthsDisposalDoesNotSynchronizeTheCallersStream) {
+  ASSERT_GE(big_scratch_bytes_, scratch_bytes_ + kMinMeasurableScratch)
+      << "the two fixture engines ask for " << scratch_bytes_ << " and " << big_scratch_bytes_
+      << " bytes of activation scratch, too close for the second to be sure of growing the pool";
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+
+  cudaStream_t stream = nullptr;
+  ASSERT_EQ(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), cudaSuccess);
+
+  LoadedEngine small;
+  LoadedEngine big;
+  ASSERT_EQ(small.load(blob(), 34), Error::Ok);
+  ASSERT_EQ(big.load(big_blob(), 35, kBigRows, kBigCols), Error::Ok);
+  ASSERT_TRUE(small.handle()->shared_scratch);
+  ASSERT_TRUE(big.handle()->shared_scratch);
+  const int device_id = big.handle()->device_id;
+
+  int memory_pools = 0;
+  ASSERT_EQ(cudaDeviceGetAttribute(&memory_pools, cudaDevAttrMemoryPoolsSupported, device_id), cudaSuccess);
+  if (memory_pools == 0) {
+    ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+    GTEST_SKIP() << "device " << device_id
+                 << " reports no stream-ordered allocator (cudaDevAttrMemoryPoolsSupported = 0), so this growth "
+                    "correctly falls back to a device-wide free, which waits for the caller's stream whichever stream "
+                    "it was offered";
+  }
+
+  // Without this the larger engine allocates rather than grows, and a growth that
+  // retires nothing disposes of nothing. Drained, so the only enqueue the growth's
+  // wait can be held by is the one it submits itself, below the gate.
+  ASSERT_EQ(small.run(stream), Error::Ok);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  const std::size_t before = shared_scratch_capacity_for_testing(device_id);
+  ASSERT_GT(before, 0u) << "the smaller engine left the pool empty, so the larger one has nothing to retire";
+
+  // Ahead of the growing engine's enqueue, so its disposal stalls on the wait for
+  // that enqueue and this thread gets a window to queue behind it.
+  StreamGate gate;
+  ASSERT_EQ(cudaLaunchHostFunc(stream, hold_stream, &gate), cudaSuccess);
+  GateRelease gate_release(gate, stream);
+
+  std::atomic<bool> growth_returned{false};
+  Error growth_error = Error::Internal;
+  JoinAtScopeExit grower{std::thread([&] {
+    growth_error = big.run(stream);
+    growth_returned.store(true);
+  })};
+
+  // A capacity above what the smaller engine left, read under the device's lock
+  // while the growing call has not returned, means the growth is past its
+  // allocation and inside the disposal: the release that disposes is the last
+  // thing between the two.
+  SharedScratchDevice& dev = scratch_pool().get(device_id);
+  bool the_disposal_started = false;
+  const auto disposal_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (!growth_returned.load() && std::chrono::steady_clock::now() < disposal_deadline) {
+    if (dev.mu.try_lock()) {
+      const std::size_t capacity_now = dev.capacity;
+      dev.mu.unlock();
+      if (capacity_now > before && !growth_returned.load()) {
+        the_disposal_started = true;
+        break;
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  // Queued whether or not the wait above saw the disposal, so that a case that
+  // missed the window leaves the stream in the same shape for the teardown below
+  // and fails on the assertion rather than on where the work landed.
+  const cudaError_t queued_behind = cudaLaunchHostFunc(stream, sleep_on_the_stream, nullptr);
+
+  // Opened here rather than through gate_release, whose release() also
+  // synchronizes the stream -- which is the very wait being measured.
+  {
+    std::lock_guard<std::mutex> lock(gate.mu);
+    gate.open = true;
+  }
+  gate.cv.notify_all();
+  const auto let_the_enqueue_go = std::chrono::steady_clock::now();
+
+  const auto give_up_at = let_the_enqueue_go + kHostWorkOnTheCallerStream + std::chrono::seconds(5);
+  while (!growth_returned.load() && std::chrono::steady_clock::now() < give_up_at) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  const auto came_back_after = std::chrono::steady_clock::now() - let_the_enqueue_go;
+
+  grower.join();
+  gate_release.release();
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+
+  ASSERT_EQ(queued_behind, cudaSuccess) << "could not queue the caller's own work behind the growing enqueue";
+  ASSERT_FALSE(gate.forced_open.load())
+      << "the watchdog had to open the gate rather than this test, so more than the watchdog interval passed while the "
+         "growing engine's enqueue was parked and nothing here was measured under the conditions it describes";
+  ASSERT_EQ(growth_error, Error::Ok);
+  ASSERT_TRUE(the_disposal_started)
+      << "the growing call's disposal was never seen in flight, so the caller's work may have been queued ahead of the "
+         "enqueue rather than behind it and this case measured nothing";
+  ASSERT_GT(shared_scratch_capacity_for_testing(device_id), before)
+      << "the pool did not grow, so no buffer was retired and nothing was disposed of";
+  EXPECT_LT(came_back_after, kHostWorkOnTheCallerStream / 3)
+      << "the growing call came back " << std::chrono::duration_cast<std::chrono::milliseconds>(came_back_after).count()
+      << " ms after its own enqueue was let go, with " << kHostWorkOnTheCallerStream.count()
+      << " ms of the caller's own work queued on that stream behind it, so its disposal synchronized the caller's "
+         "stream rather than the pool's -- which makes every growth wait for whatever the caller has queued";
+}
+
+// ---------------------------------------------------------------------------
+// A failing call and the host-input copy it queued
+// ---------------------------------------------------------------------------
+
+// An input that is not device-resident is staged with cudaMemcpyAsync from the
+// caller's own memory, and from pinned memory that copy reads the caller's bytes
+// when the stream reaches it, not when it is queued. So a call that fails after
+// queueing one must not return while it is still pending: the caller owns that
+// buffer again the moment execute() returns, and what it writes there is what
+// the device then receives.
+//
+// The failure driven here is the pool's allocation, the one early return in the
+// pooled scratch block that can be reached from inside this process. The stream
+// is parked ahead of the copy so it cannot complete on its own, and the caller
+// overwrites its buffer as soon as the call comes back -- which is exactly what a
+// caller may do.
+//
+// Three outcomes are separated at the end, by giving the failing call a
+// different input from the successful one before it: the sentinel means the copy
+// took the caller's post-return write, the first call's pattern means it never
+// ran at all, and the second call's pattern is the only pass. Which of the three
+// happens is decided by where the caller's write falls relative to the copy and
+// not by any interval this case picks, so a slow return cannot turn the first
+// outcome into the third.
+TEST_F(SharedScratchBackendTest, AFailedPooledCallDrainsTheHostInputCopyItQueued) {
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+
+  cudaStream_t stream = nullptr;
+  ASSERT_EQ(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), cudaSuccess);
+
+  LoadedEngine pooled;
+  ASSERT_EQ(pooled.load(blob(), 41), Error::Ok);
+  ASSERT_TRUE(pooled.handle()->shared_scratch);
+  const int device_id = pooled.handle()->device_id;
+
+  // Pinned: cudaMemcpyAsync from pageable memory does not return until the
+  // driver has taken the bytes, so a later write cannot reach the device and
+  // there is no hazard to pin.
+  float* host_in = nullptr;
+  ASSERT_EQ(cudaHostAlloc(reinterpret_cast<void**>(&host_in), pooled.bytes(), cudaHostAllocDefault), cudaSuccess);
+  for (std::size_t i = 0; i < pooled.elems(); ++i) {
+    host_in[i] = pattern(i, 41);
+  }
+
+  // One good run first, so the failing one reaches the copy: the staging buffer
+  // is allocated on the call that first needs it, and with the device full that
+  // allocation would fail ahead of everything this case is about.
+  ASSERT_EQ(pooled.run_from_host_input(stream, host_in), Error::Ok);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  void* const staging = pooled.staging_buffer_for_input_0();
+  ASSERT_NE(staging, nullptr) << "the run bound the caller's host memory directly, so nothing was staged and there is "
+                                 "no asynchronous copy to leave running";
+
+  // The second call's input, so what the device holds at the end says which of
+  // the three outcomes happened.
+  for (std::size_t i = 0; i < pooled.elems(); ++i) {
+    host_in[i] = pattern(i, 42);
+  }
+
+  // Empties the pool, so the failing run allocates instead of reusing what the
+  // run above left in it.
+  ASSERT_TRUE(reset_shared_scratch_pool_for_testing());
+  ASSERT_EQ(shared_scratch_capacity_for_testing(device_id), 0u);
+
+  DeviceMemoryHog hog;
+  if (!hog.leave_less_free_than(scratch_bytes_)) {
+    ASSERT_EQ(cudaFreeHost(host_in), cudaSuccess);
+    ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+    GTEST_SKIP() << "could not take the device below the " << scratch_bytes_
+                 << " bytes this engine's scratch needs, so its allocation would have succeeded";
+  }
+
+  StreamGate gate;
+  ASSERT_EQ(cudaLaunchHostFunc(stream, hold_stream, &gate), cudaSuccess);
+  GateRelease gate_release(gate, stream);
+
+  // The caller overwrites its own buffer the moment the call comes back, in the
+  // thread that made the call, which is what a caller is entitled to do and is
+  // what decides this case. A build that returns with the copy still queued does
+  // that write before the gate opens, so the copy reads the sentinel and the
+  // comparison at the end sees it. A build that drains cannot reach the write
+  // until the copy has run. Neither outcome depends on how long anything takes:
+  // the wait below is a bound on this case, not the thing that discriminates.
+  std::atomic<bool> call_returned{false};
+  std::atomic<bool> caller_overwrote_its_buffer{false};
+  Error failed_run = Error::Ok;
+  std::thread caller([&] {
+    failed_run = pooled.run_from_host_input(stream, host_in);
+    call_returned.store(true);
+    for (std::size_t i = 0; i < pooled.elems(); ++i) {
+      host_in[i] = kSentinel;
+    }
+    caller_overwrote_its_buffer.store(true);
+  });
+
+  // Waited for rather than slept through, so a build that returns early is not
+  // handed the rest of the interval to finish its write in. Reaching the deadline
+  // is the passing outcome: the stream cannot move until the gate opens, so a call
+  // that waits for its own copy is still inside execute() here.
+  const auto give_up_waiting_at = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+  while (!caller_overwrote_its_buffer.load() && std::chrono::steady_clock::now() < give_up_waiting_at) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  const bool returned_with_the_copy_still_queued = call_returned.load();
+  gate_release.release();
+  caller.join();
+  // After the gate, because a free is device-wide and would otherwise block on it.
+  hog.release();
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+  std::vector<float> staged(pooled.elems(), 0.0f);
+  ASSERT_EQ(cudaMemcpy(staged.data(), staging, pooled.bytes(), cudaMemcpyDeviceToHost), cudaSuccess);
+  ASSERT_EQ(cudaFreeHost(host_in), cudaSuccess);
+  ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+
+  ASSERT_FALSE(gate.forced_open.load())
+      << "the watchdog had to open the gate, so the timings below were not measured under the conditions they describe";
+  if (failed_run == Error::Ok) {
+    GTEST_SKIP() << "the pooled allocation succeeded with the device full, so this run did not fail where the case "
+                    "needs it to";
+  }
+  ASSERT_EQ(failed_run, Error::MemoryAllocationFailed)
+      << "the run failed somewhere other than the pool's allocation, so it says nothing about that early return";
+
+  EXPECT_FALSE(returned_with_the_copy_still_queued)
+      << "the failing call returned while the copy reading the caller's host input was still queued behind a parked "
+         "stream, so whatever the caller writes next is what the device receives";
+  std::size_t elements_the_device_did_not_get = 0;
+  for (std::size_t i = 0; i < pooled.elems(); ++i) {
+    if (staged[i] != pattern(i, 42)) {
+      ++elements_the_device_did_not_get;
+    }
+  }
+  EXPECT_EQ(elements_the_device_did_not_get, 0u)
+      << "the device does not hold the input this call was made with. It holds " << staged[0]
+      << " at element 0: " << kSentinel << " is what the caller wrote after execute() returned, " << pattern(0, 41)
+      << " is the previous call's input and means the copy never ran, and " << pattern(0, 42) << " is a pass";
+}
+
+// The drain above belongs to the pooled path, and this branch's account of
+// itself rests on it staying there: with the option off an engine is meant to be
+// what it was before the option existed, down to what its error returns wait for.
+// A guard that read the staging flag alone would put a whole-stream wait on every
+// error return an unpooled call makes after that copy -- the rest of the input
+// loop, inferShapes, the whole output-binding loop, enqueueV3 and the returns
+// past it -- and that wait covers work the caller queued before calling, which
+// this delegate never submitted and cannot bound.
+//
+// The failure driven here is the allocation of the device buffer an output that
+// is not device-resident is staged through. It is made after the input's copy has
+// been queued, and it is the only failure past that point this suite can force on
+// an unpooled call. The stream is parked ahead of the copy, so a call that drains
+// cannot return until this case opens the gate, and one that does not returns
+// straight away.
+//
+// This is not a claim that the copy outliving the return is harmless on this
+// path. It is what this delegate did before this branch, and closing it means
+// changing what a default-off call does; what this case pins is that this branch
+// did not change it by accident.
+TEST_F(SharedScratchBackendTest, AFailedUnpooledCallLeavesTheHostInputCopyItQueuedAlone) {
+  cudaStream_t stream = nullptr;
+  ASSERT_EQ(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), cudaSuccess);
+
+  // Loaded with the option off, which the fixture set before this case began.
+  LoadedEngine unpooled;
+  ASSERT_EQ(unpooled.load(blob(), 43), Error::Ok);
+  ASSERT_FALSE(unpooled.handle()->shared_scratch)
+      << "the engine took the pooled path, so this case says nothing about the option-off one";
+
+  // Pinned, for the same reason as the case above: a copy from pageable memory
+  // waits for the parked stream itself, so the call would block whatever the
+  // guard does and nothing here would discriminate.
+  float* host_in = nullptr;
+  ASSERT_EQ(cudaHostAlloc(reinterpret_cast<void**>(&host_in), unpooled.bytes(), cudaHostAllocDefault), cudaSuccess);
+  for (std::size_t i = 0; i < unpooled.elems(); ++i) {
+    host_in[i] = pattern(i, 43);
+  }
+  std::vector<float> host_out(unpooled.elems(), 0.0f);
+
+  // One good run first, so the failing one reaches the copy rather than failing
+  // on the input's own staging allocation with the device full. Its output stays
+  // device-resident, so the output staging buffer is still unallocated -- which is
+  // what the failing run below fails on.
+  ASSERT_EQ(unpooled.run_from_host_input(stream, host_in), Error::Ok);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  ASSERT_NE(unpooled.staging_buffer_for_input_0(), nullptr)
+      << "the run bound the caller's host memory directly, so nothing was staged and there is no asynchronous copy to "
+         "leave running";
+
+  DeviceMemoryHog hog;
+  if (!hog.leave_less_free_than(unpooled.bytes())) {
+    ASSERT_EQ(cudaFreeHost(host_in), cudaSuccess);
+    ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+    GTEST_SKIP() << "could not take the device below the " << unpooled.bytes()
+                 << " bytes this call's output staging needs, so its allocation would have succeeded";
+  }
+
+  StreamGate gate;
+  ASSERT_EQ(cudaLaunchHostFunc(stream, hold_stream, &gate), cudaSuccess);
+  GateRelease gate_release(gate, stream);
+
+  std::atomic<bool> call_returned{false};
+  Error failed_run = Error::Ok;
+  std::thread caller([&] {
+    failed_run = unpooled.run_from_host_input_to_host_output(stream, host_in, host_out.data());
+    call_returned.store(true);
+  });
+
+  // Generous, because reaching it is the failing outcome and nothing here is
+  // timed: a call that returns is waited for and no longer, and a call that
+  // drains cannot return before the gate opens however long this waits.
+  const auto give_up_waiting_at = std::chrono::steady_clock::now() + std::chrono::seconds(20);
+  while (!call_returned.load() && std::chrono::steady_clock::now() < give_up_waiting_at) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  const bool returned_while_the_stream_was_parked = call_returned.load();
+
+  gate_release.release();
+  caller.join();
+  // After the gate, because a free is device-wide and would otherwise block on it.
+  hog.release();
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  ASSERT_EQ(cudaFreeHost(host_in), cudaSuccess);
+  ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+
+  ASSERT_FALSE(gate.forced_open.load())
+      << "the watchdog had to open the gate rather than this case, so what is asserted below was not observed under "
+         "the conditions it describes";
+  if (failed_run == Error::Ok) {
+    GTEST_SKIP() << "the output staging allocation succeeded with the device full, so this run did not fail where the "
+                    "case needs it to";
+  }
+  ASSERT_EQ(failed_run, Error::MemoryAllocationFailed)
+      << "the run failed somewhere other than the output staging allocation, so it says nothing about the error "
+         "returns between a staged input's copy and the synchronize on the success path";
+
+  EXPECT_TRUE(returned_while_the_stream_was_parked)
+      << "a failing call with the option off waited on the caller's stream, which nothing before this branch made it "
+         "do. The option is documented as costing an unpooled call a bool test or two per execute() and nothing else, "
+         "and this is a wait with no bound: the caller's stream carries work this delegate never submitted";
+}
+
+// ---------------------------------------------------------------------------
+// The pooled path under two concurrent callers
+// ---------------------------------------------------------------------------
+
+// The window a dropped lock would leave open is a few microseconds wide, so one
+// pair of runs would find it only by luck. At this count a build that leaves the
+// window open loses most of the runs, and the test costs about two seconds.
+constexpr int kConcurrentRunsPerThread = 60;
+
+// Two pooled engines on one device, submitted from two threads on two streams,
+// with nothing but the backend ordering them. Both are backed by the same buffer,
+// so a claim that ends before the enqueue is recorded hands a second caller the
+// same scratch with nothing ordering the two -- silently wrong output, no CUDA
+// error, no TensorRT error. Each thread compares byte-for-byte against what its own
+// engine produces with private scratch.
+TEST_F(SharedScratchBackendTest, TwoThreadsRunningPooledEnginesOnOneDeviceKeepTheirOwnOutputs) {
+  cudaStream_t reference_stream = nullptr;
+  ASSERT_EQ(cudaStreamCreate(&reference_stream), cudaSuccess);
+
+  std::vector<float> first_expected;
+  std::vector<float> second_expected;
+  {
+    LoadedEngine first_priv;
+    LoadedEngine second_priv;
+    ASSERT_EQ(first_priv.load(blob(), 17), Error::Ok);
+    ASSERT_EQ(second_priv.load(blob(), 18), Error::Ok);
+    ASSERT_FALSE(first_priv.handle()->shared_scratch);
+    ASSERT_FALSE(second_priv.handle()->shared_scratch);
+    ASSERT_EQ(first_priv.run(reference_stream), Error::Ok);
+    ASSERT_EQ(second_priv.run(reference_stream), Error::Ok);
+    ASSERT_EQ(cudaStreamSynchronize(reference_stream), cudaSuccess);
+    first_expected = first_priv.read_output();
+    second_expected = second_priv.read_output();
+  }
+  ASSERT_EQ(cudaStreamDestroy(reference_stream), cudaSuccess);
+
+  ASSERT_EQ(first_expected.size(), kElems);
+  ASSERT_EQ(second_expected.size(), kElems);
+  // Two engines producing the same bytes would let each thread pass on the other
+  // one's output, which is the outcome this test exists to catch.
+  ASSERT_NE(std::memcmp(first_expected.data(), second_expected.data(), kBytes), 0)
+      << "the two engines were given different inputs but produced the same output";
+  ASSERT_NE(first_expected[0], kSentinel) << "the reference output is the sentinel, so a skipped enqueue would pass";
+  ASSERT_NE(second_expected[0], kSentinel) << "the reference output is the sentinel, so a skipped enqueue would pass";
+
+  ASSERT_EQ(set_shared_scratch(backend_, true), Error::Ok);
+  LoadedEngine first;
+  LoadedEngine second;
+  ASSERT_EQ(first.load(blob(), 17), Error::Ok);
+  ASSERT_EQ(second.load(blob(), 18), Error::Ok);
+  ASSERT_TRUE(first.handle()->shared_scratch);
+  ASSERT_TRUE(second.handle()->shared_scratch);
+
+  cudaStream_t first_stream = nullptr;
+  cudaStream_t second_stream = nullptr;
+  ASSERT_EQ(cudaStreamCreateWithFlags(&first_stream, cudaStreamNonBlocking), cudaSuccess);
+  ASSERT_EQ(cudaStreamCreateWithFlags(&second_stream, cudaStreamNonBlocking), cudaSuccess);
+
+  // The host copies that bracket each run synchronize the whole device, so two
+  // threads left to themselves take turns rather than overlap. Against a build
+  // that leaves the window open, taking turns caught it in 2 of the 120 runs
+  // below; releasing both threads together caught nearly all of them.
+  //
+  // The wait has a deadline because the loop it sits in contains a delegate call,
+  // and a pooled call that blocks is one of the failures this case exists to
+  // catch. Without one the thread whose partner is stuck spins here until the
+  // target's own timeout, which reports as a killed binary rather than as this
+  // case; with one, the run ends and the assertion below names it.
+  //
+  // The loop below stops at the first rendezvous that expires, which is what makes
+  // the deadline affordable. It is armed per rendezvous -- a whole-case wall clock
+  // would have to cover 60 real runs and would fail a slow machine instead -- and
+  // paid at most once per thread, so the worst case is a bounded 30 s rather than
+  // the 60 x 30 s a loop that carried on would cost against this target's 900 s
+  // timeout. Stopping also keeps the surviving thread out of the delegate call
+  // that follows the rendezvous, which its wedged partner may be holding the
+  // device's pool lock across.
+  constexpr std::chrono::seconds kRendezvousDeadline{30};
+  std::atomic<int> arrived{0};
+  std::atomic<bool> partner_never_arrived{false};
+  auto submit_together = [&](int iteration) {
+    arrived.fetch_add(1);
+    const auto deadline = std::chrono::steady_clock::now() + kRendezvousDeadline;
+    while (arrived.load() < 2 * (iteration + 1)) {
+      if (partner_never_arrived.load() || std::chrono::steady_clock::now() >= deadline) {
+        partner_never_arrived.store(true);
+        return;
+      }
+      std::this_thread::yield();
+    }
+  };
+
+  std::atomic<int> wrong_outputs{0};
+  std::atomic<int> failures{0};
+  auto run_repeatedly = [&](LoadedEngine& engine, const std::vector<float>& expected, cudaStream_t stream) {
+    for (int i = 0; i < kConcurrentRunsPerThread; ++i) {
+      // Rewritten every iteration, so a run whose enqueue never reached the engine
+      // leaves the sentinel behind rather than the previous iteration's output.
+      if (!engine.fill_output(kSentinel)) {
+        failures.fetch_add(1);
+      }
+      submit_together(i);
+      if (partner_never_arrived.load()) {
+        break;
+      }
+      if (engine.run(stream) != Error::Ok || cudaStreamSynchronize(stream) != cudaSuccess) {
+        failures.fetch_add(1);
+        continue;
+      }
+      const std::vector<float> actual = engine.read_output();
+      if (actual.size() != expected.size() || std::memcmp(actual.data(), expected.data(), kBytes) != 0) {
+        wrong_outputs.fetch_add(1);
+      }
+    }
+  };
+
+  std::thread first_thread([&] { run_repeatedly(first, first_expected, first_stream); });
+  std::thread second_thread([&] { run_repeatedly(second, second_expected, second_stream); });
+  first_thread.join();
+  second_thread.join();
+
+  ASSERT_EQ(cudaStreamDestroy(first_stream), cudaSuccess);
+  ASSERT_EQ(cudaStreamDestroy(second_stream), cudaSuccess);
+
+  EXPECT_FALSE(partner_never_arrived.load())
+      << "a thread waited out the " << kRendezvousDeadline.count()
+      << "-second rendezvous deadline without its partner arriving, so a pooled call blocked instead of returning and "
+         "both threads stopped short of "
+      << kConcurrentRunsPerThread << " runs";
+  EXPECT_EQ(failures.load(), 0) << "a run failed outright, so fewer than " << (2 * kConcurrentRunsPerThread)
+                                << " runs reached the comparison below";
+  EXPECT_EQ(wrong_outputs.load(), 0) << wrong_outputs.load() << " of " << (2 * kConcurrentRunsPerThread)
+                                     << " concurrent pooled runs did not produce what the same engine produces with "
+                                        "its own scratch";
+}
+
+} // namespace
+} // namespace executorch_backend
+} // namespace torch_tensorrt

--- a/tests/cpp/executorch/test_shared_scratch_pool.cpp
+++ b/tests/cpp/executorch/test_shared_scratch_pool.cpp
@@ -1,0 +1,1192 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Pins the shared scratch pool helper: its grow, reuse and per-device policy, its
+// enqueue-handoff rule and the stream a growth disposes on, driven over fakes so
+// no CUDA device is needed.
+//
+// This exercises the helper, not the backend: it does not link the delegate, so
+// it cannot catch the delegate calling the helper wrongly or ceasing to call it.
+// test_shared_scratch_backend covers that, and needs a GPU to do it.
+//
+// One case at the end is the exception to "over fakes": the lifetime of the
+// process-wide registry scratch_pool() hands out is a property of that object and
+// not of any fake, and it is observable only after main returns. It forks to see
+// it, and still makes no CUDA call.
+
+#include "torch_tensorrt/executorch/SharedScratchPool.h"
+#include "torch_tensorrt/executorch/SharedScratchPoolReset.h"
+
+#include "gtest/gtest.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <future>
+#include <mutex>
+#include <set>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#if defined(__unix__)
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <csignal>
+#endif
+
+namespace torch_tensorrt {
+namespace executorch_backend {
+
+// Defined in test_shared_scratch_pool_other_tu.cpp; see
+// EveryTranslationUnitSeesOneProcessPool below.
+const SharedScratchPool* scratch_pool_seen_from_another_translation_unit();
+
+namespace {
+
+// Fake device allocator: hands out distinct non-null pointers and records every
+// allocation size and every buffer a growth retired, so tests can assert the
+// pool's grow/reuse policy and what each retirement has to wait for, without a
+// CUDA device.
+struct FakeAllocator {
+  std::vector<std::size_t> alloc_sizes;
+  std::vector<std::pair<void*, cudaEvent_t>> retirements;
+  std::uintptr_t next = 0x1000;
+  bool fail_next = false;
+
+  void* alloc(std::size_t bytes) {
+    if (fail_next) {
+      fail_next = false;
+      return nullptr;
+    }
+    alloc_sizes.push_back(bytes);
+    void* p = reinterpret_cast<void*>(next);
+    next += 0x1000;
+    return p;
+  }
+
+  void retire(void* p, cudaEvent_t wait_for) {
+    retirements.emplace_back(p, wait_for);
+  }
+
+  int alloc_count() const {
+    return static_cast<int>(alloc_sizes.size());
+  }
+};
+
+// Stands in for the CUDA event factory: hands out distinct non-null handles and
+// counts calls, so a test can tell a slot that reuses its event from one that
+// creates a new one every call.
+struct FakeEventFactory {
+  int created = 0;
+  std::uintptr_t next = 0xE000;
+  bool fail_next = false;
+
+  cudaEvent_t operator()() {
+    if (fail_next) {
+      fail_next = false;
+      return nullptr;
+    }
+    ++created;
+    cudaEvent_t e = reinterpret_cast<cudaEvent_t>(next);
+    next += 0x100;
+    return e;
+  }
+};
+
+// Stands in for the CUDA stream factory, the way FakeEventFactory stands in for
+// the event one: distinct non-null handles and a call count, so a test can tell a
+// slot that keeps one stream from one that creates a stream per growth.
+struct FakeStreamFactory {
+  int created = 0;
+  std::uintptr_t next = 0x5000;
+  bool fail_next = false;
+
+  cudaStream_t operator()() {
+    if (fail_next) {
+      fail_next = false;
+      return nullptr;
+    }
+    ++created;
+    cudaStream_t s = reinterpret_cast<cudaStream_t>(next);
+    next += 0x100;
+    return s;
+  }
+};
+
+// Stands in for the backend: passes the allocator through and records whatever
+// the call retired, the way execute() hands a retired buffer to its claim.
+void* call(SharedScratchDevice& dev, FakeAllocator& a, std::size_t need) {
+  RetiredScratch retired;
+  void* const p = shared_scratch_get_or_grow(
+      dev, need, [&a](std::size_t bytes) { return a.alloc(bytes); }, retired);
+  if (retired.buffer != nullptr) {
+    a.retire(retired.buffer, retired.wait_for);
+  }
+  return p;
+}
+
+TEST(SharedScratchPool, FirstRequestAllocatesExactSize) {
+  SharedScratchDevice dev;
+  FakeAllocator a;
+
+  void* p = call(dev, a, /*need=*/1024);
+
+  EXPECT_NE(p, nullptr);
+  EXPECT_EQ(dev.capacity, 1024u);
+  ASSERT_EQ(a.alloc_count(), 1);
+  EXPECT_EQ(a.alloc_sizes[0], 1024u);
+  EXPECT_TRUE(a.retirements.empty());
+}
+
+TEST(SharedScratchPool, ReusesWhenExistingBufferIsLargeEnough) {
+  SharedScratchDevice dev;
+  FakeAllocator a;
+
+  void* first = call(dev, a, 4096);
+  // A smaller and an equal request must both reuse the same buffer (no realloc).
+  void* second = call(dev, a, 1000);
+  void* third = call(dev, a, 4096);
+
+  EXPECT_EQ(second, first);
+  EXPECT_EQ(third, first);
+  // The smaller request did not shrink the pool to what it asked for.
+  EXPECT_EQ(dev.capacity, 4096u);
+  EXPECT_EQ(a.alloc_count(), 1);
+  EXPECT_TRUE(a.retirements.empty());
+}
+
+TEST(SharedScratchPool, GrowsMonotonicallyToMaxAndRetiresOldBuffer) {
+  SharedScratchDevice dev;
+  FakeAllocator a;
+
+  void* small = call(dev, a, 1024);
+  void* big = call(dev, a, 8192);
+
+  EXPECT_NE(big, small);
+  EXPECT_EQ(dev.capacity, 8192u);
+  ASSERT_EQ(a.alloc_count(), 2);
+  EXPECT_EQ(a.alloc_sizes[1], 8192u);
+  ASSERT_EQ(a.retirements.size(), 1u);
+  EXPECT_EQ(a.retirements[0].first, small);
+
+  // A subsequent smaller request reuses the grown buffer -- pool never shrinks.
+  void* reuse = call(dev, a, 512);
+  EXPECT_EQ(reuse, big);
+  EXPECT_EQ(dev.capacity, 8192u);
+  EXPECT_EQ(a.alloc_count(), 2);
+}
+
+TEST(SharedScratchPool, GrowRetiresTheOldBufferWithTheEventToWaitOn) {
+  SharedScratchDevice dev;
+  FakeAllocator a;
+  FakeEventFactory events;
+
+  void* small = call(dev, a, 1024);
+  ASSERT_NE(small, nullptr);
+
+  // An enqueue against `small` has been submitted and recorded, so its
+  // retirement has something specific to outlive.
+  const SharedScratchHandoff handoff = shared_scratch_claim_event(dev, std::ref(events));
+  ASSERT_EQ(shared_scratch_mark_in_flight(dev), handoff.event);
+
+  ASSERT_NE(call(dev, a, 8192), nullptr);
+
+  ASSERT_EQ(a.retirements.size(), 1u);
+  EXPECT_EQ(a.retirements[0].first, small);
+  // The retirement carries the event that enqueue was recorded on, so the caller
+  // has one specific enqueue to wait for, rather than needing a device-wide
+  // synchronize to be correct.
+  EXPECT_EQ(a.retirements[0].second, handoff.event);
+}
+
+TEST(SharedScratchPool, GrowHasNothingToWaitForWhenNoEnqueueWasRecorded) {
+  SharedScratchDevice dev;
+  FakeAllocator a;
+  FakeEventFactory events;
+
+  void* small = call(dev, a, 1024);
+  ASSERT_NE(small, nullptr);
+  // The slot has an event, but nothing has been recorded on it: claiming the
+  // handoff is not the same as enqueueing against the buffer.
+  ASSERT_NE(shared_scratch_claim_event(dev, std::ref(events)).event, nullptr);
+
+  ASSERT_NE(call(dev, a, 8192), nullptr);
+
+  ASSERT_EQ(a.retirements.size(), 1u);
+  EXPECT_EQ(a.retirements[0].first, small);
+  EXPECT_EQ(a.retirements[0].second, nullptr);
+}
+
+TEST(SharedScratchPool, AllocationFailureLeavesExistingBufferUntouched) {
+  SharedScratchDevice dev;
+  FakeAllocator a;
+
+  void* first = call(dev, a, 1024);
+  ASSERT_NE(first, nullptr);
+
+  // A growth whose allocation fails must return nullptr and keep the old buffer,
+  // so the caller can surface the error without corrupting the pool.
+  a.fail_next = true;
+  void* failed = call(dev, a, 8192);
+  EXPECT_EQ(failed, nullptr);
+  EXPECT_TRUE(a.retirements.empty());
+
+  // The device still holds the original buffer and serves it on the next request.
+  void* again = call(dev, a, 1024);
+  EXPECT_EQ(again, first);
+  EXPECT_EQ(dev.capacity, 1024u);
+}
+
+TEST(SharedScratchPool, FirstAllocationFailureReturnsNullAndStoresNothing) {
+  SharedScratchDevice dev;
+  FakeAllocator a;
+
+  a.fail_next = true;
+  void* p = call(dev, a, 1024);
+  EXPECT_EQ(p, nullptr);
+  EXPECT_EQ(dev.buffer, nullptr);
+  EXPECT_EQ(dev.capacity, 0u);
+
+  // Nothing stored: a later successful request allocates fresh.
+  void* q = call(dev, a, 1024);
+  EXPECT_NE(q, nullptr);
+  EXPECT_EQ(a.alloc_count(), 1);
+}
+
+// The backend passes one RetiredScratch through a call and acts on what it holds,
+// so a path that leaves the previous growth's buffer in it hands that buffer to a
+// second caller to free.
+TEST(SharedScratchPool, EveryPathClearsTheRetirementItReports) {
+  SharedScratchDevice dev;
+  FakeAllocator a;
+  // Deliberately reused across the calls below, which is the state the clearing is
+  // for; `call` above gives each of its calls a fresh one.
+  RetiredScratch retired;
+  const auto request = [&](std::size_t need) {
+    return shared_scratch_get_or_grow(
+        dev, need, [&a](std::size_t bytes) { return a.alloc(bytes); }, retired);
+  };
+
+  void* const first = request(1024);
+  ASSERT_NE(first, nullptr);
+  ASSERT_EQ(retired.buffer, nullptr);
+  ASSERT_NE(request(8192), nullptr);
+  ASSERT_EQ(retired.buffer, first) << "the growth did not report the buffer it replaced";
+
+  EXPECT_NE(request(512), nullptr);
+  EXPECT_EQ(retired.buffer, nullptr) << "a reuse left the previous growth's buffer in the result, so a caller acting "
+                                        "on it frees a buffer that was already handed back once";
+
+  void* const second = dev.buffer;
+  ASSERT_NE(request(16384), nullptr);
+  ASSERT_EQ(retired.buffer, second);
+  a.fail_next = true;
+  EXPECT_EQ(request(65536), nullptr);
+  EXPECT_EQ(retired.buffer, nullptr) << "a failed allocation left the previous growth's buffer in the result";
+}
+
+// ---------------------------------------------------------------------------
+// Ordering the shared buffer's handoff from one enqueue to the next.
+// ---------------------------------------------------------------------------
+
+TEST(SharedScratchHandoffTest, FirstUseCreatesTheSlotsEventAndWaitsForNothing) {
+  SharedScratchDevice dev;
+  FakeEventFactory events;
+
+  const SharedScratchHandoff handoff = shared_scratch_claim_event(dev, std::ref(events));
+
+  EXPECT_NE(handoff.event, nullptr);
+  EXPECT_FALSE(handoff.needs_wait);
+  EXPECT_EQ(events.created, 1);
+}
+
+TEST(SharedScratchHandoffTest, EveryUseAfterAnEnqueueWaitsOnTheSameEvent) {
+  SharedScratchDevice dev;
+  FakeEventFactory events;
+  const SharedScratchHandoff first = shared_scratch_claim_event(dev, std::ref(events));
+  ASSERT_FALSE(first.needs_wait);
+
+  EXPECT_EQ(shared_scratch_mark_in_flight(dev), first.event);
+
+  // Every later enqueue waits, however many there have been and whichever stream
+  // each of them ran on: the marker records that the buffer was handed out, not
+  // who it was handed to. Comparing stream handles instead would let a caller
+  // through whenever its handle matched the recorded one, including when CUDA has
+  // recycled that value for a different stream.
+  const SharedScratchHandoff second = shared_scratch_claim_event(dev, std::ref(events));
+  EXPECT_TRUE(second.needs_wait);
+  EXPECT_EQ(second.event, first.event);
+
+  const SharedScratchHandoff third = shared_scratch_claim_event(dev, std::ref(events));
+  EXPECT_TRUE(third.needs_wait);
+  EXPECT_EQ(third.event, first.event);
+
+  // One event serves the slot for its whole life, so the wait never targets an
+  // event some earlier enqueue was recorded on.
+  EXPECT_EQ(events.created, 1);
+}
+
+TEST(SharedScratchHandoffTest, KeepsAnIndependentMarkerPerDevice) {
+  SharedScratchPool pool;
+  FakeEventFactory events;
+  SharedScratchDevice& dev0 = pool.get(0);
+  SharedScratchDevice& dev1 = pool.get(1);
+  const SharedScratchHandoff first = shared_scratch_claim_event(dev0, std::ref(events));
+  ASSERT_EQ(shared_scratch_mark_in_flight(dev0), first.event);
+
+  // Device 1 has its own buffer, so device 0's enqueue is nothing for it to wait
+  // on, and it gets its own event.
+  const SharedScratchHandoff second = shared_scratch_claim_event(dev1, std::ref(events));
+  EXPECT_FALSE(second.needs_wait);
+  EXPECT_NE(second.event, first.event);
+  EXPECT_EQ(events.created, 2);
+
+  // Marking device 1 does not make device 0 stop waiting, or the other way round.
+  ASSERT_EQ(shared_scratch_mark_in_flight(dev1), second.event);
+  EXPECT_TRUE(shared_scratch_claim_event(dev0, std::ref(events)).needs_wait);
+  EXPECT_TRUE(shared_scratch_claim_event(dev1, std::ref(events)).needs_wait);
+}
+
+TEST(SharedScratchHandoffTest, EventCreationFailureIsReportedAndRetried) {
+  SharedScratchDevice dev;
+  FakeEventFactory events;
+
+  events.fail_next = true;
+  const SharedScratchHandoff failed = shared_scratch_claim_event(dev, std::ref(events));
+  EXPECT_EQ(failed.event, nullptr);
+  EXPECT_FALSE(failed.needs_wait);
+
+  // The failure leaves nothing behind, so the next call tries again and succeeds
+  // rather than serving an unusable slot for the rest of the process.
+  const SharedScratchHandoff retried = shared_scratch_claim_event(dev, std::ref(events));
+  EXPECT_NE(retried.event, nullptr);
+  EXPECT_FALSE(retried.needs_wait);
+  EXPECT_EQ(events.created, 1);
+}
+
+TEST(SharedScratchHandoffTest, ASlotWithNoEventIsNotMarked) {
+  SharedScratchDevice dev;
+  FakeEventFactory events;
+
+  // Nothing can be recorded without an event, so nothing is claimed to have been.
+  EXPECT_EQ(shared_scratch_mark_in_flight(dev), nullptr);
+
+  // Otherwise, once an event is finally created for the slot, the next caller
+  // would wait on it believing an enqueue had been recorded on it that never was.
+  EXPECT_FALSE(shared_scratch_claim_event(dev, std::ref(events)).needs_wait);
+}
+
+// ---------------------------------------------------------------------------
+// The stream a growth queues its free on.
+// ---------------------------------------------------------------------------
+
+TEST(SharedScratchDisposalStream, FirstUseCreatesTheSlotsStreamAndEveryLaterOneReusesIt) {
+  SharedScratchDevice dev;
+  FakeStreamFactory streams;
+
+  const cudaStream_t first = shared_scratch_disposal_stream(dev, std::ref(streams));
+  EXPECT_NE(first, nullptr);
+  EXPECT_EQ(streams.created, 1);
+
+  // A stream per growth would be a stream leaked per growth: nothing destroys one
+  // in the normal path, by the same argument that leaves the buffers and the
+  // events alone at teardown.
+  EXPECT_EQ(shared_scratch_disposal_stream(dev, std::ref(streams)), first);
+  EXPECT_EQ(shared_scratch_disposal_stream(dev, std::ref(streams)), first);
+  EXPECT_EQ(streams.created, 1);
+}
+
+TEST(SharedScratchDisposalStream, StreamCreationFailureIsReportedAndRetried) {
+  SharedScratchDevice dev;
+  FakeStreamFactory streams;
+
+  streams.fail_next = true;
+  // Null is what the disposal reads as "no stream to queue the free on", so it
+  // falls back to a device-wide free rather than passing this to cudaFreeAsync,
+  // where it would name the legacy default stream.
+  EXPECT_EQ(shared_scratch_disposal_stream(dev, std::ref(streams)), nullptr);
+
+  // The failure leaves nothing behind, so the next growth tries again rather than
+  // taking the fallback for the rest of the process.
+  EXPECT_NE(shared_scratch_disposal_stream(dev, std::ref(streams)), nullptr);
+  EXPECT_EQ(streams.created, 1);
+}
+
+// A stream belongs to the device that was current when it was created, and the
+// free queued on it is of that device's memory. One stream shared across devices
+// would put every growth's free on whichever device grew first.
+TEST(SharedScratchDisposalStream, KeepsAnIndependentStreamPerDevice) {
+  SharedScratchPool pool;
+  FakeStreamFactory streams;
+
+  const cudaStream_t zero = shared_scratch_disposal_stream(pool.get(0), std::ref(streams));
+  const cudaStream_t one = shared_scratch_disposal_stream(pool.get(1), std::ref(streams));
+
+  EXPECT_NE(zero, nullptr);
+  EXPECT_NE(one, nullptr);
+  EXPECT_NE(zero, one);
+  EXPECT_EQ(streams.created, 2);
+  EXPECT_EQ(shared_scratch_disposal_stream(pool.get(0), std::ref(streams)), zero);
+}
+
+// ---------------------------------------------------------------------------
+// The registry that owns one entry per device.
+// ---------------------------------------------------------------------------
+
+TEST(SharedScratchPoolRegistry, KeepsAnIndependentBufferPerDevice) {
+  SharedScratchPool pool;
+  FakeAllocator a;
+
+  void* dev0 = call(pool.get(0), a, 2048);
+  void* dev1 = call(pool.get(1), a, 2048);
+
+  EXPECT_NE(dev0, dev1);
+  EXPECT_EQ(a.alloc_count(), 2);
+  EXPECT_TRUE(a.retirements.empty());
+
+  // Growing device 1 must not touch device 0's buffer.
+  void* dev1_big = call(pool.get(1), a, 9000);
+  void* dev0_again = call(pool.get(0), a, 2048);
+  EXPECT_NE(dev1_big, dev1);
+  EXPECT_EQ(dev0_again, dev0);
+  ASSERT_EQ(a.retirements.size(), 1u);
+  EXPECT_EQ(a.retirements[0].first, dev1);
+}
+
+TEST(SharedScratchPoolRegistry, HandsOutOneStableEntryPerDevice) {
+  SharedScratchPool pool;
+
+  SharedScratchDevice* const seven = &pool.get(7);
+  EXPECT_EQ(&pool.get(7), seven);
+  EXPECT_NE(&pool.get(8), seven);
+
+  // Callers keep using an entry after the registry's lock is dropped, and go on
+  // using it across their CUDA calls, so adding devices must not move it.
+  std::set<SharedScratchDevice*> distinct;
+  for (int id = 0; id < 512; ++id) {
+    distinct.insert(&pool.get(id));
+  }
+  EXPECT_EQ(&pool.get(7), seven);
+  // Two devices must never land on one entry, or a claimant is handed another
+  // device's buffer as its own. A bounded or folded key space is a plausible way
+  // to write this registry and an invisible way to break it.
+  EXPECT_EQ(distinct.size(), 512u);
+}
+
+// scratch_pool() is inline so that the backend and the pool's test hooks, which
+// are separate translation units, reach one registry. Nothing else here can see
+// that: every case above builds its own SharedScratchPool. Give the accessor
+// internal linkage instead and each translation unit gets a registry of its own,
+// at which point the reset hook clears one nobody uses, the capacity hook always
+// answers zero, and several of the backend suite's pool assertions pass without
+// testing anything -- on a GPU host, which is the only place they run.
+//
+// The second translation unit is test_shared_scratch_pool_other_tu.cpp.
+TEST(SharedScratchPoolRegistry, EveryTranslationUnitSeesOneProcessPool) {
+  EXPECT_EQ(scratch_pool_seen_from_another_translation_unit(), &scratch_pool())
+      << "two translation units got different process pools, so scratch_pool() no longer has external linkage and "
+         "the pool's test hooks operate on a registry the backend never uses";
+}
+
+TEST(SharedScratchPoolRegistry, ResetHandsBackEverySlotAndLeavesItEmpty) {
+  // The backend test fixture runs this between cases, so every case that reads
+  // what the pool holds depends on it. The two things it has to get right are
+  // handing the caller everything the slot held -- the buffer, the event and the
+  // disposal stream, none of which the pool or the disposer can find afterwards --
+  // and clearing the slot, so the next claim allocates instead of reusing a
+  // pointer that has been freed.
+  SharedScratchPool pool;
+  FakeAllocator zero;
+  FakeAllocator one;
+  FakeEventFactory events;
+  FakeStreamFactory streams;
+
+  SharedScratchDevice& dev0 = pool.get(0);
+  SharedScratchDevice& dev1 = pool.get(1);
+  void* const dev0_buffer = call(dev0, zero, 4096);
+  void* const dev1_buffer = call(dev1, one, 2048);
+  const cudaEvent_t dev0_event = shared_scratch_claim_event(dev0, std::ref(events)).event;
+  shared_scratch_mark_in_flight(dev0);
+  const cudaStream_t dev0_stream = shared_scratch_disposal_stream(dev0, std::ref(streams));
+  // Device 1 is left with a buffer and neither an event nor a disposal stream,
+  // which is the state of a slot whose event creation failed and which never grew:
+  // the reset has to cope with nulls there.
+  ASSERT_NE(dev0_buffer, nullptr);
+  ASSERT_NE(dev1_buffer, nullptr);
+  ASSERT_NE(dev0_event, nullptr);
+  ASSERT_NE(dev0_stream, nullptr);
+  ASSERT_EQ(dev1.marker.event, nullptr);
+  ASSERT_EQ(dev1.disposal_stream, nullptr);
+
+  struct Disposal {
+    int device_id;
+    void* buffer;
+    cudaEvent_t event;
+    cudaStream_t disposal_stream;
+  };
+  std::vector<Disposal> disposed;
+  reset_shared_scratch_pool_slots(
+      pool, [&](int device_id, void* buffer, cudaEvent_t event, cudaStream_t disposal_stream) {
+        disposed.push_back({device_id, buffer, event, disposal_stream});
+      });
+
+  // The registry iterates in unspecified order, so each device is looked up.
+  const auto disposal_for = [&disposed](int device_id) -> const Disposal* {
+    for (const Disposal& d : disposed) {
+      if (d.device_id == device_id) {
+        return &d;
+      }
+    }
+    return nullptr;
+  };
+  ASSERT_EQ(disposed.size(), 2u) << "the reset skipped a device's slot, whose buffer is then never freed";
+  ASSERT_NE(disposal_for(0), nullptr);
+  ASSERT_NE(disposal_for(1), nullptr);
+  EXPECT_EQ(disposal_for(0)->buffer, dev0_buffer);
+  EXPECT_EQ(disposal_for(0)->event, dev0_event);
+  EXPECT_EQ(disposal_for(0)->disposal_stream, dev0_stream);
+  EXPECT_EQ(disposal_for(1)->buffer, dev1_buffer);
+  EXPECT_EQ(disposal_for(1)->event, nullptr);
+  EXPECT_EQ(disposal_for(1)->disposal_stream, nullptr);
+
+  // The slot the reset cleared is the one a later lookup finds, so the reads below
+  // are of the entry the backend would go on using. One address cannot tell a
+  // surviving entry from a recycled allocation, so the invariant itself is pinned
+  // by ResetLeavesEveryEntryWhereItWas rather than here.
+  EXPECT_EQ(&pool.get(0), &dev0);
+  EXPECT_EQ(dev0.buffer, nullptr);
+  EXPECT_EQ(dev0.capacity, 0u);
+  EXPECT_EQ(dev0.marker.event, nullptr);
+  EXPECT_FALSE(dev0.marker.pending);
+  EXPECT_EQ(dev0.disposal_stream, nullptr);
+
+  // A smaller request than the freed buffer served: reuse would satisfy it from
+  // the stale capacity and allocate nothing, so this is what distinguishes a
+  // cleared slot from one the reset only emptied of its event.
+  void* const fresh = call(dev0, zero, 1024);
+  EXPECT_NE(fresh, nullptr);
+  EXPECT_EQ(dev0.capacity, 1024u);
+  EXPECT_EQ(zero.alloc_count(), 2) << "the slot was not cleared, so the request reused the freed buffer";
+  EXPECT_TRUE(zero.retirements.empty()) << "the cleared slot retired a buffer the reset had already handed back";
+}
+
+// The mirror of device 1 in the case above: an event and no buffer. That state is
+// reachable, because the handoff event is created before the allocation, so a
+// claim whose allocation fails leaves one behind. A reset that skipped slots with
+// no buffer would leak that event and pass every other case in this file.
+TEST(SharedScratchPoolRegistry, ResetHandsBackTheEventOfASlotThatNeverGotABuffer) {
+  SharedScratchPool pool;
+  FakeAllocator a;
+  FakeEventFactory events;
+
+  SharedScratchDevice& dev = pool.get(3);
+  const cudaEvent_t event = shared_scratch_claim_event(dev, std::ref(events)).event;
+  ASSERT_NE(event, nullptr);
+  a.fail_next = true;
+  ASSERT_EQ(call(dev, a, 1024), nullptr);
+  ASSERT_EQ(dev.buffer, nullptr) << "the allocation did not fail, so this slot is not the state under test";
+
+  std::vector<std::pair<void*, cudaEvent_t>> disposed;
+  reset_shared_scratch_pool_slots(pool, [&](int, void* buffer, cudaEvent_t slot_event, cudaStream_t) {
+    disposed.emplace_back(buffer, slot_event);
+  });
+
+  ASSERT_EQ(disposed.size(), 1u) << "the reset skipped a slot holding an event and no buffer, so nothing ever destroys "
+                                    "that event";
+  EXPECT_EQ(disposed[0].first, nullptr);
+  EXPECT_EQ(disposed[0].second, event);
+  EXPECT_EQ(dev.marker.event, nullptr) << "the slot kept the event the reset handed to the disposer";
+}
+
+// The registry hands out a reference and drops its lock, so callers go on using
+// that reference; the reset has to empty a slot without moving it. Checking one
+// address cannot pin that. An erasing reset returns the node to the allocator,
+// which hands the very same address back to the next lookup, so the comparison
+// still holds -- and every read through the old reference between the two is of
+// freed memory. Enough entries and the allocator cannot reproduce them all.
+TEST(SharedScratchPoolRegistry, ResetLeavesEveryEntryWhereItWas) {
+  constexpr int kDevices = 512;
+  SharedScratchPool pool;
+  FakeAllocator alloc;
+  FakeEventFactory events;
+
+  std::vector<SharedScratchDevice*> before;
+  before.reserve(kDevices);
+  for (int id = 0; id < kDevices; ++id) {
+    SharedScratchDevice& dev = pool.get(id);
+    // Give each slot something, so the reset has work to do on all of them rather
+    // than skipping past empty ones.
+    ASSERT_NE(call(dev, alloc, 1024), nullptr);
+    ASSERT_NE(shared_scratch_claim_event(dev, std::ref(events)).event, nullptr);
+    before.push_back(&dev);
+  }
+
+  int disposed = 0;
+  reset_shared_scratch_pool_slots(pool, [&disposed](int, void*, cudaEvent_t, cudaStream_t) { ++disposed; });
+  ASSERT_EQ(disposed, kDevices);
+
+  int moved = 0;
+  for (int id = 0; id < kDevices; ++id) {
+    if (&pool.get(id) != before[static_cast<std::size_t>(id)]) {
+      ++moved;
+    }
+  }
+  EXPECT_EQ(moved, 0) << moved << " of " << kDevices
+                      << " entries moved, so a reference the registry handed out before the reset names freed memory "
+                         "or another device's slot";
+}
+
+// The reset's disposer frees device memory, and a device-wide free waits on
+// everything queued on that device -- a parked host function included. Under
+// either lock that would hold up whatever the lock covers: the device's own next
+// claimant under the device lock, and every device's claimants under the
+// registry's. So each slot is emptied under its own device lock, and what came
+// out of it is disposed of with that dropped too. The registry lock is dropped
+// earlier still, after the snapshot of which slots exist; the case below it is
+// what watches that.
+TEST(SharedScratchPoolRegistry, ResetDisposesWithNoLockHeld) {
+  constexpr int kUntouchedDevice = 99;
+  SharedScratchPool pool;
+  FakeAllocator alloc;
+
+  SharedScratchDevice& dev0 = pool.get(0);
+  ASSERT_NE(call(dev0, alloc, 1024), nullptr);
+
+  std::atomic<bool> disposing{false};
+  std::atomic<bool> reset_returned{false};
+  std::atomic<bool> nothing_disposed{false};
+  std::atomic<bool> claimed{false};
+  std::atomic<bool> device_lock_free{false};
+  std::thread claimer([&] {
+    // The regression this case exists to catch is a reset that disposes of
+    // nothing, and this wait is where that regression arrives. Waiting for
+    // `disposing` alone would turn it into a target that hangs until Bazel kills
+    // it, with no assertion to say what broke.
+    const auto rendezvous_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (!disposing.load() && !reset_returned.load() && std::chrono::steady_clock::now() < rendezvous_deadline) {
+      std::this_thread::yield();
+    }
+    if (!disposing.load()) {
+      nothing_disposed.store(true);
+      return;
+    }
+    if (dev0.mu.try_lock()) {
+      device_lock_free.store(true);
+      dev0.mu.unlock();
+    }
+    pool.get(kUntouchedDevice);
+    claimed.store(true);
+  });
+
+  // Read inside the disposer: the claim completes once the reset returns either
+  // way, so only what was true while the disposer ran tells the two apart.
+  bool claimed_during_dispose = false;
+  reset_shared_scratch_pool_slots(pool, [&](int, void*, cudaEvent_t, cudaStream_t) {
+    disposing.store(true);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (!claimed.load() && std::chrono::steady_clock::now() < deadline) {
+      std::this_thread::yield();
+    }
+    claimed_during_dispose = claimed.load();
+  });
+  reset_returned.store(true);
+  claimer.join();
+
+  ASSERT_FALSE(nothing_disposed.load()) << "the reset returned without disposing of the slot that holds a buffer, so "
+                                           "there was no window in which to observe either lock";
+  EXPECT_TRUE(device_lock_free.load()) << "the disposer ran holding the slot's own device lock, so a claim on that "
+                                          "device waits for a free that waits on the whole device";
+  EXPECT_TRUE(claimed_during_dispose) << "a lookup for a device the reset never touched could not complete while the "
+                                         "disposer ran, so the registry's lock was held across it and one device's "
+                                         "teardown blocks every other device";
+}
+
+// The other half of the same rule. The case above watches the disposer, which
+// runs after the retry loop; this one watches the loop itself, which is where the
+// reset spends its whole deadline whenever a slot's lock is held. Every pooled
+// call on every device takes the registry lock to find its own slot, so a reset
+// that held it across that loop would stop devices it never takes for as long as
+// the loop runs.
+//
+// The lookup is timed in a loop rather than once, because the reset takes the
+// registry lock at an instant this thread does not control and a single lookup
+// could land before it and measure nothing. What the reset cost a device it never
+// touched is the longest of them.
+TEST(SharedScratchPoolRegistry, ALockedSlotDoesNotBlockLookupsForTheDevicesTheResetNeverTakes) {
+  constexpr int kUntouchedDevice = 7;
+  // Generous enough for a loaded machine and still far below what a reset holding
+  // the registry lock across its retry spends, which is the whole deadline: what
+  // is being told apart is milliseconds from seconds.
+  const auto longest_acceptable_block = kResetLockWait / 5;
+
+  SharedScratchPool pool;
+  FakeAllocator alloc;
+  SharedScratchDevice& leaked = pool.get(0);
+  ASSERT_NE(call(leaked, alloc, 1024), nullptr);
+  // Created before the reset, so what is timed below is a lookup and not an
+  // insertion racing the reset's walk.
+  pool.get(kUntouchedDevice);
+
+  std::atomic<bool> holding{false};
+  std::atomic<bool> release_it{false};
+  std::thread holder([&] {
+    leaked.mu.lock();
+    holding.store(true);
+    const auto deadline = std::chrono::steady_clock::now() + kResetLockWait + std::chrono::seconds{25};
+    while (!release_it.load() && std::chrono::steady_clock::now() < deadline) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    leaked.mu.unlock();
+  });
+  while (!holding.load()) {
+    std::this_thread::yield();
+  }
+
+  std::atomic<bool> reset_returned{false};
+  std::size_t left_alone = 0;
+  std::thread resetter([&] {
+    left_alone = reset_shared_scratch_pool_slots(pool, [](int, void*, cudaEvent_t, cudaStream_t) {});
+    reset_returned.store(true);
+  });
+
+  std::chrono::steady_clock::duration longest_block{};
+  int lookups = 0;
+  while (!reset_returned.load()) {
+    const auto before = std::chrono::steady_clock::now();
+    pool.get(kUntouchedDevice);
+    const auto blocked = std::chrono::steady_clock::now() - before;
+    ++lookups;
+    if (blocked > longest_block) {
+      longest_block = blocked;
+    }
+    // Enough of a gap that this loop does not starve the reset of the very lock
+    // the case is about.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  resetter.join();
+  release_it.store(true);
+  holder.join();
+
+  ASSERT_EQ(left_alone, 1u) << "the reset did not spend its deadline retrying the locked slot, so nothing below was "
+                               "measured against a reset that was retrying";
+  ASSERT_GT(lookups, 1) << "the reset was over before this thread had looked the untouched device up twice";
+  EXPECT_LT(longest_block, longest_acceptable_block)
+      << "a lookup for a device the reset never takes blocked "
+      << std::chrono::duration_cast<std::chrono::milliseconds>(longest_block).count() << " ms of the reset's "
+      << std::chrono::duration_cast<std::chrono::milliseconds>(kResetLockWait).count()
+      << " ms deadline, so the registry lock is held across the retry loop and one slot the reset cannot take holds "
+         "off every device";
+}
+
+// A device lock still held between cases is a claim that was never released --
+// the defect the backend suite's own case hunts. Waiting for it would hang the
+// fixture that resets before and after every case, so the run would end in a
+// target timeout and the message naming the leak would never be printed. The
+// reset reports the slot and leaves it instead.
+//
+// The holder below releases on its own deadline, so a reset that waits for the
+// lock rather than reporting it ends this case in a failure rather than a hang.
+TEST(SharedScratchPoolRegistry, ResetReportsALockedSlotRatherThanWaitingForIt) {
+  constexpr std::chrono::seconds kHolderDeadline{30};
+
+  SharedScratchPool pool;
+  FakeAllocator alloc;
+
+  // Two unlocked slots against one locked one, so the number the reset answers
+  // with -- devices it could not take -- differs from the number it cleared. With
+  // one of each the two are both 1 and a reset that reported the wrong one of them
+  // would pass.
+  SharedScratchDevice& leaked = pool.get(0);
+  SharedScratchDevice& ordinary = pool.get(1);
+  SharedScratchDevice& also_ordinary = pool.get(2);
+  ASSERT_NE(call(leaked, alloc, 1024), nullptr);
+  ASSERT_NE(call(ordinary, alloc, 2048), nullptr);
+  ASSERT_NE(call(also_ordinary, alloc, 4096), nullptr);
+
+  std::atomic<bool> holding{false};
+  std::atomic<bool> release_it{false};
+  std::thread holder([&] {
+    leaked.mu.lock();
+    holding.store(true);
+    const auto deadline = std::chrono::steady_clock::now() + kHolderDeadline;
+    while (!release_it.load() && std::chrono::steady_clock::now() < deadline) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    leaked.mu.unlock();
+  });
+  while (!holding.load()) {
+    std::this_thread::yield();
+  }
+
+  int disposed = 0;
+  const auto started = std::chrono::steady_clock::now();
+  const std::size_t still_locked =
+      reset_shared_scratch_pool_slots(pool, [&](int, void*, cudaEvent_t, cudaStream_t) { ++disposed; });
+  const auto took = std::chrono::steady_clock::now() - started;
+  release_it.store(true);
+  holder.join();
+
+  EXPECT_EQ(still_locked, 1u) << "the reset did not report the one device whose lock it could not take";
+  EXPECT_LT(took, kHolderDeadline) << "the reset returned only once the lock was released, so it waited for a claim "
+                                      "that a leak would never release";
+  EXPECT_EQ(disposed, 2) << "the reset disposed of " << disposed
+                         << " slots: it should hand back the two unlocked ones and leave the locked one alone";
+  EXPECT_NE(leaked.buffer, nullptr) << "the reset emptied a slot whose lock it never held, so it handed the disposer a "
+                                       "buffer a live claimant is still using";
+  EXPECT_EQ(ordinary.buffer, nullptr) << "one locked slot stopped the reset clearing the others";
+  EXPECT_EQ(also_ordinary.buffer, nullptr) << "one locked slot stopped the reset clearing the others";
+}
+
+// The budget covers the whole reset, so a leaked lock has to be prevented from
+// spending it on behalf of the devices it shares the pool with. A device that is
+// merely busy -- claims arriving and finishing, which is every device the pool is
+// for -- must still be taken, and a single try_lock made once the leak has run the
+// clock down only takes it if it happens to be idle at that one instant.
+//
+// So the neighbour below is locked when the reset starts, free for half a second
+// in the middle, and locked again long before the deadline. A reset that retries
+// takes it inside that window; one that spends its budget on the leak first and
+// then tries once reports it as locked and never hands its buffer to the disposer
+// -- which, in the fixture that resets between cases, means the next case starts
+// on a device still holding what an earlier one grew.
+//
+// Which slot is which is decided by the map rather than by this case, and only a
+// leak the reset reaches *before* the busy slot can cost it anything. So the order
+// is read off a reset of the same three entries first -- entries are never erased,
+// so the second walk takes them in the same order -- and the roles are handed out
+// from that.
+TEST(SharedScratchPoolRegistry, ALeakedLockDoesNotCostTheResetTheSlotsItSharesThePoolWith) {
+  constexpr std::chrono::milliseconds kNeighbourFreeFrom{200};
+  constexpr std::chrono::milliseconds kNeighbourBusyAgainFrom{700};
+  const auto holder_deadline = kResetLockWait + std::chrono::seconds{25};
+
+  SharedScratchPool pool;
+  FakeAllocator alloc;
+  // Three slots, so the number the reset answers with and the number it cleared
+  // stay different figures: one leaked, one busy, one free throughout.
+  for (const int device_id : {0, 1, 2}) {
+    ASSERT_NE(call(pool.get(device_id), alloc, 1024), nullptr);
+  }
+  std::vector<int> walk_order;
+  ASSERT_EQ(
+      reset_shared_scratch_pool_slots(
+          pool, [&](int id, void*, cudaEvent_t, cudaStream_t) { walk_order.push_back(id); }),
+      0u)
+      << "a reset of three unlocked slots reported one it could not take";
+  ASSERT_EQ(walk_order.size(), 3u);
+
+  SharedScratchDevice& leaked = pool.get(walk_order[0]);
+  SharedScratchDevice& busy = pool.get(walk_order[1]);
+  SharedScratchDevice& ordinary = pool.get(walk_order[2]);
+  ASSERT_NE(call(leaked, alloc, 1024), nullptr);
+  ASSERT_NE(call(busy, alloc, 2048), nullptr);
+  ASSERT_NE(call(ordinary, alloc, 4096), nullptr);
+
+  std::atomic<bool> both_held{false};
+  std::atomic<bool> release_it{false};
+  const auto started = std::chrono::steady_clock::now();
+  std::thread holder([&] {
+    leaked.mu.lock();
+    busy.mu.lock();
+    both_held.store(true);
+    std::this_thread::sleep_until(started + kNeighbourFreeFrom);
+    busy.mu.unlock();
+    std::this_thread::sleep_until(started + kNeighbourBusyAgainFrom);
+    // Locked again well inside the deadline, so only a reset that looked during
+    // the window above ever had it.
+    busy.mu.lock();
+    const auto deadline = std::chrono::steady_clock::now() + holder_deadline;
+    while (!release_it.load() && std::chrono::steady_clock::now() < deadline) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    busy.mu.unlock();
+    leaked.mu.unlock();
+  });
+  while (!both_held.load()) {
+    std::this_thread::yield();
+  }
+
+  int disposed = 0;
+  const std::size_t still_locked =
+      reset_shared_scratch_pool_slots(pool, [&](int, void*, cudaEvent_t, cudaStream_t) { ++disposed; });
+  release_it.store(true);
+  holder.join();
+
+  EXPECT_EQ(still_locked, 1u) << "the reset reported " << still_locked
+                              << " locked slots: only the leaked one is unreachable, and the busy one was free for "
+                              << (kNeighbourBusyAgainFrom - kNeighbourFreeFrom).count() << " ms of the "
+                              << std::chrono::duration_cast<std::chrono::milliseconds>(kResetLockWait).count()
+                              << " ms it had to look";
+  EXPECT_EQ(disposed, 2) << "the reset disposed of " << disposed
+                         << " slots: the leaked one it must leave alone, and the busy one it must come back to rather "
+                            "than give up on because another device's lock spent the budget";
+  EXPECT_EQ(busy.buffer, nullptr) << "one leaked lock left a busy device's buffer resident, so the pool a case is "
+                                     "reset for still holds what an earlier one grew";
+  EXPECT_EQ(ordinary.buffer, nullptr) << "the reset left a slot nothing ever locked";
+  EXPECT_NE(leaked.buffer, nullptr) << "the reset emptied a slot whose lock it never held";
+}
+
+TEST(SharedScratchPoolRegistry, AGrowthOnOneDeviceDoesNotBlockAClaimOnAnother) {
+  SharedScratchPool pool;
+  // One allocator per thread: the two claims share the registry and nothing else.
+  FakeAllocator zero;
+  FakeAllocator one;
+
+  std::promise<void> entered_alloc;
+  std::promise<void> leave_alloc;
+  std::future<void> entered = entered_alloc.get_future();
+  std::shared_future<void> leave = leave_alloc.get_future().share();
+
+  SharedScratchDevice& dev0 = pool.get(0);
+  std::thread grower([&] {
+    std::lock_guard<std::mutex> lk(dev0.mu);
+    RetiredScratch retired;
+    shared_scratch_get_or_grow(
+        dev0,
+        4096,
+        [&](std::size_t bytes) {
+          entered_alloc.set_value();
+          leave.wait();
+          return zero.alloc(bytes);
+        },
+        retired);
+  });
+  // The cap matters as much as the wait: a growth that takes the reuse path never
+  // reaches its allocation, so nothing fires this promise and an uncapped wait
+  // would hang the harness rather than fail the test.
+  if (entered.wait_for(std::chrono::seconds(10)) != std::future_status::ready) {
+    leave_alloc.set_value();
+    grower.join();
+    FAIL() << "the growth on device 0 never reached its allocation";
+  }
+
+  // Device 0's growth is stalled inside its allocation with device 0's lock held.
+  // Without this the rest of the test would pass against any implementation.
+  if (dev0.mu.try_lock()) {
+    dev0.mu.unlock();
+    ADD_FAILURE() << "device 0's lock was not held across its allocation";
+  }
+
+  auto claim = std::async(std::launch::async, [&] {
+    SharedScratchDevice& dev1 = pool.get(1);
+    std::lock_guard<std::mutex> lk(dev1.mu);
+    RetiredScratch retired;
+    return shared_scratch_get_or_grow(
+        dev1, 2048, [&](std::size_t bytes) { return one.alloc(bytes); }, retired);
+  });
+  const bool served = claim.wait_for(std::chrono::seconds(10)) == std::future_status::ready;
+
+  leave_alloc.set_value();
+  grower.join();
+
+  ASSERT_TRUE(served) << "a claim on device 1 waited for a growth on device 0";
+  EXPECT_NE(claim.get(), nullptr);
+  EXPECT_EQ(one.alloc_count(), 1);
+}
+
+TEST(SharedScratchPoolRegistry, ConcurrentLookupsKeepTheRegistryIntact) {
+  // Every other test reaches the registry from one thread at a time, so the
+  // registry's own lock is the one mechanism here that nothing else exercises:
+  // without this test it can be deleted outright and the suite stays green.
+  //
+  // An unsynchronized std::unordered_map mutated from several threads has no
+  // defined behaviour, so this cannot assert on a specific corruption. It
+  // hammers the lookup and then asks the two questions the corruption answers
+  // wrongly: is every id still where the race left it, and did any two ids land
+  // on one entry. Each round is an independent chance to observe that; the
+  // rounds are what make a miss unlikely rather than the assertions.
+  constexpr int kThreads = 4;
+  constexpr int kPerThread = 4000;
+  constexpr int kRounds = 8;
+
+  for (int round = 0; round < kRounds; ++round) {
+    SharedScratchPool pool;
+    std::vector<std::vector<SharedScratchDevice*>> seen(kThreads);
+    std::atomic<int> ready{0};
+    std::atomic<bool> go{false};
+
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+      threads.emplace_back([&, t] {
+        std::vector<SharedScratchDevice*> mine;
+        mine.reserve(kPerThread);
+        // Rehashing is what corrupts an unsynchronized map, and it happens on a
+        // handful of the inserts in a round, so the threads have to be inside
+        // their loops at the same time.
+        ready.fetch_add(1);
+        while (!go.load()) {
+        }
+        for (int i = 0; i < kPerThread; ++i) {
+          mine.push_back(&pool.get(t * kPerThread + i));
+        }
+        seen[t] = std::move(mine);
+      });
+    }
+    while (ready.load() < kThreads) {
+    }
+    go.store(true);
+    for (std::thread& t : threads) {
+      t.join();
+    }
+
+    std::set<SharedScratchDevice*> distinct;
+    for (int t = 0; t < kThreads; ++t) {
+      ASSERT_EQ(seen[t].size(), static_cast<std::size_t>(kPerThread));
+      for (int i = 0; i < kPerThread; ++i) {
+        const int id = t * kPerThread + i;
+        ASSERT_EQ(&pool.get(id), seen[t][i]) << "device " << id << " in round " << round;
+        distinct.insert(seen[t][i]);
+      }
+    }
+    ASSERT_EQ(distinct.size(), static_cast<std::size_t>(kThreads * kPerThread)) << "round " << round;
+  }
+}
+
+#if defined(__unix__)
+
+// scratch_pool() hands back a registry that is allocated once and never
+// destroyed. The alternative -- an object with static storage duration -- is
+// destroyed after main returns, which destroys the registry's mutex, every
+// device's mutex and the map nodes a live reference points into, while a thread
+// anywhere between the lookup and the release of its device lock still holds
+// them.
+//
+// Nothing gtest asserts inside this process can see that: it happens after the
+// last test has finished. So these run in forked children that put a thread
+// inside the pooled path and then exit, and read the status the child died with.
+//
+// Probabilistic in one direction only. A child that is torn down under a live
+// claimant does not have to crash, so the count below is a floor on how often it
+// would; a child that is not torn down under one cannot crash at all, so a
+// single non-zero status is a real failure and not a flake.
+constexpr int kTeardownChildren = 24;
+
+// What a child exits with when it could not get as far as the state under test --
+// starting a thread, two dozen forks in, is the way that happens. Distinct from
+// zero and from the teardown crash this case counts, so a run that could not set
+// itself up is not read as evidence either way.
+constexpr int kChildCouldNotStart = 121;
+
+// Long enough that the children below -- a thread, a 30 ms sleep and exit() --
+// are nowhere near it.
+constexpr std::chrono::seconds kChildDeadline{30};
+
+// Reaps `child`, killing it if it overruns `kChildDeadline`; returns false when
+// it had to. Without a deadline a wedged child parks the parent here until the
+// whole target times out, which reports as a timeout on the binary rather than as
+// this case failing. The deadline only delivers that if the whole reaping loop
+// fits inside the target's timeout -- kTeardownChildren children at kChildDeadline
+// each is 720 s -- which is why the BUILD file gives this target the long (900 s)
+// timeout rather than leaving it Bazel's 300 s default. An interrupted wait is
+// retried, since a signal can arrive at any point and says nothing about the
+// child.
+bool reap_child(pid_t child, int& status) {
+  const auto deadline = std::chrono::steady_clock::now() + kChildDeadline;
+  for (;;) {
+    const pid_t reaped = waitpid(child, &status, WNOHANG);
+    if (reaped == child) {
+      return true;
+    }
+    if (reaped == -1 && errno != EINTR) {
+      return false;
+    }
+    if (std::chrono::steady_clock::now() >= deadline) {
+      kill(child, SIGKILL);
+      // Reaped even so. A zombie is not inherited by anything -- it stays this
+      // process's child until this process reaps it or exits -- so what leaving it
+      // costs is a process-table entry per overrun, held for the rest of the run.
+      while (waitpid(child, &status, 0) == -1 && errno == EINTR) {
+      }
+      return false;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+}
+
+[[noreturn]] void hold_the_pool_open_then_exit() {
+  static std::atomic<bool> inside{false};
+  std::thread claimant([] {
+    for (unsigned i = 0;; ++i) {
+      SharedScratchDevice& dev = scratch_pool().get(static_cast<int>(i % 8));
+      std::lock_guard<std::mutex> lk(dev.mu);
+      dev.capacity += 1;
+      inside.store(true);
+    }
+  });
+  // Never joined: the point is for it to still be in there at teardown.
+  claimant.detach();
+  while (!inside.load()) {
+    std::this_thread::yield();
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(30));
+  // exit() and not _exit(): static destruction is the event under test.
+  std::exit(0);
+}
+
+TEST(SharedScratchPoolRegistry, TheProcessPoolOutlivesStaticDestructionUnderALiveClaimant) {
+  int killed_by_signal = 0;
+  int exited_nonzero = 0;
+  int could_not_start = 0;
+  int overran = 0;
+  for (int i = 0; i < kTeardownChildren; ++i) {
+    // Anything gtest has buffered would otherwise be written twice, once by each
+    // side of the fork.
+    std::fflush(nullptr);
+    const pid_t child = fork();
+    ASSERT_NE(child, -1) << "fork failed: " << std::strerror(errno);
+    if (child == 0) {
+      // Nothing may leave the child by any route but exit. Left to unwind, a
+      // failed thread construction returns into the test body and the child
+      // carries on through the rest of the binary as a second gtest process,
+      // forking children of its own and writing over the parent's output.
+      try {
+        hold_the_pool_open_then_exit();
+      } catch (...) {
+        _exit(kChildCouldNotStart);
+      }
+    }
+    int status = 0;
+    if (!reap_child(child, status)) {
+      ++overran;
+      continue;
+    }
+    if (WIFSIGNALED(status)) {
+      ++killed_by_signal;
+    } else if (WEXITSTATUS(status) == kChildCouldNotStart) {
+      ++could_not_start;
+    } else if (WEXITSTATUS(status) != 0) {
+      ++exited_nonzero;
+    }
+  }
+
+  EXPECT_EQ(overran, 0) << overran << " of " << kTeardownChildren << " children were still running after "
+                        << kChildDeadline.count()
+                        << " seconds and were killed, so they neither reached teardown nor reported anything about it";
+  EXPECT_EQ(could_not_start, 0) << could_not_start << " of " << kTeardownChildren
+                                << " children could not start their claimant thread, so those runs never put anything "
+                                   "inside the pool and say nothing about what teardown does to a live claimant";
+  EXPECT_EQ(killed_by_signal, 0) << killed_by_signal << " of " << kTeardownChildren
+                                 << " children died on a signal at exit with a thread still inside the pool, so the "
+                                    "registry is being destroyed out from under a live claimant";
+  EXPECT_EQ(exited_nonzero, 0) << exited_nonzero << " of " << kTeardownChildren
+                               << " children exited non-zero at teardown with a thread still inside the pool";
+}
+
+#endif // defined(__unix__)
+
+} // namespace
+} // namespace executorch_backend
+} // namespace torch_tensorrt

--- a/tests/cpp/executorch/test_shared_scratch_pool_other_tu.cpp
+++ b/tests/cpp/executorch/test_shared_scratch_pool_other_tu.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// A second translation unit, so the pool's test target can see whether
+// scratch_pool() hands the same registry to every one of them.
+//
+// It has to be a separate file: the property is a linkage one, and a single-file
+// target cannot observe it. scratch_pool() is inline for exactly this reason --
+// the backend and the pool's test hooks are different translation units and both
+// have to reach the one registry -- and with internal linkage instead each would
+// get a registry of its own, the reset hook would clear one nobody uses and the
+// capacity hook would always answer zero.
+//
+// The backend suite does not let that through: six of its assertions across five
+// cases read the capacity back and expect a figure above zero, and every one of
+// them would fail. What it cannot do is say why, since those cases are named for
+// the empty input, the capture refusal and the three growths rather than for
+// linkage. That is what this file buys -- one named case in the pool's own target,
+// which needs no GPU.
+
+#include "torch_tensorrt/executorch/SharedScratchPool.h"
+
+namespace torch_tensorrt {
+namespace executorch_backend {
+
+const SharedScratchPool* scratch_pool_seen_from_another_translation_unit() {
+  return &scratch_pool();
+}
+
+} // namespace executorch_backend
+} // namespace torch_tensorrt

--- a/third_party/cuda/BUILD
+++ b/third_party/cuda/BUILD
@@ -17,6 +17,17 @@ config_setting(
     ],
 )
 
+# Every header in the toolkit, and the only place the glob is written: the library
+# targets below take their headers from here. One catch-all pattern rather than a
+# list of extensions, because `include/**/*` already matches every .h, .hpp and
+# .inl under it. Keeping the headers in a target of their own is the shape
+# third_party/cublas and third_party/cudnn/archive already use.
+cc_library(
+    name = "cuda_headers",
+    hdrs = glob(["include/**/*"]),
+    includes = ["include/"],
+)
+
 cc_library(
     name = "cudart",
     srcs = select({
@@ -30,13 +41,7 @@ cc_library(
             "lib64/libcudart.so",
         ],
     }),
-    hdrs = glob([
-        "include/**/*.h",
-        "include/**/*.hpp",
-        "include/**/*.inl",
-        "include/**/*",
-    ]),
-    includes = ["include/"],
+    deps = [":cuda_headers"],
 )
 
 cc_library(
@@ -71,14 +76,8 @@ cc_library(
             allow_empty = True,
         ),
     }),
-    hdrs = glob([
-        "include/**/*.h",
-        "include/**/*.hpp",
-        "include/**/*.inl",
-        "include/**/*",
-    ]),
-    includes = ["include/"],
     linkopts = ["-Wl,-rpath,lib/"],
+    deps = [":cuda_headers"],
 )
 
 cc_library(
@@ -97,12 +96,6 @@ cc_library(
             allow_empty = True,
         ),
     }),
-    hdrs = glob([
-        "include/**/*cublas*.h",
-        "include/**/*.hpp",
-        "include/**/*.inl",
-        "include/**/*",
-    ]),
-    includes = ["include/"],
     linkopts = ["-Wl,-rpath,lib/"],
+    deps = [":cuda_headers"],
 )


### PR DESCRIPTION
# Description

A multi-layer model lowered to the ExecuTorch TensorRT delegate becomes N separate single-layer engines, and by default every execution context allocates its own activation scratch and holds it for as long as the context lives. Device memory scales with the layer count, and multi-layer models OOM at runtime on the layer count alone.

This adds an **opt-in** shared per-device pool: every context created while the option is on takes its activation scratch from one buffer, grown to the largest figure any call on that device has asked for. It **ships disabled** — with `use_shared_activation_scratch` unset each context keeps its private `kSTATIC` scratch, no extra log output is emitted, and the only added work is one relaxed atomic load per engine init and, per `execute()`, four tests of the handle's `claims_pooled_scratch` — three `if` branches and one in a scope guard's destructor — plus an empty `SharedScratchClaim` released and destroyed without ever having held anything. A context whose engine reports needing no activation scratch under any shape stays outside the pool entirely.

Whatever `updateDeviceMemorySizeForShapes()` answers is binding rather than advisory: `setDeviceMemoryV2` refuses a smaller buffer, and an engine backed by less than it asked for writes past the end. Whether it answers what the shapes just bound need or the engine's profile maximum is settled when the engine is built — `PreviewFeature::kRUNTIME_ACTIVATION_RESIZE_10_10` produces the former, without it either can happen — so the pool can settle well above the live data and no runtime can change that.

**Every figure here comes from local runs on one A100 host**, TensorRT 11.2.1.2 and CUDA 13. The CI lane that would build and run these tests has not executed them at this head, so nothing here has a CI run behind it.

Memory from `cudaMemGetInfo` after a `cudaFree(0)` baseline on one 80GB A100. N per-engine copies collapse to one, so what is reclaimed is the sum of the N per-engine requirements less the largest of them:

- four execution contexts of one engine holding two fp32 8-head attention blocks over `[1,2048,512]`: **1188MB → 372MB**. Uniform engines, so that sum-less-largest is 3 × 272MB.
- one Method holding six one-block engines of the same shape interleaved with six CUDA delegates: **1656MB → 316MB**. Also uniform: 5 × 268MB.
- the same shape of Method with its six engines at differing sizes: **792MB → 316MB**. Sum 780,140,544 B less the largest 281,018,368 B is 476.0MB, which is what the A/B reads.

Outputs are identical between the two modes in every case.

The default path was A/B'd against a binary built from the commit this PR branches from, over nine runs (three models, three repetitions each): canonicalised stderr identical every time, at 45 / 45 / 17 lines. That stderr is the whole of the evidence — this harness writes nothing to stdout — and the canonicaliser normalises timestamps, pointers, source line numbers and the harness's own device-wide memory reading, which moves by a tenth of a megabyte between runs of one binary. The control, the same binary with the option on, differs at 47 lines against 45, so the comparison can fail.

Once the option is on, the pool never shrinks — a growth disposes of the buffer it replaces, but the high-water mark never comes down — so a device keeps the largest scratch it was ever asked for until the process exits, where per-context `kSTATIC` scratch is released with its context. It also keeps a handoff `cudaEvent_t` for every device a pooled call was ever made on, and, for every device that ever grew, the CUDA stream its growths queue their frees on — neither ever destroyed, for the same teardown-order reason as the buffer: nothing here runs a CUDA call at process exit. A growth allocates the new buffer before disposing of the old, so both are resident for that moment, which is what leaves the existing buffer usable when an allocation fails. Every growth then disposes of the old buffer the same way, and where the buffer it retires has an enqueue recorded against it the first of that disposal's three steps is a host wait for a whole inference with no upper bound. First known gap.

No dependencies; this does not stack on anything. Orthogonal to weight streaming (#4336), which targets engine *weight* memory rather than activation scratch. It composes with the zero-copy KV work if that lands too — measured together on the same model, byte-identical generated ids — but the two branches touch one hunk in common: this branch computes `must_sync` before the scratch claim rather than after the enqueue, and the zero-copy branch rewrites the comment at the old site, so `TensorRTBackend.cpp` conflicts, and resolves by keeping the hoisted computation with the zero-copy comment moved up to it.

### Where I would spend review attention

**The enqueue handoff, not the allocation.** Contexts share one buffer while their enqueues can still be in flight, so each device slot carries a pool-owned `cudaEvent_t`: wait on it before enqueueing, record after. An earlier revision tracked the last *stream* and was wrong three ways — synchronizing a destroyed stream segfaults rather than returning an error, CUDA recycles stream handle values so two distinct streams compare equal, and the NULL stream is a legal caller stream indistinguishable from "no previous user". All three are structural with an event, and `~EngineHandle` in the same file had already made this choice.

**A reported zero is ambiguous.** `updateDeviceMemorySizeForShapes()` answers zero for three things: a failed query, bound shapes that need no scratch (a valid empty input on a dynamic profile), and an engine needing none under *any* shape. Only the last can be told apart before any call is made, and it is, once at init: each engine loaded with the option on records whether `ICudaEngine::getDeviceMemorySizeV2()` is non-zero — `claims_pooled_scratch`, false on a handle loaded with the option off because nothing was ever asked there — and one reporting zero is left out of the pool entirely, so it claims no per-device lock and does not serialize against the engines that do.

The other two reach `execute()` indistinguishable, and neither can be handed nothing. `setDeviceMemoryV2(nullptr, 0)` is refused (`condition: memory != nullptr || expectedSize == 0`), so a context handed a zero keeps whatever buffer it last held, which a growth may already have freed — forcing that path reproduces an illegal memory access. And `enqueueV3` refuses a `kUSER_MANAGED` context with no device memory installed as soon as the engine needs some under *any* shape, however little the bound shapes need: `Parameter check failed, condition: noDeviceMemory`. So neither sizes the pool: a zero is handed whatever the pool already holds at its current size, growing nothing; only against an empty pool does it allocate, and then one byte, leaving the first real requirement to size it. Standing the engine's own `getDeviceMemorySizeV2()` in for the zero instead satisfies `enqueueV3` but covers the whole profile: on the dynamic engine the tests build that is 4 MiB against the 128 KiB the next call needs, and since the pool never shrinks a single empty batch would pin it at 32x for the process lifetime, on the path the pool exists to keep small.

**Only one of the two is safe with a buffer that small, and the install separates them.** Where the shapes genuinely need nothing the engine expects nothing and one byte is accepted; where the query *failed* the engine still expects what it always did and `setDeviceMemoryV2` refuses — but it returns `void`, so a caller that does not ask cannot tell them apart. Measured on TensorRT 11.2.1.2 against this branch's two-softmax net (expecting 8388608 bytes): install one byte and `enqueueV3` returns true, `cudaStreamSynchronize` reports no error, output matches byte for byte, and the engine writes the buffer the context was last given; free that buffer, let the next `cudaMalloc` take the address, and 4090 of 4096 bytes of an unrelated allocation are overwritten with nothing reporting an error anywhere. So the install is read back through a TensorRT `IErrorRecorder` attached for that one call: a correct install records nothing, an undersized one records `kINVALID_ARGUMENT` naming both sizes, and the genuinely-empty case (expected size zero, one byte installed) records nothing and keeps working. A refusal ends the call with `Error::InvalidState` and nothing reaches `enqueueV3`. Because the refusal is observable, the profile-wide figure never has to be installed.

**What is installed is the call's own requirement, not the pool's capacity.** They differ after any growth, and the pool never clears the buffer between users, so the larger figure would tell TensorRT it owns bytes still holding another engine's activations and would hide an engine overrunning its own requirement. It would also blunt the check above: after a growth the capacity can cover exactly what a failed query concealed. The choice is not observable from a test — TensorRT accepts an oversized install in silence and offers no getter for the installed size — so what the suite sees is the other direction, in `ALargerEngineGrowsThePoolAndFreesTheBufferItReplaces`, where the smaller engine runs again after the growth and installs less than the pool holds.

**Two hazards the pool does not absorb.** CUDA graph capture is not supported around this delegate, with the option on or off, and the shipped documentation says exactly that rather than pointing a caller anywhere. With the option on, a pooled `execute()` whose selected stream is capturing is refused with `Error::NotSupported`. A query that cannot answer is told apart from a capture: `cudaStreamIsCapturing` also hands back a sticky fault left by earlier work on the device, and a call that meets one fails with that fault's own message and `Error::InvalidProgram` rather than being told it is capturing. Everything here was measured directly against CUDA 13.0 on this device, one process per cell:

- the handoff wait is on an event recorded outside the capture, so `cudaStreamWaitEvent` fails it with `cudaErrorStreamCaptureIsolation` and invalidates the capture under *every* mode, `Relaxed` included — the caller learns of that only from `cudaStreamEndCapture` returning 901 and a null graph, far from the cause. That wait, not the allocation, produced the 901 when the guard was removed and measured: the pool was already large enough, so no growth ran.
- a growth's `cudaMalloc` returns `cudaErrorStreamCaptureUnsupported` and invalidates under Global and ThreadLocal, while Relaxed permits it and runs it uncaptured, leaving a replay pointed at a buffer the pool may since have freed.
- a growth's disposal is prohibited at its first step, the host wait on the handoff event, and the `cudaFree` it falls back to behaves like the `cudaMalloc` above. Queuing the free on the pool's own stream is no way round that, because the wait ahead of it has already happened.

The guard is one `cudaStreamIsCapturing` on the selected stream, placed ahead of everything `execute()` does that a capture cannot take, not merely ahead of the pool's own calls: the host wait on a previous enqueue and the `cudaMalloc` that grows a host-input staging buffer come earlier and, outside `Relaxed`, would invalidate the capture first. Only the device query and the device switch run before it, and a capture takes both.

Loading with the option off is not a way round any of this. Nothing refuses there — the guard sits inside the pooled branch — but the delegate does not support capture that way either, and this PR does not change what the option-off path does with a capturing stream: the completion event `execute()` records would become a node of the graph rather than an event the host can wait on. Making that path work means reworking the completion event, which the caller-stream contract's asynchronous return rests on; moving the guard out of the pooled branch instead would refuse calls for contexts that never touch the pool.

The check cannot cover a capture live on some *other* stream: under Global, and under ThreadLocal from the calling thread, the same calls invalidate it and the call is not refused. `cudaStreamIsCapturing(cudaStreamLegacy)` does not close the gap — measured, it reports another stream's capture only when that stream is a blocking one, and then reports it under Relaxed and under another thread's ThreadLocal too, where the pool's calls are permitted and refusing would be wrong. CUDA offers no "is a capture live in this process" query, so the rule is the caller's to keep and the installed header and the README say so. `cudaDeviceReset()` is documented in both rather than guarded: the pool holds its buffer, its handoff event and its disposal stream for the process lifetime and a reset destroys all three, and catching that would mean revalidating all three on every call, which costs as much as the work it protects.

**The lock scope.** The registry that finds a device's entry has one lock, held for a single find-or-insert with no CUDA call under it. The device's own lock is held from the claim through `setDeviceMemoryV2`, the enqueue, and the record of that enqueue on the handoff event — releasing earlier leaves an enqueue live in a window the event does not yet cover, and a second claimant entering that window is handed the same buffer with nothing ordering the two. That produced silently wrong output on every trial before the fix. The lock nests inside the per-handle `EngineHandle::mu`, which already spans the enqueue, and is never taken in the other order. Entries are never erased and `std::unordered_map` keeps references valid across rehashing, which is what lets the registry lock be dropped before the entry is used.

**A failing pooled call no longer returns with a copy of the caller's memory still running.** A host-resident input is staged with a `cudaMemcpyAsync` reading the caller's buffer, which the caller owns again the moment `execute()` returns. The success path synchronizes whenever anything was staged; the error returns between the copy and that point did not. From pinned memory that is live, not theoretical: measured on a 16 MiB copy on a gated stream, the copy returned in 0.0 ms having read nothing, and 4194304 of 4194304 elements the device received were what the caller wrote after the return; the same copy from pageable memory blocked for 1005.8 ms and took the bytes it was called with. A scope guard declared with the staging flag and the call's pooled flag now synchronizes on destruction unless the call reached the block that was already going to. It is scoped by the call rather than by the return: a pooled call is covered at *every* return in between, and an unpooled one at none of them. That scoping is what leaves an engine loaded with the option off waiting nowhere it did not already wait, and it is the same scoping the capture refusal has. The hazard is reachable on an unpooled call too and is not closed here: closing it would change what a default-off call does on every error return it makes past that copy, which is a change of its own to make. Of the six error returns *after* the enqueue, the four that are not already behind a synchronize drain the stream through one helper that clears the flag too, so they synchronize once rather than twice, and no path that did not already synchronize gains one. `AFailedPooledCallDrainsTheHostInputCopyItQueued` drives the one early return in the pooled scratch block that is reachable in-process — the pool's allocation, with the device full — and reads back what the device ended up holding; the failing call gets a different input from the successful one before it, so "the copy never ran at all" cannot pass either. `AFailedUnpooledCallLeavesTheHostInputCopyItQueuedAlone` pins the other half, on the one failure this suite can force past an unpooled call's staging copy — the output staging buffer's `cudaMalloc`, with the device full. Neither is redundant: un-gating the guard fails the unpooled case and leaves the pooled one green, and disabling it outright does the reverse.

**The per-handle capture.** A context's allocation strategy is fixed at creation, so each `EngineHandle` records the setting in effect at its own `init()` and `execute()` consults that, never the global. That is what lets a later `set_option` govern only subsequent engines and lets pooled and private-scratch contexts coexist, with no freeze and no rejected calls.

**What the release package exposes.** `SharedScratchPool.h` was in `executorch_api_headers` to deliver one string constant — `TensorRTBackend.h` never included it and named the option key only in comments. The key now sits beside `set_option`, and the header moved to `cpp/src/torch_tensorrt/executorch/`; `install_pooled_scratch` moved with it, into `PooledScratchInstall.h` — a separate header rather than the pool's, because it names `nvinfer1::IExecutionContext` and the pool header is kept buildable against the CUDA headers alone. Built `//:include_executorch`, the header half of the release tarball, and read the tar: five headers, none mentioning it. Dropping either header from the package was not open — `libtorchtrt.tar.gz` ships `TensorRTBackend.cpp` as buildable source and that source includes both — so they move rather than leave, and every header remaining in `cpp/include/` is installed, the invariant the original placement broke. The symbol is still a global `T` in the release object, because the backend's test links against it to cover a refusal `execute()` cannot be made to produce. The pool's two test-only entry points — one of which frees the live pool with no wait for work in flight — were defined in `TensorRTBackend.cpp` and so exported from the archive the README tells a consumer to build. They now live in a `SharedScratchPoolTestHooks` translation unit only a `testonly` Bazel target compiles, and `nm`/`readelf` on the release object shows neither symbol. The reset's *body* moved likewise, to a `testonly` `SharedScratchPoolReset.h` in neither the packaged include tree nor the packaged source set; the shipped header keeps the friend declaration alone. A three-line consumer built against only the packaged sources no longer compiles.

**`third_party/cuda/BUILD` gains a target.** The pool header needs the `cudaEvent_t` typedef — a compile-time dependency, not a runtime one — and the repo had no headers-only CUDA target. Depending on `cudart` instead put `libcudart` in the `DT_NEEDED` of a host-side test that makes no CUDA call, and broke it with exit 127. The new target is also the only place the toolkit header glob is now written: the three targets beside it that repeated it depend on it instead.

### Known gaps

- **A growth waits out an inference on the host, and that is documented rather than fixed.** A growth must dispose of the buffer it replaces before `execute()` returns, or the bytes of every size the pool ever grew to stay resident at once. Every growth disposes of it the same way: wait on the host for the enqueue the handoff event names, queue a `cudaFreeAsync` on a stream the pool owns for that device, and synchronize that stream, which is what returns the bytes. The host wait is the cost wherever the retired buffer has an enqueue recorded against it — where it has none, which is what a pooled call that returned between taking the buffer and recording its enqueue leaves behind, the handoff carries no recording and the disposal goes straight to the free. Where it is paid it is a whole inference: a call that reached its own enqueue has recorded that enqueue on the handoff event before releasing the claim, so the wait covers this call's inference as well as the one before it and such a growth returns with its own engine work finished rather than in flight. It has no upper bound, and a caller can make it permanent — park a host function ahead of the growing engine's enqueue, release it only once `execute()` has returned, and the growing call never comes back, the thread that would unblock it being inside the wait. What a growth does *not* wait for is the rest of the device, which is what the pool's own stream buys: measured on CUDA 13.0 with driver 13.0, freeing a 512 MiB buffer behind a 10 ms enqueue with a host function parked for 1500 ms on a stream nothing else in the measurement submitted to, 1500.8–1501.4 ms device-wide against 10.6–11.7 ms on the pool's stream, both with every byte back by the time the disposal returned. That device-wide wait is not hypothetical: the backend's own tests deadlocked on it once, when a change of test order made a case that parks a host function on its own stream the one that grew the pool. The stream has to be the pool's rather than the caller's, because a `cudaFreeAsync` of a `cudaMalloc`'d pointer — which is what this pool holds — hands the bytes back at the next `cudaStreamSynchronize` of the stream it was queued on and at no point before it — measured, a stream `cudaStreamQuery` reports as drained still holds the bytes, `cudaMemGetInfo` does not move, and a `cudaMalloc` of the same size fails with out of memory until the synchronize — so whoever queues the free has to be able to promise that synchronize, and only the pool can. On the caller's stream the disposal costs 0.0 ms and leaves the whole 512 MiB resident on return; where the caller does synchronize, the call reaches the same point at the same time (10.4–11.8 ms against the 10.6–11.7 above), and where it does not — the caller-stream, device-resident path this option exists for — the bytes never come back: measured, replaying the pool's growth sequence on such a stream — 8, 16, 24 and 32 GiB with no synchronize between them — turns four growths that all succeed when the disposal returns the bytes into an out-of-memory on the fourth, free stuck at 30.83 GiB on a device that started with 78.83 GiB of it. That last is a property of the pointer rather than of stream-ordered freeing in general: replayed with `cudaMallocAsync` on both sides of the same never-synchronized stream all four growths succeed, the free moving 54.83 to 38.83 GiB for the 24 GiB request as the retired 16 GiB is reused with nothing having synchronized anything, because those bytes go back to the device's memory pool rather than to the driver. The pool allocates with `cudaMalloc`, so it is in the first shape, and the pool-owned disposal stream is what that shape costs. Telling those two kinds of call apart is a claim about what the caller has still to do, and three defects on this path in a row were a disposal getting that claim wrong, the last of them a call that failed after the growth and so had no synchronization left to make; so the disposal takes no argument and the claim records nothing about the caller. A device-wide `cudaFree`, and the wait for the whole device with it, is still the fallback — where the device has no stream-ordered allocator (`cudaFreeAsync` reports `cudaErrorNotSupported` where `cudaDevAttrMemoryPoolsSupported` is absent), where it reports anything else, since a queued free that did not happen is not a free, and where the pool's stream could not be created; `cudaFreeAsync` takes the pointer `cudaMalloc` returned, so nothing here moves the pool onto the stream-ordered allocator, it only needs the device to have one. The disposal runs with the device lock dropped, so it does not hold the next claimant off — two pooled calls still serialize at submission, as the caller-stream contract promises, and a growth is no exception. Dropping the lock leaves the slot looking idle for the length of the disposal, which matters to the one observer that destroys what a slot holds rather than reading it: a test-only reset run while a disposal is still using the handoff event and the disposal stream destroys both under it — a harness over the real reset with real CUDA handles had the disposal's next `cudaStreamSynchronize` report `cudaErrorDeviceUninitialized`. Both of the reset's headers now carry the precondition that rules that out: safe only with no claim outstanding, which covers a claim whose release is still disposing. One further consequence for a growing call: its aliased reflects and D2H copies are queued after its enqueue has completed rather than while it runs, because the disposal's wait sits between them. That is in the noise end to end, but it is a real change in what a growing call does and the README states it. Seven cases cover the disposal itself. `ALargerEngineGrowsThePoolAndFreesTheBufferItReplaces` and `AGrowthOnASynchronizedCallFreesTheBufferItReplaces` take each kind of call and require the retired bytes back the moment `execute()` returns, reading before the test synchronizes anything, since a synchronize is what would release a free the disposal had only queued. `AGrowthDoesNotWaitForUnrelatedWorkQueuedOnTheDevice` and `AGrowthOnACallerStreamDoesNotWaitForUnrelatedWorkQueuedOnTheDevice` pin that neither kind waits for work parked on a stream it never submitted to: forcing the disposal device-wide fails both at the gate's 60 s watchdog, and only the caller-stream one could have failed before the pool owned the stream. `AGrowthOnACallerStreamWaitsForTheEnqueueOnTheBufferItRetires`: skipping the wait for the enqueue against the buffer being retired fails through `cudaErrorIllegalAddress`, the engine reading a buffer freed under it. `AGrowthOnACallerStreamDisposesWithTheDeviceLockDropped` takes the device's pool lock while the growth is still inside `execute()`, and asserts it was free. `AGrowthsDisposalDoesNotSynchronizeTheCallersStream` reaches for the same lock in the same window, as the precondition that says the interval it times is the disposal, so it depends on the unlock too. Measured: with the unlock moved below the disposal exactly those two fail — the first on its own assertion, the second on that precondition, both after their 5 s try-lock deadline expires — and the other five, which run their growth with nothing contending for that lock, stay green, 94 of 96 cases passing. `AGrowthsDisposalDoesNotSynchronizeTheCallersStream`: moving the free and its synchronize onto the caller's stream leaves every other case in the file green, this one included until it was written. **Nothing covers the device-wide fallback.** Reaching it needs `cudaFreeAsync` to fail a call that is correct as made, or the pool's stream creation to fail, and neither can be induced from inside the test process. That is a real loss against an earlier revision of this branch, where the caller-stream path's normal disposal *was* the device-wide free and every caller-stream growth on this hardware ran it; the skip in the two parked-work cases says the fallback is uncovered rather than pointing at coverage that no longer exists. How often a growth happens depends on the engine: `execute()` re-queries the requirement on every call once the shapes are bound, so an engine whose answer does not vary with the shapes grows the pool at most once, on its first run, and a program built only from those settles after its largest engine has run; one whose answer does vary can grow it on any call needing more than every call before it, and with one of those in the program nothing bounds the number of allocations. Run order, not load order: loading an engine allocates nothing.
- **Two growths at once can hold both retired buffers, and nothing bounds that.** The disposal runs outside the device lock, so a second grower can take the lock and allocate while the first grower's retired buffer is still resident: three staggered growths of 64, 128 and 192 MiB peak at 384 MiB rather than 192. What the peak is bounded by is the sum of the distinct scratch sizes, which is what the unpooled configuration holds permanently and for the whole process — 384 MiB transient against 384 MiB steady-state, collapsing to 192 once the disposals land — so the pool is never worse than no pool, and this is a startup transient rather than a regression the pool introduces. Bounding it would mean a grower waiting on how much another grower's disposal still holds, and the reason not to is not a missing mechanism — the bookkeeping was never the hard part: the only sound place to consult such a signal is under the device lock, where the only action available is to wait out a whole inference. That is the coupling the disposal deliberately does not have: adding the wait back would close a cycle — a claim waiting on a disposal that waits on an enqueue only the claiming thread will release.
- **Sharing one buffer has an unbounded wait of its own, growth or no growth.** A call that synchronizes the stream waits, through the handoff, for every pooled enqueue submitted before it on that device — what one buffer per device costs, and the premise of the feature rather than a defect in it. Park a host function ahead of one pooled call's enqueue and release it only once a later pooled call has returned, and the later call is the one that never returns. The installed `execute()` contract and the README both say so.
- **The option cannot be enabled from Python or from a `.pte`.** It arrives only through the C++ `set_option`; there is no load-time runtime spec and no compile-spec fallback of the kind `weight_streaming_budget` has. Deferred rather than built here.
- **The backend-linked test needs a real GPU, and the job that would give it one rarely runs.** `tests/cpp/executorch/test_shared_scratch_backend.cpp` is the only target in that package that links the delegate, and it covers `set_option`, the per-engine capture, the pooled path, the install check, the capture refusal, the two-thread concurrency regression and the one place this branch could have moved the option-off path without meaning to, its error returns. Without a device it skips every case and exits zero, which Bazel reports as a passing target: measured when the target carried 26 cases, 26 of 26 skipped and exit 0, behind a banner saying the target passing means nothing. `TORCHTRT_EXECUTORCH_REQUIRE_CUDA=1` turns a skip into a failure — same binary, same empty device list, exit 1 with 26 failures. It now carries 27. That variable covers the missing device and nothing else: eight cases carry skips it does not reach — three need the device full, two need its memory quiet, three need the device's stream-ordered allocator. The cases are counted and listed by name and reason at teardown whether or not the variable is set. That list is in the test log, which `--test_output=errors` prints nothing of for a passing target, so the CI invocation also passes `--test_summary=detailed`, which names every skipped case in Bazel's own summary. Three of them take the device to essentially zero free bytes while they hold it, measured at 16 MiB free of 81151 MiB with a neighbouring process getting out-of-memory on 256 MiB allocations throughout the window; Bazel's `exclusive` tag keeps other actions in the same build off the device but cannot keep anything else off it, and the file carries that warning. The CI invocation now passes the required-CUDA variable, and the job it sits in already asks for a GPU runner and starts its container with `--gpus all`. The job's own lane gate is not what keeps these cases off an ordinary pull-request push — it sits out only when the lane is `skip` or the backend is RTX, and `_decide.yml` resolves an unlabelled `pull_request` to `lane=fast`, `backend=standard`. What drops the job is the cancelled standard channel, below.
- **The zero-answer path is covered, but not by inducing a real query failure.** `AnEmptyInputRunsWithThePoolEnabled` reaches it through a legitimate empty input on a dynamic profile and reads the pool's capacity at three points, pinning the first to the one-byte minimum exactly — which kills a zero handed no buffer at all, a zero sized from the engine's profile-wide figure, and a minimum raised to anything the next call's requirement would still bound. `AnUndersizedScratchInstallIsSeenAsRefused` drives the same TensorRT call `execute()` makes over a live `kUSER_MANAGED` context: correct install accepted, one-byte install for an engine expecting more refused, empty-batch context still accepting one byte. A genuine *failed* `updateDeviceMemorySizeForShapes()` cannot be induced in-process — what `execute()` installs is the figure that query just returned, over a buffer grown to at least that, so the installed size is never short of what the context expects — so what is pinned end to end is the check that catches the consequence, not the cause. That `execute()` still goes through the checked install is pinned by `ExecuteInstallsPooledScratchThroughTheCheckedHelper`: a counting `IErrorRecorder` on the delegate's own context, asserted replaced and restored exactly once per pooled run, and replacing the checked call with a bare `setDeviceMemoryV2` takes both counts to zero with no other case noticing. `AnInstallKeepsAReferenceOnTheRecorderItSwapsOut` covers the swap itself: TensorRT drops a reference on the recorder it replaces and takes one again on the restore, so the install holds one of its own across the swap and the case fails if it stops. What no test pins is the refusal reaching a caller as `Error::InvalidState`, because the refusal cannot be reached.
- **The disposal's failure handling is not tested, and neither is the bail-out that also reaches it.** A failed wait on the handoff event leaks the retired buffer rather than freeing it under a possibly-live enqueue, drains the stream this call already submitted to, and returns `Error::InvalidProgram` — a device that fails a wait on device work is already faulted. The disposal does run on this hardware, on every growth, but none of a failed event wait, a `cudaFreeAsync` that refuses a call correct as made, or a failed synchronize of the pool's stream can be induced from inside the suite without corrupting the device for every case after it. Nor does any case reach a growth whose call then fails: reaching either of the two returns that could would need TensorRT or CUDA to fail a call correct as made, and every in-process injection tried is worse than the coverage — a fabricated or destroyed `cudaEvent_t` segfaults rather than returning `cudaErrorInvalidResourceHandle`, a misaligned device binding gets past `setTensorAddress` and `enqueueV3` and then raises a *sticky* asynchronous fault that poisons every teardown after it, and a foreign-device stream or event needs a second GPU and so a conditional skip. What holds that path is the shape of the code rather than a case: nothing is recorded at the claim for a bail-out to falsify, so a return between the claim and the release makes exactly the disposal every other path makes. A named case would need a test target that `#include`s `TensorRTBackend.cpp`, and a Bazel split so it does not also link the backend library; not built here.
- **`cudaDeviceReset()` is documented, not tested.** Reproducing it would destroy the primary context for every test that ran after it in the same process. The stream-capture refusal beside it *is* tested, twice: `APooledEngineRefusesACaptureBeforeAnythingCanInvalidateIt` under the default `Global`, which is the one that can see *where* in `execute()` the refusal comes, and `ARefusedPooledCallLeavesTheCallersPendingCudaErrorAlone` under `Relaxed`, which pins that the refusal does not clear a CUDA error the caller left pending. Nothing covers what a capture does with the option off, deliberately: that path is base-branch behaviour this PR does not change.
- **The ExecuTorch runtime CI job has been skipped on every run at this head**, gated on a channel that concurrency kept cancelling, and the gate ignores skipped channels — which is why every number here is local. `tests/cpp/executorch` carries 4 `cc_test` targets and 40 cases at the merge base with `main`; this PR takes it to 6 targets and 96 cases, the two new targets being `test_shared_scratch_pool` (29) and `test_shared_scratch_backend` (27). All 6 targets and all 96 cases have been compiled and run under bazel on a real A100 with `--nocache_test_results` and `TORCHTRT_EXECUTORCH_REQUIRE_CUDA=1` set, so a missing device would have been a failure; nothing skipped and all pass. The lane itself still needs one clean run. The suite also moved to the end of that job's script, so a missing or flaky device no longer takes down everything it used to sit above under `set -e`: the three example exports, `verify-executorch-reference-runner.sh` — the check that unpacks `libtorchtrt.tar.gz` and builds the packaged CMake backend out of it — and `load_model.py`. Run with a `bazel` whose `test` exits 3, the verify check never ran before the move and does after.
- **The stream-handle hazards are argued, not reproduced end to end.** The destroyed-stream crash was reproduced through the delegate; handle recycling and the NULL-stream collision were measured at the CUDA level. Corruption from a missing wait was never reproduced through a real engine, on either design.
- **Three things this PR deliberately does not do, each raised and each left.** The pool's locking rule is enforced by prose and by where the calls sit, not by a type: `SharedScratchDevice`'s state and its mutex are public members and nothing checks the rule. Wrapping them in a lock object is the right direction and a redesign of a header's public shape, the backend and the pool suite at once, so it is not folded into a change to what the disposal does. The same reasoning holds for the disposal rules, which are stated in four places — the installed contract, the README, `SharedScratchClaim::release()` and the pool header. The measurements behind them are not: they live in the README alone, and the code says what it does — the installed contract and `SharedScratchClaim::release()` pointing at the README for the rest, the pool header stating the rule without them. Picking one home per *rule* as well would restructure all four in the same change that alters the semantics they describe, so it is left, and it is the largest thing open here. And the pool is not rebuilt on `cudaMallocAsync`, which would delete the growth path, the retirement, the handoff event and most of the capture material: a different feature rather than a fix to this one.
- Not measured: an A/B of the memory saving on the ~210-engine target model — what was measured there is only how often the pool grows, once, because its largest engine runs first — and weight streaming combined with the pool end to end. The saving is linear by construction and the growth policy is exercised by the three models above.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the relevant labels to my PR in so that relevant reviewers are notified
