### PR TITLE
fix: name the engine and the binding in execute_engine failures

### DIFF
--- a/core/runtime/execute_engine.cpp
+++ b/core/runtime/execute_engine.cpp
@@ -106,11 +106,14 @@ void setup_input_tensors(
     const auto& name = binding.name;
 
     TORCHTRT_CHECK(
-        inputs[i].is_cuda(), "Expected input tensors to have device cuda, found device " << inputs[i].device());
+        inputs[i].is_cuda(),
+        "Input " << i << " (\"" << name << "\") of engine " << compiled_engine->name
+                 << " must be on a CUDA device, found device " << inputs[i].device());
 
     TORCHTRT_CHECK(
         inputs[i].dtype() == binding.expected_type,
-        "Expected input tensors to have type " << binding.expected_type << ", found type " << inputs[i].dtype());
+        "Input " << i << " (\"" << name << "\") of engine " << compiled_engine->name << " expects type "
+                 << binding.expected_type << ", found type " << inputs[i].dtype());
 
     auto dims = core::util::toDims(inputs[i].sizes());
     auto shape = core::util::toVec(dims);
@@ -126,7 +129,8 @@ void setup_input_tensors(
       compiled_engine->active_shape_tensor_values.emplace_back(std::move(inputs_cpu_vec));
       TORCHTRT_CHECK(
           ctx->setTensorAddress(name.c_str(), compiled_engine->active_shape_tensor_values.back().data()),
-          "Error while setting the tensor address for shape inputs");
+          "Error while setting the tensor address for shape input " << i << " (\"" << name << "\") of engine "
+                                                                    << compiled_engine->name);
 
       if (cudagraphs_enabled) {
         // @peri044 I dont know if this makes sense since they are supposed to be GPU buffers
@@ -134,7 +138,8 @@ void setup_input_tensors(
       }
       TORCHTRT_CHECK(
           ctx->setTensorAddress(name.c_str(), compiled_engine->active_shape_tensor_values.back().data()),
-          "Error while setting the tensor address for shape inputs");
+          "Error while setting the tensor address for shape input " << i << " (\"" << name << "\") of engine "
+                                                                    << compiled_engine->name);
 
     } else {
       compiled_engine->active_input_tensors[i] = inputs[i].view(shape).contiguous();
@@ -155,7 +160,11 @@ void setup_input_tensors(
         compiled_engine->cudagraph_input_staging_buffers[i] = compiled_engine->active_input_tensors[i].clone();
       }
 
-      TORCHTRT_CHECK(ctx->setInputShape(name.c_str(), dims), "Error while setting the input shape");
+      TORCHTRT_CHECK(
+          ctx->setInputShape(name.c_str(), dims),
+          "Error while setting the input shape for input "
+              << i << " (\"" << name << "\") of engine " << compiled_engine->name << ". TensorRT refused shape " << dims
+              << ", the engine declares " << compiled_engine->cuda_engine->getTensorShape(name.c_str()));
 
       at::Tensor final_input;
       if (cudagraphs_enabled && !is_aliased_input) {
@@ -172,7 +181,10 @@ void setup_input_tensors(
       // empty_tensor_placeholder is pre-allocated in TRTEngine constructor
       void* input_addr = final_input.numel() == 0 ? compiled_engine->empty_tensor_placeholder : final_input.data_ptr();
 
-      TORCHTRT_CHECK(ctx->setTensorAddress(name.c_str(), input_addr), "Failed to bind tensor address for " << name);
+      TORCHTRT_CHECK(
+          ctx->setTensorAddress(name.c_str(), input_addr),
+          "Failed to bind the tensor address for input " << i << " (\"" << name << "\") of engine "
+                                                         << compiled_engine->name);
 
       // Record the bound tensor by binding name so the output-binding loop
       // can resolve aliased outputs to their source input's storage.
@@ -225,7 +237,14 @@ std::vector<at::Tensor> create_output_tensors(
                        .layout(at::kStrided)
                        .device(at::kCUDA, compiled_engine->device_info.id)
                        .requires_grad(false);
-    outputs[pyt_idx] = std::move(at::empty(dims, options).contiguous());
+    try {
+      outputs[pyt_idx] = std::move(at::empty(dims, options).contiguous());
+    } catch (const std::exception& e) {
+      TORCHTRT_THROW_ERROR(
+          "Failed to allocate output \"" << name << "\" of engine " << compiled_engine->name << " with shape " << dims
+                                         << " and dtype " << type << ".\n"
+                                         << e.what());
+    }
   }
 
   return outputs;
@@ -280,8 +299,15 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
   torch::Tensor dynamic_workspace;
   if (compiled_engine->resource_allocation_strategy == TRTEngine::ResourceAllocationStrategy::kDynamic) {
     const auto workspace_bytes = compiled_engine->cuda_engine->getDeviceMemorySizeV2();
-    dynamic_workspace =
-        torch::empty({workspace_bytes}, torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA));
+    try {
+      dynamic_workspace =
+          torch::empty({workspace_bytes}, torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA));
+    } catch (const std::exception& e) {
+      TORCHTRT_THROW_ERROR(
+          "Failed to allocate the " << workspace_bytes << "-byte activation workspace of engine "
+                                    << compiled_engine->name << ".\n"
+                                    << e.what());
+    }
     ctx->setDeviceMemoryV2(dynamic_workspace.data_ptr(), workspace_bytes);
   }
 
@@ -389,9 +415,9 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
       int32_t const nbNames = ctx->inferShapes(names.size(), names.data());
       TORCHTRT_CHECK(
           nbNames == 0,
-          "The shapes of the inputs: "
-              << names
-              << " cannot be inferred. This could happen if the input tensor addresses/shapes haven't been configured correctly");
+          "The shapes of the inputs: " << names << " of engine " << compiled_engine->name
+                                       << " cannot be inferred. This could happen if the input tensor "
+                                          "addresses/shapes haven't been configured correctly");
     }
 
     { // Output Setup
@@ -439,11 +465,13 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
           TORCHTRT_CHECK(
               ctx->setTensorAddress(
                   name.c_str(), compiled_engine->cudagraph_output_staging_buffers[pyt_idx].data_ptr()),
-              "Error while setting the output tensor address");
+              "Error while setting the tensor address for output \"" << name << "\" of engine "
+                                                                     << compiled_engine->name);
         } else {
           TORCHTRT_CHECK(
               ctx->setTensorAddress(name.c_str(), outputs[pyt_idx].data_ptr()),
-              "Error while setting the output tensor address");
+              "Error while setting the tensor address for output \"" << name << "\" of engine "
+                                                                     << compiled_engine->name);
         }
       }
     }
