### PR TITLE
Put a CUDA runtime on the library path for CUDA 12 rows too

### DIFF
--- a/.github/scripts/install-torch-tensorrt.sh
+++ b/.github/scripts/install-torch-tensorrt.sh
@@ -44,10 +44,20 @@ python -m pip uninstall -y torch torchvision
 python -m pip install --force-reinstall --pre ${TORCHVISION} --index-url ${INDEX_URL} --extra-index-url https://pypi.org/simple
 python -m pip install --force-reinstall --pre ${TORCH} --index-url ${INDEX_URL} --extra-index-url https://pypi.org/simple
 
-# If CUDA 13 (cu13), prepend venv's NVIDIA CUDA 13 libs to LD_LIBRARY_PATH
-if [[ "${CU_VERSION}" == cu13* ]]; then
-    SITE_PACKAGES="$(python -c 'import sysconfig; print(sysconfig.get_path("platlib"))')"
-    export LD_LIBRARY_PATH="${SITE_PACKAGES}/nvidia/cu13/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+# Prepend the venv's NVIDIA CUDA runtime libs to LD_LIBRARY_PATH. The two majors ship
+# different layouts: nvidia-cuda-runtime-cu12 installs nvidia/cuda_runtime/lib/libcudart.so.12
+# while the CUDA 13 line installs nvidia/cu13/lib/libcudart.so.13. Naming only the cu13 path
+# left every CUDA 12 row without a CUDA runtime on the search path, so a binary linked against
+# libcudart died at startup with "libcudart.so.12: cannot open shared object file" even though
+# the package was installed.
+SITE_PACKAGES="$(python -c 'import sysconfig; print(sysconfig.get_path("platlib"))')"
+case "${CU_VERSION}" in
+cu13*) CUDA_RUNTIME_LIB_DIR="${SITE_PACKAGES}/nvidia/cu13/lib" ;;
+cu12*) CUDA_RUNTIME_LIB_DIR="${SITE_PACKAGES}/nvidia/cuda_runtime/lib" ;;
+*) CUDA_RUNTIME_LIB_DIR="" ;;
+esac
+if [[ -n "${CUDA_RUNTIME_LIB_DIR}" ]]; then
+    export LD_LIBRARY_PATH="${CUDA_RUNTIME_LIB_DIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 fi
 
 # Install Torch-TensorRT

--- a/tests/py/dynamo/executorch/test_api.py
+++ b/tests/py/dynamo/executorch/test_api.py
@@ -340,6 +340,33 @@ def test_runtime_extension_has_dependency_wheel_rpaths():
 
 
 @pytest.mark.unit
+def test_the_install_script_puts_a_cuda_runtime_on_the_library_path_for_both_majors():
+    """Every CUDA row gets a CUDA runtime directory, not just the CUDA 13 ones.
+
+    The two majors ship different layouts: nvidia-cuda-runtime-cu12 installs
+    nvidia/cuda_runtime/lib/libcudart.so.12 while the CUDA 13 line installs
+    nvidia/cu13/lib/libcudart.so.13. Naming only the cu13 path left every CUDA 12 row with no
+    CUDA runtime on the search path, and the ExecuTorch reference runner died at startup with
+    "libcudart.so.12: cannot open shared object file" while the package was installed all along.
+    The runtime wheel's own RPATH already lists both directories; this keeps the CI install
+    script consistent with it.
+    """
+    script = (_REPO_ROOT / ".github/scripts/install-torch-tensorrt.sh").read_text(
+        encoding="utf-8"
+    )
+    for directory in ("nvidia/cuda_runtime/lib", "nvidia/cu13/lib"):
+        assert directory in script, (
+            f"{directory} is not on LD_LIBRARY_PATH, so a row of that CUDA major cannot resolve "
+            "libcudart at run time"
+        )
+    # Matched on the major, so a future cu128 or cu134 row is covered without another edit.
+    for pattern in ("cu12*)", "cu13*)"):
+        assert (
+            pattern in script
+        ), f"{pattern} is gone, so a CUDA row of that major would fall through to no directory"
+
+
+@pytest.mark.unit
 def test_runtime_extension_does_not_require_an_embeddable_python():
     """Development.Embed must stay optional, or the release build cannot configure.
 


### PR DESCRIPTION
## The problem

On this branch, all five CUDA 12.6 `executorch-runtime-test` rows fail. The ExecuTorch reference runner builds fine, then dies the moment it starts:

```
example_executorch_runner: error while loading shared libraries:
libcudart.so.12: cannot open shared object file: No such file or directory
```

`libcudart` is the CUDA runtime library. The confusing part is that it **is** installed. The job log shows `nvidia-cuda-runtime-cu12-12.6.77` going in. The program just cannot find it.

## Why

When a program starts, the system searches a list of directories for its libraries. `install-torch-tensorrt.sh` adds a CUDA directory to that list, but only for CUDA 13:

```bash
if [[ "${CU_VERSION}" == cu13* ]]; then
    export LD_LIBRARY_PATH="${SITE_PACKAGES}/nvidia/cu13/lib:..."
fi
```

A CUDA 12 row does not match `cu13*`, so no CUDA directory is added at all. The logs confirm it: the passing CUDA 13 row exports that path, and the failing CUDA 12.6 row has **zero** occurrences of it.

One directory could not serve both anyway. Taken from the wheels themselves:

```
nvidia_cuda_runtime_cu12-12.6.77  ->  nvidia/cuda_runtime/lib/libcudart.so.12
nvidia_cuda_runtime-13.0.96       ->  nvidia/cu13/lib/libcudart.so.13
```

## The fix

Pick the directory that matches the CUDA major:

```bash
case "${CU_VERSION}" in
cu13*) CUDA_RUNTIME_LIB_DIR="${SITE_PACKAGES}/nvidia/cu13/lib" ;;
cu12*) CUDA_RUNTIME_LIB_DIR="${SITE_PACKAGES}/nvidia/cuda_runtime/lib" ;;
*)     CUDA_RUNTIME_LIB_DIR="" ;;
esac
```

CUDA 13 keeps exactly the directory it had before. Matching on the major rather than an exact version means a future `cu128` or `cu134` row works with no further edit.

The runtime wheel already lists both directories in its own RPATH, so this only brings the CI script in line with the wheel it installs.

The Python side was never broken: those same rows run 225 passing tests, and only the native runner check fails. The wheel finds `libcudart` through its RPATH, while the standalone runner depends on the search path.


## Testing

Checked over `cu126`, `cu128`, `cu130`, `cu132`, `cpu` and an empty value. CUDA 12 rows resolve to `nvidia/cuda_runtime/lib`, CUDA 13 rows keep `nvidia/cu13/lib` unchanged, a non-CUDA row adds nothing rather than an empty path entry, and an existing library path is still kept. The added test fails if either directory or either match arm is removed.

CI here confirms the change is harmless on CUDA 13: the resolved path still ends in `nvidia/cu13/lib`, with no trace of the CUDA 12 directory, and both ExecuTorch rows pass.

One limit worth stating: pull request builds only run CUDA 13.2, so this pull request's own CI cannot exercise the CUDA 12 path it fixes. That comes after merge, when the full matrix runs on the branch.
