### PR TITLE
fix(executorch): back device-planned arenas when loading in Python

### DIFF
--- a/.github/scripts/filter-executorch-cuda-arches.py
+++ b/.github/scripts/filter-executorch-cuda-arches.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Drop CUDA architectures ExecuTorch's shims cannot compile for.
+
+The shims call ``__dp4a``, which nvcc does not declare before sm_61, so a list carrying
+5.0 or 6.0 fails with ``identifier "__dp4a" is undefined`` whichever CUDA is in use. The
+cu126 build environment asks for ``5.0;6.0;7.0;7.5;8.0;8.6;9.0`` while the CUDA 13 ones
+start at 7.5, which is why only cu126 broke.
+
+Filtering what the environment asked for rather than pinning a list here, so a channel
+that adds a newer architecture still builds for it without editing this file.
+"""
+
+from __future__ import annotations
+
+import sys
+
+# The first architecture that declares __dp4a. GP100 is 6.0 and does not have it; the
+# rest of Pascal is 6.1 and does.
+MINIMUM = 6.1
+
+# PyTorch accepts named architectures and expands each to a version list before building
+# its gencode flags (torch/utils/cpp_extension.py). Expand them the same way here, or a
+# name would pass through untouched and carry its sub-6.1 members into the build: Pascal
+# alone expands to 6.0;6.1+PTX, and 6.0 is precisely what this filter exists to drop.
+#
+# Ordered longest-key-first, and applied by substring replacement, because that is what
+# torch does: "Maxwell+Tegra" has to be replaced before "Maxwell", or the suffix is left
+# behind as "5.0;5.2+PTX+Tegra".
+NAMED_ARCHES = (
+    ("Kepler+Tesla", "3.7"),
+    ("Kepler", "3.5+PTX"),
+    ("Maxwell+Tegra", "5.3"),
+    ("Maxwell", "5.0;5.2+PTX"),
+    ("Pascal", "6.0;6.1+PTX"),
+    ("Volta+Tegra", "7.2"),
+    ("Volta", "7.0+PTX"),
+    ("Turing", "7.5+PTX"),
+    ("Ampere+Tegra", "8.7"),
+    ("Ampere", "8.0;8.6+PTX"),
+    ("Ada", "8.9+PTX"),
+    ("Hopper", "9.0+PTX"),
+    ("Blackwell+Tegra", "11.0"),
+    ("Blackwell", "10.0;10.3;12.0;12.1+PTX"),
+    ("Rubin", "10.7+PTX"),
+)
+
+
+def filter_arches(requested: str) -> list[str]:
+    for name, versions in NAMED_ARCHES:
+        requested = requested.replace(name, versions)
+    kept = []
+    # A list may be comma, space or semicolon separated. torch normalises spaces the same way
+    # (torch/utils/cpp_extension.py does _arch_list.replace(' ', ';')), so accept all three rather
+    # than silently passing a space-separated list through unfiltered.
+    for entry in requested.replace(",", ";").replace(" ", ";").split(";"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        # An entry may carry a suffix such as "8.6+PTX", which sorts by its number.
+        number = entry.split("+", 1)[0]
+        try:
+            if float(number) >= MINIMUM:
+                kept.append(entry)
+        except ValueError:
+            # Not a version this understands. Keep it and let the compiler judge,
+            # rather than silently dropping a target that may be real.
+            kept.append(entry)
+    return kept
+
+
+def main(argv: list[str]) -> int:
+    requested = argv[1] if len(argv) > 1 else ""
+    kept = filter_arches(requested)
+    if requested.strip() and not kept:
+        # Printing nothing would leave nvcc to pick its own default, which is not what
+        # the channel asked for and would ship a wheel for the wrong architectures.
+        print(
+            f"No CUDA architecture in {requested!r} is at or above sm_61, "
+            "which ExecuTorch's CUDA shims require.",
+            file=sys.stderr,
+        )
+        return 1
+    print(";".join(kept))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/workflows/executorch-build-linux.yml
+++ b/.github/workflows/executorch-build-linux.yml
@@ -96,6 +96,13 @@ jobs:
         # setup.py already forwards BAZEL_ARGS, so raise the limit rather than
         # debugging blind.
         export BAZEL_ARGS="--experimental_ui_max_stdouterr_bytes=33554432"
+        # ExecuTorch's CUDA shims call __dp4a, which nvcc does not declare before
+        # sm_61, and the cu126 build environment asks for 5.0;6.0;... while the CUDA
+        # 13 ones start higher. Building the pinned ExecuTorch for those two
+        # architectures cannot work, so narrow the list to what it can compile.
+        TORCH_CUDA_ARCH_LIST="$(python .github/scripts/filter-executorch-cuda-arches.py "${TORCH_CUDA_ARCH_LIST:-}")"
+        export TORCH_CUDA_ARCH_LIST
+        echo "TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}"
 
         # Build the no-compile-for-users Python runtime wheel.
         python -m pip wheel --no-build-isolation --no-deps --wheel-dir dist py/torch-tensorrt-executorch-runtime

--- a/.github/workflows/executorch-test-linux.yml
+++ b/.github/workflows/executorch-test-linux.yml
@@ -86,6 +86,14 @@ jobs:
 
         source tests/py/utils/ci_helpers.sh
         trt_tier_executorch
+        # This job builds the reference runner, whose CMakeLists forces
+        # EXECUTORCH_BUILD_CUDA=ON, so it compiles the same aoti_cuda_shims the build job
+        # does and needs the same architecture floor. It sources the channel's build env,
+        # which on cu126 asks for architectures without __dp4a, so filter here too rather
+        # than moving that failure from the build job into this one.
+        TORCH_CUDA_ARCH_LIST="$(python .github/scripts/filter-executorch-cuda-arches.py "${TORCH_CUDA_ARCH_LIST:-}")"
+        export TORCH_CUDA_ARCH_LIST
+        echo "TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}"
 
         bazel build //:libtorchtrt --compilation_mode opt --config=linux
         executorch_cmake_location="$(bazel query @executorch//:executorch/CMakeLists.txt --output=location)"

--- a/py/torch-tensorrt-executorch-runtime/README.md
+++ b/py/torch-tensorrt-executorch-runtime/README.md
@@ -71,6 +71,12 @@ Consequently, the Python API does not use the backend's device-resident
 input/output fast path. Applications that need to keep inputs and outputs on
 GPU should use the ExecuTorch C++ runner.
 
+The device copies around the delegate need the program's device-tagged
+memory-planned arenas backed by real device memory, which ExecuTorch does only
+through its Module API. `Program` therefore loads through
+`_load_for_executorch_from_buffer` rather than through `executorch.runtime`,
+whose program loader plans every arena on the host.
+
 ## Use
 
 ```bash

--- a/py/torch-tensorrt-executorch-runtime/setup.py
+++ b/py/torch-tensorrt-executorch-runtime/setup.py
@@ -21,7 +21,6 @@ HERE = pathlib.Path(__file__).resolve().parent
 REPO_ROOT = HERE.parents[1]
 BAZEL_TARGET = "//py/torch-tensorrt-executorch-runtime/native:delegate_native"
 BUILD_NONCE = os.getenv("TORCH_TENSORRT_EXECUTORCH_BUILD_NONCE", uuid.uuid4().hex)
-CUDA_RUNTIME_DISTRIBUTION = "nvidia-cuda-runtime"
 
 
 def torchtrt_version() -> str:
@@ -50,14 +49,39 @@ def installed_version(distribution: str) -> str:
 
 
 def tensorrt_distribution() -> str:
-    """Return the TensorRT distribution matching the PyTorch CUDA build."""
+    """Return the TensorRT distribution matching the PyTorch CUDA build.
+
+    Matched on the major. test-infra's matrix carries cu128 alongside cu126, and the filter
+    drops it rather than the build rejecting it, but a 12.x that is not exactly 12.6 used to
+    reach the "Unsupported CUDA version" path here even though tensorrt-cu12 is what it needs.
+    """
     cuda_version = torch.version.cuda
     if cuda_version is None:
         raise RuntimeError("CUDA-enabled PyTorch is required to build this wheel")
-    if cuda_version.startswith("12.6"):
+    if cuda_version.startswith("12."):
         return "tensorrt-cu12"
     if cuda_version.startswith("13."):
         return "tensorrt-cu13"
+    raise RuntimeError(f"Unsupported CUDA version: {cuda_version}")
+
+
+def cuda_runtime_distribution() -> str:
+    """Return the CUDA runtime distribution matching the PyTorch CUDA build.
+
+    NVIDIA splits this one by major: the CUDA 12 wheels are published as
+    ``nvidia-cuda-runtime-cu12``, while the unsuffixed ``nvidia-cuda-runtime``
+    is the CUDA 13 line. Naming the unsuffixed one unconditionally made every
+    CUDA 12 row fail with "No package metadata was found for
+    nvidia-cuda-runtime", because what torch installed there was the suffixed
+    distribution.
+    """
+    cuda_version = torch.version.cuda
+    if cuda_version is None:
+        raise RuntimeError("CUDA-enabled PyTorch is required to build this wheel")
+    if cuda_version.startswith("12."):
+        return "nvidia-cuda-runtime-cu12"
+    if cuda_version.startswith("13."):
+        return "nvidia-cuda-runtime"
     raise RuntimeError(f"Unsupported CUDA version: {cuda_version}")
 
 
@@ -141,6 +165,7 @@ class BazelBuild(build_ext):
 
 
 TENSORRT_DISTRIBUTION = tensorrt_distribution()
+CUDA_RUNTIME_DISTRIBUTION = cuda_runtime_distribution()
 executorch_version = installed_version("executorch")
 tensorrt_version = installed_version(TENSORRT_DISTRIBUTION)
 cuda_runtime_version = installed_version(CUDA_RUNTIME_DISTRIBUTION)

--- a/py/torch-tensorrt-executorch-runtime/torch_tensorrt_executorch_runtime/__init__.py
+++ b/py/torch-tensorrt-executorch-runtime/torch_tensorrt_executorch_runtime/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ctypes
 import importlib
+import importlib.util
 import os
 import sys
 from types import ModuleType

--- a/py/torch-tensorrt-executorch-runtime/torch_tensorrt_executorch_runtime/runtime.py
+++ b/py/torch-tensorrt-executorch-runtime/torch_tensorrt_executorch_runtime/runtime.py
@@ -3,21 +3,35 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Collection, Sequence, Union, cast
-
-if TYPE_CHECKING:
-    from torch_tensorrt_executorch_runtime import _Runtime
+from typing import Any, Collection, Sequence, Union, cast
 
 
-def _get_runtime() -> _Runtime:
+def _load_module(data: bytes) -> Any:
+    """Load a program through ExecuTorch's Module API.
+
+    A TensorRT delegated program is exported with device-tagged memory-planned
+    arenas, and ExecuTorch backs those with real device memory only through
+    this API. Its program loader plans every arena on the host, so the device
+    copy the exporter inserts around the delegate would hand ``cudaMemcpy`` a
+    host destination and fail with ``invalid argument``.
+    """
     try:
-        from torch_tensorrt_executorch_runtime import get_runtime
+        from torch_tensorrt_executorch_runtime import activate, get_runtime
     except ImportError as error:
         raise ImportError(
             "ExecuTorch Python inference requires the prebuilt delegate. "
             'Install it with: pip install "torch-tensorrt[executorch]"'
         ) from error
-    return get_runtime()
+
+    # get_runtime verifies TensorRTBackend is registered; activate returns the native module it
+    # installed as the process portable runtime, which is what loads the program.
+    get_runtime()
+    native = activate()
+    # Taken off the native module rather than imported through
+    # executorch.extension.pybindings.portable_lib. That wrapper's presence in sys.modules is how
+    # activate() detects that ExecuTorch's stock runtime was imported first, so importing it here
+    # would make a later activate() in the same process refuse.
+    return native._load_for_executorch_from_buffer(data)
 
 
 class Program:
@@ -30,14 +44,14 @@ class Program:
     ExecuTorch C++ runner.
     """
 
