### PR TITLE
Short-circuit index_put with a statically-empty index

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/impl/select.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/select.py
@@ -772,6 +772,13 @@ def index_put_converter(
     else:
         N = 1
 
+    if isinstance(N, int) and N == 0:
+        # Empty index -> no-op. Building the scatter path anyway trips a
+        # TensorRT squeezeDims assertion on DGX Spark (GB10, SM 12.1).
+        identity_layer = ctx.net.add_identity(input_tensor)
+        set_layer_name(identity_layer, target, f"{name}_empty_index_noop", source_ir)
+        return identity_layer.get_output(0)
+
     # Compute shapes and volume for the free dimensions.
     # F_shapes: static ints (-1 for dynamic dims), used where static ints are required.
     # F_shape_values: per-free-dim size as int (static) or ITensor (dynamic).


### PR DESCRIPTION
# Description

An empty index means no positions to scatter into, so index_put is a no-op. Building the scatter path anyway (reshaping an index tensor to a shape containing a 0) trips a TensorRT-internal squeezeDims assertion at build time on DGX Spark (GB10, SM 12.1) -- Error Code 2, "Assertion inputDims != nullptr failed" in validationUtils.cpp. Other platforms don't hit it (verified: passes on H100/A100/GB200-family/ORIN_IGX), but the operation is a no-op regardless of platform, so avoid building it at all.

Related but distinct from #4621 (dynamic-index broadcast bug in the same converter) -- different trigger condition, different TRT error, different fix location.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes