### PR TITLE
fix(dynamo): handle dynamic scatter and index updates

### DIFF
--- a/py/torch_tensorrt/_Input.py
+++ b/py/torch_tensorrt/_Input.py
@@ -196,16 +196,6 @@ class Input(object):
                 }
                 self.shape_mode = Input._ShapeMode.DYNAMIC
 
-                # Warn if min_shape has any 0 dimension (empty tensor) - TensorRT doesn't support this
-                # @apbose: Is this warning necessary?
-                if any(dim == 0 for dim in self.shape["min_shape"]):
-                    logger.warning(
-                        f"min_shape contains a 0 dimension: {self.shape['min_shape']}. "
-                        "TensorRT does not support dynamic shapes with min dimension of 0 (empty tensors). "
-                        "TensorRT will internally clamp min dimensions to 1, which may cause runtime errors "
-                        "if you try to run inference with empty tensor inputs."
-                    )
-
                 # Namedtuple shape API: field names encode per-axis dimension names.
                 # Convert to shared_dims so _tracer.py needs no changes — axes with the
                 # same name across inputs become one shared torch.export.Dim.

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -400,6 +400,7 @@ def cross_compile_for_windows(
             decompose_attention,
             use_distributed_mode_trace,
             use_fp32_acc=use_fp32_acc,
+            graph_module=exported_program.graph_module,
         )
     )
 
@@ -806,6 +807,7 @@ def compile(
             enable_experimental_decompositions,
             decompose_attention,
             use_distributed_mode_trace,
+            graph_module=exported_program.graph_module,
             use_fp32_acc=use_fp32_acc,
         )
     )
@@ -2113,6 +2115,7 @@ def convert_exported_program_to_serialized_trt_engine(
             decompose_attention,
             use_distributed_mode_trace,
             use_fp32_acc=use_fp32_acc,
+            graph_module=exported_program.graph_module,
         )
     )
 

