### PR TITLE
fix: preserve integer precision in cumulative sums

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
+++ b/py/torch_tensorrt/dynamo/conversion/aten_ops_converters.py
@@ -1489,12 +1489,40 @@ def aten_ops_slice(
     )
 
 
+# The cumulative layer accepts these and nothing else. A dtype outside the set would abort
+# the whole compile from inside the cast, with a message naming neither cumsum nor the dtype.
+_CUMSUM_ACCUMULATOR_DTYPES = {
+    torch.float32,
+    torch.float16,
+    torch.bfloat16,
+    torch.int32,
+    torch.int64,
+}
+
+
 def cumsum_validator(
     node: Node, settings: Optional[CompilationSettings] = None
 ) -> bool:
-    # TensorRT-RTX before 1.7 cannot build a refittable cumsum when its loop
-    # trip count is a constant. Standard TensorRT and TensorRT-RTX 1.7+ do not
-    # have this limitation.
+    requested_dtype = node.kwargs.get("dtype", None)
+    if (
+        requested_dtype is not None
+        and requested_dtype not in _CUMSUM_ACCUMULATOR_DTYPES
+    ):
+        # float64 is the exception: truncate_double already means the caller accepts
+        # float32, and the converter maps it. Everything else has to fall back.
+        if not (
+            requested_dtype is torch.float64
+            and settings is not None
+            and settings.truncate_double
+        ):
+            _LOGGER.debug(
+                f"cumsum with dtype={requested_dtype} is not supported by the cumulative "
+                "layer, falling back to PyTorch"
+            )
+            return False
+
+    # TensorRT-RTX before 1.7 cannot build a refittable cumsum when its trip count is a
+    # constant. Standard TensorRT and TensorRT-RTX 1.7+ do not have this limitation.
     if (
         is_tensorrt_rtx_version_supported("1.7")
         or settings is None
@@ -1528,7 +1556,7 @@ def cumsum_validator(
     if isinstance(axis_size, int) and axis_size >= 0:
         _LOGGER.debug(
             f"cumsum node {node.name} has a static axis {dim} of size {axis_size}; "
-            "TensorRT-RTX < 1.7 cannot build its refittable constant loop trip count."
+            "TensorRT-RTX < 1.7 cannot build a refittable cumsum with a constant extent."
         )
         return False
 
@@ -1563,6 +1591,7 @@ def aten_ops_cumsum(
         name,
         args[0],
         args[1],
+        kwargs.get("dtype", None),
     )
 
 

--- a/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/slice/ops.py
@@ -4,13 +4,17 @@ from typing import Optional, Sequence, Union
 
 import numpy as np
 import tensorrt as trt
+import torch
 from tensorrt import ITensor as TRTTensor
 from torch.fx.node import Target
+from torch_tensorrt import _enums
+from torch_tensorrt._utils import is_tensorrt_version_supported
 from torch_tensorrt.dynamo._SourceIR import SourceIR
 from torch_tensorrt.dynamo.conversion import impl
 from torch_tensorrt.dynamo.conversion._ConversionContext import ConversionContext
 from torch_tensorrt.dynamo.conversion.converter_utils import (
     calculate_strides,
+    cast_trt_tensor,
     flatten_dims,
     get_positive_dim,
     get_trt_tensor,
@@ -379,7 +383,7 @@ def expand(
     return layer.get_output(0)
 
 
-def cumsum(
+def _cumsum_with_loop(
     ctx: ConversionContext,
     target: Target,
     source_ir: Optional[SourceIR],
@@ -387,6 +391,9 @@ def cumsum(
     input: TRTTensor,
     dim: int,
 ) -> TRTTensor:
+    # Kept for TensorRT without the cumulative layer. It seeds its accumulator with a
+    # float32 zero, so an integer total loses exactness above 2**24; the layer path does
+    # not have that problem.
     input_shape = input.shape
     dim = get_positive_dim(dim, len(input_shape))
     if input_shape[dim] < 0:
@@ -445,6 +452,66 @@ def cumsum(
     set_layer_name(loop_output, target, f"{name}_loop_output", source_ir)
     loop_output.set_input(1, trip_limit)
     return loop_output.get_output(0)
+
+
+def cumsum(
+    ctx: ConversionContext,
+    target: Target,
+    source_ir: Optional[SourceIR],
+    name: str,
+    input: TRTTensor,
+    dim: int,
+    dtype: Optional[torch.dtype] = None,
+) -> TRTTensor:
+    if not is_tensorrt_version_supported("10.8.0"):
+        # No cumulative layer before this version, so build it out of a loop.
+        return _cumsum_with_loop(ctx, target, source_ir, name, input, dim)
+
+    # torch.cumsum accumulates a bool or integer input in int64 and returns int64, so
+    # accumulating in the input type would turn every non-zero running total for a bool
+    # input back into True. An explicit dtype argument overrides that choice.
+    input_dtype = _enums.dtype._from(input.dtype).to(torch.dtype)
+    if dtype is not None:
+        # The layer has no float64, so a caller who asked for it has already accepted
+        # float32 by setting truncate_double; the validator refuses it otherwise.
+        output_dtype = torch.float32 if dtype is torch.float64 else dtype
+    elif input_dtype.is_floating_point:
+        output_dtype = input_dtype
+    else:
+        output_dtype = torch.int64
+
+    # A running sum loses precision fast in a narrow float: every partial total is rounded
+    # to the operand type, so a long float16 or bfloat16 sum drifts far from eager, which
+    # accumulates in float32. Accumulate in float32 and cast the result back, the way the
+    # old loop did by seeding a float32 accumulator.
+    accumulator_dtype = output_dtype
+    if output_dtype in (torch.float16, torch.bfloat16):
+        accumulator_dtype = torch.float32
+
+    casted_input = cast_trt_tensor(
+        ctx, input, accumulator_dtype, f"{name}_casted", target, source_ir
+    )
+
+    # addCumulative requires a rank 0 axis; a shape (1,) axis fails its parameter check
+    # and returns None.
+    axis = get_trt_tensor(
+        ctx,
+        get_positive_dim(dim, len(input.shape)),
+        f"{name}_axis",
+        dtype=trt.int32,
+        min_rank=0,
+    )
+    layer = ctx.net.add_cumulative(
+        casted_input, axis, trt.CumulativeOperation.SUM, exclusive=False, reverse=False
+    )
+    assert layer, f"Failed to add a cumulative layer for {name}"
+    set_layer_name(layer, target, name, source_ir)
+    result = layer.get_output(0)
+    if accumulator_dtype is not output_dtype:
+        result = cast_trt_tensor(
+            ctx, result, output_dtype, f"{name}_output_cast", target, source_ir
+        )
+    return result
 
 
 def tile(

--- a/tests/py/dynamo/conversion/test_cumsum_aten.py
+++ b/tests/py/dynamo/conversion/test_cumsum_aten.py
@@ -123,6 +123,129 @@ class TestCumsumConverter(DispatchTestCase):
             use_dynamo_tracer=True,
         )
 
+    @parameterized.expand(
+        [
+            ("int32", torch.int32, 2**24, 6),
+            ("int64", torch.int64, 10**15, 4),
+        ]
+    )
+    def test_cumsum_integer_stays_exact(self, _, dtype, first, count):
+        """The running total has to be accumulated in an integer type.
+
+        This asserts equality rather than going through run_test, whose tolerance is
+        relative: accumulating in float32 puts a total of 1e15 out by about 13 million,
+        which is well inside that tolerance and so invisible to an approximate comparison.
+        """
+
+        class Cumsum(nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.cumsum.default(x, 1)
+
+        values = torch.tensor([[first] + [1] * (count - 1)], dtype=dtype, device="cuda")
+        module = Cumsum().eval().cuda()
+        expected = module(values)
+
+        compiled = torch_tensorrt.dynamo.compile(
+            torch.export.export(module, (values,)),
+            inputs=[values],
+            min_block_size=1,
+            enabled_precisions={torch.float32},
+            truncate_double=True,
+        )
+        self.assertTrue(
+            torch.equal(compiled(values).cpu(), expected.cpu()),
+            f"expected {expected.flatten().tolist()}, "
+            f"got {compiled(values).flatten().tolist()}",
+        )
+
+    @parameterized.expand(
+        [
+            ("float16", torch.float16),
+            ("bfloat16", torch.bfloat16),
+        ]
+    )
+    def test_cumsum_reduced_precision_float_stays_accurate(self, _, dtype):
+        """A long running sum in a narrow float drifts, because every partial total is
+        rounded to the operand type. eager accumulates in float32, so the engine has to as
+        well and cast the result back, or a thousand-long sum is off by many units.
+        """
+
+        class Cumsum(nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.cumsum.default(x, 1)
+
+        values = torch.ones((2, 1000), dtype=dtype, device="cuda")
+        module = Cumsum().eval().cuda()
+        expected = module(values)
+
+        compiled = torch_tensorrt.dynamo.compile(
+            torch.export.export(module, (values,)),
+            inputs=[values],
+            min_block_size=1,
+            enabled_precisions={torch.float32},
+            truncate_double=True,
+        )
+        result = compiled(values)
+        self.assertEqual(result.dtype, expected.dtype)
+        max_abs_diff = (result.float() - expected.float()).abs().max().item()
+        self.assertLess(
+            max_abs_diff,
+            1.0,
+            f"cumsum drifted by {max_abs_diff}, so it accumulated in {dtype} not float32",
+        )
+
+    @parameterized.expand(
+        [
+            ("bool", torch.bool),
+            ("int32", torch.int32),
+        ]
+    )
+    def test_cumsum_integer_accumulates_in_int64(self, _, dtype):
+        """A bool input must not accumulate in bool, or every non-zero running total comes
+        back as True."""
+
+        class Cumsum(nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.cumsum.default(x, 1)
+
+        if dtype is torch.bool:
+            inputs = [torch.tensor([[True, False, True, True, False, True]])]
+        else:
+            inputs = [torch.tensor([[1, 0, 1, 1, 0, 1]], dtype=dtype)]
+        self.run_test(
+            Cumsum(),
+            inputs,
+            use_dynamo_tracer=True,
+        )
+
+    def test_cumsum_honors_dtype_argument(self):
+        """The keyword-only dtype argument selects the accumulator type."""
+
+        class Cumsum(nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.cumsum.default(x, 1, dtype=torch.float32)
+
+        inputs = [torch.tensor([[1, 0, 1, 1]], dtype=torch.int32)]
+        self.run_test(
+            Cumsum(),
+            inputs,
+            use_dynamo_tracer=True,
+        )
+
+    def test_cumsum_rank4(self):
+        """Rank 4 static, which the existing cases cover only with dynamic shapes."""
+
+        class Cumsum(nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.cumsum.default(x, 2)
+
+        inputs = [torch.randn(1, 2, 5, 3)]
+        self.run_test(
+            Cumsum(),
+            inputs,
+            use_dynamo_tracer=True,
+        )
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
## Problem

The `cumsum` converter builds a loop with a float32 accumulator. Integer totals can lose precision: a row starting at 16777216 followed by five ones should end at 16777221, but the converter loses those increments.

## Change

Use TensorRT's cumulative-sum layer when available. Accumulate integer and boolean inputs in int64 by default. Forward an explicit `dtype` argument and keep unsupported requested types in PyTorch. Float64 is allowed only when `truncate_double=True` permits float32 arithmetic.

Accumulate float16 and bfloat16 inputs in float32, then convert the output back, preserving the existing reduced-precision behavior. Keep the old loop on TensorRT versions before 10.8.

## Tests

Passed 28/28 cumulative-sum tests covering fixed and changing shapes, integer and boolean outputs, and reduced-precision floating-point inputs. Both exact integer tests fail on the base branch, losing unit increments at large int32 and int64 values.

An earlier separate dynamic-batch int32 check also matched PyTorch exactly for the row described above and lost its unit increments without this change.

An existing limit remains: explicitly requesting float16 or bfloat16 for a wider input does not always match PyTorch's input-rounding behavior. Earlier comparisons found the same mismatches with and without this change. The passing small `dtype` test does not prove that broader behavior is fixed.

The focused rerun used Linux x86_64, Python 3.12, PyTorch 2.15 nightly, and TensorRT 11.3 with the Python runtime. Earlier native-runtime coverage used TensorRT 11.2; a native TensorRT 11.3 build was not tested.

Windows, aarch64, TensorRT-RTX, the older-version loop path, and updates to engine weights after compilation were not tested.
