### PR TITLE
fix: Dynamo compile support for None outputs

### DIFF
--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -1575,6 +1575,8 @@ def compile_module(
             # than a tuple/list of Nodes.
             outputs = arg if isinstance(arg, (list, tuple)) else [arg]
             for output in outputs:
+                if output is None:
+                    continue
                 target = output.target
                 if "_run_on_acc" not in str(target):
                     continue

--- a/tests/py/dynamo/models/test_models.py
+++ b/tests/py/dynamo/models/test_models.py
@@ -634,3 +634,44 @@ def test_bf16_fallback_model(ir):
 
     # Clean up model env
     torch._dynamo.reset()
+
+
+@pytest.mark.unit
+def test_model_with_none_output(ir):
+    class ModelWithNoneOutput(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.relu = nn.ReLU()
+
+        def forward(self, x):
+            return self.relu(x), None
+
+    model = ModelWithNoneOutput().eval().to("cuda")
+    input = torch.randn((1, 5)).to("cuda")
+
+    compile_spec = {
+        "inputs": [
+            torchtrt.Input(
+                input.shape, dtype=torch.float, format=torch.contiguous_format
+            )
+        ],
+        "device": torchtrt.Device("cuda:0"),
+        "enabled_precisions": {torch.float},
+        "ir": ir,
+        "pass_through_build_failures": True,
+        "min_block_size": 1,
+        "cache_built_engines": False,
+        "reuse_cached_engines": False,
+    }
+
+    trt_mod = torchtrt.compile(model, **compile_spec)
+    trt_out = trt_mod(input)
+    assertions.assertIsInstance(trt_out, tuple)
+    assertions.assertEqual(len(trt_out), 2)
+    assertions.assertIsNone(trt_out[1])
+
+    torch_out = model(input)
+    torch.testing.assert_close(trt_out[0], torch_out[0])
+
+    # Clean up model env
+    torch._dynamo.reset()


### PR DESCRIPTION
# Description

Currently, any model outputs that are `None` literals (e.g., auxiliary outputs) cause a compile crash when trying to access the attribute `target`.

This PR adds a `continue` if `is None`, and adds a simple test.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
