### PR TITLE
fix(deps): bump js-yaml to patch DoS advisories in assigner action

### DIFF
--- a/.github/actions/assigner/package-lock.json
+++ b/.github/actions/assigner/package-lock.json
@@ -11,8 +11,7 @@
       "dependencies": {
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.0",
-        "fs": "^0.0.1-security",
-        "js-yaml": "^4.1.1"
+        "js-yaml": "^4.3.2"
       },
       "devDependencies": {
         "@types/node": "^17.0.35",
@@ -264,15 +263,20 @@
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "license": "ISC"
     },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
-    },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -544,15 +548,10 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
-    "fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
-    },
     "js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "requires": {
         "argparse": "^2.0.1"
       }

--- a/.github/actions/assigner/package.json
+++ b/.github/actions/assigner/package.json
@@ -21,8 +21,7 @@
   "dependencies": {
     "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.0",
-    "fs": "^0.0.1-security",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.3.2"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",


### PR DESCRIPTION
Automated dependency bump to address disclosed CVEs in the `assigner` GitHub Action's own dependencies.

- **CVEs/Advisories:** GHSA-2883-xcg3-v3hh, GHSA-52cp-r559-cp3m, GHSA-5p4m-2wfm-xmqj, GHSA-h67p-54hq-rp68
- **Severity:** high
- **Package:** `js-yaml` `^4.1.1` → `^4.3.2` (same major, no breaking changes; `npm view js-yaml@4.3.2` confirms zero remaining advisories at this version)

Also drops the unused `fs` dependency (`^0.0.1-security`) — this is npm's inert
security-holding placeholder for the reserved `fs` name (it does nothing; the
real `fs` is a Node.js built-in and doesn't need to be installed). `osv-scanner`
flagged it as `MAL-2025-21003`; removing it is a zero-risk cleanup alongside
the CVE fix.

**Not fully remediated by this PR:** `undici` `5.29.0` (a transitive dependency
of `@actions/github@^6.0.0`) carries several advisories (GHSA-vrm6-8vpv-qv8q
and others, high severity) whose fixes require `undici@6.24.0+`. `@actions/github`
only ever shipped `6.0.0`/`6.0.1` (both pin `undici@^5.28.5`, itself capped at
5.29.0 — no patched 5.x exists), so closing this fully means jumping
`@actions/github` to its current `9.x` line, a 3-major bump that could change
this action's runtime API surface. That's out of scope for a same-major
dependency-lockfile PR; flagging it here as a manual follow-up rather than
forcing a risky major bump silently.

Detected by [osv-scanner](https://google.github.io/osv-scanner/) as part of a
broader security audit of this repository (see the accompanying private
security advisory for two unrelated code-level findings filed separately).

---
Filed by [Aeon](https://github.com/aeonfun/aeon).