@@ -588,9 +616,9 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
       int32_t const nbNames = ctx->inferShapes(names.size(), names.data());
       TORCHTRT_CHECK(
           nbNames == 0,
-          "The shapes of the inputs: "
-              << names
-              << " cannot be inferred. This could happen if the input tensor addresses/shapes haven't been configured correctly");
+          "The shapes of the inputs: " << names << " of engine " << compiled_engine->name
+                                       << " cannot be inferred. This could happen if the input tensor "
+                                          "addresses/shapes haven't been configured correctly");
     }
 
     { // OutputAllocator Setup

--- a/core/runtime/execute_engine.cpp
+++ b/core/runtime/execute_engine.cpp
@@ -239,11 +239,18 @@ std::vector<at::Tensor> create_output_tensors(
                        .requires_grad(false);
     try {
       outputs[pyt_idx] = std::move(at::empty(dims, options).contiguous());
-    } catch (const std::exception& e) {
-      TORCHTRT_THROW_ERROR(
-          "Failed to allocate output \"" << name << "\" of engine " << compiled_engine->name << " with shape " << dims
-                                         << " and dtype " << type << ".\n"
-                                         << e.what());
+    } catch (c10::Error& e) {
+      TORCH_RETHROW(
+          e,
+          "Failed to allocate output \"",
+          name,
+          "\" of engine ",
+          compiled_engine->name,
+          " with shape ",
+          dims,
+          " and dtype ",
+          type,
+          ".");
     }
   }
 
@@ -302,11 +309,14 @@ std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intr
     try {
       dynamic_workspace =
           torch::empty({workspace_bytes}, torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA));
-    } catch (const std::exception& e) {
-      TORCHTRT_THROW_ERROR(
-          "Failed to allocate the " << workspace_bytes << "-byte activation workspace of engine "
-                                    << compiled_engine->name << ".\n"
-                                    << e.what());
+    } catch (c10::Error& e) {
+      TORCH_RETHROW(
+          e,
+          "Failed to allocate the ",
+          workspace_bytes,
+          "-byte activation workspace of engine ",
+          compiled_engine->name,
+          ".");
     }
     ctx->setDeviceMemoryV2(dynamic_workspace.data_ptr(), workspace_bytes);
   }

