### PR TITLE
Added dynamo-torchao test suite under the full CI lane

### DIFF
--- a/.github/scripts/install-torch-tensorrt.sh
+++ b/.github/scripts/install-torch-tensorrt.sh
@@ -43,6 +43,8 @@ PY
 python -m pip uninstall -y torch torchvision
 python -m pip install --force-reinstall --pre ${TORCHVISION} --index-url ${INDEX_URL} --extra-index-url https://pypi.org/simple
 python -m pip install --force-reinstall --pre ${TORCH} --index-url ${INDEX_URL} --extra-index-url https://pypi.org/simple
+# dynamo-torchao full/nightly suite
+python -m pip install torchao
 
 # If CUDA 13 (cu13), prepend venv's NVIDIA CUDA 13 libs to LD_LIBRARY_PATH
 if [[ "${CU_VERSION}" == cu13* ]]; then

--- a/tests/ci/suites.py
+++ b/tests/ci/suites.py
@@ -237,8 +237,16 @@ _L2: list[Suite] = [
         tier="l2",
         lanes=("full", "nightly"),
         paths=("models/",),
-        markers="not critical",
+        # TorchAO compile tests live in dynamo-torchao.
+        markers="not critical and not torchao",
         jobs=_MODEL,
+    ),
+    Suite(
+        "dynamo-torchao",
+        tier="l2",
+        lanes=("full", "nightly"),
+        paths=("models/test_torchao*.py",),
+        jobs=_HEAVY,
     ),
     Suite(
         "dynamo-llm",

--- a/tests/py/dynamo/models/conftest.py
+++ b/tests/py/dynamo/models/conftest.py
@@ -22,3 +22,19 @@ def pytest_addoption(parser):
 def ir(request):
     ir_opt = request.config.getoption("--ir")
     return ir_opt[0] if ir_opt else "dynamo"
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "torchao: TorchAO quantization compile tests; collected by the dynamo-torchao full-lane suite",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Mark TorchAO model tests so the dynamo-torchao suite can own them."""
+    marker = pytest.mark.torchao
+    for item in items:
+        path = str(getattr(item, "path", item.fspath))
+        if "test_torchao" in path:
+            item.add_marker(marker)


### PR DESCRIPTION
# Description

Adds a dedicated **`dynamo-torchao`** suite on the `full` and `nightly` lanes so TorchAO compile tests are their own CI job instead of mixed into `dynamo-models`.

`tests/py/dynamo/models/test_torchao*.py` is auto-marked `torchao`. `dynamo-models` is now `-m "not critical and not torchao"` so those tests do not double-run. linux-test installs `torchao` after the pinned torch reinstall so the suite actually executes (tests skip if the extra is missing).

Locally: `cd tests && TRT_PYTEST_RERUNS=0 python3 -m ci run dynamo-torchao --variant standard` (5 passed: FP8 WOQ, static FP8, INT4 WOQ, NVFP4 WOQ, MXFP4).

Stacked on #4595 (MXFP4) → #4593 (NVFP4) → #4590 (INT4) → #4589 (FP8). Stack: https://github.com/pytorch/TensorRT/stack/4591

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] `dynamo-torchao` 5 passed locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified