### PR TITLE
fix(executorch): drop the unused cuRAND link from the CUDA shims

### DIFF
--- a/py/torch-tensorrt-executorch-runtime/native/CMakeLists.txt
+++ b/py/torch-tensorrt-executorch-runtime/native/CMakeLists.txt
@@ -227,6 +227,7 @@ target_link_libraries(portable_lib PRIVATE
 # selects CMAKE_CXX_COMPILER and those standard libraries for these targets, so it has
 # to be set on every one of them.
 #
+
 # The CUDA backend brings two shared libraries of its own. They get the same treatment,
 # because libaoti_cuda_shims.so is the first DT_NEEDED of _portable_lib.so and so leads
 # the whole dlopen group in symbol search order.
@@ -248,6 +249,33 @@ foreach(_torch_tensorrt_executorch_runtime_target
         IN LISTS _torch_tensorrt_executorch_runtime_targets)
   set_property(TARGET ${_torch_tensorrt_executorch_runtime_target}
     PROPERTY LINKER_LANGUAGE CXX)
+endforeach()
+
+# ExecuTorch links CUDA::curand into aoti_cuda_shims, but nothing in it calls a curand
+# host function: the only curand use in the pinned source is the device-side API from
+# curand_kernel.h inside rand.cu, which nvcc compiles into the fatbinary. Measured on the
+# shipped artifact: DT_NEEDED carries libcurand.so.10 while the dynamic symbol table
+# imports no curand symbol at all.
+#
+# The over-link is not harmless: the wheel declares a dependency it never calls, and
+# nothing guarantees an installer provides it, so importing the runtime can fail on a
+# missing shared object before any delegate runs. Which installers happen to supply
+# libcurand.so.10 is not stable and has already changed more than once, so the reason to
+# drop the link is that nothing uses it, not that a particular resolver omits it.
+#
+# Dropped here rather than patched into ExecuTorch. This becomes a no-op only once the
+# pin includes upstream's own removal, which landed on their main line AFTER the pinned
+# release. The 1.4 series still links cuRAND, so a patch bump within 1.4 does not make
+# this redundant: check that the pinned tree has no CUDA::curand in
+# backends/cuda/CMakeLists.txt before deleting this block.
+foreach(_torch_tensorrt_curand_property LINK_LIBRARIES INTERFACE_LINK_LIBRARIES)
+  get_target_property(_torch_tensorrt_curand_value
+    aoti_cuda_shims ${_torch_tensorrt_curand_property})
+  if(_torch_tensorrt_curand_value AND CUDA::curand IN_LIST _torch_tensorrt_curand_value)
+    list(REMOVE_ITEM _torch_tensorrt_curand_value CUDA::curand)
+    set_property(TARGET aoti_cuda_shims
+      PROPERTY ${_torch_tensorrt_curand_property} "${_torch_tensorrt_curand_value}")
+  endif()
 endforeach()
 
 # The runtime wheel intentionally does not bundle PyTorch, TensorRT, or CUDA.


### PR DESCRIPTION
# Description

Importing the ExecuTorch runtime wheel on a CUDA 13 install fails before anything runs:

```
OSError: libcurand.so.10: cannot open shared object file: No such file or directory
  -> DelegateCompatibilityError: Could not load the prebuilt Torch-TensorRT ExecuTorch runtime
```

The wheel's dependency probe dlopens the bundled `_portable_lib`. Its first `DT_NEEDED` is
`libaoti_cuda_shims.so`, and that library declares a dependency on cuRAND that nothing
installs: torch requests `cuda-toolkit` without its `curand` extra, so `libcurand.so.10` is
not present alongside these wheels.

The dependency is unused. The only cuRAND use in the pinned ExecuTorch is the device-side API
from `curand_kernel.h` in `rand.cu`, which nvcc compiles into the fatbinary. Measured on the
shipped artifact, all four bundled libraries:

| library | cuRAND `DT_NEEDED` | cuRAND symbols imported |
| --- | --- | --- |
| `_portable_lib...so` | no | 0 |
| `data_loader...so` | no | 0 |
| `libextension_cuda.so` | no | 0 |
| `libaoti_cuda_shims.so` | **yes** | **0** |

So one library declares it and none of them call it. The link survives in the release image,
which is what matters here: the shipped artifact carries the `DT_NEEDED`. It does not survive on
every toolchain, because a gcc whose spec defaults to `--as-needed` drops an unused library, so
the same over-link is invisible on some hosts and fatal on the ones these wheels are built for.

This drops the link in Torch-TensorRT's own CMake rather than patching ExecuTorch, and it is
written to disarm itself: upstream removed the same link after the pinned release, so once the
pin moves this becomes a no-op and can be deleted.

# Test plan

Built a shared library from `curand_kernel.h` device code with the same linker configuration the
wheel uses, with the target defined in a subdirectory and stripped from the parent, which is the
shape this project has:

```
with the strip:                    cuRAND DT_NEEDED = 0
negative control, same shape,
without the strip:                 cuRAND DT_NEEDED = 1
```

The control matters: it shows the test can fail, so the pass is meaningful.

Confirmed against the real thing as well, configuring this project's own CMakeLists with the
pinned ExecuTorch and reading the generated `link.txt`, patched against unpatched:

```
            aoti_cuda_shims link.txt    portable_lib link.txt
unpatched   libcurand.so tokens = 1     libcurand.so tokens = 1
patched     libcurand.so tokens = 0     libcurand.so tokens = 0
```

`cudart` appears twice in both, so the link line is real rather than empty. The file warns that
removing something after `add_subdirectory` is too late for CMake *variables*; this measures that
target properties are still mutable there, which the existing `set_property` calls on the same
targets in the same region already relied on.

Ran both artifacts on an sm_110 device through ctypes. The Philox value is `3823634032` either
way, so removing the host library changed no numerics.

Exercised the CMake logic against both shapes of ExecuTorch, with cuRAND linked and with it
already absent. Both yield `CUDA::cudart`, so the edit is a no-op once the pin moves past
upstream's removal.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes

This change is one build file. It adds no test and no documentation, so those three are
left unticked: the measurement in the test plan above, with its control, is what stands
in for a test here. The strongest evidence is in CI rather than in this description: the
base commit has ten red `executorch-runtime-test` rows failing with exactly this
`OSError`, and this head has zero failures across 48 check runs.