--- a/tests/py/dynamo/runtime/test_engine_failure_diagnostics.py
+++ b/tests/py/dynamo/runtime/test_engine_failure_diagnostics.py
@@ -1,0 +1,67 @@
+import unittest
+
+import torch
+import torch_tensorrt
+from torch.testing._internal.common_utils import TestCase, run_tests
+from torch_tensorrt.dynamo.runtime import TorchTensorRTModule
+
+INPUT_SHAPE = (8, 16)
+
+
+class Scale(torch.nn.Module):
+    def forward(self, x):
+        return torch.relu(x * 2.0)
+
+
+@unittest.skipIf(
+    not torch_tensorrt.ENABLED_FEATURES.torch_tensorrt_runtime,
+    "Torch-TensorRT runtime is not available",
+)
+class TestEngineFailureDiagnostics(TestCase):
+    def setUp(self):
+        self.addCleanup(torch._dynamo.reset)
+        compiled = torch_tensorrt.compile(
+            Scale().eval().cuda(),
+            ir="dynamo",
+            inputs=(torch.randn(INPUT_SHAPE, device="cuda"),),
+            min_block_size=1,
+            pass_through_build_failures=True,
+            use_python_runtime=False,
+        )
+        engines = [
+            module
+            for module in compiled.modules()
+            if isinstance(module, TorchTensorRTModule)
+        ]
+        self.assertEqual(len(engines), 1)
+        self.engine_module = engines[0]
+        self.binding = self.engine_module.input_binding_names[0]
+        # The engine's own name is this module's name plus an "_engine" suffix, so
+        # the module name is what the message has to carry to identify the engine.
+        self.assertNotEqual(self.engine_module.name, "")
+
+    def test_input_dtype_mismatch_names_the_engine_and_the_binding(self):
+        wrong_dtype = torch.randint(0, 4, INPUT_SHAPE, dtype=torch.int32, device="cuda")
+
+        with self.assertRaises(Exception) as caught:
+            self.engine_module(wrong_dtype)
+
+        message = str(caught.exception)
+        self.assertIn(self.engine_module.name, message)
+        self.assertIn(self.binding, message)
+
+    def test_input_shape_mismatch_reports_the_rejected_and_declared_shapes(self):
+        wrong_shape = (INPUT_SHAPE[0], INPUT_SHAPE[1] + 1)
+
+        with self.assertRaises(Exception) as caught:
+            self.engine_module(torch.randn(wrong_shape, device="cuda"))
+
+        message = str(caught.exception)
+        self.assertIn(self.engine_module.name, message)
+        self.assertIn(self.binding, message)
+        self.assertIn(str(list(wrong_shape)), message)
+        self.assertIn(str(list(INPUT_SHAPE)), message)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
# Description

Every runtime check in `execute_engine` says what went wrong and none says where. On a model
with 14 engines that is all the caller gets — and because a refused engine writes none of its
outputs, what usually surfaces first is an unrelated node reading one of them.

Diagnostics only, no behavior change. Each check now carries the engine name and the binding
index and name, the input-shape check reports the shape TensorRT refused next to the one the
engine declares, and both allocations are caught and re-thrown naming the engine and the size
it asked for, appending to the allocator's message rather than replacing it. `TORCHTRT_CHECK`
only evaluates its message on failure, so the success path is unchanged.

Before:

```
Expected input tensors to have device cuda, found device cpu
Expected input tensors to have type Float, found type int
Error while setting the input shape
Error while setting the tensor address for shape inputs
Failed to bind tensor address for x
Error while setting the output tensor address
The shapes of the inputs: [x] cannot be inferred. This could happen if ...
<the allocator's own error, uncaught, for the output tensors>
<the allocator's own error, uncaught, for the activation workspace>
```

After:

```
Input 0 ("x") of engine _run_on_acc_0_engine must be on a CUDA device, found device cpu
Input 0 ("x") of engine _run_on_acc_0_engine expects type Float, found type int
Error while setting the input shape for input 0 ("x") of engine _run_on_acc_0_engine. TensorRT refused shape [8, 17], the engine declares [8, 16]
Error while setting the tensor address for shape input 0 ("x") of engine _run_on_acc_0_engine
Failed to bind the tensor address for input 0 ("x") of engine _run_on_acc_0_engine
Error while setting the tensor address for output "output0" of engine _run_on_acc_0_engine
The shapes of the inputs: [x] of engine _run_on_acc_0_engine cannot be inferred. This could happen if ...
Failed to allocate output "output0" of engine _run_on_acc_0_engine with shape [8, 16] and dtype Float.
Failed to allocate the 134217728-byte activation workspace of engine _run_on_acc_0_engine.
```

`torch.ops.tensorrt.set_logging_level(4)` does not help, because the `LOG_DEBUG` that names the
binding runs *after* the check that throws. TensorRT does report the shapes on the
`setInputShape` path, but only to its own logger, never into the exception.

# Issues

Closes #4678

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Testing

- [x] adds a new unit test `tests/py/dynamo/runtime/test_engine_failure_diagnostics.py` 
- [x] existing unit tests pass

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