-    def __init__(self, program: Any, data: bytes) -> None:
+    def __init__(self, module: Any, data: bytes) -> None:
         # ExecuTorch's BufferDataLoader references this memory without copying it.
         self._data = data
-        self._program = program
+        self._module = module
 
     @property
     def method_names(self) -> Collection[str]:
-        return cast(Collection[str], self._program.method_names)
+        return cast(Collection[str], self._module.method_names())
 
     def run(self, inputs: Sequence[Any], method: str = "forward") -> Sequence[Any]:
         """Run a method using CPU inputs and return CPU outputs.
@@ -56,10 +70,7 @@ class Program:
             raise ValueError(
                 f"Unknown method {method!r}; available methods: {sorted(self.method_names)}"
             )
-        loaded = self._program.load_method(method)
-        if loaded is None:
-            raise RuntimeError(f"ExecuTorch failed to load method {method!r}")
-        return cast(Sequence[Any], loaded.execute(inputs))
+        return cast(Sequence[Any], self._module.run_method(method, inputs))
 
     def forward(self, *inputs: Any) -> Sequence[Any]:
         return self.run(inputs, "forward")
@@ -75,7 +86,7 @@ def load(path: Union[str, Path]) -> Program:
     if not model_path.is_file():
         raise FileNotFoundError(f"ExecuTorch model not found: {model_path}")
     data = model_path.read_bytes()
-    return Program(_get_runtime().load_program(data), data)
+    return Program(_load_module(data), data)
 
 
 __all__ = ["Program", "load"]

--- a/tests/py/dynamo/executorch/test_api.py
+++ b/tests/py/dynamo/executorch/test_api.py
@@ -1,5 +1,7 @@
 import ast
 import importlib
+import importlib.util
+import subprocess
 import sys
 import types
 from pathlib import Path
@@ -10,6 +12,198 @@ from torch._library.fake_class_registry import FakeScriptObject
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.export.graph_signature import InputKind
 from torch_tensorrt.dynamo._exporter import _resolve_lifted_custom_obj, lift
+
+
+@pytest.mark.unit
+def test_the_python_loader_uses_the_api_that_backs_device_arenas():
+    """Loading must go through the Module API, not the program loader.
+
+    A delegated program is exported with device-tagged memory-planned arenas. Only the Module API
+    allocates device memory for those; the program loader behind ``executorch.runtime`` plans every
+    arena on the host, so the device copy the exporter inserts is handed a host destination and
+    ``cudaMemcpy`` fails with ``invalid argument``. Asserting the call rather than trusting a
+    comment, since the two APIs differ by one function name and swapping back would be silent until
+    someone ran a delegated model on a GPU.
+    """
+    source = _RUNTIME_PY.read_text(encoding="utf-8")
+    assert "_load_for_executorch_from_buffer" in source, (
+        "the runtime no longer loads through the Module API, so device-planned arenas would be "
+        "planned on the host and every delegate boundary copy would fail"
+    )
+    assert (
+        "load_program" not in source
+    ), "the runtime still references the program loader, which does not back device-tagged arenas"
+
+
+@pytest.mark.unit
+def test_every_lane_that_builds_the_cuda_shims_filters_the_arch_list():
+    """Both ExecuTorch lanes compile the shims, so both need the architecture floor.
+
+    The build lane builds the wheel and the reference runner; the test lane builds the runner
+    again, whose CMakeLists forces EXECUTORCH_BUILD_CUDA=ON. Both source the channel's build
+    environment, so filtering in only one of them moves the cu126 failure from that job into the
+    other rather than removing it. Checked by parsing, because the ordering matters: the filter has
+    to run before whatever compiles.
+    """
+    import yaml
+
+    for name in ("executorch-build-linux.yml", "executorch-test-linux.yml"):
+        workflow = yaml.safe_load(
+            (_REPO_ROOT / ".github/workflows" / name).read_text(encoding="utf-8")
+        )
+        scripts = [
+            (job.get("with") or {}).get("script", "")
+            for job in workflow.get("jobs", {}).values()
+        ]
+        script = next(
+            (s for s in scripts if "verify-executorch-reference-runner" in s), None
+        )
+        assert script is not None, f"{name} no longer builds the reference runner"
+
+        lines = script.splitlines()
+        filtered = [
+            i for i, line in enumerate(lines) if "filter-executorch-cuda-arches" in line
+        ]
+        assert filtered, (
+            f"{name} builds the CUDA shims without narrowing TORCH_CUDA_ARCH_LIST, so a channel "
+            "asking for an architecture without __dp4a fails to compile"
+        )
+        for marker in ("verify-executorch-reference-runner", "pip wheel"):
+            compiled = [i for i, line in enumerate(lines) if marker in line]
+            if compiled:
+                assert filtered[0] < compiled[0], (
+                    f"{name} filters the architecture list after {marker!r}, so the value in "
+                    "effect while compiling is the unfiltered one"
+                )
+
+
+@pytest.mark.unit
+def test_the_cuda_arch_filter_drops_only_what_executorch_cannot_compile():
+    """The delegate build must not be asked for an architecture without ``__dp4a``.
+
+    ExecuTorch's CUDA shims call that intrinsic, which nvcc does not declare before
+    sm_61, so a list carrying 5.0 or 6.0 fails to compile at all. The cu126 build
+    environment asks for exactly that while the CUDA 13 ones start higher, which is why
+    only cu126 broke. The filter narrows the request rather than pinning a list, so this
+    checks both that the unbuildable entries go and that everything else survives.
+    """
+    script = _REPO_ROOT / ".github/scripts/filter-executorch-cuda-arches.py"
+
+    def run(requested):
+        return subprocess.run(
+            [sys.executable, str(script), requested],
+            capture_output=True,
+            text=True,
+        )
+
+    # The list the cu126 environment actually exports.
+    result = run("5.0;6.0;7.0;7.5;8.0;8.6;9.0")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "7.0;7.5;8.0;8.6;9.0"
+
+    # A CUDA 13 list is already buildable and must come back untouched, including
+    # architectures newer than anything named in the filter.
+    unchanged = "7.5;8.0;8.6;9.0;10.0;12.0"
+    assert run(unchanged).stdout.strip() == unchanged
+
+    # A "+PTX" suffix sorts by its number and keeps its suffix.
+    assert run("5.0;6.0;8.6+PTX").stdout.strip() == "8.6+PTX"
+
+    # PyTorch also accepts named architectures and expands each before building its gencode
+    # flags, so a name has to be expanded here too. Pascal is 6.0;6.1+PTX, and passing the name
+    # through untouched would carry 6.0 into the build, which is the target this filter exists to
+    # drop. The longer keys go first, or "Maxwell+Tegra" leaves a "+Tegra" tail behind.
+    assert run("Pascal").stdout.strip() == "6.1+PTX"
+    assert run("Ampere").stdout.strip() == "8.0;8.6+PTX"
+    assert run("Pascal;7.5").stdout.strip() == "6.1+PTX;7.5"
+    for name in ("Maxwell", "Maxwell+Tegra", "Kepler"):
+        rejected = run(name)
+        assert rejected.returncode != 0, f"{name} has no member at or above sm_61"
+        assert "sm_61" in rejected.stderr
+
+    # Space separated is the other spelling torch accepts, and it normalises spaces the same way
+    # (torch/utils/cpp_extension.py does _arch_list.replace(" ", ";")). Filtering only on
+    # semicolons let a space separated list through untouched, which is silent rather than loud.
+    assert run("5.0 6.0 7.5 8.6").stdout.strip() == "7.5;8.6"
+    assert run("5.0, 6.0, 7.5").stdout.strip() == "7.5"
+
+    # Nothing buildable must fail loudly. Printing an empty list would leave nvcc to
+    # pick its own default and ship a wheel for architectures nobody asked for.
+    empty = run("5.0;6.0")
+    assert empty.returncode != 0
+    assert "sm_61" in empty.stderr
+
+    # An unset list is not this script's problem to invent.
+    assert run("").returncode == 0
+
+
+def _is_importable_module(name: str) -> bool:
+    """Whether ``name`` is a module, so reaching through it needs its own import.
+
+    find_spec raises rather than returning None for a dotted name whose parent is a module but
+    whose child is an ordinary attribute: ``sys.modules`` gives ModuleNotFoundError, "__path__
+    attribute not found on 'sys'". Treating that as "not a module" is the point, since an attribute
+    is reachable without a second import.
+    """
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (AttributeError, ImportError, ValueError):
+        return False
+
+
+@pytest.mark.unit
+def test_the_runtime_package_imports_every_submodule_it_reaches_through():
+    """Every dotted module the runtime package uses must be imported, not assumed.
+
+    ``import importlib`` does not bind ``importlib.util``: the attribute exists only once something
+    else in the process has imported that submodule. The package used ``importlib.util.find_spec``
+    on the strength of a bare ``import importlib``, which worked whenever torch was imported first,
+    since torch pulls the submodule in, and raised AttributeError when the runtime wheel was
+    imported on its own. Compiling the module here is not enough to catch it, because the attribute
+    is only read at call time, so match the source against what it imports.
+    """
+    source = _RUNTIME_INIT_PY.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.asname is None:
+                    parts = alias.name.split(".")
+                    for index in range(len(parts)):
+                        imported.add(".".join(parts[: index + 1]))
+                else:
+                    imported.add(alias.asname)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            for alias in node.names:
+                imported.add(f"{node.module}.{alias.name}")
+                imported.add(alias.asname or alias.name)
+
+    used: set[str] = set()
+    for node in ast.walk(tree):
+        # Only two-level attribute reads, so importlib.util.find_spec yields importlib.util rather
+        # than the function. A deeper chain would report a name that is never importable.
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Attribute)
+            and isinstance(node.value.value, ast.Name)
+        ):
+            used.add(f"{node.value.value.id}.{node.value.attr}")
+
+    # Only names that are importable modules matter. sys.modules is an attribute of an imported
+    # module, not a submodule, so it is reachable without a second import and is not a finding.
+    missing = sorted(
+        name
+        for name in used
+        if name.split(".")[0] in imported
+        and name not in imported
+        and _is_importable_module(name)
+    )
+    assert not missing, (
+        "the runtime package reaches through a submodule it never imports, so the attribute exists "
+        f"only when another import happens to have loaded it first: {missing}. Import it explicitly."
+    )
 
 
 @pytest.mark.unit
@@ -107,6 +301,14 @@ def test_public_api_symbols_present():
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _SETUP_PY = _REPO_ROOT / "setup.py"
 _RUNTIME_SETUP_PY = _REPO_ROOT / "py/torch-tensorrt-executorch-runtime/setup.py"
+_RUNTIME_PY = (
+    _REPO_ROOT
+    / "py/torch-tensorrt-executorch-runtime/torch_tensorrt_executorch_runtime/runtime.py"
+)
+_RUNTIME_INIT_PY = (
+    _REPO_ROOT
+    / "py/torch-tensorrt-executorch-runtime/torch_tensorrt_executorch_runtime/__init__.py"
+)
 
 
 @pytest.mark.unit
@@ -204,14 +406,72 @@ def test_runtime_wheel_uses_public_torch_version():
 
 
 @pytest.mark.unit
-def test_runtime_wheel_pins_cuda_13_native_dependencies():
+def test_runtime_wheel_pins_its_native_dependencies_per_cuda_major():
+    """Both native dependencies are resolved from the CUDA the build actually uses.
+
+    Hardcoding the CUDA 13 spellings was right while only CUDA 13 shipped and wrong once 12.6 came
+    back. NVIDIA splits the runtime by major: CUDA 12 publishes nvidia-cuda-runtime-cu12 while the
+    unsuffixed name is the CUDA 13 line, so naming the unsuffixed one unconditionally failed every
+    CUDA 12 row with "No package metadata was found for nvidia-cuda-runtime". TensorRT splits the
+    same way.
+    """
     setup_source = _RUNTIME_SETUP_PY.read_text(encoding="utf-8")
-    assert 'TENSORRT_DISTRIBUTION = "tensorrt-cu13"' in setup_source
-    assert 'CUDA_RUNTIME_DISTRIBUTION = "nvidia-cuda-runtime"' in setup_source
+    assert "TENSORRT_DISTRIBUTION = tensorrt_distribution()" in setup_source, (
+        "the TensorRT distribution is no longer resolved from the build's CUDA version, so a CUDA "
+        "12.6 row would declare the CUDA 13 distribution"
+    )
+    assert "CUDA_RUNTIME_DISTRIBUTION = cuda_runtime_distribution()" in setup_source, (
+        "the CUDA runtime distribution is no longer resolved from the build's CUDA version, so a "
+        "CUDA 12 row would look for a distribution torch did not install"
+    )
+
+    # Execute both resolvers rather than grepping for the names. Checking that each spelling
+    # appears somewhere in the file still passes when the two mappings are swapped, which would
+    # send every CUDA 12 row after CUDA 13 packages and vice versa.
+    tree = ast.parse(setup_source)
+    wanted = ("tensorrt_distribution", "cuda_runtime_distribution")
+    functions = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in wanted
+    ]
+    assert {node.name for node in functions} == set(wanted), (
+        f"expected both resolvers to be module-level functions, found "
+        f"{sorted(node.name for node in functions)}"
+    )
+    fake_torch = types.SimpleNamespace(version=types.SimpleNamespace(cuda=None))
+    namespace: dict = {"torch": fake_torch}
+    exec(
+        compile(ast.Module(body=functions, type_ignores=[]), "<setup.py>", "exec"),
+        namespace,
+    )
+
+    for cuda_version, tensorrt, cuda_runtime in (
+        ("12.6", "tensorrt-cu12", "nvidia-cuda-runtime-cu12"),
+        ("12.9", "tensorrt-cu12", "nvidia-cuda-runtime-cu12"),
+        ("13.0", "tensorrt-cu13", "nvidia-cuda-runtime"),
+        ("13.2", "tensorrt-cu13", "nvidia-cuda-runtime"),
+    ):
+        fake_torch.version.cuda = cuda_version
+        assert namespace["tensorrt_distribution"]() == tensorrt, (
+            f"CUDA {cuda_version} resolves the wrong TensorRT distribution, so that row installs "
+            "the other CUDA major's native libraries"
+        )
+        assert namespace["cuda_runtime_distribution"]() == cuda_runtime, (
+            f"CUDA {cuda_version} resolves the wrong CUDA runtime distribution, so that row looks "
+            "for metadata torch did not install"
+        )
+
+    # A CUDA-less torch and an unsupported major are refused rather than guessed at.
+    for cuda_version in (None, "11.8"):
+        fake_torch.version.cuda = cuda_version
+        for name in wanted:
+            with pytest.raises(RuntimeError):
+                namespace[name]()
+
     assert "torch=={public_version(torch.__version__)}" in setup_source
     assert "{TENSORRT_DISTRIBUTION}=={tensorrt_version}" in setup_source
     assert "{CUDA_RUNTIME_DISTRIBUTION}=={cuda_runtime_version}" in setup_source
-    assert "nvidia-cuda-runtime-cu12" not in setup_source
 
 
 @pytest.mark.unit

--- a/tests/py/dynamo/executorch/test_python_runtime.py
+++ b/tests/py/dynamo/executorch/test_python_runtime.py
@@ -35,42 +35,73 @@ def load_delegate_module():
     return module
 
 
-class FakeMethod:
-    def execute(self, inputs):
+class FakeModule:
+    """Stands in for what the Module API returns.
+
+    method_names is a call and running a method is one step, unlike the program loader's
+    load_method(...).execute(...). The runtime moved to this API because only it backs
+    device-tagged memory-planned arenas with real device memory.
+    """
+
+    def __init__(self, data):
+        self.data = data
+
+    def method_names(self):
+        return {"forward"}
+
+    def run_method(self, name, inputs):
+        if name != "forward":
+            raise RuntimeError(f"unknown method {name!r}")
         return [inputs[0] + 1]
 
 
-class FakeProgram:
-    method_names = {"forward"}
-
-    def load_method(self, name):
-        return FakeMethod() if name == "forward" else None
-
-
 class FakeRuntime:
-    def load_program(self, data):
-        self.data = data
-        return FakeProgram()
+    def __init__(self):
+        self.data = None
+
+    def __call__(self):
+        return self
+
+
+def _install_fakes(monkeypatch):
+    """Stub the delegate and the Module loader the runtime imports.
+
+    The runtime calls get_runtime() to check the backend is registered and activate() to get the
+    native module it installed, then takes the loader off that module. Faking activate() keeps the
+    canonical portable_lib name out of sys.modules, which is what activate() itself treats as a
+    sign the stock runtime was imported first.
+    """
+    loaded = {}
+
+    def fake_load_from_buffer(data):
+        loaded["data"] = data
+        return FakeModule(data)
+
+    native = types.ModuleType("fake_portable_lib")
+    native._load_for_executorch_from_buffer = fake_load_from_buffer
+
+    delegate = types.ModuleType("torch_tensorrt_executorch_runtime")
+    delegate.get_runtime = lambda: None
+    delegate.activate = lambda: native
+    monkeypatch.setitem(sys.modules, delegate.__name__, delegate)
+    return loaded
 
 
 def test_load_and_forward(monkeypatch, tmp_path):
-    delegate = types.ModuleType("torch_tensorrt_executorch_runtime")
-    fake_runtime = FakeRuntime()
-    delegate.get_runtime = lambda: fake_runtime
-    monkeypatch.setitem(sys.modules, delegate.__name__, delegate)
+    loaded = _install_fakes(monkeypatch)
     model = tmp_path / "model.pte"
     model.write_bytes(b"pte")
 
     program = load_runtime_module().load(model)
 
     assert program.forward(2) == [3]
-    assert program._data is fake_runtime.data
+    # The bytes reach the loader without a copy, and the wrapper keeps them alive because
+    # ExecuTorch references that memory rather than owning it.
+    assert program._data is loaded["data"]
 
 
 def test_unknown_method(monkeypatch, tmp_path):
-    delegate = types.ModuleType("torch_tensorrt_executorch_runtime")
-    delegate.get_runtime = FakeRuntime
-    monkeypatch.setitem(sys.modules, delegate.__name__, delegate)
+    _install_fakes(monkeypatch)
     model = tmp_path / "model.pte"
     model.write_bytes(b"pte")
 


### PR DESCRIPTION
Running a TensorRT delegated `.pte` through the Python runtime wheel fails on the very first operator, as reported by @lanluo-nvidia:

```
[cuda_allocator.cpp:88] cudaMemcpy H2D failed: invalid argument (384 bytes, device 0)
[op__device_copy.cpp:251] Check failed: _h2d_copy: copy_host_to_device failed
[method.cpp:1480] KernelCall failed at instruction 0:0 in operator et_copy::_h2d_copy.out
```

When a program is exported for a GPU delegate, ExecuTorch adds a copy at each delegate boundary and tags the memory-planned arenas those copies write into with the device they live on. A runner has to read those tags and allocate real device memory for the tagged arenas, otherwise the copy is handed a plain host pointer and CUDA rejects it. That rejection is the error above, and 384 bytes is exactly the example input.

ExecuTorch has two ways to load a program from Python and only one reads the tags. The Module API allocates device memory for a tagged arena. The program loader behind `executorch.runtime` plans every arena on the host and never looks at the tags, so every device copy gets a host destination. This wheel used the second one, which is why the C++ reference runner, which allocates the device arenas itself, worked while Python did not.

Load through the Module API instead. Inputs and outputs still cross the Python boundary as CPU tensors and the delegate still runs on the GPU.

## The cu126 build failure

ExecuTorch's CUDA shims call `__dp4a`, which nvcc does not declare before sm_61. The cu126 build environment exports `TORCH_CUDA_ARCH_LIST='5.0;6.0;7.0;7.5;8.0;8.6;9.0'`, so those two passes fail with `identifier "__dp4a" is undefined`, in `int4_plain_mm.cuh`, `int5_plain_mm.cuh`, `int6_plain_mm.cuh` and `int8_plain_mm.cuh`. The CUDA 13 channels start higher and build fine.

The pinned ExecuTorch has no `__CUDA_ARCH__` guard around those calls, so no configuration of 1.4.1 compiles for 5.0 or 6.0. This narrows the requested list on our side instead: nothing in ExecuTorch changes and the pin stays at 1.4.1. Filtering rather than pinning a list here, so a channel that adds a newer architecture still builds for it without editing the filter.

This is also why the wheel went untested. `executorch-runtime-test` is gated on `executorch-runtime-build` succeeding, so the cu126 failure skipped the whole test job and `load_model.py` never ran, which is how the arena bug above reached a release.

## The standalone import

`__init__.py` calls `importlib.util.find_spec` on the strength of a bare `import importlib`, which does not bind the `util` submodule. Anything that imports `torch` first has it bound transitively, so this surfaced only when the runtime wheel was imported on its own, and it is unrelated to the arena bug. The same line is on `main`, so that part wants forward-porting.

## Not #4581

That fixed `kernel 'et_copy::_h2d_copy.out' not found`, where the kernel never ran, and `release/2.14` already contains it. Re-applying it produces `Allocator already registered for device type: 1`, because `EXECUTORCH_BUILD_CUDA=ON` links `cuda_backend.cpp`, whose static initializer already registers `CudaAllocator`.

## Test plan

Measured on the pinned ExecuTorch release with a CUDA delegated program carrying the same device copies, one arena tagged for the GPU: the program loader plans that arena on the host and never asks about devices, while the Module API asks for device memory for it. End to end on a build that registers a device allocator, the Module API returns the expected result where the program loader hits the failure above.

The architecture filter is exercised against the list the cu126 environment actually exports: 5.0 and 6.0 are dropped and the rest kept, a CUDA 13 list comes back byte for byte, a `+PTX` suffix survives with its number, and a request with nothing at or above sm_61 exits non-zero rather than printing an empty list, which would leave nvcc to pick its own default.

For the import, confirmed in a clean interpreter that `import importlib` leaves `hasattr(importlib, "util")` False and that after `import torch` it is True. The added test reports any dotted name the package reads through without importing, restricted to importable modules so an ordinary attribute like `sys.modules` is not flagged.

Not verified here: the end-to-end run used a CUDA delegated program rather than a TensorRT delegated one. The arena machinery is backend independent and carries the identical `et_copy` ops, but the TensorRT path end to end is unproven by me.
