### PR TITLE
fix(dynamo): harden dynamic converter boundaries

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/_ConverterRegistry.py
+++ b/py/torch_tensorrt/dynamo/conversion/_ConverterRegistry.py
@@ -138,40 +138,37 @@ def _has_dynamic_shapes(
         node, torch.fx.Node
     ), "Inputs to validator functions must be FX Nodes"
 
-    def _is_subnode_dynamic(subnode: torch.fx.Node) -> bool:
-        """Checks if a node itself has Dynamic properties"""
-        _has_symbolic_sizes_strides, is_shape_dynamic = False, False
-        if "val" in subnode.meta:
-            _has_symbolic_sizes_strides = getattr(
-                subnode.meta["val"], "_has_symbolic_sizes_strides", False
-            )
-            meta_val = subnode.meta["val"]
-            if isinstance(meta_val, (list, tuple)):
-                for val in meta_val:
-                    if val is None:
-                        continue
-                    if isinstance(val, (SymFloat, SymInt, SymBool)):
-                        is_shape_dynamic = True
-                        break
-                    if not hasattr(val, "size"):
-                        continue
-                    shape = val.size()
-                    if any(
-                        isinstance(dim, (SymFloat, SymInt, SymBool)) for dim in shape
-                    ):
-                        is_shape_dynamic = True
-                        break
-            elif isinstance(meta_val, (SymFloat, SymInt, SymBool)):
-                is_shape_dynamic = True
-            elif isinstance(meta_val, (int, float, bool)):
-                is_shape_dynamic = False
-            else:
-                shape = subnode.meta["val"].size()
-                is_shape_dynamic = any(
-                    isinstance(dim, (SymFloat, SymInt, SymBool)) for dim in shape
-                )
+    def _contains_dynamic_value(value: Any) -> bool:
+        """Recursively checks FX metadata for symbolic values or dimensions."""
+        if isinstance(value, (SymFloat, SymInt, SymBool)):
+            return True
+        if isinstance(value, dict):
+            return any(_contains_dynamic_value(item) for item in value.values())
+        if isinstance(value, (list, tuple)):
+            return any(_contains_dynamic_value(item) for item in value)
+        if value is None or isinstance(value, (int, float, bool)):
+            return False
+        if hasattr(value, "size"):
+            return any(_contains_dynamic_value(dim) for dim in value.size())
+        return False
 
-        return _has_symbolic_sizes_strides or is_shape_dynamic
+    def _is_subnode_dynamic(subnode: torch.fx.Node) -> bool:
+        """Checks if a node itself has Dynamic properties."""
+        meta_val = subnode.meta.get("val", subnode.meta.get("example_value"))
+        return bool(
+            getattr(meta_val, "_has_symbolic_sizes_strides", False)
+            or _contains_dynamic_value(meta_val)
+        )
+
+    def _is_argument_dynamic(argument: Argument) -> bool:
+        """Checks nodes nested inside FX container arguments."""
+        if isinstance(argument, torch.fx.Node):
+            return _is_subnode_dynamic(argument)
+        if isinstance(argument, dict):
+            return any(_is_argument_dynamic(item) for item in argument.values())
+        if isinstance(argument, (list, tuple)):
+            return any(_is_argument_dynamic(item) for item in argument)
+        return False
 
     # Check node value itself
     if arg_positions_to_check is None and _is_subnode_dynamic(node):
