### PR TITLE
fix: bind a scalar engine output at rank 0

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
+++ b/py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py
@@ -751,6 +751,48 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
         layer.name = f"Cast output {output_name} from {output.dtype} to {output_dtype}"
         return layer.get_output(0)
 
+    def _scalar_output_positions(self) -> Set[int]:
+        """Positions in the FX output node whose value is a scalar, not a tensor.
+
+        These are exactly the positions ``extract_symbolic_shape_expressions``
+        records with ``is_scalar``, so the two stay in step.
+        """
+        if self._cur_node is None:
+            return set()
+
+        fx_outputs = self._cur_node.args[0]
+        if not isinstance(fx_outputs, (tuple, list)):
+            fx_outputs = (fx_outputs,)
+
+        positions = set()
+        for i, fx_output in enumerate(fx_outputs):
+            val = (
+                fx_output.meta.get("val")
+                if isinstance(fx_output, torch.fx.Node)
+                else fx_output
+            )
+            if isinstance(val, (torch.SymInt, torch.SymFloat, int, float, bool)):
+                positions.add(i)
+        return positions
+
+    def _reshape_output_to_scalar(
+        self, output: trt.ITensor, output_name: str
+    ) -> trt.ITensor:
+        if len(output.shape) == 0:
+            return output
+
+        if tuple(output.shape) != (1,):
+            _LOGGER.warning(
+                f"Output {output_name} is a scalar in the graph but the network "
+                f"produced shape {tuple(output.shape)}, leaving its rank alone."
+            )
+            return output
+
+        layer = self.ctx.net.add_shuffle(output)
+        layer.reshape_dims = ()
+        layer.name = f"Reshape output {output_name} to a scalar"
+        return layer.get_output(0)
+
     def output(self, target: str, args: Any, kwargs: Any) -> List[Any]:
         assert len(args) == 1
         if isinstance(args[0], tuple):
@@ -798,6 +840,8 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
             raise RuntimeError(
                 f"Specified output dtypes ({len(self.output_dtypes)}) differ from number of outputs ({len(outputs)})"
             )
+
+        scalar_output_positions = self._scalar_output_positions()
 
         marked_outputs_ids = []
         for i, output in enumerate(outputs):
@@ -854,6 +898,15 @@ class TRTInterpreter(torch.fx.Interpreter):  # type: ignore[misc]
                     output_dtype.to(trt.DataType, use_default=True),
                     name,
                 )
+
+            # TensorRT has no scalar type, so a converter emits a graph scalar as
+            # a rank-1 tensor of length 1. The engine's shape metadata is read off
+            # the FX graph, where the value is rank 0, so reshape the output back
+            # to rank 0 or the meta kernel and the engine report different ranks
+            # for the same binding. Skipped for aliased outputs for the same
+            # reason as the cast above.
+            if alias_info is None and i in scalar_output_positions:
+                output = self._reshape_output_to_scalar(output, name)
 
             output.name = name
             outputs = outputs[:i] + (output,) + outputs[i + 1 :]