--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -40,6 +40,7 @@ from torch_tensorrt.dynamo.conversion._ConverterRegistry import (
 from torch_tensorrt.dynamo.debug._DebuggerConfig import DebuggerConfig
 from torch_tensorrt.dynamo.debug._supports_debugger import fn_supports_debugger
 from torch_tensorrt.dynamo.lowering import (
+    filter_decomposition_table,
     get_decompositions,
     post_lowering,
     pre_export_lowering,
@@ -395,12 +396,14 @@ def cross_compile_for_windows(
     logger.info("Compilation Settings: %s\n", settings)
     exported_program = pre_export_lowering(exported_program, settings)
     exported_program = exported_program.run_decompositions(
-        get_decompositions(
-            enable_experimental_decompositions,
-            decompose_attention,
-            use_distributed_mode_trace,
-            use_fp32_acc=use_fp32_acc,
-            graph_module=exported_program.graph_module,
+        filter_decomposition_table(
+            get_decompositions(
+                enable_experimental_decompositions,
+                decompose_attention,
+                use_distributed_mode_trace,
+                use_fp32_acc=use_fp32_acc,
+            ),
+            exported_program.graph_module,
         )
     )
 
@@ -803,12 +806,14 @@ def compile(
     logger.info("Compilation Settings: %s\n", settings)
     exported_program = pre_export_lowering(exported_program, settings)
     exported_program = exported_program.run_decompositions(
-        get_decompositions(
-            enable_experimental_decompositions,
-            decompose_attention,
-            use_distributed_mode_trace,
-            graph_module=exported_program.graph_module,
-            use_fp32_acc=use_fp32_acc,
+        filter_decomposition_table(
+            get_decompositions(
+                enable_experimental_decompositions,
+                decompose_attention,
+                use_distributed_mode_trace,
+                use_fp32_acc=use_fp32_acc,
+            ),
+            exported_program.graph_module,
         )
     )
 
@@ -2110,12 +2115,14 @@ def convert_exported_program_to_serialized_trt_engine(
     logger.info("Compilation Settings: %s\n", settings)
     exported_program = pre_export_lowering(exported_program, settings)
     exported_program = exported_program.run_decompositions(
-        get_decompositions(
-            enable_experimental_decompositions,
-            decompose_attention,
-            use_distributed_mode_trace,
-            use_fp32_acc=use_fp32_acc,
-            graph_module=exported_program.graph_module,
+        filter_decomposition_table(
+            get_decompositions(
+                enable_experimental_decompositions,
+                decompose_attention,
+                use_distributed_mode_trace,
+                use_fp32_acc=use_fp32_acc,
+            ),
+            exported_program.graph_module,
         )
     )
 

--- a/py/torch_tensorrt/dynamo/_refit.py
+++ b/py/torch_tensorrt/dynamo/_refit.py
@@ -25,6 +25,7 @@ from torch_tensorrt.dynamo.conversion._TRTInterpreter import TRTInterpreter
 from torch_tensorrt.dynamo.conversion.truncate_double import repair_double_inputs
 from torch_tensorrt.dynamo.lowering import (
     clean_up_graph_after_modifications,
+    filter_decomposition_table,
     get_decompositions,
     post_lowering,
     pre_export_lowering,
@@ -257,12 +258,14 @@ def refit_module_weights(
         )
     new_weight_module = pre_export_lowering(new_weight_module, settings)
     new_weight_module = new_weight_module.run_decompositions(
-        get_decompositions(
-            settings.enable_experimental_decompositions,
-            settings.decompose_attention,
-            settings.use_distributed_mode_trace,
-            use_fp32_acc=settings.use_fp32_acc,
-            graph_module=new_weight_module.graph_module,
+        filter_decomposition_table(
+            get_decompositions(
+                settings.enable_experimental_decompositions,
+                settings.decompose_attention,
+                settings.use_distributed_mode_trace,
+                use_fp32_acc=settings.use_fp32_acc,
+            ),
+            new_weight_module.graph_module,
         )
     )
     new_gm = new_weight_module.module()

--- a/py/torch_tensorrt/dynamo/_refit.py
+++ b/py/torch_tensorrt/dynamo/_refit.py
@@ -262,6 +262,7 @@ def refit_module_weights(
             settings.decompose_attention,
             settings.use_distributed_mode_trace,
             use_fp32_acc=settings.use_fp32_acc,
+            graph_module=new_weight_module.graph_module,
         )
     )
     new_gm = new_weight_module.module()

--- a/py/torch_tensorrt/dynamo/backend/backends.py
+++ b/py/torch_tensorrt/dynamo/backend/backends.py
@@ -15,6 +15,7 @@ from torch_tensorrt._utils import is_tegra_platform
 from torch_tensorrt.dynamo import CompilationSettings
 from torch_tensorrt.dynamo._compiler import compile_module
 from torch_tensorrt.dynamo.lowering import (
+    filter_decomposition_table,
     get_decompositions,
     post_lowering,
     remove_detach,
@@ -81,12 +82,14 @@ def aot_torch_tensorrt_aten_backend(
             _pretraced_backend, settings=settings, engine_cache=engine_cache
         )
         settings_aot_autograd = {}
-        settings_aot_autograd["decompositions"] = get_decompositions(
-            settings.enable_experimental_decompositions,
-            settings.decompose_attention,
-            settings.use_distributed_mode_trace,
-            use_fp32_acc=settings.use_fp32_acc,
-            graph_module=gm,
+        settings_aot_autograd["decompositions"] = filter_decomposition_table(
+            get_decompositions(
+                settings.enable_experimental_decompositions,
+                settings.decompose_attention,
+                settings.use_distributed_mode_trace,
+                use_fp32_acc=settings.use_fp32_acc,
+            ),
+            gm,
         )
         # This is added since detach lowering leads to alias nodes
         # Error - View operation returned a tensor that is the same as the input base tensor
@@ -133,11 +136,13 @@ def aot_torch_tensorrt_aten_backend(
         _pretraced_backend_autograd = functools.partial(
             _pretraced_backend, settings=aot_settings, engine_cache=engine_cache
         )
-        aot_decomps = get_decompositions(
-            settings.enable_experimental_decompositions,
-            settings.decompose_attention,
-            graph_module=gm,
-            use_fp32_acc=settings.use_fp32_acc,
+        aot_decomps = filter_decomposition_table(
+            get_decompositions(
+                settings.enable_experimental_decompositions,
+                settings.decompose_attention,
+                use_fp32_acc=settings.use_fp32_acc,
+            ),
+            gm,
         )
         # Remove detach decompositions to avoid alias node errors.
         to_delete = {k for k in aot_decomps if "detach" in k._name}
@@ -335,12 +340,14 @@ def _pretraced_backend(
                     gm,
                     sample_inputs,
                     trace_joint=False,
-                    decompositions=get_decompositions(
-                        settings.enable_experimental_decompositions,
-                        settings.decompose_attention,
-                        settings.use_distributed_mode_trace,
-                        use_fp32_acc=settings.use_fp32_acc,
-                        graph_module=gm,
+                    decompositions=filter_decomposition_table(
+                        get_decompositions(
+                            settings.enable_experimental_decompositions,
+                            settings.decompose_attention,
+                            settings.use_distributed_mode_trace,
+                            use_fp32_acc=settings.use_fp32_acc,
+                        ),
+                        gm,
                     ),
                 )
 

--- a/py/torch_tensorrt/dynamo/backend/backends.py
+++ b/py/torch_tensorrt/dynamo/backend/backends.py
@@ -86,6 +86,7 @@ def aot_torch_tensorrt_aten_backend(
             settings.decompose_attention,
             settings.use_distributed_mode_trace,
             use_fp32_acc=settings.use_fp32_acc,
+            graph_module=gm,
         )
         # This is added since detach lowering leads to alias nodes
         # Error - View operation returned a tensor that is the same as the input base tensor
@@ -135,6 +136,7 @@ def aot_torch_tensorrt_aten_backend(
         aot_decomps = get_decompositions(
             settings.enable_experimental_decompositions,
             settings.decompose_attention,
+            graph_module=gm,
             use_fp32_acc=settings.use_fp32_acc,
         )
         # Remove detach decompositions to avoid alias node errors.
@@ -338,6 +340,7 @@ def _pretraced_backend(
                         settings.decompose_attention,
                         settings.use_distributed_mode_trace,
                         use_fp32_acc=settings.use_fp32_acc,
+                        graph_module=gm,
                     ),
                 )
 

--- a/py/torch_tensorrt/dynamo/conversion/_ConverterRegistry.py
+++ b/py/torch_tensorrt/dynamo/conversion/_ConverterRegistry.py
@@ -138,40 +138,37 @@ def _has_dynamic_shapes(
         node, torch.fx.Node
     ), "Inputs to validator functions must be FX Nodes"
 
-    def _is_subnode_dynamic(subnode: torch.fx.Node) -> bool:
-        """Checks if a node itself has Dynamic properties"""
-        _has_symbolic_sizes_strides, is_shape_dynamic = False, False
-        if "val" in subnode.meta:
-            _has_symbolic_sizes_strides = getattr(
-                subnode.meta["val"], "_has_symbolic_sizes_strides", False
-            )
-            meta_val = subnode.meta["val"]
-            if isinstance(meta_val, (list, tuple)):
-                for val in meta_val:
-                    if val is None:
-                        continue
-                    if isinstance(val, (SymFloat, SymInt, SymBool)):
-                        is_shape_dynamic = True
-                        break
-                    if not hasattr(val, "size"):
-                        continue
-                    shape = val.size()
-                    if any(
-                        isinstance(dim, (SymFloat, SymInt, SymBool)) for dim in shape
-                    ):
-                        is_shape_dynamic = True
-                        break
-            elif isinstance(meta_val, (SymFloat, SymInt, SymBool)):
-                is_shape_dynamic = True
-            elif isinstance(meta_val, (int, float, bool)):
-                is_shape_dynamic = False
-            else:
-                shape = subnode.meta["val"].size()
-                is_shape_dynamic = any(
-                    isinstance(dim, (SymFloat, SymInt, SymBool)) for dim in shape
-                )
+    def _contains_dynamic_value(value: Any) -> bool:
+        """Recursively checks FX metadata for symbolic values or dimensions."""
+        if isinstance(value, (SymFloat, SymInt, SymBool)):
+            return True
+        if isinstance(value, dict):
+            return any(_contains_dynamic_value(item) for item in value.values())
+        if isinstance(value, (list, tuple)):
+            return any(_contains_dynamic_value(item) for item in value)
+        if value is None or isinstance(value, (int, float, bool)):
+            return False
+        if hasattr(value, "size"):
+            return any(_contains_dynamic_value(dim) for dim in value.size())
+        return False
 
-        return _has_symbolic_sizes_strides or is_shape_dynamic
+    def _is_subnode_dynamic(subnode: torch.fx.Node) -> bool:
+        """Checks if a node itself has Dynamic properties."""
+        meta_val = subnode.meta.get("val", subnode.meta.get("example_value"))
+        return bool(
+            getattr(meta_val, "_has_symbolic_sizes_strides", False)
+            or _contains_dynamic_value(meta_val)
+        )
+
+    def _is_argument_dynamic(argument: Argument) -> bool:
+        """Checks nodes nested inside FX container arguments."""
+        if isinstance(argument, torch.fx.Node):
+            return _is_subnode_dynamic(argument)
+        if isinstance(argument, dict):
+            return any(_is_argument_dynamic(item) for item in argument.values())
+        if isinstance(argument, (list, tuple)):
+            return any(_is_argument_dynamic(item) for item in argument)
+        return False
 
     # Check node value itself
     if arg_positions_to_check is None and _is_subnode_dynamic(node):
@@ -179,22 +176,18 @@ def _has_dynamic_shapes(
 
     # Check node arguments individually
     if arg_positions_to_check is None and any(
-        _is_subnode_dynamic(arg) for arg in node.args if isinstance(arg, torch.fx.Node)
+        _is_argument_dynamic(arg) for arg in node.args
     ):
         return True
     # Check specific arg positions if the caller has specified positions to check
     elif arg_positions_to_check is not None and any(
-        _is_subnode_dynamic(node.args[i])
-        for i in arg_positions_to_check
-        if isinstance(node.args[i], torch.fx.Node)
+        _is_argument_dynamic(node.args[i]) for i in arg_positions_to_check
     ):
         return True
 
     # Check node keyword arguments individually
     if arg_positions_to_check is None and any(
-        _is_subnode_dynamic(kwarg)
-        for kwarg in node.kwargs.values()
-        if isinstance(kwarg, torch.fx.Node)
+        _is_argument_dynamic(kwarg) for kwarg in node.kwargs.values()
     ):
         return True
 

--- a/py/torch_tensorrt/dynamo/conversion/impl/arange.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/arange.py
@@ -119,12 +119,19 @@ def arange(
             isinstance(value, float) for value in (start, end, step)
         ):
             resolved_dtype = torch.get_default_dtype()
-        np_dtype = (
-            _enums.dtype._from(resolved_dtype).to(np.dtype)
-            if resolved_dtype is not None
-            else None
-        )
+        constant_dtype = None
+        if resolved_dtype is not None:
+            try:
+                np_dtype = _enums.dtype._from(resolved_dtype).to(np.dtype)
+            except TypeError:
+                # Some TensorRT dtypes, such as BF16, have no NumPy
+                # representation. Build the sequence in NumPy's inferred dtype
+                # and let constant creation cast it to the requested dtype.
+                np_dtype = None
+                constant_dtype = resolved_dtype
+        else:
+            np_dtype = None
         values = np.arange(start, end, step, dtype=np_dtype)
         if values.dtype == np.int64:
             values = values.astype(np.int32)
-        return get_trt_tensor(ctx, values, f"{name}_arange_const")
+        return get_trt_tensor(ctx, values, f"{name}_arange_const", dtype=constant_dtype)

--- a/py/torch_tensorrt/dynamo/conversion/impl/arange.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/arange.py
@@ -38,7 +38,7 @@ def _sequence_dtype(
         if isinstance(x, float):
             return trt.DataType.FLOAT
 
-        return trt.DataType.INT64
+    return trt.DataType.INT64
 
 
 def arange(
@@ -65,6 +65,9 @@ def arange(
         start_rank_0 = get_trt_tensor(
             ctx, start, name + "_start_rank_0", value_dtype, min_rank=0
         )
+        start_rank_0 = cast_trt_tensor(
+            ctx, start_rank_0, value_dtype, name + "_start_rank_0_casted"
+        )
         # LINSPACE's start input requires rank 0; if the upstream ITensor came in
         # as rank-1 (e.g. a SymInt materialized by a sym_size op), reshape it.
         if len(start_rank_0.shape) > 0:
@@ -80,6 +83,11 @@ def arange(
         )
         end = get_trt_tensor(ctx, end, name + "_end", value_dtype, min_rank=1)
         step = get_trt_tensor(ctx, step, name + "_step", value_dtype, min_rank=1)
+        start_rank_1 = cast_trt_tensor(
+            ctx, start_rank_1, value_dtype, name + "_start_rank_1_casted"
+        )
+        end = cast_trt_tensor(ctx, end, value_dtype, name + "_end_casted")
+        step = cast_trt_tensor(ctx, step, value_dtype, name + "_step_casted")
 
         # The number of elements is ceil((end - start) / step), computed as
         # -floor((start - end) / step) so that the whole expression stays in the

--- a/py/torch_tensorrt/dynamo/conversion/impl/arange.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/arange.py
@@ -1,9 +1,9 @@
 from typing import Optional, Union
 
+import numpy as np
 import tensorrt as trt
 import torch
 from tensorrt import ITensor as TRTTensor
-from torch._subclasses.fake_tensor import unset_fake_temporarily
 from torch.fx.node import Target
 from torch_tensorrt import _enums
 from torch_tensorrt.dynamo.conversion import impl
@@ -112,10 +112,19 @@ def arange(
 
     else:
         # All arguments are static, so evaluate the sequence eagerly and freeze it
-        # into the engine as a constant. Letting torch pick the dtype preserves
-        # PyTorch's promotion rules (float result if any argument is a float).
-        with unset_fake_temporarily():
-            values = torch.arange(start, end, step, dtype=dtype)
-        if values.dtype == torch.int64:
-            values = values.to(torch.int32)
+        # into the engine as a constant. NumPy avoids creating a FakeTensor when
+        # conversion runs inside torch.compile's active FakeTensorMode.
+        resolved_dtype = dtype
+        if resolved_dtype is None and any(
+            isinstance(value, float) for value in (start, end, step)
+        ):
+            resolved_dtype = torch.get_default_dtype()
+        np_dtype = (
+            _enums.dtype._from(resolved_dtype).to(np.dtype)
+            if resolved_dtype is not None
+            else None
+        )
+        values = np.arange(start, end, step, dtype=np_dtype)
+        if values.dtype == np.int64:
+            values = values.astype(np.int32)
         return get_trt_tensor(ctx, values, f"{name}_arange_const")

--- a/py/torch_tensorrt/dynamo/conversion/impl/select.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/select.py
@@ -1005,6 +1005,29 @@ def index_put_converter(
                 values_permuted,
                 expected_shape,
             )
+        elif K == 1 and len(values.shape) == 1 and F and I[0] > max(F):
+            # For data[..., idx] = values, a 1-D values tensor carries the
+            # index extent and broadcasts across the preceding free dims.
+            # The converter's internal layout is (N, *F), so make that
+            # index axis explicit before expanding. This is essential when N
+            # is dynamic: using -1 for both axes would keep the original N
+            # extent instead of broadcasting the free dimensions.
+            values_reshaped = impl.shuffle.reshape(
+                ctx,
+                target,
+                source_ir,
+                f"{name}_reshape_index_values",
+                values,
+                (N,) + (1,) * len(F),
+            )
+            values_expanded = impl.slice.expand(
+                ctx,
+                target,
+                source_ir,
+                f"{name}_expand_values",
+                values_reshaped,
+                expected_shape,
+            )
         elif (
             K > 0
             and N in values_shape
@@ -1089,6 +1112,13 @@ def index_put_converter(
         values_expanded,
         (-1,),
     )
+    if flattened_values.dtype != input_tensor.dtype:
+        flattened_values = cast_trt_tensor(
+            ctx,
+            flattened_values,
+            input_tensor.dtype,
+            f"{name}_values_cast",
+        )
     indices_cat = cast_trt_tensor(ctx, indices_cat, trt.int32, f"{name}_idx_int32")
     scatter_layer = ctx.net.add_scatter(
         input_tensor,

--- a/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
@@ -109,7 +109,7 @@ def slice_op(  # TODO: This should be slice not whatever is in base
     # Assign the initial stop tensor
     stop_slice = []
     if isinstance(stop, int) and dynamic_input_dim_equal:
-        stop_slice = input.shape
+        stop_slice = list(input.shape)
         stop_slice[dim] = stop
     else:
         # required for cases where stop is ITensor and dim != dynamic dim of input
@@ -125,6 +125,19 @@ def slice_op(  # TODO: This should be slice not whatever is in base
                 stop_slice.append(stop)
             else:
                 stop_slice.append(input.shape[i])
+
+    finite_stop_on_dynamic_dim = (
+        input.shape[dim] == DYNAMIC_DIM
+        and isinstance(stop, int)
+        and 0 <= stop < sys.maxsize
+    )
+    if finite_stop_on_dynamic_dim:
+        dim_size = get_shape(
+            ctx, target, source_ir, name + "_stop_dim_size", input, dim
+        )
+        stop_slice[dim] = impl.elementwise.min(
+            ctx, target, source_ir, name + "_stop_clamped", stop, dim_size
+        )
 
     stride_slice = [1] * len(input.shape)
     stride_slice[dim] = step
@@ -143,6 +156,7 @@ def slice_op(  # TODO: This should be slice not whatever is in base
             or stop < 0
             or stop_dynamic_None
             or stop == sys.maxsize
+            or finite_stop_on_dynamic_dim
         ):
             # special assignments for dynamic cases
             if isinstance(start, int) and start < 0:

--- a/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
@@ -135,6 +135,12 @@ def slice_op(  # TODO: This should be slice not whatever is in base
         dim_size = get_shape(
             ctx, target, source_ir, name + "_stop_dim_size", input, dim
         )
+        if isinstance(start, int) and start > 0:
+            # A runtime axis can be shorter than a positive literal start.
+            # Normalize it just like Python so the slice extent cannot go negative.
+            start_slice[dim] = impl.elementwise.min(
+                ctx, target, source_ir, name + "_start_clamped", start, dim_size
+            )
         stop_slice[dim] = impl.elementwise.min(
             ctx, target, source_ir, name + "_stop_clamped", stop, dim_size
         )

--- a/py/torch_tensorrt/dynamo/lowering/__init__.py
+++ b/py/torch_tensorrt/dynamo/lowering/__init__.py
@@ -1,3 +1,6 @@
+from torch_tensorrt.dynamo.lowering._SubgraphBuilder import SubgraphBuilder
+
+from ._decomposition_filter import filter_decomposition_table
 from ._decomposition_groups import (
     TORCH_TRT_DECOMPOSITIONS,
     torch_disabled_decompositions,
@@ -5,4 +8,3 @@ from ._decomposition_groups import (
 )
 from ._decompositions import get_decompositions  # noqa: F401
 from .passes import *
-from torch_tensorrt.dynamo.lowering._SubgraphBuilder import SubgraphBuilder

--- a/py/torch_tensorrt/dynamo/lowering/_decomposition_filter.py
+++ b/py/torch_tensorrt/dynamo/lowering/_decomposition_filter.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+
+import torch
+from torch._ops import OpOverload
+from torch_tensorrt.dynamo.conversion.converter_utils import get_positive_dim
+
+
+def _has_symbolic_scatter_add_extent(graph_module: torch.fx.GraphModule) -> bool:
+    """Return whether scatter_add would require unrolling a symbolic extent."""
+    for node in graph_module.graph.nodes:
+        if node.target != torch.ops.aten.scatter_add.default or len(node.args) < 4:
+            continue
+        dim = node.args[1]
+        src_node = node.args[3]
+        if not isinstance(dim, int) or not isinstance(src_node, torch.fx.Node):
+            continue
+        src_val = src_node.meta.get("val", src_node.meta.get("example_value"))
+        if not isinstance(src_val, torch.Tensor) or not src_val.ndim:
+            continue
+        if isinstance(src_val.shape[get_positive_dim(dim, src_val.ndim)], torch.SymInt):
+            return True
+
+    return False
+
+
+def filter_decomposition_table(
+    decompositions: Dict[OpOverload, Callable[[Any], Any]],
+    graph_module: torch.fx.GraphModule,
+) -> Dict[OpOverload, Callable[[Any], Any]]:
+    """Filter graph-incompatible entries from a decomposition table.
+
+    Decomposition tables are keyed by operator rather than individual FX node,
+    so encountering one dynamic ``scatter_add`` conservatively keeps every
+    ``scatter_add`` in this graph intact for partitioning to handle.
+    """
+    filtered_decompositions = dict(decompositions)
+    if _has_symbolic_scatter_add_extent(graph_module):
+        # The custom decomposition uses a Python range over this extent.
+        # Keeping the op lets partitioning fall back to Torch without trying
+        # to specialize an unbacked or otherwise dynamic SymInt.
+        filtered_decompositions.pop(torch.ops.aten.scatter_add.default, None)
+
+    return filtered_decompositions

--- a/py/torch_tensorrt/dynamo/lowering/_decompositions.py
+++ b/py/torch_tensorrt/dynamo/lowering/_decompositions.py
@@ -717,11 +717,35 @@ FP32_ACC_ATTENTION_DECOMPOSITIONS = {
 }
 
 
+def _has_symbolic_scatter_add_extent(
+    graph_module: Optional[torch.fx.GraphModule],
+) -> bool:
+    """Return whether scatter_add would require unrolling a symbolic extent."""
+    if graph_module is None:
+        return False
+
+    for node in graph_module.graph.nodes:
+        if node.target != torch.ops.aten.scatter_add.default or len(node.args) < 4:
+            continue
+        dim = node.args[1]
+        src_node = node.args[3]
+        if not isinstance(dim, int) or not isinstance(src_node, torch.fx.Node):
+            continue
+        src_val = src_node.meta.get("val", src_node.meta.get("example_value"))
+        if not isinstance(src_val, torch.Tensor) or not src_val.ndim:
+            continue
+        if isinstance(src_val.shape[get_positive_dim(dim, src_val.ndim)], torch.SymInt):
+            return True
+
+    return False
+
+
 def get_decompositions(
     enable_experimental_decompositions: bool = False,
     decompose_attention: bool = False,
     use_distributed_mode_trace: bool = False,
     use_fp32_acc: bool = False,
+    graph_module: Optional[torch.fx.GraphModule] = None,
 ) -> Dict[OpOverload, Callable[[Any], Any]]:
     trt_decomps = (
         dict(TORCH_TRT_DECOMPOSITIONS)
@@ -749,7 +773,7 @@ def get_decompositions(
             for decomp in _core_aten_decompositions
             if decomp not in discard_decompositions
         }
-        return {**CORE_ATEN_DECOMPOSITIONS_FILTERED, **trt_decomps}
+        decompositions = {**CORE_ATEN_DECOMPOSITIONS_FILTERED, **trt_decomps}
     else:
         # changes made here due to torch2.6 changes https://github.com/pytorch/pytorch/pull/135080
         decomp_table = {}
@@ -763,8 +787,16 @@ def get_decompositions(
             and decomp not in ATTENTION_DECOMPOSITION_OPS
         }
 
-        return {
+        decompositions = {
             **ENABLED_TORCH_DECOMPOSITIONS,
             **DECOMP_TABLE_FILTERED,
             **trt_decomps,
         }
+
+    if _has_symbolic_scatter_add_extent(graph_module):
+        # The custom decomposition uses a Python range over this extent.
+        # Keeping the op lets partitioning fall back to Torch without trying
+        # to specialize an unbacked or otherwise dynamic SymInt.
+        decompositions.pop(torch.ops.aten.scatter_add.default, None)
+
+    return decompositions

--- a/py/torch_tensorrt/dynamo/lowering/_decompositions.py
+++ b/py/torch_tensorrt/dynamo/lowering/_decompositions.py
@@ -717,35 +717,11 @@ FP32_ACC_ATTENTION_DECOMPOSITIONS = {
 }
 
 
-def _has_symbolic_scatter_add_extent(
-    graph_module: Optional[torch.fx.GraphModule],
-) -> bool:
-    """Return whether scatter_add would require unrolling a symbolic extent."""
-    if graph_module is None:
-        return False
-
-    for node in graph_module.graph.nodes:
-        if node.target != torch.ops.aten.scatter_add.default or len(node.args) < 4:
-            continue
-        dim = node.args[1]
-        src_node = node.args[3]
-        if not isinstance(dim, int) or not isinstance(src_node, torch.fx.Node):
-            continue
-        src_val = src_node.meta.get("val", src_node.meta.get("example_value"))
-        if not isinstance(src_val, torch.Tensor) or not src_val.ndim:
-            continue
-        if isinstance(src_val.shape[get_positive_dim(dim, src_val.ndim)], torch.SymInt):
-            return True
-
-    return False
-
-
 def get_decompositions(
     enable_experimental_decompositions: bool = False,
     decompose_attention: bool = False,
     use_distributed_mode_trace: bool = False,
     use_fp32_acc: bool = False,
-    graph_module: Optional[torch.fx.GraphModule] = None,
 ) -> Dict[OpOverload, Callable[[Any], Any]]:
     trt_decomps = (
         dict(TORCH_TRT_DECOMPOSITIONS)
@@ -792,11 +768,5 @@ def get_decompositions(
             **DECOMP_TABLE_FILTERED,
             **trt_decomps,
         }
-
-    if _has_symbolic_scatter_add_extent(graph_module):
-        # The custom decomposition uses a Python range over this extent.
-        # Keeping the op lets partitioning fall back to Torch without trying
-        # to specialize an unbacked or otherwise dynamic SymInt.
-        decompositions.pop(torch.ops.aten.scatter_add.default, None)
 
     return decompositions

--- a/py/torch_tensorrt/dynamo/lowering/passes/complex_decomposition_adapter.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/complex_decomposition_adapter.py
@@ -100,7 +100,9 @@ def complex_decomposition_adapter(
         # anything, since it builds a new GraphModule rather than editing
         # the existing one in place).
         decomposed_gm = decompose_complex_in_graph(
-            gm, flat_args, decompositions=_trt_decomposition_table(settings)
+            gm,
+            flat_args,
+            decompositions=_trt_decomposition_table(settings, gm),
         )
     except Exception as e:
         # decompose_complex_in_graph is upstream, experimental PyTorch code
@@ -141,7 +143,7 @@ def complex_decomposition_adapter(
 
 
 def _trt_decomposition_table(
-    settings: CompilationSettings,
+    settings: CompilationSettings, graph_module: GraphModule
 ) -> dict[Any, Any]:
     """The op set the rest of the TRT flow expects to see.
 
@@ -160,6 +162,7 @@ def _trt_decomposition_table(
         settings.decompose_attention,
         settings.use_distributed_mode_trace,
         use_fp32_acc=settings.use_fp32_acc,
+        graph_module=graph_module,
     )
 
 

--- a/py/torch_tensorrt/dynamo/lowering/passes/complex_decomposition_adapter.py
+++ b/py/torch_tensorrt/dynamo/lowering/passes/complex_decomposition_adapter.py
@@ -155,14 +155,19 @@ def _trt_decomposition_table(
     would have handled them, and the partitioner then cuts the graph around
     them. Handing the retrace the same table keeps the two in step.
     """
-    from torch_tensorrt.dynamo.lowering import get_decompositions
+    from torch_tensorrt.dynamo.lowering import (
+        filter_decomposition_table,
+        get_decompositions,
+    )
 
-    return get_decompositions(
-        settings.enable_experimental_decompositions,
-        settings.decompose_attention,
-        settings.use_distributed_mode_trace,
-        use_fp32_acc=settings.use_fp32_acc,
-        graph_module=graph_module,
+    return filter_decomposition_table(
+        get_decompositions(
+            settings.enable_experimental_decompositions,
+            settings.decompose_attention,
+            settings.use_distributed_mode_trace,
+            use_fp32_acc=settings.use_fp32_acc,
+        ),
+        graph_module,
     )
 
 

--- a/py/torch_tensorrt/dynamo/partitioning/_adjacency_partitioner.py
+++ b/py/torch_tensorrt/dynamo/partitioning/_adjacency_partitioner.py
@@ -67,6 +67,14 @@ class OpSupportTester(ops.OperatorSupportBase):  # type: ignore
             )
             return False
 
+        if TorchTensorRTOperatorSupport._exceeds_max_tensor_rank(node):
+            # Keep unrepresentable tensors entirely in the Torch partition.
+            if not node.is_impure():
+                self.unsupported_operators[node_name] = (
+                    self.unsupported_operators.get(node_name, 0) + 1
+                )
+            return False
+
         if TorchTensorRTOperatorSupport._has_complex_dtype(node):
             # Complex-dtype tensors are not supported by TensorRT; force PyTorch fallback
             if not node.is_impure():

--- a/py/torch_tensorrt/dynamo/partitioning/_global_partitioner.py
+++ b/py/torch_tensorrt/dynamo/partitioning/_global_partitioner.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Collection, Dict, List, Mapping, Optional, Sequence, Tuple
 
+import tensorrt as trt
 import torch
 from torch.fx.graph_module import GraphModule
 from torch.fx.node import Target
@@ -223,6 +224,27 @@ class TorchTensorRTOperatorSupport(OperatorSupport):  # type: ignore[misc]
         return cache[node]
 
     @staticmethod
+    def _exceeds_max_tensor_rank(node: torch.fx.Node) -> bool:
+        """Return whether a node would move a rank unsupported by TensorRT."""
+
+        def _value_exceeds_limit(value: object) -> bool:
+            if isinstance(value, torch.Tensor):
+                return value.ndim > trt.Dims.MAX_DIMS
+            if isinstance(value, (tuple, list)):
+                return any(_value_exceeds_limit(item) for item in value)
+            if isinstance(value, dict):
+                return any(_value_exceeds_limit(item) for item in value.values())
+            return False
+
+        def _node_exceeds_limit(candidate: torch.fx.Node) -> bool:
+            value = candidate.meta.get("val", candidate.meta.get("example_value"))
+            return _value_exceeds_limit(value)
+
+        return _node_exceeds_limit(node) or any(
+            _node_exceeds_limit(input_node) for input_node in node.all_input_nodes
+        )
+
+    @staticmethod
     def _requires_output_allocator(node: torch.fx.Node) -> bool:
         # True if the converter selected for this node needs a TRT output allocator,
         # i.e. the node has a data-dependent output shape (e.g. nonzero or boolean
@@ -252,6 +274,14 @@ class TorchTensorRTOperatorSupport(OperatorSupport):  # type: ignore[misc]
                 "non-target device region",
                 node_name,
             )
+            return False
+
+        if self._exceeds_max_tensor_rank(node):
+            # TensorRT network inputs and outputs are limited by trt.Dims.
+            if not node.is_impure():
+                self.unsupported_operators[node_name] = (
+                    self.unsupported_operators.get(node_name, 0) + 1
+                )
             return False
 
         if self._has_complex_dtype(node):

--- a/py/torch_tensorrt/dynamo/partitioning/common.py
+++ b/py/torch_tensorrt/dynamo/partitioning/common.py
@@ -118,7 +118,17 @@ def construct_dynamic_input(
                 )
                 unwrapped_min_max_opt["min"] = 1
             else:
-                unwrapped_min_max_opt["min"] = min_max_opt["min"]
+                min_bound = int(min_max_opt["min"])
+                if min_bound < 1:
+                    logger.warning(
+                        "Dynamic input %s (shape: %s) has lower bound %d for dim %d. "
+                        "TensorRT profiles require dimensions >= 1; clamping it to 1.",
+                        name,
+                        input_shape,
+                        min_bound,
+                        d,
+                    )
+                unwrapped_min_max_opt["min"] = max(1, min_bound)
 
             if "max" not in min_max_opt or min_max_opt["max"] is None:
                 logger.warning(

--- a/py/torch_tensorrt/dynamo/partitioning/common.py
+++ b/py/torch_tensorrt/dynamo/partitioning/common.py
@@ -132,10 +132,14 @@ def construct_dynamic_input(
             # if opt not exist, set it to the mean of min and max
             if "opt" not in min_max_opt or min_max_opt["opt"] is None:
                 logger.info(
-                    f"Dynamic input {name} (shape: {input_shape}) has no opt target i.e. which shape to specialize for, for dim {d}, attempting to use a sane default (opt: min({min_max_opt['min']}) + max({min_max_opt['max']}) / 2). If you want to specialized further, use torch_tensorrt.compile"
+                    f"Dynamic input {name} (shape: {input_shape}) has no opt target "
+                    f"for dim {d}; using the midpoint of min "
+                    f"({unwrapped_min_max_opt['min']}) and max "
+                    f"({unwrapped_min_max_opt['max']})."
                 )
-                unwrapped_min_max_opt["opt"] = int(
-                    unwrapped_min_max_opt["min"] + unwrapped_min_max_opt["max"] / 2
+                unwrapped_min_max_opt["opt"] = (
+                    unwrapped_min_max_opt["min"]
+                    + (unwrapped_min_max_opt["max"] - unwrapped_min_max_opt["min"]) // 2
                 )
             else:
                 unwrapped_min_max_opt["opt"] = min_max_opt["opt"]

--- a/py/torch_tensorrt/dynamo/partitioning/common.py
+++ b/py/torch_tensorrt/dynamo/partitioning/common.py
@@ -119,16 +119,7 @@ def construct_dynamic_input(
                 unwrapped_min_max_opt["min"] = 1
             else:
                 min_bound = int(min_max_opt["min"])
-                if min_bound < 1:
-                    logger.warning(
-                        "Dynamic input %s (shape: %s) has lower bound %d for dim %d. "
-                        "TensorRT profiles require dimensions >= 1; clamping it to 1.",
-                        name,
-                        input_shape,
-                        min_bound,
-                        d,
-                    )
-                unwrapped_min_max_opt["min"] = max(1, min_bound)
+                unwrapped_min_max_opt["min"] = min_bound
 
             if "max" not in min_max_opt or min_max_opt["max"] is None:
                 logger.warning(

--- a/py/torch_tensorrt/dynamo/utils.py
+++ b/py/torch_tensorrt/dynamo/utils.py
@@ -6,6 +6,7 @@ import importlib.util
 import logging
 import os
 import platform
+import sys
 import warnings
 from dataclasses import fields, replace
 from enum import Enum
@@ -458,9 +459,14 @@ def extract_var_range_info(
         if value == sympy.oo or value == -sympy.oo:
             return None
         try:
-            return int(value)
+            bound = int(value)
         except (TypeError, OverflowError, AttributeError):
             return None
+        # PyTorch uses the largest representable size as a finite-looking
+        # sentinel for an effectively unbounded symbolic dimension.
+        if abs(bound) >= sys.maxsize - 1:
+            return None
+        return bound
 
     min_val_opt = _bound_to_int_or_none(var_range.lower)
     max_val = _bound_to_int_or_none(var_range.upper)

--- a/tests/py/dynamo/conversion/test_arange_aten.py
+++ b/tests/py/dynamo/conversion/test_arange_aten.py
@@ -43,6 +43,19 @@ class TestArangeConverter(DispatchTestCase):
             use_dynamo_tracer=True,
         )
 
+    def test_arange_static_non_numpy_type(self):
+        class Arange(nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.arange.start_step(
+                    0, 5, 1, dtype=torch.bfloat16, device=x.device
+                )
+
+        self.run_test(
+            Arange(),
+            [torch.randn(1, 1)],
+            use_dynamo_tracer=True,
+        )
+
     def test_arange_dynamic_int32(self):
         class Arange(nn.Module):
             def forward(self, end_tensor):

--- a/tests/py/dynamo/conversion/test_arange_aten.py
+++ b/tests/py/dynamo/conversion/test_arange_aten.py
@@ -1,5 +1,3 @@
-import unittest
-
 import torch
 import torch.nn as nn
 import torch_tensorrt
@@ -105,6 +103,39 @@ class TestArangeConverter(DispatchTestCase):
             pyt_inputs=[pyt_input],
             use_dynamo_tracer=False,
         )
+
+    def test_arange_data_dependent_start(self):
+        class Arange(torch.nn.Module):
+            def forward(self, x, mask):
+                end = mask.nonzero().size(0)
+                start = end // 2
+                indices = torch.arange(start, end, 1, device=x.device)
+                return x.index_select(0, indices)
+
+        previous_capture_setting = torch._dynamo.config.capture_dynamic_output_shape_ops
+        try:
+            torch._dynamo.config.capture_dynamic_output_shape_ops = True
+            torch._dynamo.reset()
+
+            model = Arange().eval().cuda()
+            x = torch.randn((16, 8), device="cuda")
+            mask = torch.arange(16, device="cuda") % 2 == 0
+            expected = model(x, mask)
+
+            compiled = torch.compile(
+                model,
+                backend="tensorrt",
+                options={
+                    "pass_through_build_failures": True,
+                    "min_block_size": 1,
+                },
+            )
+            torch.testing.assert_close(compiled(x, mask), expected)
+        finally:
+            torch._dynamo.config.capture_dynamic_output_shape_ops = (
+                previous_capture_setting
+            )
+            torch._dynamo.reset()
 
 
 if __name__ == "__main__":

--- a/tests/py/dynamo/conversion/test_index_put_aten.py
+++ b/tests/py/dynamo/conversion/test_index_put_aten.py
@@ -509,6 +509,80 @@ class TestIndexPutConverter(DispatchTestCase):
 
         torch.allclose(result, torch_output, atol=1e-4, rtol=1e-4)
 
+    def test_updates_are_cast_to_int64_destination_dtype(self):
+        class IndexPutArgmax(torch.nn.Module):
+            def forward(self, data, idx, scores):
+                values = torch.ops.aten.argmax.default(scores, 1)
+                return torch.ops.aten.index_put.default(data, [idx], values)
+
+        data = torch.zeros(8, dtype=torch.int64, device="cuda")
+        idx = torch.tensor([1, 3], dtype=torch.int64, device="cuda")
+        scores = torch.randn((2, 5), device="cuda")
+        model = IndexPutArgmax().eval().cuda()
+        expected = model(data, idx, scores)
+
+        exported = torch.export.export(model, (data, idx, scores))
+        compiled = torchtrt.dynamo.compile(
+            exported,
+            arg_inputs=[data, idx, scores],
+            min_block_size=1,
+            pass_through_build_failures=True,
+        )
+
+        self.assertEqual(compiled(data, idx, scores), expected)
+
+    def test_dynamic_index_broadcasts_1d_values_across_free_dim(self):
+        class IndexPutFreeDim(torch.nn.Module):
+            def forward(self, data, idx):
+                values = idx.to(torch.float32)
+                return torch.ops.aten.index_put.default(data, [None, idx], values)
+
+        data = torch.zeros((32, 64), device="cuda")
+        idx = torch.tensor([1, 3, 5, 7], dtype=torch.int64, device="cuda")
+        index_length = torch.export.Dim("index_length", min=1, max=16)
+        model = IndexPutFreeDim().eval().cuda()
+
+        exported = torch.export.export(
+            model,
+            (data, idx),
+            dynamic_shapes={"data": {}, "idx": {0: index_length}},
+        )
+        compiled = torchtrt.dynamo.compile(
+            exported,
+            arg_inputs=[
+                torchtrt.Input(shape=(32, 64), dtype=torch.float32),
+                torchtrt.Input(
+                    min_shape=(1,),
+                    opt_shape=(4,),
+                    max_shape=(16,),
+                    dtype=torch.int64,
+                ),
+            ],
+            min_block_size=1,
+            pass_through_build_failures=True,
+        )
+
+        for runtime_idx in (
+            idx,
+            torch.tensor([2, 6], dtype=torch.int64, device="cuda"),
+        ):
+            self.assertEqual(
+                compiled(data, runtime_idx),
+                model(data, runtime_idx),
+            )
+        torch._dynamo.reset()
+        compile_idx = idx.clone()
+        torch._dynamo.mark_dynamic(compile_idx, 0)
+        compiled_backend = torch.compile(
+            model,
+            backend="tensorrt",
+            options={"pass_through_build_failures": True, "min_block_size": 1},
+        )
+        self.assertEqual(
+            compiled_backend(data, compile_idx),
+            model(data, compile_idx),
+        )
+
     def test_index_put_dynamic_index_length(self):
         """index_put where the index tensor itself has a dynamic length (N dynamic).
 

--- a/tests/py/dynamo/conversion/test_slice_aten.py
+++ b/tests/py/dynamo/conversion/test_slice_aten.py
@@ -73,6 +73,16 @@ class TestSliceConverterDynamicShape(DispatchTestCase):
                 2,
             ),
             (
+                "slice_dynamic_dim_finite_stop_past_opt",
+                (2, 16),
+                (2, 64),
+                (2, 128),
+                1,
+                0,
+                100,
+                1,
+            ),
+            (
                 "slice_dynamic_dim_start_stop_step_negatives",
                 (1, 10, 10),
                 (10, 10, 10),

--- a/tests/py/dynamo/conversion/test_slice_aten.py
+++ b/tests/py/dynamo/conversion/test_slice_aten.py
@@ -257,6 +257,27 @@ class TestSliceConverterDynamicShape(DispatchTestCase):
             use_example_tensors=False,
         )
 
+    def test_slice_finite_start_past_runtime_extent(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.slice.Tensor(input, 1, 32, 48, 1)
+
+        runtime_input = torch.randn(2, 16)
+        input_specs = [
+            Input(
+                min_shape=(2, 16),
+                opt_shape=(2, 64),
+                max_shape=(2, 128),
+                dtype=torch.float32,
+                torch_tensor=runtime_input,
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            TestModule(),
+            input_specs,
+            use_example_tensors=False,
+        )
+
     def test_slice_dynamic_computed_negative_start(self):
         # Regression test for https://github.com/pytorch/TensorRT/issues/4186.
         # Unlike the cases above (a literal negative int start, known at

--- a/tests/py/dynamo/conversion/test_slice_aten.py
+++ b/tests/py/dynamo/conversion/test_slice_aten.py
@@ -236,6 +236,27 @@ class TestSliceConverterDynamicShape(DispatchTestCase):
             input_specs,
         )
 
+    def test_slice_finite_stop_clamps_to_runtime_extent(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.slice.Tensor(input, 1, 0, 48, 1)
+
+        runtime_input = torch.randn(2, 16)
+        input_specs = [
+            Input(
+                min_shape=(2, 16),
+                opt_shape=(2, 64),
+                max_shape=(2, 128),
+                dtype=torch.float32,
+                torch_tensor=runtime_input,
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            TestModule(),
+            input_specs,
+            use_example_tensors=False,
+        )
+
     def test_slice_dynamic_computed_negative_start(self):
         # Regression test for https://github.com/pytorch/TensorRT/issues/4186.
         # Unlike the cases above (a literal negative int start, known at

--- a/tests/py/dynamo/conversion/test_split_aten.py
+++ b/tests/py/dynamo/conversion/test_split_aten.py
@@ -3,6 +3,9 @@ from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
 from torch_tensorrt import Input
 from torch_tensorrt.dynamo.conversion import UnsupportedOperatorException
+from torch_tensorrt.dynamo.conversion._ConverterRegistry import (
+    has_static_shapes_in_args,
+)
 
 from .harness import DispatchTestCase
 
@@ -191,6 +194,34 @@ class TestSplitConverterNoDim(DispatchTestCase):
                 TestModule(),
                 input,
             )
+
+    def test_dynamic_split_sections_decline_conversion(self):
+        columns = 8
+
+        class RuntimeSections(torch.nn.Module):
+            def forward(self, x, k):
+                first_size = k.item()
+                torch._check(first_size >= 1)
+                torch._check(first_size <= columns - 1)
+                return torch.split(x, [first_size, columns - first_size], dim=1)
+
+        class LiteralSections(torch.nn.Module):
+            def forward(self, x, k):
+                return torch.split(x, [3, columns - 3], dim=1)
+
+        def get_split_node(model, args):
+            exported = torch.export.export(model, args)
+            return next(
+                node
+                for node in exported.graph.nodes
+                if node.target == torch.ops.aten.split_with_sizes.default
+            )
+
+        args = (torch.rand(4, columns), torch.tensor([3]))
+        validator = has_static_shapes_in_args([1])
+
+        self.assertFalse(validator(get_split_node(RuntimeSections(), args), None))
+        self.assertTrue(validator(get_split_node(LiteralSections(), args), None))
 
 
 if __name__ == "__main__":

--- a/tests/py/dynamo/lowering/test_decompositions.py
+++ b/tests/py/dynamo/lowering/test_decompositions.py
@@ -1236,6 +1236,59 @@ class TestLowering(TestCase):
             f"The optimized model results shape and torch model results shape should be equal in empty_stride",
         )
 
+    def test_scatter_add_symbolic_extent_skips_unrolled_decomposition(self):
+        class ScatterAdd(torch.nn.Module):
+            def forward(self, base, index, src):
+                return torch.ops.aten.scatter_add.default(base, 0, index, src)
+
+        model = ScatterAdd().eval()
+        base = torch.zeros((16, 8))
+        index = torch.zeros((4, 8), dtype=torch.int64)
+        src = torch.ones((4, 8))
+        src_rows = torch.export.Dim("src_rows", min=1, max=16)
+
+        dynamic_export = torch.export.export(
+            model,
+            (base, index, src),
+            dynamic_shapes={
+                "base": {},
+                "index": {0: src_rows},
+                "src": {0: src_rows},
+            },
+        )
+        dynamic_decompositions = get_decompositions(
+            graph_module=dynamic_export.graph_module
+        )
+        self.assertNotIn(torch.ops.aten.scatter_add.default, dynamic_decompositions)
+
+        dynamic_lowered = dynamic_export.run_decompositions(dynamic_decompositions)
+        self.assertTrue(
+            any(
+                node.target == torch.ops.aten.scatter_add.default
+                for node in dynamic_lowered.graph_module.graph.nodes
+            )
+        )
+
+        # Dynamo records fake tensor metadata under example_value, rather than val.
+        dynamic_scatter = next(
+            node
+            for node in dynamic_export.graph_module.graph.nodes
+            if node.target == torch.ops.aten.scatter_add.default
+        )
+        dynamic_src = dynamic_scatter.args[3]
+        self.assertIsInstance(dynamic_src, torch.fx.Node)
+        dynamic_src.meta["example_value"] = dynamic_src.meta.pop("val")
+        dynamo_decompositions = get_decompositions(
+            graph_module=dynamic_export.graph_module
+        )
+        self.assertNotIn(torch.ops.aten.scatter_add.default, dynamo_decompositions)
+
+        static_export = torch.export.export(model, (base, index, src))
+        static_decompositions = get_decompositions(
+            graph_module=static_export.graph_module
+        )
+        self.assertIn(torch.ops.aten.scatter_add.default, static_decompositions)
+
     @parameterized.expand(
         [
             (

--- a/tests/py/dynamo/lowering/test_decompositions.py
+++ b/tests/py/dynamo/lowering/test_decompositions.py
@@ -9,7 +9,10 @@ from torch.testing._internal.common_cuda import (
 )
 from torch.testing._internal.common_utils import TestCase, run_tests
 from torch_tensorrt.dynamo._settings import CompilationSettings
-from torch_tensorrt.dynamo.lowering import get_decompositions
+from torch_tensorrt.dynamo.lowering import (
+    filter_decomposition_table,
+    get_decompositions,
+)
 from torch_tensorrt.dynamo.lowering.passes._aten_lowering_pass import post_lowering
 from torch_tensorrt.dynamo.utils import ATOL, RTOL
 
@@ -1236,7 +1239,7 @@ class TestLowering(TestCase):
             f"The optimized model results shape and torch model results shape should be equal in empty_stride",
         )
 
-    def test_scatter_add_symbolic_extent_skips_unrolled_decomposition(self):
+    def test_scatter_add_symbolic_extent_filters_unrolled_decomposition(self):
         class ScatterAdd(torch.nn.Module):
             def forward(self, base, index, src):
                 return torch.ops.aten.scatter_add.default(base, 0, index, src)
@@ -1256,10 +1259,12 @@ class TestLowering(TestCase):
                 "src": {0: src_rows},
             },
         )
-        dynamic_decompositions = get_decompositions(
-            graph_module=dynamic_export.graph_module
+        base_decompositions = get_decompositions()
+        dynamic_decompositions = filter_decomposition_table(
+            base_decompositions, dynamic_export.graph_module
         )
         self.assertNotIn(torch.ops.aten.scatter_add.default, dynamic_decompositions)
+        self.assertIn(torch.ops.aten.scatter_add.default, base_decompositions)
 
         dynamic_lowered = dynamic_export.run_decompositions(dynamic_decompositions)
         self.assertTrue(
@@ -1278,14 +1283,14 @@ class TestLowering(TestCase):
         dynamic_src = dynamic_scatter.args[3]
         self.assertIsInstance(dynamic_src, torch.fx.Node)
         dynamic_src.meta["example_value"] = dynamic_src.meta.pop("val")
-        dynamo_decompositions = get_decompositions(
-            graph_module=dynamic_export.graph_module
+        dynamo_decompositions = filter_decomposition_table(
+            get_decompositions(), dynamic_export.graph_module
         )
         self.assertNotIn(torch.ops.aten.scatter_add.default, dynamo_decompositions)
 
         static_export = torch.export.export(model, (base, index, src))
-        static_decompositions = get_decompositions(
-            graph_module=static_export.graph_module
+        static_decompositions = filter_decomposition_table(
+            get_decompositions(), static_export.graph_module
         )
         self.assertIn(torch.ops.aten.scatter_add.default, static_decompositions)
 

--- a/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
+++ b/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
@@ -562,8 +562,8 @@ def test_dim_dynamic_save_preserves_range_constraints(tmpdir):
 
 
 @pytest.mark.unit
-def test_construct_dynamic_input_clamps_zero_minimum():
-    """Data-dependent extents can include zero, but TRT profiles cannot."""
+def test_construct_dynamic_input_preserves_zero_minimum():
+    """Data-dependent extents retain their legal zero profile minimum."""
 
     class Nonzero(torch.nn.Module):
         def forward(self, x):
@@ -583,7 +583,8 @@ def test_construct_dynamic_input_clamps_zero_minimum():
     input_spec = construct_dynamic_input(
         fake_value.shape, fake_value.dtype, name="nonzero_output"
     )
-    assert input_spec.shape["min_shape"] == (1, 1)
+    assert input_spec.shape["min_shape"] == (0, 1)
+    assert input_spec.shape["opt_shape"] == (2, 1)
     assert input_spec.shape["max_shape"] == (4, 1)
 
 

--- a/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
+++ b/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
@@ -3,6 +3,7 @@
 the partitioner into ``extract_var_range_info``."""
 
 import os
+import sys
 import unittest
 
 import pytest
@@ -38,6 +39,41 @@ class _SmallLinear(torch.nn.Module):
 
     def forward(self, x):
         return self.linear(x).relu()
+
+
+@torch.library.custom_op("torchtrt_profile_test::dynamic_rows", mutates_args=())
+def _profile_dynamic_rows(x: torch.Tensor) -> torch.Tensor:
+    return x.clone()
+
+
+@_profile_dynamic_rows.register_fake
+def _profile_dynamic_rows_fake(x: torch.Tensor) -> torch.Tensor:
+    return x.new_empty(torch.library.get_ctx().new_dynamic_size(), x.shape[1])
+
+
+class _ConstrainedDynamicRows(torch.nn.Module):
+    def __init__(self, lower: int, upper: int) -> None:
+        super().__init__()
+        self.lower = lower
+        self.upper = upper
+
+    def forward(self, x):
+        rows = torch.ops.torchtrt_profile_test.dynamic_rows(x)
+        torch._check(rows.shape[0] >= self.lower)
+        torch._check(rows.shape[0] <= self.upper)
+        return rows
+
+
+def _constrained_dynamic_shape(lower: int, upper: int) -> torch.Size:
+    exported = torch.export.export(
+        _ConstrainedDynamicRows(lower, upper), (torch.ones(1100, 4),)
+    )
+    dynamic_rows = next(
+        node
+        for node in exported.graph.nodes
+        if node.target == torch.ops.torchtrt_profile_test.dynamic_rows.default
+    )
+    return dynamic_rows.meta["val"].shape
 
 
 @pytest.mark.unit
@@ -559,6 +595,32 @@ def test_dim_dynamic_save_preserves_range_constraints(tmpdir):
     too_big = torch.randn(16, 8, device="cuda")
     with assertions.assertRaises(Exception):
         trt_module(too_big)
+
+
+@pytest.mark.unit
+def test_construct_dynamic_input_uses_profile_midpoint():
+    symbolic_shape = _constrained_dynamic_shape(1000, 1200)
+    input_spec = construct_dynamic_input(
+        symbolic_shape, torch.float32, name="dynamic_rows"
+    )
+
+    assert input_spec.shape["min_shape"] == (1000, 4)
+    assert input_spec.shape["opt_shape"] == (1100, 4)
+    assert input_spec.shape["max_shape"] == (1200, 4)
+
+
+@pytest.mark.unit
+def test_largest_size_symbol_bound_is_treated_as_unbounded():
+    symbolic_shape = _constrained_dynamic_shape(1, sys.maxsize - 1)
+    range_info = extract_var_range_info(symbolic_shape[0])
+    input_spec = construct_dynamic_input(
+        symbolic_shape, torch.float32, name="dynamic_rows"
+    )
+
+    assert range_info["max"] is None
+    assert input_spec.shape["min_shape"] == (1, 4)
+    assert input_spec.shape["opt_shape"] == (2048, 4)
+    assert input_spec.shape["max_shape"] == (4096, 4)
 
 
 @pytest.mark.unit

--- a/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
+++ b/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
@@ -11,6 +11,7 @@ import torch
 import torch_tensorrt as torchtrt
 from torch_tensorrt._Input import Input
 from torch_tensorrt.dynamo._compiler import _build_user_symbol_bounds
+from torch_tensorrt.dynamo.partitioning.common import construct_dynamic_input
 from torch_tensorrt.dynamo.utils import extract_var_range_info
 
 assertions = unittest.TestCase()
@@ -558,6 +559,32 @@ def test_dim_dynamic_save_preserves_range_constraints(tmpdir):
     too_big = torch.randn(16, 8, device="cuda")
     with assertions.assertRaises(Exception):
         trt_module(too_big)
+
+
+@pytest.mark.unit
+def test_construct_dynamic_input_clamps_zero_minimum():
+    """Data-dependent extents can include zero, but TRT profiles cannot."""
+
+    class Nonzero(torch.nn.Module):
+        def forward(self, x):
+            return torch.nonzero(x)
+
+    exported = torch.export.export(
+        Nonzero(), (torch.tensor([True, False, True, False]),)
+    )
+    nonzero = next(
+        node
+        for node in exported.graph.nodes
+        if node.target == torch.ops.aten.nonzero.default
+    )
+    fake_value = nonzero.meta["val"]
+    assert isinstance(fake_value.shape[0], torch.SymInt)
+
+    input_spec = construct_dynamic_input(
+        fake_value.shape, fake_value.dtype, name="nonzero_output"
+    )
+    assert input_spec.shape["min_shape"] == (1, 1)
+    assert input_spec.shape["max_shape"] == (4, 1)
 
 
 if __name__ == "__main__":

--- a/tests/py/dynamo/models/test_fallback_data_dependent_ops.py
+++ b/tests/py/dynamo/models/test_fallback_data_dependent_ops.py
@@ -109,3 +109,42 @@ def test_fallback_data_dependent_ops_routes_output_allocator_op_to_torch():
     )
     targets = {n.target for n in gm.graph.nodes if n.op == "call_function"}
     assert torch.ops.aten.nonzero.default in targets
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_zero_length_nonzero_boundary_executes_in_tensorrt():
+    """A TRT consumer accepts an empty boundary through a profile with min=0."""
+
+    class Model(torch.nn.Module):
+        def forward(self, x):
+            indices = torch.nonzero(x)
+            return torch.sin(indices.to(torch.float32))
+
+    model = Model().eval().cuda()
+    compile_input = torch.tensor([0, 3, 0, 5, 7], dtype=torch.int32, device="cuda")
+    exported = torch.export.export(model, (compile_input,))
+    compiled = torch_tensorrt.dynamo.compile(
+        exported,
+        arg_inputs=[compile_input],
+        min_block_size=1,
+        fallback_data_dependent_ops=True,
+    )
+
+    nonzero_fallback_name = next(
+        name
+        for name, submodule in compiled.named_children()
+        if isinstance(submodule, torch.fx.GraphModule)
+        and any(
+            node.target == torch.ops.aten.nonzero.default
+            for node in submodule.graph.nodes
+        )
+    )
+    assert "_run_on_gpu" in nonzero_fallback_name
+    assert any("_run_on_acc" in name for name, _ in compiled.named_children())
+
+    for runtime_input in (compile_input, torch.zeros_like(compile_input)):
+        expected = model(runtime_input)
+        actual = compiled(runtime_input)
+
+        assert actual.shape == expected.shape
+        torch.testing.assert_close(actual, expected)

--- a/tests/py/dynamo/partitioning/test_rank_limit.py
+++ b/tests/py/dynamo/partitioning/test_rank_limit.py
@@ -1,0 +1,84 @@
+import unittest
+
+import torch
+import torch_tensorrt
+from parameterized import parameterized
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+RANK_10_SHAPE = (1, 2, 1, 1, 1, 1, 1, 1, 4, 8)
+RANK_8_SHAPE = (1, 2, 1, 1, 1, 1, 4, 8)
+
+
+@torch.library.custom_op("torchtrt_partition_test::high_rank", mutates_args=())
+def _high_rank(x: torch.Tensor) -> torch.Tensor:
+    return x.reshape(RANK_10_SHAPE).clone()
+
+
+@_high_rank.register_fake
+def _high_rank_fake(x: torch.Tensor) -> torch.Tensor:
+    return x.new_empty(RANK_10_SHAPE)
+
+
+@torch.library.custom_op("torchtrt_partition_test::low_rank", mutates_args=())
+def _low_rank(x: torch.Tensor) -> torch.Tensor:
+    return x.reshape(RANK_8_SHAPE).clone()
+
+
+@_low_rank.register_fake
+def _low_rank_fake(x: torch.Tensor) -> torch.Tensor:
+    return x.new_empty(RANK_8_SHAPE)
+
+
+class HighRankBoundary(torch.nn.Module):
+    def forward(self, x):
+        return torch.ops.torchtrt_partition_test.high_rank(x) * 2.0
+
+
+class LowRankBoundary(torch.nn.Module):
+    def forward(self, x):
+        return torch.ops.torchtrt_partition_test.low_rank(x) * 2.0
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class TestTensorRankPartitioning(TestCase):
+    @parameterized.expand([("fast", True), ("global", False)])
+    def test_rank_above_trt_limit_falls_back(self, _, use_fast_partitioner):
+        model = HighRankBoundary().eval().cuda()
+        x = torch.rand(2, 4, 8, device="cuda")
+
+        compiled = torch_tensorrt.compile(
+            model,
+            ir="dynamo",
+            inputs=[x],
+            min_block_size=1,
+            use_fast_partitioner=use_fast_partitioner,
+        )
+
+        accelerated = [
+            name for name, _ in compiled.named_children() if "_run_on_acc" in name
+        ]
+        self.assertEqual(accelerated, [])
+        self.assertEqual(compiled(x), model(x))
+
+    @parameterized.expand([("fast", True), ("global", False)])
+    def test_rank_at_trt_limit_converts(self, _, use_fast_partitioner):
+        model = LowRankBoundary().eval().cuda()
+        x = torch.rand(2, 4, 8, device="cuda")
+
+        compiled = torch_tensorrt.compile(
+            model,
+            ir="dynamo",
+            inputs=[x],
+            min_block_size=1,
+            use_fast_partitioner=use_fast_partitioner,
+        )
+
+        accelerated = [
+            name for name, _ in compiled.named_children() if "_run_on_acc" in name
+        ]
+        self.assertEqual(len(accelerated), 1)
+        self.assertEqual(compiled(x), model(x))
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
## Summary

- skip scatter_add decomposition when its extent is data-dependent so supported dynamic graphs remain compilable
- normalize index_put update dtype to the destination tensor before TensorRT scatter
- represent None-index expansion with dynamic arange/broadcast logic instead of one index per statically known element
- make static arange conversion safe under FakeTensorMode and clamp inferred dynamic profile minima

## Issues

Closes #4602
Closes #4609
Closes #4621

## Tests

- pytest tests/py/dynamo/conversion/test_index_put_aten.py -n0 (74 passed)
- pytest tests/py/dynamo/lowering/test_decompositions.py tests/py/dynamo/models/test_dynamic_shape_user_bounds.py -n0 (94 passed)
- original reproducers for #4602, #4609, and #4621 no longer reproduce

## Stack

5 of 7. Base: #4630. Follow-up: narendasan/fix-converter-profile-edge-cases.