### PR TITLE
fix: run select with a computed index

### DIFF
--- a/py/torch_tensorrt/dynamo/_exporter.py
+++ b/py/torch_tensorrt/dynamo/_exporter.py
@@ -896,11 +896,14 @@ def inline_trt_modules(
         )
     )
 
-    def scalar_tensor_meta(dtype: torch.dtype, device: torch.device) -> torch.Tensor:
+    def scalar_tensor_meta(
+        dtype: torch.dtype, device: torch.device, rank: int = 0
+    ) -> torch.Tensor:
+        shape = (1,) * rank
         if fake_mode is None:
-            return torch.empty((), dtype=dtype, device="meta")
+            return torch.empty(shape, dtype=dtype, device="meta")
         with fake_mode:
-            return torch.empty((), dtype=dtype, device=device)
+            return torch.empty(shape, dtype=dtype, device=device)
 
     for name, _ in gm.named_children():
         if "_run_on_acc" not in name:
@@ -952,9 +955,23 @@ def inline_trt_modules(
                         "device": trt_module.target_device,
                     },
                 )
+                # Set meta on the scalar_tensor node itself before wrapping it. The
+                # non-retracing export path builds an ExportedProgram straight from this
+                # graph and its verifier requires a val on every node, so a node left
+                # without one fails verification.
                 scalar_input.meta["val"] = scalar_tensor_meta(
                     info["dtype"], trt_module.target_device
                 )
+                binding_rank = info.get("binding_rank", 0)
+                if binding_rank:
+                    # scalar_tensor is rank 0, and this binding declares a higher rank, so
+                    # lift it here too. The runtime does the same from the same record.
+                    scalar_input = gm.graph.call_function(
+                        torch.ops.aten.unsqueeze.default, (scalar_input, 0)
+                    )
+                    scalar_input.meta["val"] = scalar_tensor_meta(
+                        info["dtype"], trt_module.target_device, binding_rank
+                    )
                 engine_inputs[index] = scalar_input
 
             if cross_compile_module:

