### PR TITLE
fix(dynamo): check bool before int in to_numpy/to_torch

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/converter_utils.py
+++ b/py/torch_tensorrt/dynamo/conversion/converter_utils.py
@@ -760,14 +760,14 @@ def to_numpy(
 
             output = value.cpu().detach().contiguous().numpy()
 
+        elif isinstance(value, bool):
+            output = np.array([value], dtype=np.bool_)
+
         elif isinstance(value, int):
             output = np.array([value], dtype=np.int32)
 
         elif isinstance(value, float):
             output = np.array([value], dtype=np.float32)
-
-        elif isinstance(value, bool):
-            output = np.array([value], dtype=np.bool_)
 
         if isinstance(output, np.ndarray) or output is None:
             return (
@@ -813,14 +813,14 @@ def to_torch(
         elif isinstance(value, np.ndarray):
             output = torch.from_numpy(value).to(cpu_device).contiguous()
 
+        elif isinstance(value, bool):
+            output = torch.tensor([value], device=cpu_device, dtype=torch.bool)
+
         elif isinstance(value, int):
             output = torch.tensor([value], device=cpu_device, dtype=torch.int32)
 
         elif isinstance(value, float):
             output = torch.tensor([value], device=cpu_device, dtype=torch.float32)
-
-        elif isinstance(value, bool):
-            output = torch.tensor([value], device=cpu_device, dtype=torch.bool)
 
         else:
             raise AssertionError(


### PR DESCRIPTION
## Description

`bool` is a subclass of `int`, so in both `to_numpy()` and `to_torch()` the `isinstance(value, int)` branch swallows Python bools and the `isinstance(value, bool)` branch below it is dead code:

```python
elif isinstance(value, int):
    output = np.array([value], dtype=np.int32)
elif isinstance(value, float):
    ...
elif isinstance(value, bool):          # unreachable
    output = np.array([value], dtype=np.bool_)
```

Both functions advertise `bool` in their type hints and docstrings (`Union[torch.Tensor, np.ndarray, int, float, bool]`, "A PyTorch tensor, Numpy array, int, float, or bool"), and both `AssertionError` messages list `bool` as an accepted input — but a `bool` never reaches the branch written for it.

Concretely, `create_constant()` passes the value through `to_torch(value, dtype)` and hands the result straight to `ctx.net.add_constant()`, so a Python `bool` with no explicit `dtype` produces an **INT32** constant layer where a **BOOL** one was intended.

`impl/full.py` already works around exactly this pitfall, with a comment linking to the canonical explanation:

```python
# https://stackoverflow.com/questions/37888620/comparing-boolean-and-int-using-isinstance
if type(fill_value) in (int, float):
    ...
if isinstance(fill_value, bool):
    ...
```

so the intended contract in this conversion path is clearly "bool is not an int".

## Fix

Move the `bool` branch ahead of the `int` branch in both helpers. No other change — the branch bodies are untouched.

## Verification

The two functions were extracted from the file with `ast.get_source_segment` and executed against real `numpy` / `torch` (a `nullcontext` stands in for `unset_fake_temporarily`, `dtype=None` throughout so the `_enums` path is not involved), before and after the patch:

| input | fn | before | after | changed |
|---|---|---|---|---|
| `True` | `to_numpy` | `int32` | `bool` | **YES** |
| `True` | `to_torch` | `torch.int32` | `torch.bool` | **YES** |
| `False` | `to_numpy` | `int32` | `bool` | **YES** |
| `False` | `to_torch` | `torch.int32` | `torch.bool` | **YES** |
| `1` | `to_numpy` / `to_torch` | `int32` | `int32` | – |
| `0` | `to_numpy` / `to_torch` | `int32` | `int32` | – |
| `3` | `to_numpy` / `to_torch` | `int32` | `int32` | – |
| `2.5` | `to_numpy` / `to_torch` | `float32` | `float32` | – |
| `np.array([1, 2])` | `to_numpy` / `to_torch` | `int64` | `int64` | – |
| `torch.tensor([1.0])` | `to_numpy` / `to_torch` | `float32` | `float32` | – |

Only Python bools change; every other input keeps its dtype, and `True`/`False` keep their values (`bool(out[0]) == value`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
