### PR TITLE
fix(dynamo): preserve zero-length partition boundaries

### DIFF
--- a/py/torch_tensorrt/dynamo/_compiler.py
+++ b/py/torch_tensorrt/dynamo/_compiler.py
@@ -1432,7 +1432,8 @@ def compile_module(
         if attr.startswith("_frozen_param"):
             delattr(gm, attr)
 
-    for name, _ in partitioned_module.named_children():
+    renamed_fallback_submodule = False
+    for name, _ in list(partitioned_module.named_children()):
         submodule = getattr(partitioned_module, name)
         # filter on the GraphModule
         if not isinstance(submodule, torch.fx.graph_module.GraphModule):
@@ -1485,12 +1486,54 @@ def compile_module(
         # Get the submodule inputs for min, opt, max shapes of the graph inputs.
         # With multi-profile compile, propagate the profiles (by index) to each
         # submodule input by symbolic substitution.
-        submodule_inputs = partitioning.construct_submodule_inputs(
-            submodule,
-            profile_source_bounds=profile_source_bounds,
-            num_profiles=num_profiles,
-            user_symbol_bounds=user_symbol_bounds,
-        )
+        try:
+            submodule_inputs = partitioning.construct_submodule_inputs(
+                submodule,
+                profile_source_bounds=profile_source_bounds,
+                num_profiles=num_profiles,
+                user_symbol_bounds=user_symbol_bounds,
+            )
+        except partitioning.ZeroLengthInputError as exc:
+            if settings.require_full_compilation:
+                raise ValueError(
+                    "A TensorRT submodule input may contain a zero-length "
+                    "dimension, which is incompatible with "
+                    "require_full_compilation=True."
+                ) from exc
+            logger.warning(
+                "Leaving submodule %s in PyTorch because one of its inputs may "
+                "contain a zero-length dimension: %s",
+                name,
+                exc,
+            )
+            dryrun_tracker.to_run_in_torch.extend(parse_non_trt_nodes(submodule))
+            if settings.offload_module_to_cpu:
+                submodule.to(to_torch_device(settings.device))
+
+            # The partitioner named this as an accelerator submodule before its
+            # input profile was constructed. Keep the returned graph truthful by
+            # relabeling the late fallback as a PyTorch/GPU submodule.
+            fallback_base_name = name.replace("_run_on_acc", "_run_on_gpu", 1)
+            fallback_name = fallback_base_name
+            existing_node_names = {
+                node.name
+                for node in partitioned_module.graph.nodes
+                if node is not submodule_node_dict[name]
+            }
+            suffix = 1
+            while (
+                hasattr(partitioned_module, fallback_name)
+                or fallback_name in existing_node_names
+            ):
+                fallback_name = f"{fallback_base_name}_{suffix}"
+                suffix += 1
+
+            delattr(partitioned_module, name)
+            partitioned_module.add_submodule(fallback_name, submodule)
+            submodule_node_dict[name].target = fallback_name
+            submodule_node_dict[name].name = fallback_name
+            renamed_fallback_submodule = True
+            continue
 
         assert submodule_inputs is not None
 
@@ -1573,6 +1616,10 @@ def compile_module(
         if settings.lazy_engine_init and not settings.enable_cross_compile_for_windows:
             trt_module = getattr(partitioned_module, name)
             trt_module.setup_engine()
+
+    if renamed_fallback_submodule:
+        partitioned_module.graph.lint()
+        partitioned_module.recompile()
 
     # Post-partition complex I/O boundary pass — runs in both normal and dryrun mode
     # so the wrapper graph reflects the exact graph that will be executed/built.

--- a/py/torch_tensorrt/dynamo/partitioning/__init__.py
+++ b/py/torch_tensorrt/dynamo/partitioning/__init__.py
@@ -2,6 +2,7 @@ from ._adjacency_partitioner import partition as fast_partition
 from ._global_partitioner import partition as global_partition
 from ._hierarchical_partitioner import hierarchical_adjacency_partition
 from .common import (
+    ZeroLengthInputError,
     build_profile_source_bounds,
     construct_submodule_inputs,
     get_graph_converter_support,

--- a/py/torch_tensorrt/dynamo/partitioning/common.py
+++ b/py/torch_tensorrt/dynamo/partitioning/common.py
@@ -22,6 +22,10 @@ logger = logging.getLogger(__name__)
 ProfileSourceBounds = List[Dict[str, Dict[str, int]]]
 
 
+class ZeroLengthInputError(ValueError):
+    """Raised when a TensorRT engine input may contain a zero-length dimension."""
+
+
 def _build_submodule_profiles(
     input_shape: torch.Size,
     union_min: Sequence[int],
@@ -102,6 +106,9 @@ def construct_dynamic_input(
             :func:`extract_var_range_info` to fill unbounded exporter uppers.
     Returns:
         A dynamic shaped torch_tensorrt.Input which has the properties of the symbolic shaped input.
+    Raises:
+        ZeroLengthInputError: If a dimension's legal lower bound is below one
+            and therefore cannot be represented by a TensorRT input profile.
     """
     min_shape = []
     opt_shape = []
@@ -120,15 +127,12 @@ def construct_dynamic_input(
             else:
                 min_bound = int(min_max_opt["min"])
                 if min_bound < 1:
-                    logger.warning(
-                        "Dynamic input %s (shape: %s) has lower bound %d for dim %d. "
-                        "TensorRT profiles require dimensions >= 1; clamping it to 1.",
-                        name,
-                        input_shape,
-                        min_bound,
-                        d,
+                    raise ZeroLengthInputError(
+                        f"Dynamic input {name} (shape: {input_shape}) has lower "
+                        f"bound {min_bound} for dim {d}. TensorRT profiles require "
+                        "dimensions >= 1, so this input must remain in PyTorch."
                     )
-                unwrapped_min_max_opt["min"] = max(1, min_bound)
+                unwrapped_min_max_opt["min"] = min_bound
 
             if "max" not in min_max_opt or min_max_opt["max"] is None:
                 logger.warning(

--- a/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
+++ b/tests/py/dynamo/models/test_dynamic_shape_user_bounds.py
@@ -12,7 +12,10 @@ import torch
 import torch_tensorrt as torchtrt
 from torch_tensorrt._Input import Input
 from torch_tensorrt.dynamo._compiler import _build_user_symbol_bounds
-from torch_tensorrt.dynamo.partitioning.common import construct_dynamic_input
+from torch_tensorrt.dynamo.partitioning.common import (
+    ZeroLengthInputError,
+    construct_dynamic_input,
+)
 from torch_tensorrt.dynamo.utils import extract_var_range_info
 
 assertions = unittest.TestCase()
@@ -624,8 +627,8 @@ def test_largest_size_symbol_bound_is_treated_as_unbounded():
 
 
 @pytest.mark.unit
-def test_construct_dynamic_input_clamps_zero_minimum():
-    """Data-dependent extents can include zero, but TRT profiles cannot."""
+def test_construct_dynamic_input_rejects_zero_minimum():
+    """Do not narrow a legal zero-length extent to make a TRT profile."""
 
     class Nonzero(torch.nn.Module):
         def forward(self, x):
@@ -642,11 +645,10 @@ def test_construct_dynamic_input_clamps_zero_minimum():
     fake_value = nonzero.meta["val"]
     assert isinstance(fake_value.shape[0], torch.SymInt)
 
-    input_spec = construct_dynamic_input(
-        fake_value.shape, fake_value.dtype, name="nonzero_output"
-    )
-    assert input_spec.shape["min_shape"] == (1, 1)
-    assert input_spec.shape["max_shape"] == (4, 1)
+    with pytest.raises(ZeroLengthInputError, match="must remain in PyTorch"):
+        construct_dynamic_input(
+            fake_value.shape, fake_value.dtype, name="nonzero_output"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/py/dynamo/models/test_fallback_data_dependent_ops.py
+++ b/tests/py/dynamo/models/test_fallback_data_dependent_ops.py
@@ -109,3 +109,41 @@ def test_fallback_data_dependent_ops_routes_output_allocator_op_to_torch():
     )
     targets = {n.target for n in gm.graph.nodes if n.op == "call_function"}
     assert torch.ops.aten.nonzero.default in targets
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_zero_length_nonzero_boundary_remains_in_torch():
+    """A legal empty nonzero result must not enter a TRT profile with min=1."""
+
+    class Model(torch.nn.Module):
+        def forward(self, x):
+            indices = torch.nonzero(x)
+            return torch.sin(indices.to(torch.float32))
+
+    model = Model().eval().cuda()
+    compile_input = torch.tensor([0, 3, 0, 5, 7], dtype=torch.int32, device="cuda")
+    exported = torch.export.export(model, (compile_input,))
+    compiled = torch_tensorrt.dynamo.compile(
+        exported,
+        arg_inputs=[compile_input],
+        min_block_size=1,
+        fallback_data_dependent_ops=True,
+    )
+
+    sin_fallback_name = next(
+        name
+        for name, submodule in compiled.named_children()
+        if isinstance(submodule, torch.fx.GraphModule)
+        and any(
+            node.target == torch.ops.aten.sin.default for node in submodule.graph.nodes
+        )
+    )
+    assert "_run_on_gpu" in sin_fallback_name
+    assert "_run_on_acc" not in sin_fallback_name
+
+    runtime_input = torch.zeros_like(compile_input)
+    expected = model(runtime_input)
+    actual = compiled(runtime_input)
+
+    assert actual.shape == (0, 1)
+    torch.testing.assert_close(actual, expected)


### PR DESCRIPTION
Follow-up to #4631. Stops construct_dynamic_input from clamping zero-capable symbolic extents to one. Affected TensorRT submodules remain in PyTorch, while require_full_compilation fails clearly. Adds an all-false nonzero runtime regression that fails on the parent when setInputShape rejects [0, 1].