### PR TITLE
fix(dynamo): fall back to PyTorch for nonzero on TensorRT-RTX

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -20,7 +20,6 @@ import torch
 from tensorrt import ITensor as TRTTensor
 from torch.fx.node import Argument, Node, Target
 from torch_tensorrt import ENABLED_FEATURES
-from torch_tensorrt._features import needs_not_tensorrt_rtx
 from torch_tensorrt._utils import (
     is_tensorrt_rtx_version_supported,
     is_tensorrt_version_supported,
@@ -4371,14 +4370,32 @@ def aten_ops_full(
     )
 
 
-# currently nonzero is not supported for tensorrt_rtx
-# TODO: lan to add the nonzero support once tensorrt_rtx team has added the support
+def nonzero_validator(
+    node: Node, settings: Optional[CompilationSettings] = None
+) -> bool:
+    """Reject nonzero on TensorRT-RTX, which has no non-zero layer.
+
+    The rejection has to happen in a capability validator rather than in the
+    converter body. The partitioner only consults the validator, so a converter
+    that raises instead leaves the node inside a TensorRT block and fails the
+    build, never reaching the PyTorch fallback.
+    """
+    if not ENABLED_FEATURES.tensorrt_rtx:
+        return True
+
+    _LOGGER.debug(
+        "nonzero '%s' is not supported on TensorRT-RTX. Falling back to PyTorch.",
+        node.name,
+    )
+    return False
+
+
 @dynamo_tensorrt_converter(
     torch.ops.aten.nonzero.default,
+    capability_validator=nonzero_validator,
     supports_dynamic_shapes=True,
     requires_output_allocator=True,
 )
-@needs_not_tensorrt_rtx
 def aten_ops_nonzero(
     ctx: ConversionContext,
     target: Target,

--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -4373,13 +4373,7 @@ def aten_ops_full(
 def nonzero_validator(
     node: Node, settings: Optional[CompilationSettings] = None
 ) -> bool:
-    """Reject nonzero on TensorRT-RTX, which has no non-zero layer.
-
-    The rejection has to happen in a capability validator rather than in the
-    converter body. The partitioner only consults the validator, so a converter
-    that raises instead leaves the node inside a TensorRT block and fails the
-    build, never reaching the PyTorch fallback.
-    """
+    """Reject nonzero on TensorRT-RTX, which has no non-zero layer."""
     if not ENABLED_FEATURES.tensorrt_rtx:
         return True
 

--- a/tests/py/dynamo/conversion/test_nonzero_aten.py
+++ b/tests/py/dynamo/conversion/test_nonzero_aten.py
@@ -6,6 +6,7 @@ import torch_tensorrt
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
 from torch_tensorrt import Input
+from torch_tensorrt.dynamo.conversion.aten_ops_converters import nonzero_validator
 
 from .harness import DispatchTestCase
 
@@ -145,6 +146,41 @@ class TestNonZeroConverter(DispatchTestCase):
         ]
 
         self.run_test_with_dynamic_shape(NonZero(), input_specs)
+
+
+class TestNonZeroValidator(unittest.TestCase):
+    """nonzero_validator decides, at partition time, whether nonzero reaches TensorRT.
+
+    It has to reject on TensorRT-RTX so the partitioner leaves the node in a
+    PyTorch block; a converter-side raise would fail the build instead.
+    """
+
+    @staticmethod
+    def _nonzero_node() -> torch.fx.Node:
+        class NonZero(nn.Module):
+            def forward(self, x):
+                return torch.nonzero(x)
+
+        gm = torch.export.export(NonZero(), (torch.tensor([0, 3, 0, 5]),)).module()
+        return next(
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target == torch.ops.aten.nonzero.default
+        )
+
+    @unittest.skipUnless(
+        torch_tensorrt.ENABLED_FEATURES.tensorrt_rtx,
+        "nonzero_validator only rejects on tensorrt_rtx",
+    )
+    def test_nonzero_validator_false_on_rtx(self):
+        self.assertFalse(nonzero_validator(self._nonzero_node()))
+
+    @unittest.skipIf(
+        torch_tensorrt.ENABLED_FEATURES.tensorrt_rtx,
+        "On non-RTX, nonzero_validator always passes",
+    )
+    def test_nonzero_validator_true_on_non_rtx(self):
+        self.assertTrue(nonzero_validator(self._nonzero_node()))
 
 
 if __name__ == "__main__":

--- a/tests/py/dynamo/models/test_fallback_data_dependent_ops.py
+++ b/tests/py/dynamo/models/test_fallback_data_dependent_ops.py
@@ -8,6 +8,11 @@ from torch_tensorrt.dynamo.partitioning._global_partitioner import (
     TorchTensorRTOperatorSupport,
 )
 
+# TensorRT-RTX has no non-zero layer, so nonzero_validator rejects the node and no
+# converter is ever selected for it. Both the output-allocator predicate and node
+# support follow from whether a converter exists.
+NONZERO_HAS_TRT_CONVERTER = not ENABLED_FEATURES.tensorrt_rtx
+
 
 def test_fallback_data_dependent_ops_setting_default():
     # Off by default; opt-in only.
@@ -48,12 +53,10 @@ def test_requires_output_allocator_is_setting_independent():
     # _requires_output_allocator is a pure predicate: it reports whether the
     # converter selected for the node needs a TRT output allocator (decided per node
     # via the selected converter, not by op target), independent of any setting.
-    # On TensorRT-RTX nonzero_validator rejects the node, so no converter is
-    # selected and no output allocator is required.
     node = _nonzero_node()
     assert (
         TorchTensorRTOperatorSupport._requires_output_allocator(node)
-        is not ENABLED_FEATURES.tensorrt_rtx
+        is NONZERO_HAS_TRT_CONVERTER
     )
 
 
@@ -67,9 +70,7 @@ def test_output_allocator_node_falls_back_only_when_enabled():
         CONVERTERS.set_compilation_settings(
             CompilationSettings(fallback_data_dependent_ops=False)
         )
-        # On TensorRT-RTX nonzero has no usable converter at all, so it falls
-        # back whatever the setting says.
-        assert support.is_node_supported({}, node) is not ENABLED_FEATURES.tensorrt_rtx
+        assert support.is_node_supported({}, node) is NONZERO_HAS_TRT_CONVERTER
         CONVERTERS.set_compilation_settings(
             CompilationSettings(fallback_data_dependent_ops=True)
         )

--- a/tests/py/dynamo/models/test_fallback_data_dependent_ops.py
+++ b/tests/py/dynamo/models/test_fallback_data_dependent_ops.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 import torch_tensorrt
+from torch_tensorrt import ENABLED_FEATURES
 from torch_tensorrt.dynamo._settings import CompilationSettings
 from torch_tensorrt.dynamo.conversion import DYNAMO_CONVERTERS as CONVERTERS
 from torch_tensorrt.dynamo.partitioning._global_partitioner import (
@@ -47,8 +48,13 @@ def test_requires_output_allocator_is_setting_independent():
     # _requires_output_allocator is a pure predicate: it reports whether the
     # converter selected for the node needs a TRT output allocator (decided per node
     # via the selected converter, not by op target), independent of any setting.
+    # On TensorRT-RTX nonzero_validator rejects the node, so no converter is
+    # selected and no output allocator is required.
     node = _nonzero_node()
-    assert TorchTensorRTOperatorSupport._requires_output_allocator(node) is True
+    assert (
+        TorchTensorRTOperatorSupport._requires_output_allocator(node)
+        is not ENABLED_FEATURES.tensorrt_rtx
+    )
 
 
 def test_output_allocator_node_falls_back_only_when_enabled():
@@ -61,7 +67,9 @@ def test_output_allocator_node_falls_back_only_when_enabled():
         CONVERTERS.set_compilation_settings(
             CompilationSettings(fallback_data_dependent_ops=False)
         )
-        assert support.is_node_supported({}, node) is True
+        # On TensorRT-RTX nonzero has no usable converter at all, so it falls
+        # back whatever the setting says.
+        assert support.is_node_supported({}, node) is not ENABLED_FEATURES.tensorrt_rtx
         CONVERTERS.set_compilation_settings(
             CompilationSettings(fallback_data_dependent_ops=True)
         )


### PR DESCRIPTION
# Description

## What

This PR fixes a crash. A model that contains `nonzero` now runs the operator in PyTorch on TensorRT-RTX. Before this change the compilation stopped with an error.

## Why

`aten.nonzero.default` had no `capability_validator`. The partitioner thus put the node in a TensorRT block. The only guard was the `@needs_not_tensorrt_rtx` decorator on the converter body. That decorator raises at conversion time, and the converter registry cannot see it. The node entered a TensorRT block and then failed:

```
NotImplementedError: This is only available in non TensorRT-RTX environments,
currently running in TensorRT-RTX
While executing %nonzero : call_function[target=torch.ops.aten.nonzero.default]
```

TensorRT-RTX has no non-zero layer, so the node must go to PyTorch. #4631 added `TestArangeConverter::test_arange_data_dependent_start`, which calls `nonzero` and shows the defect.

## How

Add `nonzero_validator` and give it to the converter as `capability_validator` similar in style to other TensorRT-RTX capability validators limits.

## Testing

Tested on an L40S with the nightly wheels of both flavours. The wheel Python tree was identical to `main` for all files that this change touches.

Partition check on TensorRT-RTX: `nonzero` goes to submodule `_run_on_gpu_0`, and TensorRT still builds `_run_on_acc_1`. The output agrees with eager mode. On standard TensorRT the node stays in `_run_on_acc_0`, as before.

| Test file | TensorRT-RTX before to after | TensorRT before to after |
| --- | --- | --- |
| `test_arange_aten.py` | 1 failed, 20 passed to **21 passed** | 21 passed to 21 passed |
| `test_nonzero_aten.py` | 16 skipped to 1 passed, 17 skipped | 16 passed to 17 passed, 1 skipped |
| `test_index_aten.py` | 14 passed, 6 skipped to same | 20 passed to same |
| `test_index_bool_split_aten.py` | 13 passed, 3 skipped to same | 15 passed, 1 skipped to same |
| `test_fallback_data_dependent_ops.py` | 7 passed to same | 7 passed to same |
| `test_output_allocator.py` | 12 skipped to same | 12 passed to same |

## Followups

Eight skips exist for this same cause: `test_index_aten.py:117,152,183`, `test_index_bool_split_aten.py:136`, and four in `runtime/test_output_allocator.py`. They are now unnecessary. To remove them is a separate change.

`needs_not_tensorrt_rtx` in `_features.py` now has no callers. Its neighbour `needs_tensorrt_rtx` already had none. To delete both is a separate change.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