--- a/tests/py/dynamo/runtime/test_scalar_engine_outputs.py
+++ b/tests/py/dynamo/runtime/test_scalar_engine_outputs.py
@@ -1,0 +1,103 @@
+import unittest
+
+import torch
+import torch_tensorrt
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
+from torch.testing._internal.common_utils import TestCase, run_tests
+from torch_tensorrt.dynamo.runtime import TorchTensorRTModule
+
+import tensorrt as trt  # isort: skip  # imported after torch_tensorrt for RTX alias
+
+ROWS = 16
+
+
+class ScalarSecondOutput(torch.nn.Module):
+    """Returns a tensor and a symbolic int, so the engine has a scalar output."""
+
+    def forward(self, x):
+        y = x * 2.0
+        return y.sum(), y.shape[0]
+
+
+class UnitTensorSecondOutput(torch.nn.Module):
+    """Returns a tensor and a genuine shape-[1] tensor, whose rank must be left alone."""
+
+    def forward(self, x):
+        y = x * 2.0
+        return y.sum(), y[:1]
+
+
+@unittest.skipIf(
+    not torch_tensorrt.ENABLED_FEATURES.torch_tensorrt_runtime,
+    "Torch-TensorRT runtime is not available",
+)
+class TestScalarEngineOutputs(TestCase):
+    def _compile_to_single_engine(self, model):
+        self.addCleanup(torch._dynamo.reset)
+        inputs = (torch.randn((ROWS,), device="cuda"),)
+        rows = torch.export.Dim("rows", min=2, max=4 * ROWS)
+        exported = torch.export.export(
+            model.eval().cuda(), inputs, dynamic_shapes={"x": {0: rows}}
+        )
+        gm = torch_tensorrt.dynamo.compile(
+            exported,
+            inputs=inputs,
+            min_block_size=1,
+            pass_through_build_failures=True,
+            use_python_runtime=False,
+        )
+        engines = [
+            module for module in gm.modules() if isinstance(module, TorchTensorRTModule)
+        ]
+        self.assertEqual(len(engines), 1)
+        return engines[0]
+
+    def _meta_and_real_output_shapes(self, engine_module):
+        real = [
+            tuple(output.shape)
+            for output in engine_module(torch.randn((ROWS,), device="cuda"))
+        ]
+        # The meta kernel answers from the engine's recorded shape metadata, which
+        # is the only account of the engine any later trace sees.
+        with FakeTensorMode(shape_env=ShapeEnv(), allow_non_fake_inputs=True):
+            meta = [
+                tuple(output.shape)
+                for output in engine_module(
+                    torch.empty((ROWS,), dtype=torch.float32, device="cuda")
+                )
+            ]
+        return meta, real
+
+    def test_meta_kernel_and_engine_agree_on_scalar_output(self):
+        engine_module = self._compile_to_single_engine(ScalarSecondOutput())
+
+        meta, real = self._meta_and_real_output_shapes(engine_module)
+
+        self.assertEqual(meta, real)
+
+    def test_scalar_output_is_bound_at_rank_zero(self):
+        engine_module = self._compile_to_single_engine(ScalarSecondOutput())
+        recorded = engine_module.symbolic_shape_expressions["outputs"]
+        scalar_position = 1
+        self.assertTrue(recorded[scalar_position].get("is_scalar", False))
+        self.assertEqual(recorded[scalar_position]["shape_exprs"], [])
+
+        runtime = trt.Runtime(trt.Logger(trt.Logger.ERROR))
+        engine = runtime.deserialize_cuda_engine(engine_module.serialized_engine)
+
+        self.assertIsNotNone(engine)
+        binding = engine_module.output_binding_names[scalar_position]
+        self.assertEqual(len(engine.get_tensor_shape(binding)), 0)
+
+    def test_unit_length_tensor_output_keeps_its_rank(self):
+        engine_module = self._compile_to_single_engine(UnitTensorSecondOutput())
+
+        meta, real = self._meta_and_real_output_shapes(engine_module)
+
+        self.assertEqual(meta, real)
+        self.assertEqual(real[1], (1,))
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
# Description

`extract_symbolic_shape_expressions` runs before the engine is built and records an output
whose FX `meta["val"]` is a `SymInt`/`SymFloat`/scalar as rank 0:

```python
elif isinstance(out_val, (torch.SymInt, torch.SymFloat, int, float, bool)):
    output_info.append({"shape_exprs": [], "dtype": scalar_dtype, "is_scalar": True})
```

TensorRT builds something else. `impl/shape.py :: shape` -- the `aten.sym_size.int`
converter -- gathers with an index built by `get_trt_tensor`, whose `min_rank` defaults to 1,
so the engine binds `[1]`:

```
meta kernel reports    : [(), ()]
engine actually returns: [(), (1,)]
```

That record is the only account of the engine the `execute_engine` meta kernel consults, so
every later trace and every AOTInductor buffer sized from it carries a rank the engine does
not produce, with nothing comparing the two.

This reshapes those outputs back to rank 0 in `TRTInterpreter.output`, after the dtype cast
and before `mark_output`, which makes the two accounts agree without changing the model's
scalar semantics. Only an output the FX graph calls a scalar and that the network produced as
shape `[1]` is reshaped; any other rank is left alone and logged. Aliased outputs are skipped
for the same reason the dtype cast skips them, since a shuffle layer's output no longer shares
storage with the source input. TensorRT 11 binds rank-0 tensors directly, so the runtime is
unchanged.

# Issues

Closes #4677

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Testing

Three cases in `tests/py/dynamo/runtime/test_scalar_engine_outputs.py`: the meta kernel's
output shapes equal the engine's, the engine declares rank 0 for a binding the metadata
records as a scalar, and -- as a control -- a genuine shape-`[1]` tensor output keeps rank 1,
so over-squeezing does not pass. The first two fail without this change. There were no
existing tests covering `symbolic_shape_expressions`.

Run in `nvcr.io/nvidia/pytorch:26.07-py3` (TensorRT 11.1.0.106) with this patch applied to
the container's installed copy: `2 failed, 1 passed` before, `3 passed` after. End to end
through AOTInductor, for a model returning `(y.sum(), y.shape[0])`:

```
eager  : (tensor(-4.5675), 16)
before : (tensor(-4.5675), tensor([16]))   # shape (1,)
after  : (tensor(-4.5675), tensor(16))     # shape ()
```

`conversion/test_sym_size.py`, `conversion/test_sym_numel_aten.py`,
`conversion/test_sym_not_aten.py`, and `models/test_dyn_models.py` are unaffected: 23 passed
before, 23 passed after.

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
