### PR TITLE
fix(tests): gate the BF16 suite on the minor SM version for sm_87

### DIFF
--- a/tests/py/dynamo/models/test_dtype_support.py
+++ b/tests/py/dynamo/models/test_dtype_support.py
@@ -188,7 +188,7 @@ class Test64BitSupport(TestCase):
     torch.cuda.get_device_properties(torch.cuda.current_device()).major < 8
     or (
         torch.cuda.get_device_properties(torch.cuda.current_device()).major == 8
-        and torch.cuda.get_device_properties(torch.cuda.current_device()).major == 7
+        and torch.cuda.get_device_properties(torch.cuda.current_device()).minor == 7
     ),
     "Platform does not have BF16 support",
 )


### PR DESCRIPTION
### Problem

The class-level guard on `TestBF16Support` in `tests/py/dynamo/models/test_dtype_support.py` reads `.major` twice:

```python
@unittest.skipIf(
    torch.cuda.get_device_properties(torch.cuda.current_device()).major < 8
    or (
        torch.cuda.get_device_properties(torch.cuda.current_device()).major == 8
        and torch.cuda.get_device_properties(torch.cuda.current_device()).major == 7
    ),
    "Platform does not have BF16 support",
)
```

`.major` cannot be both `8` and `7`, so the parenthesised disjunct is always `False` and the guard collapses to plain `major < 8`. The board it was meant to exclude still runs the whole BF16 suite.

### Why `.minor` is the intended attribute

`(major, minor) == (8, 7)` is Jetson AGX Orin, and the repo already spells that exact check out in `py/torch_tensorrt/dynamo/conversion/_TRTInterpreter.py`:

```python
assert (device_info.major == 8 and device_info.minor == 7) or (
    device_info.major == 7 and device_info.minor == 2
), "DLA is not available on non AGX systems"
```

so the second `.major` in the test guard is a typo for `.minor`.

### Fix

```python
        and torch.cuda.get_device_properties(torch.cuda.current_device()).minor == 7
```

### Verification

I sliced the real `skipIf` expression out of the file before and after the patch (via `git show HEAD:…` vs the working copy) and evaluated both over the SM capability grid with `torch.cuda.get_device_properties` stubbed:

```
sm       skip(before)  skip(after)
sm_61    True          True
sm_70    True          True
sm_72    True          True
sm_75    True          True
sm_80    False         False
sm_86    False         False
sm_87    False         True     <== CHANGED
sm_89    False         False
sm_90    False         False
sm_100   False         False
sm_120   False         False

changed cells: 1 / 11
```

sm_87 is the only capability whose behaviour changes, and it is exactly the board `_TRTInterpreter.py` identifies the same way. Every other platform, including all the ones CI runs on, is unaffected.

`black` 26.3.1 (the pinned `.pre-commit-config.yaml` revision) reports the file unchanged, and `ruff` returns an identical result before and after the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
