### PR TITLE
fix select empty tensor squeeze dgx spark

### DIFF
--- a/core/conversion/converters/impl/select.cpp
+++ b/core/conversion/converters/impl/select.cpp
@@ -146,10 +146,6 @@ auto select_registrations TORCHTRT_UNUSED =
                LOG_DEBUG("Gather tensor shape: " << out->getDimensions());
 
                if (out->getDimensions().nbDims != 1) {
-                 // IShuffleLayer removes redundant dimensions
-                 auto shuffle_layer = ctx->net->addShuffle(*out);
-                 TORCHTRT_CHECK(shuffle_layer, "Unable to create shuffle layer from node: " << *n);
-
                  auto num_zero_dimensions =
                      util::validateInputDimsForShuffle(out->getDimensions(), ctx->input_is_dynamic);
                  TORCHTRT_CHECK(
@@ -157,17 +153,26 @@ auto select_registrations TORCHTRT_UNUSED =
                      "Detected multiple zero dimensions and dynamic shape in aten::select, "
                          << "which is not currently supported in TensorRT");
 
-                 // If the input is not dynamic, and the tensor is empty (has some dimension 0)
-                 // Then 0 is no longer a placeholder for inherited dimensions
-                 if (!ctx->input_is_dynamic && (num_zero_dimensions > 0)) {
-                   LOG_DEBUG("Setting zero as a true dimension (not placeholder) in aten::select");
-                   shuffle_layer->setZeroIsPlaceholder(false);
-                 }
+                 auto squeezed_dims = util::squeezeDims(
+                     out->getDimensions(), dim, false, ctx->input_is_dynamic && (num_zero_dimensions > 0));
 
-                 shuffle_layer->setReshapeDimensions(util::squeezeDims(
-                     out->getDimensions(), dim, false, ctx->input_is_dynamic && (num_zero_dimensions > 0)));
-                 shuffle_layer->setName(util::node_info(n).c_str());
-                 out = shuffle_layer->getOutput(0);
+                 if (!ctx->input_is_dynamic && num_zero_dimensions > 0) {
+                   // A statically-empty tensor (a true 0-size dimension) has no data
+                   // to move, but building an IShuffleLayer to squeeze it trips a
+                   // TensorRT-internal squeezeDims assertion at build time on some
+                   // platforms (e.g. DGX Spark). Emit an empty constant of the target
+                   // shape directly instead, since it has zero elements either way.
+                   auto scalar_type = util::TRTDataTypeToScalarType(in->getType());
+                   auto empty_out = at::empty(util::toVec(squeezed_dims), at::TensorOptions().dtype(scalar_type));
+                   out = tensor_to_const(ctx, empty_out);
+                 } else {
+                   // IShuffleLayer removes redundant dimensions
+                   auto shuffle_layer = ctx->net->addShuffle(*out);
+                   TORCHTRT_CHECK(shuffle_layer, "Unable to create shuffle layer from node: " << *n);
+                   shuffle_layer->setReshapeDimensions(squeezed_dims);
+                   shuffle_layer->setName(util::node_info(n).c_str());
+                   out = shuffle_layer->getOutput(0);
+                 }
                }
 
                out = ctx->AssociateValueAndTensor(n->outputs()[0], out);

--- a/tests/core/conversion/converters/test_select.cpp
+++ b/tests/core/conversion/converters/test_select.cpp
@@ -191,6 +191,36 @@ TEST(Converters, ATenSelectEmptyTensorConvertsCorrectly) {
   ASSERT_TRUE(torch_tensorrt::tests::util::sameShape(jit_results[0], trt_results[0]));
 }
 
+// Regression test: an empty (0-element) select result built at a non-default
+// precision. Exercises the dtype-preservation path taken when the squeeze is
+// skipped in favor of directly emitting an empty constant of the target
+// shape (see aten::select.int in select.cpp).
+TEST(Converters, ATenSelectEmptyTensorHalfConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor):
+        %2 : int = prim::Constant[value=1]()
+        %3 : int = prim::Constant[value=0]()
+        %4 : Tensor = aten::select(%0, %3, %2)
+        return (%4))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(graph, g.get());
+
+  auto in = torch::ones({2, 20, 0, 768}).to(at::kCUDA).to(at::kHalf);
+
+  auto jit_in = at::clone(in);
+  auto params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto jit_results = torch_tensorrt::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  params = torch_tensorrt::core::ir::get_static_params(g->inputs(), {});
+  auto trt_results = torch_tensorrt::tests::util::RunGraphEngine(g, params, {trt_in}, {nvinfer1::DataType::kHALF});
+
+  ASSERT_TRUE(torch_tensorrt::tests::util::sameShape(jit_results[0], trt_results[0]));
+  ASSERT_EQ(trt_results[0].scalar_type(), at::kHalf);
+}
+
 TEST(Converters, ATenNarrowStartScalarConvertsCorrectly) {
   const auto graph = R"IR(
       graph(%x.1 : Tensor):


### PR DESCRIPTION
Building an IShuffleLayer to squeeze a genuinely empty (0-size) dimension trips a TensorRT-internal squeezeDims assertion at build time on some platforms (e.g. DGX Spark, Error Code 2 in validationUtils.cpp) -- a 26.09 regression on Spark. Since a tensor with a static 0-size dimension has zero elements regardless of dtype/values, emit an empty constant of the target shape directly instead of asking TensorRT to reshape/squeeze it.

Adds a half-precision variant of the existing empty-tensor select test to exercise the new dtype-preservation path.

related to https://github.com/pytorch/TensorRT/pull/4641 failure on spark. skip TRT shuffle/reshape for statically empty shapes.
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added the relevant labels to my PR in so that relevant reviewers are notified
