### PR TITLE
fix: preserve results when evaluating constant tensor operations

### DIFF
--- a/py/torch_tensorrt/dynamo/conversion/impl/elementwise/base.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/elementwise/base.py
@@ -1,7 +1,7 @@
 import logging
 import operator
 import warnings
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 import tensorrt as trt
 import torch
@@ -23,39 +23,53 @@ from torch_tensorrt.dynamo.types import TRTDataType, TRTElementWiseOp, TRTTensor
 logger = logging.getLogger(__name__)
 
 
-def get_python_op_from_trt_elementwise_op(
+_PYTHON_FOLD_OPS: Dict[TRTElementWiseOp, Callable[[Any, Any], Any]] = {
+    trt.ElementWiseOperation.SUM: operator.add,
+    trt.ElementWiseOperation.PROD: operator.mul,
+    trt.ElementWiseOperation.SUB: operator.sub,
+    trt.ElementWiseOperation.DIV: operator.truediv,
+    trt.ElementWiseOperation.POW: operator.pow,
+    trt.ElementWiseOperation.FLOOR_DIV: operator.floordiv,
+    trt.ElementWiseOperation.EQUAL: operator.eq,
+    trt.ElementWiseOperation.GREATER: operator.gt,
+    trt.ElementWiseOperation.LESS: operator.lt,
+    trt.ElementWiseOperation.MAX: max,
+    trt.ElementWiseOperation.MIN: min,
+    trt.ElementWiseOperation.AND: lambda a, b: bool(a) and bool(b),
+    trt.ElementWiseOperation.OR: lambda a, b: bool(a) or bool(b),
+    trt.ElementWiseOperation.XOR: lambda a, b: bool(a) != bool(b),
+}
+
+_TORCH_FOLD_OPS: Dict[TRTElementWiseOp, Callable[[Any, Any], Any]] = {
+    trt.ElementWiseOperation.MAX: torch.maximum,
+    trt.ElementWiseOperation.MIN: torch.minimum,
+    trt.ElementWiseOperation.AND: torch.logical_and,
+    trt.ElementWiseOperation.OR: torch.logical_or,
+    trt.ElementWiseOperation.XOR: torch.logical_xor,
+}
+
+
+def _fold_constants(
     trt_op: TRTElementWiseOp,
-) -> Callable[[Any, Any], Any]:
-    if trt_op == trt.ElementWiseOperation.SUM:
-        return operator.add
-    elif trt_op == trt.ElementWiseOperation.PROD:
-        return operator.mul
-    elif trt_op == trt.ElementWiseOperation.MAX:
-        return lambda a, b: max(a, b)
-    elif trt_op == trt.ElementWiseOperation.MIN:
-        return lambda a, b: min(a, b)
-    elif trt_op == trt.ElementWiseOperation.SUB:
-        return operator.sub
-    elif trt_op == trt.ElementWiseOperation.DIV:
-        return operator.truediv
-    elif trt_op == trt.ElementWiseOperation.POW:
-        return operator.pow
-    elif trt_op == trt.ElementWiseOperation.FLOOR_DIV:
-        return operator.floordiv
-    elif trt_op == trt.ElementWiseOperation.AND:
-        return lambda a, b: a and b
-    elif trt_op == trt.ElementWiseOperation.OR:
-        return lambda a, b: a or b
-    elif trt_op == trt.ElementWiseOperation.XOR:
-        return lambda a, b: (a or b) and not (a and b)
-    elif trt_op == trt.ElementWiseOperation.EQUAL:
-        return operator.eq
-    elif trt_op == trt.ElementWiseOperation.GREATER:
-        return operator.gt
-    elif trt_op == trt.ElementWiseOperation.LESS:
-        return operator.lt
-    else:
+    lhs_val: Any,
+    rhs_val: Any,
+) -> Union[int, float, bool, torch.Tensor]:
+    """Fold constants without changing scalar promotion or tensor rank."""
+    if not isinstance(lhs_val, (int, float, bool)):
+        lhs_val = torch.as_tensor(lhs_val)
+    if not isinstance(rhs_val, (int, float, bool)):
+        rhs_val = torch.as_tensor(rhs_val)
+    if trt_op not in _PYTHON_FOLD_OPS:
         raise RuntimeError(f"{trt_op} is not supported yet!")