--- a/py/torch_tensorrt/dynamo/conversion/_symbolic_shape_capture.py
+++ b/py/torch_tensorrt/dynamo/conversion/_symbolic_shape_capture.py
@@ -101,12 +101,18 @@ def extract_symbolic_shape_expressions(
             scalar_dtype = input_dtypes_by_name.get(
                 input_node.name, default_scalar_dtype
             )
+            # A SymInt binding is declared as a rank 1 shape tensor and a SymFloat binding
+            # as rank 0, so record which one this is. Both ends that materialize the scalar
+            # read this, and they have to agree with what the binding declares.
             input_info.append(
                 {
                     "shape_exprs": [],
                     "dtype": scalar_dtype,
                     "name": input_node.name,
                     "is_scalar": True,
+                    "binding_rank": (
+                        1 if isinstance(input_val, (torch.SymInt, int)) else 0
+                    ),
                 }
             )
         else:

--- a/py/torch_tensorrt/dynamo/conversion/impl/select.py
+++ b/py/torch_tensorrt/dynamo/conversion/impl/select.py
@@ -2,7 +2,9 @@ import logging
 from typing import List, Optional, Sequence, Union
 
 import numpy as np
+import tensorrt as trt
 import torch
+from tensorrt import ITensor
 from torch.fx.node import Target
 from torch_tensorrt._enums import dtype
 from torch_tensorrt.dynamo._SourceIR import SourceIR
@@ -21,9 +23,6 @@ from torch_tensorrt.dynamo.conversion.impl.elementwise import convert_binary_ele
 from torch_tensorrt.dynamo.conversion.impl.shape import shape as get_shape
 from torch_tensorrt.dynamo.utils import DYNAMIC_DIM
 
-import tensorrt as trt
-from tensorrt import ITensor
-
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
@@ -34,7 +33,7 @@ def select(
     name: str,
     input: ITensor,
     dim: int,
-    index: int,
+    index: Union[int, ITensor],
 ) -> ITensor:
     if not isinstance(input, ITensor):
         raise RuntimeError(
@@ -45,10 +44,24 @@ def select(
     ranks = len(input.shape)
     dim = get_positive_dim(dim, ranks)
 
-    indices_tensor = get_trt_tensor(
-        ctx, np.array(index, dtype=np.int32), f"{name}_indices_tensor"
-    )
+    if isinstance(index, ITensor):
+        # The index was computed at runtime, so it cannot be folded into a constant.
+        indices_tensor = cast_trt_tensor(
+            ctx, index, trt.int32, f"{name}_cast_index_tensor", target, source_ir
+        )
+        # add_gather keeps the axis it gathers along for an index of rank 1 or higher, and
+        # a scalar crossing a partition boundary arrives as shape (1,), so squeezing to
+        # rank 0 is what makes the result match eager.
+        if len(indices_tensor.shape) == 1 and indices_tensor.shape[0] == 1:
+            indices_tensor = impl.shuffle.reshape(
+                ctx, target, source_ir, f"{name}_index_rank0", indices_tensor, ()
+            )
+    else:
+        indices_tensor = get_trt_tensor(
+            ctx, np.array(index, dtype=np.int32), f"{name}_indices_tensor"
+        )
     layer = ctx.net.add_gather(input, indices_tensor, dim)
+    set_layer_name(layer, target, f"{name}_gather", source_ir)
 
     return layer.get_output(0)
 

--- a/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
+++ b/py/torch_tensorrt/dynamo/runtime/_TorchTensorRTModule.py
@@ -730,7 +730,8 @@ class TorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
         #
         # This also avoids the need for type-checking inputs, since they are now explicitly casted to Torch tensors
         input_tensors: List[torch.Tensor] = []
-        for i in inputs:
+        input_info = (self.symbolic_shape_expressions or {}).get("inputs", [])
+        for index, i in enumerate(inputs):
             if isinstance(i, torch.Tensor):
                 if not i.is_cuda:
                     logger.warning(
@@ -741,7 +742,19 @@ class TorchTensorRTModule(torch.nn.Module):  # type: ignore[misc]
                     i = i.cuda()
                 input_tensors.append(i)
             else:
-                input_tensors.append(torch.tensor(i).cuda())
+                # A scalar produced by a preceding Torch subgraph. Its binding rank is not
+                # always the same: an integer index is declared rank 1 while a float is
+                # declared rank 0, so build it at the rank this binding records rather than
+                # a fixed one. setInputShape refuses a mismatch without naming either side.
+                scalar_tensor = torch.tensor(i)
+                declared_rank = (
+                    input_info[index].get("binding_rank", 0)
+                    if index < len(input_info)
+                    else 0
+                )
+                while scalar_tensor.dim() < declared_rank:
+                    scalar_tensor = scalar_tensor.unsqueeze(0)
+                input_tensors.append(scalar_tensor.cuda())
 
         outputs: List[Any] = torch.ops.tensorrt.execute_engine(
             list(input_tensors), self.engine

--- a/tests/py/dynamo/conversion/test_select_aten.py
+++ b/tests/py/dynamo/conversion/test_select_aten.py
@@ -107,6 +107,26 @@ class TestSelectConverterOne(DispatchTestCase):
 
         self.run_test_with_dynamic_shape(select(), input_specs)
 
+    def test_select_runtime_index(self):
+        """The index is a tensor rather than a constant here, which is what a preceding Torch
+        subgraph produces. Selecting row 3 of an (8, 4) input must give shape (4,), the same
+        as eager: add_gather keeps the axis it gathers along unless the index is rank 0.
+        """
+
+        class SelectRuntimeIndex(nn.Module):
+            def forward(self, values, positions):
+                index = torch.ops.aten.sum.default(positions)
+                return torch.ops.aten.select.int(values, 0, index)
+
+        inputs = [
+            torch.randn(8, 4),
+            torch.tensor([1, 2], dtype=torch.int64),
+        ]
+        self.run_test(
+            SelectRuntimeIndex(),
+            inputs,
+        )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/tests/py/dynamo/models/test_symint_scalar_input.py
+++ b/tests/py/dynamo/models/test_symint_scalar_input.py
@@ -14,7 +14,10 @@ import unittest
 import pytest
 import torch
 import torch_tensorrt as torchtrt
+from torch_tensorrt import ENABLED_FEATURES
 from torch_tensorrt.dynamo._exporter import transform
+from torch_tensorrt.dynamo.runtime import TorchTensorRTModule
+from torch_tensorrt.dynamo.runtime._TRTEngine import TRTEngine
 from torch_tensorrt.dynamo.utils import COSINE_THRESHOLD, cosine_similarity
 
 assertions = unittest.TestCase()
@@ -247,3 +250,49 @@ def test_symfloat_scalar_input():
     finally:
         torch._dynamo.config.capture_scalar_outputs = False
         torch._dynamo.reset()
+
+
+@pytest.mark.unit
+def test_select_with_scalar_index_across_partition():
+    """A computed index crossing the partition boundary must give eager's shape.
+
+    The index is produced by a Torch subgraph and arrives at the engine as a runtime value.
+    TensorRT's gather keeps the axis it gathers along unless the index is rank 0, so without
+    the squeeze this returns (1, 4) where eager returns (4,), silently.
+
+    This also covers the runtime half of that path, which a converter test cannot reach: a
+    converter test builds one engine and hands it real tensors, so it never sends a host
+    scalar into a binding.
+    """
+
+    class SelectComputedIndex(torch.nn.Module):
+        def forward(self, values, positions):
+            return torch.ops.aten.select.int(values, 0, positions.sum().item())
+
+    model = SelectComputedIndex().eval().cuda()
+    values = torch.randn(8, 4, device="cuda")
+    positions = torch.tensor([1, 2], dtype=torch.int64, device="cuda")
+
+    exported = torch.export.export(model, (values, positions))
+    compiled = torchtrt.dynamo.compile(
+        exported,
+        inputs=[values, positions],
+        min_block_size=1,
+        enabled_precisions={torch.float32},
+        truncate_double=True,
+    )
+    engines = [
+        m.engine for m in compiled.modules() if isinstance(m, TorchTensorRTModule)
+    ]
+    assertions.assertTrue(engines, "expected a TensorRT engine")
+    backend = (
+        torch.ScriptObject if ENABLED_FEATURES.torch_tensorrt_runtime else TRTEngine
+    )
+    for engine in engines:
+        assertions.assertIsInstance(engine, backend)
+
+    for indices in ([1, 2], [2, 3], [0, 0]):
+        positions = torch.tensor(indices, dtype=torch.int64, device="cuda")
+        torch.testing.assert_close(
+            compiled(values, positions), model(values, positions)
+        )


### PR DESCRIPTION
## Problem

`select` cannot run in TensorRT when its index is computed from another input. The index also needs the right shape: selecting one row from an `(8, 4)` tensor should return `(4,)`, not `(1, 4)`.

## Change

Accept an index computed at runtime. Convert a one-element index tensor to a scalar before passing it to TensorRT's gather operation.

Record how many dimensions each scalar input expects. Use that information when calling the engine and when exporting the compiled model. This keeps integer and floating-point scalar inputs consistent across those paths.

Check that the model test builds an engine of the expected type. Runtime selection depends on native-library availability; the deprecated `use_python_runtime` option does not select a backend.

## Tests

Passed 7/7 converter tests with each runtime. The computed-index model passed with both; a floating-point scalar control also passed with the native runtime. Earlier testing covered that scalar control with the Python runtime too. Assertions confirmed native `ScriptObject` or Python `TRTEngine` engines. The converter control fails on the base branch when it tries to convert a TensorRT index into a NumPy constant.

Direct execution matched PyTorch shape, data type, and values for indices 3, 5, and 0. A separate check used both exporters, legacy and nonlegacy, to export, save to `BytesIO`, reload, and execute the same changing indices. All four exporter/runtime combinations passed.

The rerun used Linux x86_64, Python 3.12, and PyTorch 2.15 nightly. Python-runtime checks used TensorRT 11.3. Native checks used the published Torch-TensorRT 2.15 nightly library with its TensorRT 11.2 dependency; they do not validate a native TensorRT 11.3 build.

Export checks bound indices to the valid range. Existing gather bounds behavior and conversion to 32-bit indices are unchanged. Windows, aarch64, TensorRT-RTX, TensorRT 10.x, changing input dimensions, different input devices, concurrent calls, older saved models, and filesystem durability were not tested.