@@ -179,22 +176,18 @@ def _has_dynamic_shapes(
 
     # Check node arguments individually
     if arg_positions_to_check is None and any(
-        _is_subnode_dynamic(arg) for arg in node.args if isinstance(arg, torch.fx.Node)
+        _is_argument_dynamic(arg) for arg in node.args
     ):
         return True
     # Check specific arg positions if the caller has specified positions to check
     elif arg_positions_to_check is not None and any(
-        _is_subnode_dynamic(node.args[i])
-        for i in arg_positions_to_check
-        if isinstance(node.args[i], torch.fx.Node)
+        _is_argument_dynamic(node.args[i]) for i in arg_positions_to_check
     ):
         return True
 
     # Check node keyword arguments individually
     if arg_positions_to_check is None and any(
-        _is_subnode_dynamic(kwarg)
-        for kwarg in node.kwargs.values()
-        if isinstance(kwarg, torch.fx.Node)
+        _is_argument_dynamic(kwarg) for kwarg in node.kwargs.values()
     ):
         return True
 

--- a/py/torch_tensorrt/dynamo/conversion/impl/arange.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/arange.py
@@ -38,7 +38,7 @@ def _sequence_dtype(
         if isinstance(x, float):
             return trt.DataType.FLOAT
 
-        return trt.DataType.INT64
+    return trt.DataType.INT64
 
 
 def arange(
@@ -65,6 +65,9 @@ def arange(
         start_rank_0 = get_trt_tensor(
             ctx, start, name + "_start_rank_0", value_dtype, min_rank=0
         )
+        start_rank_0 = cast_trt_tensor(
+            ctx, start_rank_0, value_dtype, name + "_start_rank_0_casted"
+        )
         # LINSPACE's start input requires rank 0; if the upstream ITensor came in
         # as rank-1 (e.g. a SymInt materialized by a sym_size op), reshape it.
         if len(start_rank_0.shape) > 0:
@@ -80,6 +83,11 @@ def arange(
         )
         end = get_trt_tensor(ctx, end, name + "_end", value_dtype, min_rank=1)
         step = get_trt_tensor(ctx, step, name + "_step", value_dtype, min_rank=1)
+        start_rank_1 = cast_trt_tensor(
+            ctx, start_rank_1, value_dtype, name + "_start_rank_1_casted"
+        )
+        end = cast_trt_tensor(ctx, end, value_dtype, name + "_end_casted")
+        step = cast_trt_tensor(ctx, step, value_dtype, name + "_step_casted")
 
         # The number of elements is ceil((end - start) / step), computed as
         # -floor((start - end) / step) so that the whole expression stays in the

--- a/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
@@ -109,7 +109,7 @@ def slice_op(  # TODO: This should be slice not whatever is in base
     # Assign the initial stop tensor
     stop_slice = []
     if isinstance(stop, int) and dynamic_input_dim_equal:
-        stop_slice = input.shape
+        stop_slice = list(input.shape)
         stop_slice[dim] = stop
     else:
         # required for cases where stop is ITensor and dim != dynamic dim of input
@@ -125,6 +125,19 @@ def slice_op(  # TODO: This should be slice not whatever is in base
                 stop_slice.append(stop)
             else:
                 stop_slice.append(input.shape[i])
+
+    finite_stop_on_dynamic_dim = (
+        input.shape[dim] == DYNAMIC_DIM
+        and isinstance(stop, int)
+        and 0 <= stop < sys.maxsize
+    )
+    if finite_stop_on_dynamic_dim:
+        dim_size = get_shape(
+            ctx, target, source_ir, name + "_stop_dim_size", input, dim
+        )
+        stop_slice[dim] = impl.elementwise.min(
+            ctx, target, source_ir, name + "_stop_clamped", stop, dim_size
+        )
 
     stride_slice = [1] * len(input.shape)
     stride_slice[dim] = step
@@ -143,6 +156,7 @@ def slice_op(  # TODO: This should be slice not whatever is in base
             or stop < 0
             or stop_dynamic_None
             or stop == sys.maxsize
+            or finite_stop_on_dynamic_dim
         ):
             # special assignments for dynamic cases
             if isinstance(start, int) and start < 0:

--- a/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
@@ -135,6 +135,12 @@ def slice_op(  # TODO: This should be slice not whatever is in base
         dim_size = get_shape(
             ctx, target, source_ir, name + "_stop_dim_size", input, dim
         )
+        if isinstance(start, int) and start > 0:
+            # A runtime axis can be shorter than a positive literal start.
+            # Normalize it just like Python so the slice extent cannot go negative.
+            start_slice[dim] = impl.elementwise.min(
+                ctx, target, source_ir, name + "_start_clamped", start, dim_size
+            )
         stop_slice[dim] = impl.elementwise.min(
             ctx, target, source_ir, name + "_stop_clamped", stop, dim_size
         )

--- a/py/torch_tensorrt/dynamo/partitioning/_adjacency_partitioner.py
+++ b/py/torch_tensorrt/dynamo/partitioning/_adjacency_partitioner.py
@@ -67,6 +67,14 @@ class OpSupportTester(ops.OperatorSupportBase):  # type: ignore
             )
             return False
 
+        if TorchTensorRTOperatorSupport._exceeds_max_tensor_rank(node):
+            # Keep unrepresentable tensors entirely in the Torch partition.
+            if not node.is_impure():
+                self.unsupported_operators[node_name] = (
+                    self.unsupported_operators.get(node_name, 0) + 1
+                )
+            return False
+
         if TorchTensorRTOperatorSupport._has_complex_dtype(node):
             # Complex-dtype tensors are not supported by TensorRT; force PyTorch fallback
             if not node.is_impure():

--- a/py/torch_tensorrt/dynamo/partitioning/_global_partitioner.py
+++ b/py/torch_tensorrt/dynamo/partitioning/_global_partitioner.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Collection, Dict, List, Mapping, Optional, Sequence, Tuple
 
+import tensorrt as trt
 import torch
 from torch.fx.graph_module import GraphModule
 from torch.fx.node import Target
@@ -223,6 +224,27 @@ class TorchTensorRTOperatorSupport(OperatorSupport):  # type: ignore[misc]
         return cache[node]
 
     @staticmethod
+    def _exceeds_max_tensor_rank(node: torch.fx.Node) -> bool:
+        """Return whether a node would move a rank unsupported by TensorRT."""
+
+        def _value_exceeds_limit(value: object) -> bool:
+            if isinstance(value, torch.Tensor):
+                return value.ndim > trt.Dims.MAX_DIMS
+            if isinstance(value, (tuple, list)):
+                return any(_value_exceeds_limit(item) for item in value)
+            if isinstance(value, dict):
+                return any(_value_exceeds_limit(item) for item in value.values())
+            return False
+
+        def _node_exceeds_limit(candidate: torch.fx.Node) -> bool:
+            value = candidate.meta.get("val", candidate.meta.get("example_value"))
+            return _value_exceeds_limit(value)
+
+        return _node_exceeds_limit(node) or any(
+            _node_exceeds_limit(input_node) for input_node in node.all_input_nodes
+        )
+
+    @staticmethod
     def _requires_output_allocator(node: torch.fx.Node) -> bool:
         # True if the converter selected for this node needs a TRT output allocator,
         # i.e. the node has a data-dependent output shape (e.g. nonzero or boolean
@@ -252,6 +274,14 @@ class TorchTensorRTOperatorSupport(OperatorSupport):  # type: ignore[misc]
                 "non-target device region",
                 node_name,
             )
+            return False
+
+        if self._exceeds_max_tensor_rank(node):
+            # TensorRT network inputs and outputs are limited by trt.Dims.
+            if not node.is_impure():
+                self.unsupported_operators[node_name] = (
+                    self.unsupported_operators.get(node_name, 0) + 1
+                )
             return False
 
         if self._has_complex_dtype(node):

--- a/py/torch_tensorrt/dynamo/partitioning/common.py
+++ b/py/torch_tensorrt/dynamo/partitioning/common.py
@@ -132,10 +132,14 @@ def construct_dynamic_input(
             # if opt not exist, set it to the mean of min and max
             if "opt" not in min_max_opt or min_max_opt["opt"] is None:
                 logger.info(
-                    f"Dynamic input {name} (shape: {input_shape}) has no opt target i.e. which shape to specialize for, for dim {d}, attempting to use a sane default (opt: min({min_max_opt['min']}) + max({min_max_opt['max']}) / 2). If you want to specialized further, use torch_tensorrt.compile"
+                    f"Dynamic input {name} (shape: {input_shape}) has no opt target "
+                    f"for dim {d}; using the midpoint of min "
+                    f"({unwrapped_min_max_opt['min']}) and max "
+                    f"({unwrapped_min_max_opt['max']})."
                 )
-                unwrapped_min_max_opt["opt"] = int(
-                    unwrapped_min_max_opt["min"] + unwrapped_min_max_opt["max"] / 2
+                unwrapped_min_max_opt["opt"] = (
+                    unwrapped_min_max_opt["min"]
+                    + (unwrapped_min_max_opt["max"] - unwrapped_min_max_opt["min"]) // 2
                 )
             else:
                 unwrapped_min_max_opt["opt"] = min_max_opt["opt"]

--- a/py/torch_tensorrt/dynamo/utils.py
+++ b/py/torch_tensorrt/dynamo/utils.py
@@ -6,6 +6,7 @@ import importlib.util
 import logging
 import os
 import platform
+import sys
 import warnings
 from dataclasses import fields, replace
 from enum import Enum
@@ -458,9 +459,14 @@ def extract_var_range_info(
         if value == sympy.oo or value == -sympy.oo:
             return None
         try:
-            return int(value)
+            bound = int(value)
         except (TypeError, OverflowError, AttributeError):
             return None
+        # PyTorch uses the largest representable size as a finite-looking
+        # sentinel for an effectively unbounded symbolic dimension.
+        if abs(bound) >= sys.maxsize - 1:
+            return None
+        return bound
 
     min_val_opt = _bound_to_int_or_none(var_range.lower)
     max_val = _bound_to_int_or_none(var_range.upper)

--- a/tests/py/dynamo/conversion/test_arange_aten.py
+++ b/tests/py/dynamo/conversion/test_arange_aten.py
@@ -1,5 +1,3 @@
-import unittest
-
 import torch
 import torch.nn as nn
 import torch_tensorrt
@@ -105,6 +103,39 @@ class TestArangeConverter(DispatchTestCase):
             pyt_inputs=[pyt_input],
             use_dynamo_tracer=False,
         )
+
+    def test_arange_data_dependent_start(self):
+        class Arange(torch.nn.Module):
+            def forward(self, x, mask):
+                end = mask.nonzero().size(0)
+                start = end // 2
+                indices = torch.arange(start, end, 1, device=x.device)
+                return x.index_select(0, indices)
+
+        previous_capture_setting = torch._dynamo.config.capture_dynamic_output_shape_ops
+        try:
+            torch._dynamo.config.capture_dynamic_output_shape_ops = True
+            torch._dynamo.reset()
+
+            model = Arange().eval().cuda()
+            x = torch.randn((16, 8), device="cuda")
+            mask = torch.arange(16, device="cuda") % 2 == 0
+            expected = model(x, mask)
+
+            compiled = torch.compile(
+                model,
+                backend="tensorrt",
+                options={
+                    "pass_through_build_failures": True,
+                    "min_block_size": 1,
+                },
+            )
+            torch.testing.assert_close(compiled(x, mask), expected)
+        finally:
+            torch._dynamo.config.capture_dynamic_output_shape_ops = (
+                previous_capture_setting
+            )
+            torch._dynamo.reset()
 
 
 if __name__ == "__main__":

--- a/tests/py/dynamo/conversion/test_slice_aten.py
+++ b/tests/py/dynamo/conversion/test_slice_aten.py
@@ -73,6 +73,16 @@ class TestSliceConverterDynamicShape(DispatchTestCase):
                 2,
             ),
             (
+                "slice_dynamic_dim_finite_stop_past_opt",
+                (2, 16),
+                (2, 64),
+                (2, 128),
+                1,
+                0,
+                100,
+                1,
+            ),
+            (
                 "slice_dynamic_dim_start_stop_step_negatives",
                 (1, 10, 10),
                 (10, 10, 10),

--- a/tests/py/dynamo/conversion/test_slice_aten.py
+++ b/tests/py/dynamo/conversion/test_slice_aten.py
@@ -257,6 +257,27 @@ class TestSliceConverterDynamicShape(DispatchTestCase):
             use_example_tensors=False,
         )
 
+    def test_slice_finite_start_past_runtime_extent(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.slice.Tensor(input, 1, 32, 48, 1)
+
+        runtime_input = torch.randn(2, 16)
+        input_specs = [
+            Input(
+                min_shape=(2, 16),
+                opt_shape=(2, 64),
+                max_shape=(2, 128),
+                dtype=torch.float32,
+                torch_tensor=runtime_input,
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            TestModule(),
+            input_specs,
+            use_example_tensors=False,
+        )
+
     def test_slice_dynamic_computed_negative_start(self):
         # Regression test for https://github.com/pytorch/TensorRT/issues/4186.
         # Unlike the cases above (a literal negative int start, known at

--- a/tests/py/dynamo/conversion/test_slice_aten.py
+++ b/tests/py/dynamo/conversion/test_slice_aten.py
@@ -236,6 +236,27 @@ class TestSliceConverterDynamicShape(DispatchTestCase):
             input_specs,
         )
 
+    def test_slice_finite_stop_clamps_to_runtime_extent(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, input):
+                return torch.ops.aten.slice.Tensor(input, 1, 0, 48, 1)
+
+        runtime_input = torch.randn(2, 16)
+        input_specs = [
+            Input(
+                min_shape=(2, 16),
+                opt_shape=(2, 64),
+                max_shape=(2, 128),
+                dtype=torch.float32,
+                torch_tensor=runtime_input,
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            TestModule(),
+            input_specs,
+            use_example_tensors=False,
+        )
+
     def test_slice_dynamic_computed_negative_start(self):
         # Regression test for https://github.com/pytorch/TensorRT/issues/4186.
         # Unlike the cases above (a literal negative int start, known at

--- a/tests/py/dynamo/conversion/test_split_aten.py
+++ b/tests/py/dynamo/conversion/test_split_aten.py
@@ -3,6 +3,9 @@ from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
 from torch_tensorrt import Input
 from torch_tensorrt.dynamo.conversion import UnsupportedOperatorException
+from torch_tensorrt.dynamo.conversion._ConverterRegistry import (
+    has_static_shapes_in_args,
+)
 
 from .harness import DispatchTestCase
 
@@ -191,6 +194,34 @@ class TestSplitConverterNoDim(DispatchTestCase):
                 TestModule(),
                 input,
             )
+
+    def test_dynamic_split_sections_decline_conversion(self):
+        columns = 8
+
+        class RuntimeSections(torch.nn.Module):
+            def forward(self, x, k):
+                first_size = k.item()
+                torch._check(first_size >= 1)
+                torch._check(first_size <= columns - 1)
+                return torch.split(x, [first_size, columns - first_size], dim=1)
+
+        class LiteralSections(torch.nn.Module):
+            def forward(self, x, k):
+                return torch.split(x, [3, columns - 3], dim=1)
+
+        def get_split_node(model, args):
+            exported = torch.export.export(model, args)
+            return next(
+                node
+                for node in exported.graph.nodes
+                if node.target == torch.ops.aten.split_with_sizes.default
+            )
+
+        args = (torch.rand(4, columns), torch.tensor([3]))
+        validator = has_static_shapes_in_args([1])
+
+        self.assertFalse(validator(get_split_node(RuntimeSections(), args), None))
+        self.assertTrue(validator(get_split_node(LiteralSections(), args), None))
 
 
 if __name__ == "__main__":

--- a/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
+++ b/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
@@ -3,6 +3,7 @@
 the partitioner into ``extract_var_range_info``."""
 
 import os
+import sys
 import unittest
 
 import pytest
@@ -38,6 +39,41 @@ class _SmallLinear(torch.nn.Module):
 
     def forward(self, x):
         return self.linear(x).relu()
+
+
+@torch.library.custom_op("torchtrt_profile_test::dynamic_rows", mutates_args=())
+def _profile_dynamic_rows(x: torch.Tensor) -> torch.Tensor:
+    return x.clone()
+
+
+@_profile_dynamic_rows.register_fake
+def _profile_dynamic_rows_fake(x: torch.Tensor) -> torch.Tensor:
+    return x.new_empty(torch.library.get_ctx().new_dynamic_size(), x.shape[1])
+
+
+class _ConstrainedDynamicRows(torch.nn.Module):
+    def __init__(self, lower: int, upper: int) -> None:
+        super().__init__()
+        self.lower = lower
+        self.upper = upper
+
+    def forward(self, x):
+        rows = torch.ops.torchtrt_profile_test.dynamic_rows(x)
+        torch._check(rows.shape[0] >= self.lower)
+        torch._check(rows.shape[0] <= self.upper)
+        return rows
+
+
+def _constrained_dynamic_shape(lower: int, upper: int) -> torch.Size:
+    exported = torch.export.export(
+        _ConstrainedDynamicRows(lower, upper), (torch.ones(1100, 4),)
+    )
+    dynamic_rows = next(
+        node
+        for node in exported.graph.nodes
+        if node.target == torch.ops.torchtrt_profile_test.dynamic_rows.default
+    )
+    return dynamic_rows.meta["val"].shape
 
 
 @pytest.mark.unit
@@ -559,6 +595,32 @@ def test_dim_dynamic_save_preserves_range_constraints(tmpdir):
     too_big = torch.randn(16, 8, device="cuda")
     with assertions.assertRaises(Exception):
         trt_module(too_big)
+
+
+@pytest.mark.unit
+def test_construct_dynamic_input_uses_profile_midpoint():
+    symbolic_shape = _constrained_dynamic_shape(1000, 1200)
+    input_spec = construct_dynamic_input(
+        symbolic_shape, torch.float32, name="dynamic_rows"
+    )
+
+    assert input_spec.shape["min_shape"] == (1000, 4)
+    assert input_spec.shape["opt_shape"] == (1100, 4)
+    assert input_spec.shape["max_shape"] == (1200, 4)
+
+
+@pytest.mark.unit
+def test_largest_size_symbol_bound_is_treated_as_unbounded():
+    symbolic_shape = _constrained_dynamic_shape(1, sys.maxsize - 1)
+    range_info = extract_var_range_info(symbolic_shape[0])
+    input_spec = construct_dynamic_input(
+        symbolic_shape, torch.float32, name="dynamic_rows"
+    )
+
+    assert range_info["max"] is None
+    assert input_spec.shape["min_shape"] == (1, 4)
+    assert input_spec.shape["opt_shape"] == (2048, 4)
+    assert input_spec.shape["max_shape"] == (4096, 4)
 
 
 @pytest.mark.unit

--- a/tests/py/dynamo/partitioning/test_rank_limit.py
+++ b/tests/py/dynamo/partitioning/test_rank_limit.py
@@ -1,0 +1,84 @@
+import unittest
+
+import torch
+import torch_tensorrt
+from parameterized import parameterized
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+RANK_10_SHAPE = (1, 2, 1, 1, 1, 1, 1, 1, 4, 8)
+RANK_8_SHAPE = (1, 2, 1, 1, 1, 1, 4, 8)
+
+
+@torch.library.custom_op("torchtrt_partition_test::high_rank", mutates_args=())
+def _high_rank(x: torch.Tensor) -> torch.Tensor:
+    return x.reshape(RANK_10_SHAPE).clone()
+
+
+@_high_rank.register_fake
+def _high_rank_fake(x: torch.Tensor) -> torch.Tensor:
+    return x.new_empty(RANK_10_SHAPE)
+
+
+@torch.library.custom_op("torchtrt_partition_test::low_rank", mutates_args=())
+def _low_rank(x: torch.Tensor) -> torch.Tensor:
+    return x.reshape(RANK_8_SHAPE).clone()
+
+
+@_low_rank.register_fake
+def _low_rank_fake(x: torch.Tensor) -> torch.Tensor:
+    return x.new_empty(RANK_8_SHAPE)
+
+
+class HighRankBoundary(torch.nn.Module):
+    def forward(self, x):
+        return torch.ops.torchtrt_partition_test.high_rank(x) * 2.0
+
+
+class LowRankBoundary(torch.nn.Module):
+    def forward(self, x):
+        return torch.ops.torchtrt_partition_test.low_rank(x) * 2.0
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class TestTensorRankPartitioning(TestCase):
+    @parameterized.expand([("fast", True), ("global", False)])
+    def test_rank_above_trt_limit_falls_back(self, _, use_fast_partitioner):
+        model = HighRankBoundary().eval().cuda()
+        x = torch.rand(2, 4, 8, device="cuda")
+
+        compiled = torch_tensorrt.compile(
+            model,
+            ir="dynamo",
+            inputs=[x],
+            min_block_size=1,
+            use_fast_partitioner=use_fast_partitioner,
+        )
+
+        accelerated = [
+            name for name, _ in compiled.named_children() if "_run_on_acc" in name
+        ]
+        self.assertEqual(accelerated, [])
+        self.assertEqual(compiled(x), model(x))
+
+    @parameterized.expand([("fast", True), ("global", False)])
+    def test_rank_at_trt_limit_converts(self, _, use_fast_partitioner):
+        model = LowRankBoundary().eval().cuda()
+        x = torch.rand(2, 4, 8, device="cuda")
+
+        compiled = torch_tensorrt.compile(
+            model,
+            ir="dynamo",
+            inputs=[x],
+            min_block_size=1,
+            use_fast_partitioner=use_fast_partitioner,
+        )
+
+        accelerated = [
+            name for name, _ in compiled.named_children() if "_run_on_acc" in name
+        ]
+        self.assertEqual(len(accelerated), 1)
+        self.assertEqual(compiled(x), model(x))
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
## Summary

- clamp finite slice stops against a dynamic runtime axis extent
- keep rank-8-and-higher tensors out of TensorRT partitions at both producer and boundary checks
- compute optimization-profile opt extents as the true midpoint between min and max
- handle unbounded symbolic range limits without calling int() on infinity-like sentinels

## Issues

Closes #4607
Closes #4608
Closes #4610
Closes #4611

## Tests

- pytest tests/py/dynamo/conversion/test_slice_aten.py tests/py/dynamo/models/test_dynamic_shape_user_bounds.py tests/py/dynamo/partitioning/test_rank_limit.py -n0 (56 passed)
- original reproducers for #4607, #4608, #4610, and #4611 no longer reproduce

## Stack

6 of 7. Base: #4631. Follow-up: narendasan/fix-symbolic-converter-parameters.