+    if trt_op in _TORCH_FOLD_OPS and (
+        isinstance(lhs_val, torch.Tensor) or isinstance(rhs_val, torch.Tensor)
+    ):
+        dtype = torch.result_type(lhs_val, rhs_val)
+        return _TORCH_FOLD_OPS[trt_op](
+            torch.as_tensor(lhs_val, dtype=dtype), torch.as_tensor(rhs_val, dtype=dtype)
+        )
+    # Python operators also dispatch to Tensor methods, preserving weak scalar promotion.
+    return _PYTHON_FOLD_OPS[trt_op](lhs_val, rhs_val)
 
 
 def convert_binary_elementwise(
@@ -110,7 +124,7 @@ def convert_binary_elementwise(
             f"Both operands of the binary elementwise op {name} "
             "are constant. In this case, please consider constant fold the model first."
         )
-        return get_python_op_from_trt_elementwise_op(op_type)(lhs_val, rhs_val)
+        return _fold_constants(op_type, lhs_val, rhs_val)
 
     # If the following conditions are true:
     #  1. the network has implicit batch dimension,

--- a/tests/py/dynamo/conversion/test_binary_ops_aten.py
+++ b/tests/py/dynamo/conversion/test_binary_ops_aten.py
@@ -1,12 +1,14 @@
+import operator
 import unittest
 from typing import Callable
 
+import tensorrt as trt
 import torch
 import torch.nn as nn
-import torch_tensorrt
 from parameterized import parameterized
 from torch.testing._internal.common_utils import run_tests
 from torch_tensorrt import Input
+from torch_tensorrt.dynamo.conversion.impl.elementwise import base as elementwise_base
 
 from .harness import DispatchTestCase
 
@@ -115,6 +117,94 @@ class TestBinaryOpConverters(DispatchTestCase):
         m = TestModule(orig_op)
         inputs = [torch.randn(2, 2)]
         self.run_test(m, inputs)
+
+    @parameterized.expand(
+        [
+            ("maximum", torch.ops.aten.maximum.default),
+            ("minimum", torch.ops.aten.minimum.default),
+        ]
+    )
+    def test_elementwise_op_with_both_constants_multi_element(
+        self, name, orig_op: Callable
+    ):
+        """A constant of more than one element. Folding two of those in Python compares
+        the whole operands rather than their elements, so max returns one operand."""
+
+        class TestModule(nn.Module):
+            def __init__(self, orig_op):
+                super().__init__()
+                self.constant0 = torch.nn.Parameter(torch.randn(3))
+                self.constant1 = torch.nn.Parameter(torch.randn(3))
+                self.orig_op = orig_op
+
+            def forward(self, x):
+                const = self.orig_op(self.constant0, self.constant1)
+                return self.orig_op(x, const)
+
+        m = TestModule(orig_op)
+        inputs = [torch.randn(3)]
+        self.run_test(m, inputs)
+
+    @parameterized.expand(
+        [
+            ("logical_and", torch.ops.aten.logical_and.default),
+            ("logical_or", torch.ops.aten.logical_or.default),
+            ("logical_xor", torch.ops.aten.logical_xor.default),
+        ]
+    )
+    def test_logical_op_with_both_constants_multi_element(
+        self, name, orig_op: Callable
+    ):
+        """Folding two bool constants in Python calls __bool__ on an operand, which raises
+        for more than one element. The result also has to stay bool: uint8 is rejected when
+        the constant is built."""
+
+        class TestModule(nn.Module):
+            def __init__(self, orig_op):
+                super().__init__()
+                # Parameters keep this operation in the graph during legacy tracing.
+                self.constant0 = nn.Parameter(
+                    torch.tensor([True, False, True]), requires_grad=False
+                )
+                self.constant1 = nn.Parameter(
+                    torch.tensor([True, True, False]), requires_grad=False
+                )
+                self.orig_op = orig_op
+
+            def forward(self, x):
+                const = self.orig_op(self.constant0, self.constant1)
+                return self.orig_op(torch.ops.aten.gt.Scalar(x, 0), const)
+
+        m = TestModule(orig_op)
+        inputs = [torch.randn(3)]
+        self.run_test(m, inputs)
+
+    def test_constant_fold_preserves_float16_overflow(self):
+        class FoldHalf(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.constant = nn.Parameter(torch.tensor([300.0], dtype=torch.float16))
+
+            def forward(self, x):
+                value = torch.ops.aten.mul.Scalar(self.constant, 1000.0)
+                value = torch.ops.aten.div.Scalar(value, 1000.0)
+                return torch.ops.aten.add.Tensor(x, value)
+
+        self.run_test(FoldHalf(), [torch.zeros(2)])
+
+    def test_constant_fold_preserves_bool_scalar_add(self):
+        class FoldBool(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.constant = nn.Parameter(
+                    torch.tensor([True, False]), requires_grad=False
+                )
+
+            def forward(self, x):
+                value = torch.ops.aten.add.Scalar(self.constant, True)
+                return torch.ops.aten.add.Tensor(x, value)
+
+        self.run_test(FoldBool(), [torch.zeros(2)])
 
     @parameterized.expand([(lambda x, y: torch.ops.aten.div.Tensor(x, y),)])
     def test_elementwise_op_div_with_two_ints(self, orig_op: Callable):
@@ -270,6 +360,115 @@ class TestBinaryOpConverters(DispatchTestCase):
             torch.randn(8, 8, dtype=torch.float16),
         ]
         self.run_test(ZeroDimMulThenMatmul(), inputs, use_dynamo_tracer=True)
+
+
+class TestConstantFolding(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("add", trt.ElementWiseOperation.SUM, operator.add),
+            ("sub", trt.ElementWiseOperation.SUB, operator.sub),
+            ("mul", trt.ElementWiseOperation.PROD, operator.mul),
+            ("div", trt.ElementWiseOperation.DIV, operator.truediv),
+            ("floor_div", trt.ElementWiseOperation.FLOOR_DIV, operator.floordiv),
+            ("pow", trt.ElementWiseOperation.POW, operator.pow),
+            ("eq", trt.ElementWiseOperation.EQUAL, operator.eq),
+            ("gt", trt.ElementWiseOperation.GREATER, operator.gt),
+            ("lt", trt.ElementWiseOperation.LESS, operator.lt),
+            ("max", trt.ElementWiseOperation.MAX, max),
+            ("min", trt.ElementWiseOperation.MIN, min),
+        ]
+    )
+    def test_python_scalars(self, _, operation, eager):
+        for lhs, rhs in ((2, 3), (2147483647, 1), (2147483648, 2), (1.0000000001, 1.0)):
+            with self.subTest(lhs=lhs, rhs=rhs):
+                expected = eager(lhs, rhs)
+                result = elementwise_base._fold_constants(operation, lhs, rhs)
+                self.assertIs(type(result), type(expected))
+                self.assertEqual(result, expected)
+
+    @parameterized.expand(
+        [
+            ("add", trt.ElementWiseOperation.SUM, operator.add),
+            ("sub", trt.ElementWiseOperation.SUB, operator.sub),
+            ("mul", trt.ElementWiseOperation.PROD, operator.mul),
+            ("div", trt.ElementWiseOperation.DIV, operator.truediv),
+            ("floor_div", trt.ElementWiseOperation.FLOOR_DIV, operator.floordiv),
+            ("pow", trt.ElementWiseOperation.POW, operator.pow),
+            ("eq", trt.ElementWiseOperation.EQUAL, operator.eq),
+            ("gt", trt.ElementWiseOperation.GREATER, operator.gt),
+            ("lt", trt.ElementWiseOperation.LESS, operator.lt),
+        ]
+    )
+    def test_mixed_scalar_promotion(self, _, operation, eager):
+        for dtype in (torch.float16, torch.bfloat16, torch.int32):
+            for shape in ((), (2,)):
+                for scalar in (2, 1.0001):
+                    for scalar_first in (False, True):
+                        with self.subTest(
+                            dtype=dtype,
+                            shape=shape,
+                            scalar=scalar,
+                            scalar_first=scalar_first,
+                        ):
+                            tensor = torch.full(shape, 3, dtype=dtype)
+                            lhs, rhs = (
+                                (scalar, tensor) if scalar_first else (tensor, scalar)
+                            )
+                            torch.testing.assert_close(
+                                elementwise_base._fold_constants(operation, lhs, rhs),
+                                eager(lhs, rhs),
+                                rtol=0,
+                                atol=0,
+                            )
+
+    def test_bool_scalar_add(self):
+        tensor = torch.tensor([True, False])
+        for lhs, rhs in ((tensor, True), (True, tensor)):
+            torch.testing.assert_close(
+                elementwise_base._fold_constants(
+                    trt.ElementWiseOperation.SUM, lhs, rhs
+                ),
+                lhs + rhs,
+            )
+
+    def test_float16_overflow(self):
+        tensor = torch.tensor([300.0], dtype=torch.float16)
+        for lhs, rhs in ((tensor, 1000.0), (1000.0, tensor)):
+            torch.testing.assert_close(
+                elementwise_base._fold_constants(
+                    trt.ElementWiseOperation.PROD, lhs, rhs
+                ),
+                lhs * rhs,
+            )
+
+    @parameterized.expand(
+        [
+            ("max", trt.ElementWiseOperation.MAX, torch.maximum),
+            ("min", trt.ElementWiseOperation.MIN, torch.minimum),
+            ("and", trt.ElementWiseOperation.AND, torch.logical_and),
+            ("or", trt.ElementWiseOperation.OR, torch.logical_or),
+            ("xor", trt.ElementWiseOperation.XOR, torch.logical_xor),
+        ]
+    )
+    def test_tensor_operations(self, _, operation, eager):
+        lhs = torch.tensor([[0.0], [3.0]])
+        rhs = torch.tensor([2.0, 0.0, 4.0])
+        torch.testing.assert_close(
+            elementwise_base._fold_constants(operation, lhs, rhs), eager(lhs, rhs)
+        )
+        torch.testing.assert_close(
+            elementwise_base._fold_constants(operation, lhs.numpy(), rhs.numpy()),
+            eager(lhs, rhs),
+        )
+        scalar_tensor = torch.tensor(2.0, dtype=torch.float16)
+        for left, right in ((scalar_tensor, 3.0), (3.0, scalar_tensor)):
+            torch.testing.assert_close(
+                elementwise_base._fold_constants(operation, left, right),
+                eager(
+                    torch.as_tensor(left, dtype=torch.float16),
+                    torch.as_tensor(right, dtype=torch.float16),
+                ),
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The converter can evaluate an operation during compilation when both inputs are constants. This is called constant folding. Python's `max`, `min`, and logical operators do not work on tensors element by element, so folding can fail or return a whole input tensor.

Simply converting every constant through the engine's input helper would create another problem. Python numbers would become one-element tensors with fixed data types. That can overflow integers, change float16 arithmetic, and turn boolean results into integers.

## Change

Keep Python arithmetic and comparison operators for scalar values (single numbers). These operators also preserve PyTorch's choice of data type when a tensor is combined with a scalar.

Use PyTorch's element-by-element max, min, and logical operations for tensor inputs. Do not change how inputs are prepared for operations that run inside TensorRT.

Use non-trainable parameters for the logical tests' constants. This keeps their operations in the traced graph so the converter, not tracing, evaluates them.

## Tests

Passed 119/119 tests in the binary-operator module. Direct folding tests check exact values, data types, dimensions, both input orders, and mixed scalar/tensor inputs. Engine tests check float16 overflow and boolean addition, plus max/min/logical operations over multiple elements.

The five max/min/logical engine cases fail on the base branch because Python tries to interpret a multi-element tensor as one boolean. They pass with this change.

Earlier tests that removed only the scalar-preservation logic failed the scalar regressions, including both engine-output checks. Scalar arithmetic itself also works on the base branch; those checks protect existing behavior.

The focused rerun used Linux x86_64, Python 3.12, PyTorch 2.15 nightly, and TensorRT 11.3 with the Python runtime. Earlier native-runtime coverage used TensorRT 11.2; a native TensorRT 11.3 build was not tested.

Windows, aarch64, TensorRT-RTX, and TensorRT 10.x were not tested.
