### PR TITLE
fix: add the missing f-string prefix to two diagnostic messages

### DIFF
--- a/py/torch_tensorrt/dynamo/runtime/_MutableTorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_MutableTorchTensorRTModule.py
@@ -476,7 +476,7 @@ class MutableTorchTensorRTModule(object):
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:
         warnings.warn(
-            "Direct calls to {self.__class__}.forward() are currently broken by due to https://github.com/pytorch/pytorch/issues/157183. Either call {self.__class__}(...) directly or use {self.__class__}._forward as a work around"
+            f"Direct calls to {self.__class__.__name__}.forward() are currently broken by due to https://github.com/pytorch/pytorch/issues/157183. Either call {self.__class__.__name__}(...) directly or use {self.__class__.__name__}._forward as a work around"
         )
         return self._forward(*args, **kwargs)
 

--- a/py/torch_tensorrt/fx/passes/pass_utils.py
+++ b/py/torch_tensorrt/fx/passes/pass_utils.py
@@ -489,7 +489,7 @@ class InputOutputDtypeInferInterpreter(torch.fx.Interpreter):
 def apply_bfloat_float_conversion(
     gm: torch.fx.GraphModule, inputs: Any, name: str
 ) -> None:
-    _LOGGER.info("Apply bfloat-float32 conversion on {name}")
+    _LOGGER.info(f"Apply bfloat-float32 conversion on {name}")
     interpreter = InputOutputDtypeInferInterpreter(gm)
     interpreter.run(*inputs)
 


### PR DESCRIPTION
### Problem

Two diagnostic strings interpolate in-scope names but are missing the `f` prefix, so
the placeholder text reaches the user verbatim.

**1. `MutableTorchTensorRTModule.forward()`** — emitted on *every* direct `forward()` call:

```python
    def forward(self, *args: Any, **kwargs: Any) -> Any:
        warnings.warn(
            "Direct calls to {self.__class__}.forward() are currently broken by due to https://github.com/pytorch/pytorch/issues/157183. Either call {self.__class__}(...) directly or use {self.__class__}._forward as a work around"
        )
```

The message's whole job is to tell the user *what to type instead*, and all three
occurrences render as the literal `{self.__class__}`.

**2. `fx/passes/pass_utils.apply_bfloat_float_conversion()`**:

```python
    _LOGGER.info("Apply bfloat-float32 conversion on {name}")
```

`name: str` is a parameter of that function.

### Why these are typos, not deliberate literals

`pass_utils.py` uses f-strings for every other interpolated `_LOGGER` message
(lines 111, 116, 210, 398, 402); line 492 is the only one that does not. Note the
neighbouring literal in `_MutableTorchTensorRTModule.py`
(`"Allowed input types: {torch_tensorrt.Input, torch.Tensor, list, tuple, dict}"`)
is a genuine prose set literal — it is deliberately **not** touched here.

### Verification

`forward()` extracted verbatim from the file with `ast` and executed under
`warnings.catch_warnings`, before and after:

```
[BEFORE (main)]
  Direct calls to {self.__class__}.forward() are currently broken by due to
  https://github.com/pytorch/pytorch/issues/157183. Either call {self.__class__}(...)
  directly or use {self.__class__}._forward as a work around

[AFTER  (patch)]
  Direct calls to MutableTorchTensorRTModule.forward() are currently broken by due to
  https://github.com/pytorch/pytorch/issues/157183. Either call MutableTorchTensorRTModule(...)
  directly or use MutableTorchTensorRTModule._forward as a work around
```

I used `self.__class__.__name__` rather than bare `self.__class__` so the message
stays actionable — bare `{self.__class__}` would render
`<class 'torch_tensorrt.dynamo.runtime._MutableTorchTensorRTModule.MutableTorchTensorRTModule'>(...)`,
which is not something a user can type. Happy to switch to the bare form if you prefer.

`black` (26.3.1, the pinned pre-commit rev), `ruff` and `isort` were run on both files
from a repo checkout, before and after the change — identical output both times
(`pass_utils.py` has one pre-existing `C401` that this PR does not touch).

### Note, deliberately left alone

The `forward()` message also reads "are currently broken by due to". I left the
wording untouched to keep this PR to a single concern — say the word and I'll fix it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
